### PR TITLE
feat: Add Virtualization to SearchableList components

### DIFF
--- a/Tesserae.Tests/src/App.cs
+++ b/Tesserae.Tests/src/App.cs
@@ -205,7 +205,7 @@ namespace Tesserae.Tests
 
         private static BackgroundArea CenteredCardWithBackground(IComponent content)
         {
-            var card = Card(content).NoAnimation().Padding(32.px());
+            var card = Card(content, noAnimation: true).Padding(32.px());
             card.Render().style.maxHeight = "calc(100% - 32px)";
             return BackgroundArea(card).S();
         }

--- a/Tesserae.Tests/src/Samples/Collections/SearchableGroupedListSample.cs
+++ b/Tesserae.Tests/src/Samples/Collections/SearchableGroupedListSample.cs
@@ -53,7 +53,7 @@ namespace Tesserae.Tests.Samples
         {
             private readonly string _value;
             private readonly IComponent _component;
-            public SearchableGroupedListItem(string value, string group) { _value = value; Group = group; _component = Card(TextBlock(value)).Height(64.px()); }
+            public SearchableGroupedListItem(string value, string group) { _value = value; Group = group; _component = Card(TextBlock(value), noAnimation: true).Height(64.px()); }
             public bool IsMatch(string searchTerm) => _value.ToLower().Contains(searchTerm.ToLower()) || Group.ToLower().Contains(searchTerm.ToLower());
             public string Group { get; }
             public IComponent Render() => _component;

--- a/Tesserae.Tests/src/Samples/Collections/SearchableGroupedListSample.cs
+++ b/Tesserae.Tests/src/Samples/Collections/SearchableGroupedListSample.cs
@@ -31,7 +31,12 @@ namespace Tesserae.Tests.Samples
                        .Height(400.px()).MB(32),
                     SampleSubTitle("Grouped Grid Layout"),
                     SearchableGroupedList(GetItems(40), s => Label(s).Primary().Bold(), 33.percent(), 33.percent(), 34.percent())
-                       .Height(500.px())
+                       .Height(500.px()),
+                    SampleSubTitle("Virtualized Grouped List (10000 items)"),
+                    SearchableGroupedList(GetItems(10000), s => HorizontalSeparator(TextBlock(s).Primary().SemiBold()).Left())
+                       .Virtualize(64.px())
+                       .WithNoResultsMessage(() => BackgroundArea(Card(TextBlock("No matching records").Padding(16.px()))).WS().HS().MinHeight(100.px()))
+                       .Height(400.px()).MB(32)
                 ));
         }
 
@@ -48,7 +53,7 @@ namespace Tesserae.Tests.Samples
         {
             private readonly string _value;
             private readonly IComponent _component;
-            public SearchableGroupedListItem(string value, string group) { _value = value; Group = group; _component = Card(TextBlock(value)); }
+            public SearchableGroupedListItem(string value, string group) { _value = value; Group = group; _component = Card(TextBlock(value)).Height(64.px()); }
             public bool IsMatch(string searchTerm) => _value.ToLower().Contains(searchTerm.ToLower()) || Group.ToLower().Contains(searchTerm.ToLower());
             public string Group { get; }
             public IComponent Render() => _component;

--- a/Tesserae.Tests/src/Samples/Collections/SearchableListSample.cs
+++ b/Tesserae.Tests/src/Samples/Collections/SearchableListSample.cs
@@ -53,7 +53,7 @@ namespace Tesserae.Tests.Samples
         {
             private readonly string _value;
             private readonly IComponent _component;
-            public SearchableListItem(string value) { _value = value; _component = Card(TextBlock(value)).Height(64.px()); }
+            public SearchableListItem(string value) { _value = value; _component = Card(TextBlock(value), noAnimation: true).Height(64.px()); }
             public bool IsMatch(string searchTerm) => _value.ToLower().Contains(searchTerm.ToLower());
             public HTMLElement Render() => _component.Render();
             IComponent ISearchableItem.Render() => _component;

--- a/Tesserae.Tests/src/Samples/Collections/SearchableListSample.cs
+++ b/Tesserae.Tests/src/Samples/Collections/SearchableListSample.cs
@@ -33,7 +33,12 @@ namespace Tesserae.Tests.Samples
                         SearchableList(GetItems(24), 25.percent(), 25.percent(), 25.percent(), 25.percent())
                            .BeforeSearchBox(Button("Filter").SetIcon(UIcons.Filter))
                            .AfterSearchBox(Button("Add Item").Primary().SetIcon(UIcons.Plus))
-                           .Height(400.px())
+                           .Height(400.px()),
+                        SampleSubTitle("Virtualized Searchable List (10000 items)"),
+                        SearchableList(GetItems(10000))
+                           .Virtualize(64.px())
+                           .WithNoResultsMessage(() => BackgroundArea(Card(TextBlock("No matching items found").Padding(16.px()))).WS().HS().MinHeight(100.px()))
+                           .Height(400.px()).MB(32)
                     ));
         }
 
@@ -48,7 +53,7 @@ namespace Tesserae.Tests.Samples
         {
             private readonly string _value;
             private readonly IComponent _component;
-            public SearchableListItem(string value) { _value = value; _component = Card(TextBlock(value)); }
+            public SearchableListItem(string value) { _value = value; _component = Card(TextBlock(value)).Height(64.px()); }
             public bool IsMatch(string searchTerm) => _value.ToLower().Contains(searchTerm.ToLower());
             public HTMLElement Render() => _component.Render();
             IComponent ISearchableItem.Render() => _component;

--- a/Tesserae/src/Base/UI.Components.cs
+++ b/Tesserae/src/Base/UI.Components.cs
@@ -145,7 +145,7 @@ namespace Tesserae
         /// <summary>
         /// Creates a <see cref="Tesserae.Card"/> component.
         /// </summary>
-        public static Card Card(IComponent content) => new Card(content);
+        public static Card Card(IComponent content, bool noAnimation = false) => new Card(content, noAnimation);
 
         public static Plan Plan(string title) => new Plan(title);
 

--- a/Tesserae/src/Base/UI.HtmlUtil.cs
+++ b/Tesserae/src/Base/UI.HtmlUtil.cs
@@ -48,17 +48,7 @@ namespace Tesserae
         /// </summary>
         public static bool IsEqualToOrIsChildOf(this HTMLElement element, Node possibleParentElement)
         {
-            return Script.Write<bool>("{0} == {1}", element, possibleParentElement) || possibleParentElement.contains(element);
-
-            while (Script.Write<bool>("{0} != null", element)) //Short-circuit the == opeartor in C# to make this method faster
-            {
-                if (Script.Write<bool>("{0} == {1}", element, possibleParentElement)) //Short-circuit the == opeartor in C# to make this method faster
-                {
-                    return true;
-                }
-                element = element.parentElement;
-            }
-            return false;
+            return element.isSameNode(possibleParentElement) || possibleParentElement.contains(element);
         }
 
         /// <summary>

--- a/Tesserae/src/Components/Card.cs
+++ b/Tesserae/src/Components/Card.cs
@@ -8,11 +8,20 @@ namespace Tesserae
     public sealed class Card : ComponentBase<Card, HTMLElement>, IHasBackgroundColor, IRoundedStyle
     {
         private readonly HTMLElement _cardContainer;
-        public Card(IComponent content)
+        public Card(IComponent content, bool noAnimation = false)
         {
             InnerElement   = Div(_("tss-card"),           content.Render());
             _cardContainer = Div(_("tss-card-container"), InnerElement);
-            DomObserver.WhenMounted(InnerElement, () => InnerElement.classList.add("tss-ismounted"));
+
+            if (noAnimation)
+            {
+                InnerElement.classList.add("tss-noanimation", "tss-ismounted");
+            }
+            else
+            {
+                DomObserver.WhenMounted(InnerElement, () => InnerElement.classList.add("tss-ismounted"));
+            }
+
             AttachClick();
             AttachContextMenu();
         }
@@ -44,12 +53,6 @@ namespace Tesserae
         public Card Compact()
         {
             IsCompact = true;
-            return this;
-        }
-
-        public Card NoAnimation()
-        {
-            InnerElement.classList.add("tss-noanimation", "tss-ismounted");
             return this;
         }
 

--- a/Tesserae/src/Components/LazyVirtualItem.cs
+++ b/Tesserae/src/Components/LazyVirtualItem.cs
@@ -8,15 +8,15 @@ namespace Tesserae
     public class LazyVirtualItem : IComponent
     {
         private readonly HTMLElement _innerElement;
-        private readonly Func<IComponent> _componentFactory;
-        private IComponent _component;
+        private readonly HTMLElement _component;
         private bool _isRendered;
 
-        public LazyVirtualItem(Func<IComponent> componentFactory, UnitSize height)
+        public LazyVirtualItem(IComponent component, UnitSize height)
         {
-            _componentFactory = componentFactory;
+            _component = component.Render();
             _innerElement = DIV();
             _innerElement.style.height = height.ToString();
+            _innerElement.style.width  = "100%";
             _innerElement.style.overflow = "hidden";
             _innerElement.style.boxSizing = "border-box";
         }
@@ -30,29 +30,14 @@ namespace Tesserae
                 if (!_isRendered)
                 {
                     _isRendered = true;
-                    if (_component == null)
-                    {
-                        _component = _componentFactory();
-                        _innerElement.appendChild(_component.Render());
-                    }
-                    else
-                    {
-                        var el = _component.Render();
-                        el.style.display = "";
-                    }
+                    _innerElement.appendChild(_component);
                 }
+
+                _component.style.display = "";
             }
             else
             {
-                if (_isRendered)
-                {
-                    _isRendered = false;
-                    if (_component != null)
-                    {
-                        var el = _component.Render();
-                        el.style.display = "none";
-                    }
-                }
+                _component.style.display = "none";
             }
         }
     }

--- a/Tesserae/src/Components/LazyVirtualItem.cs
+++ b/Tesserae/src/Components/LazyVirtualItem.cs
@@ -1,0 +1,59 @@
+using System;
+using static H5.Core.dom;
+using static Tesserae.UI;
+
+namespace Tesserae
+{
+    [H5.Name("tss.LazyVirtualItem")]
+    public class LazyVirtualItem : IComponent
+    {
+        private readonly HTMLElement _innerElement;
+        private readonly Func<IComponent> _componentFactory;
+        private IComponent _component;
+        private bool _isRendered;
+
+        public LazyVirtualItem(Func<IComponent> componentFactory, UnitSize height)
+        {
+            _componentFactory = componentFactory;
+            _innerElement = DIV();
+            _innerElement.style.height = height.ToString();
+            _innerElement.style.overflow = "hidden";
+            _innerElement.style.boxSizing = "border-box";
+        }
+
+        public HTMLElement Render() => _innerElement;
+
+        public void UpdateVisibility(bool isVisible)
+        {
+            if (isVisible)
+            {
+                if (!_isRendered)
+                {
+                    _isRendered = true;
+                    if (_component == null)
+                    {
+                        _component = _componentFactory();
+                        _innerElement.appendChild(_component.Render());
+                    }
+                    else
+                    {
+                        var el = _component.Render();
+                        el.style.display = "";
+                    }
+                }
+            }
+            else
+            {
+                if (_isRendered)
+                {
+                    _isRendered = false;
+                    if (_component != null)
+                    {
+                        var el = _component.Render();
+                        el.style.display = "none";
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Tesserae/src/Components/SearchableGroupedList.cs
+++ b/Tesserae/src/Components/SearchableGroupedList.cs
@@ -19,6 +19,10 @@ namespace Tesserae
         private          IComparer<string>        _groupComparer;
 
         private UnitSize          _virtualizedItemHeight;
+        private double            _virtualizedTimeout = 0;
+        private double            _virtualizedViewportMinTop = 0;
+        private double            _virtualizedViewportMaxTop = 0;
+
         private readonly List<LazyVirtualItem> _virtualItems = new List<LazyVirtualItem>();
 
         public HTMLElement                StylingContainer           => _stack.InnerElement;
@@ -110,17 +114,36 @@ namespace Tesserae
         public SearchableGroupedList<T> Virtualize(UnitSize itemHeight)
         {
             _virtualizedItemHeight = itemHeight;
-            _defered.Render().addEventListener("scroll", (e) => RecomputeVisibleVirtualItems());
-            _defered.Render().addEventListener("resize", (e) => RecomputeVisibleVirtualItems());
+            _defered.Refresh();
+            var container = _defered.Render();
+            container.parentElement.addEventListener("scroll", (e) => RecomputeVisibleVirtualItems());
+            container.parentElement.addEventListener("resize", (e) => RecomputeVisibleVirtualItems());
+            RecomputeVisibleVirtualItems();
             return this;
         }
 
         private void RecomputeVisibleVirtualItems()
         {
+            window.clearTimeout(_virtualizedTimeout);
+
+            var container = _defered.Render();
+            double scrollTop = container.parentElement.scrollTop;
+            if (scrollTop > _virtualizedViewportMinTop || scrollTop < _virtualizedViewportMaxTop)
+            {
+                RecomputeVisibleVirtualItemsInner();
+            }
+            else
+            {
+                _virtualizedTimeout = window.setTimeout((_) => RecomputeVisibleVirtualItemsInner(), 50);
+            }
+        }
+
+        private void RecomputeVisibleVirtualItemsInner() 
+        { 
             if (_virtualizedItemHeight is null || _virtualItems.Count == 0) return;
             var container = _defered.Render();
-            double scrollTop = container.scrollTop;
-            double containerHeight = container.clientHeight;
+            double scrollTop = container.parentElement.scrollTop;
+            double containerHeight = container.parentElement.parentElement.scrollHeight;
             if (containerHeight == 0) return;
 
             // We use the fixed height to calculate visible indices
@@ -140,6 +163,9 @@ namespace Tesserae
                 bool isVisible = (i >= startIndex && i <= endIndex);
                 _virtualItems[i].UpdateVisibility(isVisible);
             }
+            
+            _virtualizedViewportMinTop = startIndex * itemH;
+            _virtualizedViewportMaxTop = endIndex   * itemH;
         }
 
         public HTMLElement Render() => _stack.Render();
@@ -171,7 +197,7 @@ namespace Tesserae
                         {
                             foreach (var groupedItem in groupedItems)
                             {
-                                var lazy = new LazyVirtualItem(() => groupedItem.Render(), _virtualizedItemHeight);
+                                var lazy = new LazyVirtualItem(groupedItem.Render(), _virtualizedItemHeight);
                                 _virtualItems.Add(lazy);
                                 observableList.Add(lazy);
                             }

--- a/Tesserae/src/Components/SearchableGroupedList.cs
+++ b/Tesserae/src/Components/SearchableGroupedList.cs
@@ -18,6 +18,9 @@ namespace Tesserae
         private readonly ItemsList                _list;
         private          IComparer<string>        _groupComparer;
 
+        private UnitSize          _virtualizedItemHeight;
+        private readonly List<LazyVirtualItem> _virtualItems = new List<LazyVirtualItem>();
+
         public HTMLElement                StylingContainer           => _stack.InnerElement;
         public bool                       PropagateToStackItemParent => true;
         public ObservableList<IComponent> Items                      { get; }
@@ -45,6 +48,7 @@ namespace Tesserae
                             var searchTerms   = (_searchBox.Text ?? "").Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
                             var filteredItems = originalItems.OfType<T>().Where(i => searchTerms.Length == 0 || searchTerms.All(st => i.IsMatch(st))).ToArray();
                             AddGroupedItems(filteredItems, _list.Items, isGrid: (columns is object && columns.Length > 1));
+                            window.setTimeout((_) => RecomputeVisibleVirtualItems(), 1);
                             return _list.S();
                         }
                     )
@@ -103,11 +107,47 @@ namespace Tesserae
             return this;
         }
 
+        public SearchableGroupedList<T> Virtualize(UnitSize itemHeight)
+        {
+            _virtualizedItemHeight = itemHeight;
+            _defered.Render().addEventListener("scroll", (e) => RecomputeVisibleVirtualItems());
+            _defered.Render().addEventListener("resize", (e) => RecomputeVisibleVirtualItems());
+            return this;
+        }
+
+        private void RecomputeVisibleVirtualItems()
+        {
+            if (_virtualizedItemHeight is null || _virtualItems.Count == 0) return;
+            var container = _defered.Render();
+            double scrollTop = container.scrollTop;
+            double containerHeight = container.clientHeight;
+            if (containerHeight == 0) return;
+
+            // We use the fixed height to calculate visible indices
+            double itemH = _virtualizedItemHeight.Size;
+            if (itemH <= 0) itemH = 1;
+
+            int firstVisibleIndex = (int)(scrollTop / itemH);
+            int visibleCount = (int)(containerHeight / itemH) + 1;
+
+            // Add overscan (e.g., 1x container height)
+            int overscan = visibleCount;
+            int startIndex = Math.Max(0, firstVisibleIndex - overscan);
+            int endIndex = Math.Min(_virtualItems.Count - 1, firstVisibleIndex + visibleCount + overscan);
+
+            for (int i = 0; i < _virtualItems.Count; i++)
+            {
+                bool isVisible = (i >= startIndex && i <= endIndex);
+                _virtualItems[i].UpdateVisibility(isVisible);
+            }
+        }
+
         public HTMLElement Render() => _stack.Render();
 
 
         private void AddGroupedItems(IEnumerable<T> items, ObservableList<IComponent> observableList, bool isGrid)
         {
+            _virtualItems.Clear();
             observableList.Clear();
 
             if (items is object)
@@ -126,7 +166,20 @@ namespace Tesserae
                         }
 
                         observableList.Add(header);
-                        observableList.AddRange(groupedItems.Select(t => t.Render()));
+
+                        if (_virtualizedItemHeight is object)
+                        {
+                            foreach (var groupedItem in groupedItems)
+                            {
+                                var lazy = new LazyVirtualItem(() => groupedItem.Render(), _virtualizedItemHeight);
+                                _virtualItems.Add(lazy);
+                                observableList.Add(lazy);
+                            }
+                        }
+                        else
+                        {
+                            observableList.AddRange(groupedItems.Select(t => t.Render()));
+                        }
                     }
                 }
             }

--- a/Tesserae/src/Components/SearchableList.cs
+++ b/Tesserae/src/Components/SearchableList.cs
@@ -21,6 +21,9 @@ namespace Tesserae
         private int               _minimumItemsToShowBox = 0;
         private Func<string, Task<T[]>> _backgroundSearcher;
 
+        private UnitSize          _virtualizedItemHeight;
+        private readonly List<LazyVirtualItem> _virtualItems = new List<LazyVirtualItem>();
+
         public  HTMLElement       StylingContainer           => _stack.InnerElement;
         public  bool              PropagateToStackItemParent => true;
         public  ObservableList<T> Items                      { get; }
@@ -48,15 +51,35 @@ namespace Tesserae
                             var includeItemsBackground = new List<IComponent>();
                             var excludeItems = new List<IComponent>();
 
+                            _virtualItems.Clear();
+
                             foreach (var i in Items)
                             {
                                 if (searchTerms.Length == 0 || searchTerms.All(st => i.IsMatch(st)))
                                 {
-                                    includeItems.Add(i.Render().RemoveClass("tss-searchable-list-no-match"));
+                                    if (_virtualizedItemHeight is object)
+                                    {
+                                        var lazy = new LazyVirtualItem(() => i.Render().RemoveClass("tss-searchable-list-no-match"), _virtualizedItemHeight);
+                                        _virtualItems.Add(lazy);
+                                        includeItems.Add(lazy);
+                                    }
+                                    else
+                                    {
+                                        includeItems.Add(i.Render().RemoveClass("tss-searchable-list-no-match"));
+                                    }
                                 }
                                 else if (ShowNotMatchingItems)
                                 {
-                                    excludeItems.Add(i.Render().Class("tss-searchable-list-no-match"));
+                                    if (_virtualizedItemHeight is object)
+                                    {
+                                        var lazy = new LazyVirtualItem(() => i.Render().Class("tss-searchable-list-no-match"), _virtualizedItemHeight);
+                                        _virtualItems.Add(lazy);
+                                        excludeItems.Add(lazy);
+                                    }
+                                    else
+                                    {
+                                        excludeItems.Add(i.Render().Class("tss-searchable-list-no-match"));
+                                    }
                                 }
                             }
 
@@ -85,6 +108,7 @@ namespace Tesserae
                                         }
 
                                         _searchBox.Show();
+                                        RecomputeVisibleVirtualItems();
                                     }
                                 }).FireAndForget();
                             }
@@ -106,6 +130,8 @@ namespace Tesserae
                             {
                                 _searchBox.Collapse();
                             }
+
+                            window.setTimeout((_) => RecomputeVisibleVirtualItems(), 1);
 
                             return _list.S();
                         }
@@ -172,6 +198,41 @@ namespace Tesserae
             _searchBoxContainerComponents.AddRange(afterComponents);
             _searchBoxContainer.Children(_searchBoxContainerComponents);
             return this;
+        }
+
+        public SearchableList<T> Virtualize(UnitSize itemHeight)
+        {
+            _virtualizedItemHeight = itemHeight;
+            _defered.Render().addEventListener("scroll", (e) => RecomputeVisibleVirtualItems());
+            _defered.Render().addEventListener("resize", (e) => RecomputeVisibleVirtualItems());
+            return this;
+        }
+
+        private void RecomputeVisibleVirtualItems()
+        {
+            if (_virtualizedItemHeight is null || _virtualItems.Count == 0) return;
+            var container = _defered.Render();
+            double scrollTop = container.scrollTop;
+            double containerHeight = container.clientHeight;
+            if (containerHeight == 0) return;
+
+            // We use the fixed height to calculate visible indices
+            double itemH = _virtualizedItemHeight.Size;
+            if (itemH <= 0) itemH = 1; // Prevent division by zero
+
+            int firstVisibleIndex = (int)(scrollTop / itemH);
+            int visibleCount = (int)(containerHeight / itemH) + 1;
+
+            // Add overscan (e.g., 1x container height)
+            int overscan = visibleCount;
+            int startIndex = Math.Max(0, firstVisibleIndex - overscan);
+            int endIndex = Math.Min(_virtualItems.Count - 1, firstVisibleIndex + visibleCount + overscan);
+
+            for (int i = 0; i < _virtualItems.Count; i++)
+            {
+                bool isVisible = (i >= startIndex && i <= endIndex);
+                _virtualItems[i].UpdateVisibility(isVisible);
+            }
         }
 
         public dom.HTMLElement Render() => _stack.Render();

--- a/Tesserae/src/Components/SearchableList.cs
+++ b/Tesserae/src/Components/SearchableList.cs
@@ -22,6 +22,9 @@ namespace Tesserae
         private Func<string, Task<T[]>> _backgroundSearcher;
 
         private UnitSize          _virtualizedItemHeight;
+        private double            _virtualizedTimeout = 0;
+        private double            _virtualizedViewportMinTop = 0;
+        private double            _virtualizedViewportMaxTop = 0;
         private readonly List<LazyVirtualItem> _virtualItems = new List<LazyVirtualItem>();
 
         public  HTMLElement       StylingContainer           => _stack.InnerElement;
@@ -59,7 +62,7 @@ namespace Tesserae
                                 {
                                     if (_virtualizedItemHeight is object)
                                     {
-                                        var lazy = new LazyVirtualItem(() => i.Render().RemoveClass("tss-searchable-list-no-match"), _virtualizedItemHeight);
+                                        var lazy = new LazyVirtualItem(i.Render().RemoveClass("tss-searchable-list-no-match"), _virtualizedItemHeight);
                                         _virtualItems.Add(lazy);
                                         includeItems.Add(lazy);
                                     }
@@ -72,7 +75,7 @@ namespace Tesserae
                                 {
                                     if (_virtualizedItemHeight is object)
                                     {
-                                        var lazy = new LazyVirtualItem(() => i.Render().Class("tss-searchable-list-no-match"), _virtualizedItemHeight);
+                                        var lazy = new LazyVirtualItem(i.Render().Class("tss-searchable-list-no-match"), _virtualizedItemHeight);
                                         _virtualItems.Add(lazy);
                                         excludeItems.Add(lazy);
                                     }
@@ -203,17 +206,35 @@ namespace Tesserae
         public SearchableList<T> Virtualize(UnitSize itemHeight)
         {
             _virtualizedItemHeight = itemHeight;
-            _defered.Render().addEventListener("scroll", (e) => RecomputeVisibleVirtualItems());
-            _defered.Render().addEventListener("resize", (e) => RecomputeVisibleVirtualItems());
+            var container = _defered.Render();
+            container.parentElement.addEventListener("scroll", (e) => RecomputeVisibleVirtualItems());
+            container.parentElement.addEventListener("resize", (e) => RecomputeVisibleVirtualItems());
+            _defered.Refresh();
+            RecomputeVisibleVirtualItems();
             return this;
         }
 
         private void RecomputeVisibleVirtualItems()
         {
+            window.clearTimeout(_virtualizedTimeout);
+            var container = _defered.Render();
+            double scrollTop = container.parentElement.scrollTop;
+            if (scrollTop > _virtualizedViewportMinTop || scrollTop < _virtualizedViewportMaxTop)
+            {
+                RecomputeVisibleVirtualItemsInner();
+            }
+            else
+            {
+                _virtualizedTimeout = window.setTimeout((_) => RecomputeVisibleVirtualItemsInner(), 50);
+            }
+        }
+
+        private void RecomputeVisibleVirtualItemsInner() 
+        { 
             if (_virtualizedItemHeight is null || _virtualItems.Count == 0) return;
             var container = _defered.Render();
-            double scrollTop = container.scrollTop;
-            double containerHeight = container.clientHeight;
+            double scrollTop = container.parentElement.scrollTop;
+            double containerHeight = container.parentElement.parentElement.scrollHeight;
             if (containerHeight == 0) return;
 
             // We use the fixed height to calculate visible indices
@@ -233,6 +254,9 @@ namespace Tesserae
                 bool isVisible = (i >= startIndex && i <= endIndex);
                 _virtualItems[i].UpdateVisibility(isVisible);
             }
+
+            _virtualizedViewportMinTop = startIndex * itemH;
+            _virtualizedViewportMaxTop = endIndex   * itemH;
         }
 
         public dom.HTMLElement Render() => _stack.Render();

--- a/Tesserae/src/Helpers/HTML/DomObserver.cs
+++ b/Tesserae/src/Helpers/HTML/DomObserver.cs
@@ -116,7 +116,7 @@ namespace Tesserae
                     {
                         var element = elementToTrackMountingOf.ElementOrNullIfCollected;
 
-                        if (element is object && element.IsEqualToOrIsChildOf(mountedElement))
+                        if (element != null && element.IsEqualToOrIsChildOf(mountedElement))
                         {
                             elementsMountedThatWeCareAbout.Add(elementToTrackMountingOf);
                         }
@@ -133,7 +133,7 @@ namespace Tesserae
                 {
                     var element = entry.ElementOrNullIfCollected;
 
-                    if (element is object)
+                    if (element != null)
                     {
                         if (!element.IsMounted())
                         {


### PR DESCRIPTION
Add lazy/virtualized rendering options to `SearchableList` and `SearchableGroupedList` using a fixed item height. By lazily adding DOM elements only when visible and replacing out-of-bounds nodes with `display: none`, it improves performance when searching through or rendering large datasets.

---
*PR created automatically by Jules for task [6000072157848317328](https://jules.google.com/task/6000072157848317328) started by @theolivenbaum*