### PR TITLE
Update SegmentedPivot styles and accessibility

### DIFF
--- a/Tesserae/h5/assets/css/tss.segmentedpivot.css
+++ b/Tesserae/h5/assets/css/tss.segmentedpivot.css
@@ -19,6 +19,8 @@
 }
 
 .tss-segmentedpivot-tab {
+    user-select: none;
+    outline: none;
     padding: 6px 14px;
     cursor: pointer;
     background: transparent;
@@ -30,6 +32,8 @@
 }
 
 .tss-segmentedpivot-tab:hover {
+    background-color: color-mix(in srgb, var(--tss-default-foreground-color) 10%, transparent);
+
     color: var(--tss-default-foreground-color);
 }
 
@@ -51,4 +55,15 @@
 
 .tss-segmentedpivot-cached-hidden {
     display: none !important;
+}
+
+.tss-segmentedpivot-tab:focus-visible {
+    box-shadow: 0 0 0 2px var(--tss-default-background-color), 0 0 0 4px var(--tss-default-foreground-color);
+}
+.tss-segmentedpivot-tab.tss-segmentedpivot-selected:focus-visible {
+    box-shadow: 0 0 0 2px var(--tss-default-background-color), 0 0 0 4px var(--tss-default-foreground-color);
+}
+
+.tss-segmentedpivot-tab:active {
+    background-color: color-mix(in srgb, var(--tss-default-foreground-color) 20%, transparent);
 }

--- a/Tesserae/src/Components/SegmentedPivot.cs
+++ b/Tesserae/src/Components/SegmentedPivot.cs
@@ -51,6 +51,22 @@ namespace Tesserae
             _orderedTabs.Add(tab);
 
             var titleContainer = Div(_("tss-segmentedpivot-tab"));
+            titleContainer.tabIndex = 0;
+            titleContainer.onkeydown = (e) =>
+            {
+                if (e.key == " ")
+                {
+                    StopEvent(e);
+                }
+            };
+            titleContainer.onkeyup = (e) =>
+            {
+                if (e.key == "Enter" || e.key == " ")
+                {
+                    StopEvent(e);
+                    Select(tab.Id);
+                }
+            };
             titleContainer.onclick = (e) =>
             {
                 StopEvent(e);


### PR DESCRIPTION
This PR improves the visual and interactive states of the `SegmentedPivot` component, aligning it with the provided design system blueprint. The component now fully supports hover, focus, and pressed states. Additionally, tabs can now be navigated using the keyboard (`Tab`, `Space`, `Enter`) allowing proper visibility of the newly styled focus ring.

---
*PR created automatically by Jules for task [4006469680846911774](https://jules.google.com/task/4006469680846911774) started by @theolivenbaum*