### PR TITLE
Add ResourceCard component

### DIFF
--- a/Tesserae.Tests/src/Samples/Components/ResourceCardSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/ResourceCardSample.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Threading.Tasks;
+using static H5.Core.dom;
+using static Tesserae.UI;
+using static Tesserae.Tests.Samples.SamplesHelper;
+
+namespace Tesserae.Tests.Samples
+{
+    [SampleDetails(Group = "Components", Order = 100, Icon = UIcons.IdBadge)]
+    public class ResourceCardSample : IComponent, ISample
+    {
+        private readonly IComponent _content;
+
+        public ResourceCardSample()
+        {
+            var searchList = new SearchableList<ModelItem>(GetModelItems(), 1.fr(), 1.fr(), 1.fr())
+                .WithNoResultsMessage(() => TextBlock("No models found").MediumPlus());
+
+            _content = SectionStack()
+                .Title(SampleHeader(nameof(ResourceCardSample)))
+                .Section(Stack().Children(
+                    SampleTitle("Overview"),
+                    TextBlock("ResourceCards are used to display a summary of a resource like an AI model, document, or service. They provide optional sections for title, subtitle, tags, description, date, icon, and a footer for commands."),
+                    TextBlock("The example below uses a SearchableList in grid mode to render a set of ResourceCards.")))
+                .Section(Stack().Children(
+                    SampleTitle("Usage"),
+                    searchList
+                ));
+        }
+
+        private ModelItem[] GetModelItems()
+        {
+            return new ModelItem[]
+            {
+                new ModelItem("seedream-4.0", "bytedance", "Text-to-Image", "Seedream 4.0 is ByteDance's image creation model combining text-to-image generation and advanced styling capabilities.", "Apr 8, 2026", UIcons.Picture),
+                new ModelItem("nano-banana-2", "google", "Text-to-Image", "Nano Banana 2 is Google's latest image generation model, built on Gemini 3.1 Flash with enhanced efficiency.", "Apr 8, 2026", UIcons.Picture),
+                new ModelItem("veo-3.1", "google", "Text-to-Video", "Veo 3.1 is Google's state-of-the-art video generation model with synchronized native audio generation.", "Apr 8, 2026", UIcons.VideoCameraAlt),
+                new ModelItem("kimi-k2.5", "moonshotai", "Image-Text-to-Text", "Kimi K2.5 is a native multimodal language model from Moonshot AI that understands images and text prompts.", "Apr 8, 2026", UIcons.Text),
+                new ModelItem("gpt-5.4", "openai", "Text Generation", "GPT-5.4 is OpenAI's most capable frontier model for coding, reasoning, and professional tasks.", "Apr 8, 2026", UIcons.Comment),
+                new ModelItem("claude-opus-4.6", "anthropic", "Text Generation", "Claude Opus 4.6 is Anthropic's flagship language model built for complex, multi-step problem solving.", "Apr 8, 2026", UIcons.Comment)
+            };
+        }
+
+        public HTMLElement Render()
+        {
+            return _content.Render();
+        }
+
+        private class ModelItem : ISearchableItem
+        {
+            public string Title { get; }
+            public string Author { get; }
+            public string Capability { get; }
+            public string Description { get; }
+            public string Date { get; }
+            public UIcons Icon { get; }
+
+            public ModelItem(string title, string author, string capability, string description, string date, UIcons icon)
+            {
+                Title = title;
+                Author = author;
+                Capability = capability;
+                Description = description;
+                Date = date;
+                Icon = icon;
+            }
+
+            public bool IsMatch(string searchTerm)
+            {
+                if (string.IsNullOrWhiteSpace(searchTerm)) return true;
+                searchTerm = searchTerm.ToLower();
+                return Title.ToLower().Contains(searchTerm) ||
+                       Author.ToLower().Contains(searchTerm) ||
+                       Capability.ToLower().Contains(searchTerm) ||
+                       Description.ToLower().Contains(searchTerm);
+            }
+
+            public IComponent Render()
+            {
+                return UI.ResourceCard()
+                    .SetIcon(UI.Icon(Icon, size: TextSize.Large))
+                    .SetTitle(Title)
+                    .SetSubtitle(Author)
+                    .SetTags(Badge(Capability))
+                    .SetDescription(Description)
+                    .SetDate(Date)
+                    .SetFooter(Link("https://example.com/terms", "Terms"))
+                    .SetFooterCommands(Button("Copy ID").SetIcon(UIcons.Copy).NoBorder().NoBackground());
+            }
+        }
+    }
+}

--- a/Tesserae/src/Base/UI.Components.cs
+++ b/Tesserae/src/Base/UI.Components.cs
@@ -146,6 +146,7 @@ namespace Tesserae
         /// Creates a <see cref="Tesserae.Card"/> component.
         /// </summary>
         public static Card Card(IComponent content, bool noAnimation = false) => new Card(content, noAnimation);
+        public static ResourceCard ResourceCard() => new ResourceCard();
 
         public static Plan Plan(string title) => new Plan(title);
 

--- a/Tesserae/src/Components/ResourceCard.cs
+++ b/Tesserae/src/Components/ResourceCard.cs
@@ -1,0 +1,239 @@
+using System;
+using static H5.Core.dom;
+using static Tesserae.UI;
+
+namespace Tesserae
+{
+    [H5.Name("tss.ResourceCard")]
+    public sealed class ResourceCard : ComponentBase<ResourceCard, HTMLElement>, IHasBackgroundColor, IRoundedStyle
+    {
+        private readonly Card _card;
+
+        private readonly HTMLElement _iconContainer;
+        private readonly HTMLElement _titleContainer;
+        private readonly HTMLElement _subtitleContainer;
+        private readonly HTMLElement _tagsContainer;
+        private readonly HTMLElement _descriptionContainer;
+        private readonly HTMLElement _dateContainer;
+
+        private readonly Stack _footerContainer;
+        private readonly HTMLElement _footerLeft;
+        private readonly HTMLElement _footerRight;
+
+        public ResourceCard()
+        {
+            _iconContainer = Div(_("tss-default-component-no-margin"));
+            _titleContainer = Div(_("tss-default-component-no-margin"));
+            var titleRow = HStack().AlignItems(ItemAlign.Center).Children(
+                Raw(_iconContainer),
+                Raw(_titleContainer).WS().PaddingLeft(8.px())
+            );
+
+            _subtitleContainer = Div(_("tss-default-component-no-margin"));
+            _tagsContainer = Div(_("tss-default-component-no-margin"));
+
+            var subtitleRow = HStack().AlignItems(ItemAlign.Center).PaddingTop(8.px()).Children(
+                Raw(_subtitleContainer),
+                Raw(_tagsContainer).WS().PaddingLeft(8.px())
+            );
+
+            var headerContainer = VStack().Children(titleRow, subtitleRow);
+
+            _descriptionContainer = Div(_("tss-default-component-no-margin"));
+            _dateContainer = Div(_("tss-default-component-no-margin"));
+
+            var bodyContainer = VStack().PaddingTop(16.px()).PaddingBottom(16.px()).Children(
+                Raw(_descriptionContainer),
+                Raw(_dateContainer).WS().PaddingTop(16.px())
+            );
+
+            _footerLeft = Div(_("tss-default-component-no-margin"));
+            _footerRight = Div(_("tss-default-component-no-margin"));
+
+            _footerContainer = HStack().AlignItems(ItemAlign.Center).JustifyContent(ItemJustify.Between)
+                .PaddingTop(12.px())
+                .Children(Raw(_footerLeft), Raw(_footerRight));
+
+            _footerContainer.Render().style.borderTop = "1px solid var(--tss-default-border-color, var(--tss-card-border-color, #e1dfdd))";
+
+            var mainStack = VStack().Padding(16.px()).Children(headerContainer, bodyContainer, _footerContainer);
+
+            _card = Card(mainStack).NoPadding();
+
+            InnerElement = _card.Render();
+
+            // Hide empty containers by default
+            _iconContainer.style.display = "none";
+            _titleContainer.style.display = "none";
+            _subtitleContainer.style.display = "none";
+            _tagsContainer.style.display = "none";
+            _descriptionContainer.style.display = "none";
+            _dateContainer.style.display = "none";
+            _footerContainer.Collapse();
+
+            AttachClick();
+            AttachContextMenu();
+        }
+
+        public ResourceCard SetIcon(IComponent icon)
+        {
+            ClearChildren(_iconContainer);
+            if (icon != null)
+            {
+                _iconContainer.appendChild(icon.Render());
+                _iconContainer.style.display = "";
+            }
+            else
+            {
+                _iconContainer.style.display = "none";
+            }
+            return this;
+        }
+
+        public ResourceCard SetTitle(IComponent title)
+        {
+            ClearChildren(_titleContainer);
+            if (title != null)
+            {
+                _titleContainer.appendChild(title.Render());
+                _titleContainer.style.display = "";
+            }
+            else
+            {
+                _titleContainer.style.display = "none";
+            }
+            return this;
+        }
+
+        public ResourceCard SetTitle(string title) => SetTitle(TextBlock(title).SemiBold().MediumPlus());
+
+        public ResourceCard SetSubtitle(IComponent subtitle)
+        {
+            ClearChildren(_subtitleContainer);
+            if (subtitle != null)
+            {
+                _subtitleContainer.appendChild(subtitle.Render());
+                _subtitleContainer.style.display = "";
+            }
+            else
+            {
+                _subtitleContainer.style.display = "none";
+            }
+            return this;
+        }
+
+        public ResourceCard SetSubtitle(string subtitle) => SetSubtitle(TextBlock(subtitle).SemiBold().Small());
+
+        public ResourceCard SetTags(params IComponent[] tags)
+        {
+            ClearChildren(_tagsContainer);
+            if (tags != null && tags.Length > 0)
+            {
+                var hstack = HStack().AlignItems(ItemAlign.Center).Gap(4.px());
+                foreach (var tag in tags)
+                {
+                    hstack.Add(tag);
+                }
+                _tagsContainer.appendChild(hstack.Render());
+                _tagsContainer.style.display = "";
+            }
+            else
+            {
+                _tagsContainer.style.display = "none";
+            }
+            return this;
+        }
+
+        public ResourceCard SetDescription(IComponent description)
+        {
+            ClearChildren(_descriptionContainer);
+            if (description != null)
+            {
+                _descriptionContainer.appendChild(description.Render());
+                _descriptionContainer.style.display = "";
+            }
+            else
+            {
+                _descriptionContainer.style.display = "none";
+            }
+            return this;
+        }
+
+        public ResourceCard SetDescription(string description) => SetDescription(TextBlock(description).Small().Foreground(Theme.Secondary.Foreground));
+
+        public ResourceCard SetDate(IComponent date)
+        {
+            ClearChildren(_dateContainer);
+            if (date != null)
+            {
+                _dateContainer.appendChild(date.Render());
+                _dateContainer.style.display = "";
+            }
+            else
+            {
+                _dateContainer.style.display = "none";
+            }
+            return this;
+        }
+
+        public ResourceCard SetDate(string date) => SetDate(TextBlock(date).Small().Foreground(Theme.Secondary.Foreground));
+
+        public ResourceCard SetFooter(IComponent footer)
+        {
+            ClearChildren(_footerLeft);
+            if (footer != null)
+            {
+                _footerLeft.appendChild(footer.Render());
+                _footerContainer.Show();
+            }
+            else if (_footerRight.childElementCount == 0)
+            {
+                _footerContainer.Collapse();
+            }
+            return this;
+        }
+
+        public ResourceCard SetFooterCommands(params IComponent[] commands)
+        {
+            ClearChildren(_footerRight);
+            if (commands != null && commands.Length > 0)
+            {
+                var hstack = HStack().AlignItems(ItemAlign.Center).Gap(4.px());
+                foreach (var command in commands)
+                {
+                    hstack.Add(command);
+                }
+                _footerRight.appendChild(hstack.Render());
+                _footerContainer.Show();
+            }
+            else if (_footerLeft.childElementCount == 0)
+            {
+                _footerContainer.Collapse();
+            }
+            return this;
+        }
+
+        public string Background
+        {
+            get => _card.Background;
+            set => _card.Background = value;
+        }
+
+        public ResourceCard BackgroundColor(string color)
+        {
+            _card.BackgroundColor(color);
+            return this;
+        }
+
+        public ResourceCard Border(string color, UnitSize size = null)
+        {
+            _card.Border(color, size);
+            return this;
+        }
+
+        public override HTMLElement Render()
+        {
+            return _card.Render();
+        }
+    }
+}


### PR DESCRIPTION
Added a `ResourceCard` component for Tesserae that mimics the provided AI model card examples. Includes a new sample page utilizing `SearchableList` configured in grid mode to render sample AI models.

---
*PR created automatically by Jules for task [9261981748218009131](https://jules.google.com/task/9261981748218009131) started by @theolivenbaum*