### PR TITLE
feat: add SectionTitle component and standardize sample headers

### DIFF
--- a/Tesserae.Tests/src/Samples/Collections/BreadcrumbSample.cs
+++ b/Tesserae.Tests/src/Samples/Collections/BreadcrumbSample.cs
@@ -13,7 +13,7 @@ namespace Tesserae.Tests.Samples
         public BreadcrumbSample()
         {
             _content = SectionStack()
-               .Title(SampleHeader(nameof(BreadcrumbSample)))
+               .SampleTitle(nameof(BreadcrumbSample), UIcons.AngleRight, "A breadcrumb navigation component")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("Breadcrumbs provide a secondary navigation system that reveals a user's location in a website or web app. They allow for one-click access to any higher level in the hierarchy."),

--- a/Tesserae.Tests/src/Samples/Collections/DetailsListSample.cs
+++ b/Tesserae.Tests/src/Samples/Collections/DetailsListSample.cs
@@ -20,7 +20,7 @@ namespace Tesserae.Tests.Samples
             int page  = query.ContainsKey("page") && query.TryGetValue("page", out var queryPageStr) && int.TryParse(queryPageStr, out var queryPage) ? queryPage : 2;
 
             _content = SectionStack()
-                   .Title(SampleHeader(nameof(DetailsListSample)))
+                   .SampleTitle(nameof(DetailsListSample), UIcons.List, "A list that displays details")
                    .Section(Stack().Children(
                         SampleTitle("Overview"),
                         TextBlock("DetailsList is a robust way to display an information-rich collection of items. It supports sorting, grouping, filtering, and pagination."),

--- a/Tesserae.Tests/src/Samples/Collections/InfiniteScrollingListSample.cs
+++ b/Tesserae.Tests/src/Samples/Collections/InfiniteScrollingListSample.cs
@@ -19,7 +19,7 @@ namespace Tesserae.Tests.Samples
             var pageGrid = 1;
 
             _content = SectionStack().WidthStretch()
-               .Title(SampleHeader(nameof(InfiniteScrollingListSample)))
+               .SampleTitle(nameof(InfiniteScrollingListSample), UIcons.List, "A list that scrolls infinitely")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("InfiniteScrollingList provides a way to render large sets of items by loading them on demand as the user scrolls. It uses a visibility sensor to detect when the end of the list is reached."),

--- a/Tesserae.Tests/src/Samples/Collections/ItemsListSample.cs
+++ b/Tesserae.Tests/src/Samples/Collections/ItemsListSample.cs
@@ -26,7 +26,7 @@ namespace Tesserae.Tests.Samples
             obsList.Add(vs);
 
             _content = SectionStack().WidthStretch()
-               .Title(SampleHeader(nameof(ItemsListSample)))
+               .SampleTitle(nameof(ItemsListSample), UIcons.List, "A list that displays items")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("ItemsList is a versatile component for displaying collections of items. It supports static lists, observable lists, and grid layouts."),

--- a/Tesserae.Tests/src/Samples/Collections/MasonrySample.cs
+++ b/Tesserae.Tests/src/Samples/Collections/MasonrySample.cs
@@ -15,7 +15,7 @@ namespace Tesserae.Tests.Samples
         public MasonrySample()
         {
             _content = SectionStack().S()
-               .Title(SampleHeader(nameof(MasonrySample)))
+               .SampleTitle(nameof(MasonrySample), UIcons.Table, "A masonry layout component")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("Masonry layout (also known as a Pinterest-style layout) is a grid where items are placed in optimal positions based on available vertical space."),

--- a/Tesserae.Tests/src/Samples/Collections/ObservableStackSample.cs
+++ b/Tesserae.Tests/src/Samples/Collections/ObservableStackSample.cs
@@ -49,7 +49,7 @@ namespace Tesserae.Tests.Samples
             var obsStack = new ObservableStack(_stackElementsList, debounce: true);
 
             _content = SectionStack()
-               .Title(SampleHeader(nameof(ObservableStackSample)))
+               .SampleTitle(nameof(ObservableStackSample), UIcons.Apps, "A stack that observes changes")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("ObservableStack is a specialized container that synchronizes its DOM with an observable list using an efficient reconciliation process."),

--- a/Tesserae.Tests/src/Samples/Collections/OverflowSetSample.cs
+++ b/Tesserae.Tests/src/Samples/Collections/OverflowSetSample.cs
@@ -13,7 +13,7 @@ namespace Tesserae.Tests.Samples
         public OverflowSetSample()
         {
             _content = SectionStack()
-               .Title(SampleHeader(nameof(OverflowSetSample)))
+               .SampleTitle(nameof(OverflowSetSample), UIcons.MenuDots, "A component to display an overflow set")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("OverflowSet is a container that automatically moves items that don't fit into the available space into an overflow menu."),

--- a/Tesserae.Tests/src/Samples/Collections/SearchableGroupedListSample.cs
+++ b/Tesserae.Tests/src/Samples/Collections/SearchableGroupedListSample.cs
@@ -15,7 +15,7 @@ namespace Tesserae.Tests.Samples
         public SearchableGroupedListSample()
         {
             _content = SectionStack().WidthStretch()
-                   .Title(SampleHeader(nameof(SearchableGroupedListSample)))
+                   .SampleTitle(nameof(SearchableGroupedListSample), UIcons.Search, "A grouped list that can be searched")
                    .Section(Stack().Children(
                         SampleTitle("Overview"),
                         TextBlock("SearchableGroupedList extends the functionality of SearchableList by adding automatic grouping of items based on a 'Group' property."),

--- a/Tesserae.Tests/src/Samples/Collections/SearchableListSample.cs
+++ b/Tesserae.Tests/src/Samples/Collections/SearchableListSample.cs
@@ -15,7 +15,7 @@ namespace Tesserae.Tests.Samples
         public SearchableListSample()
         {
             _content = SectionStack().WidthStretch()
-                   .Title(SampleHeader(nameof(SearchableListSample)))
+                   .SampleTitle(nameof(SearchableListSample), UIcons.Search, "A list that can be searched")
                    .Section(Stack().Children(
                         SampleTitle("Overview"),
                         TextBlock("SearchableList combines a search box with a list of items, providing instant filtering as the user types."),

--- a/Tesserae.Tests/src/Samples/Collections/StackSample.cs
+++ b/Tesserae.Tests/src/Samples/Collections/StackSample.cs
@@ -30,7 +30,7 @@ namespace Tesserae.Tests.Samples
             var countSlider = Slider(5, 0, 10, 1);
 
             _content = SectionStack()
-               .Title(SampleHeader(nameof(StackSample)))
+               .SampleTitle(nameof(StackSample), UIcons.Apps, "A layout container that stacks its children")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("Stacks are container components that simplify the use of Flexbox for layout. They allow you to arrange children components either horizontally (HStack) or vertically (VStack)."),

--- a/Tesserae.Tests/src/Samples/Collections/TimelineSample.cs
+++ b/Tesserae.Tests/src/Samples/Collections/TimelineSample.cs
@@ -16,7 +16,7 @@ namespace Tesserae.Tests.Samples
         public TimelineSample()
         {
             _content = SectionStack().WidthStretch()
-               .Title(SampleHeader(nameof(TimelineSample)))
+               .SampleTitle(nameof(TimelineSample), UIcons.Clock, "A component to display a timeline")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("Timeline displays a series of events in chronological order, using a vertical line to connect them."),

--- a/Tesserae.Tests/src/Samples/Collections/VirtualizedListSample.cs
+++ b/Tesserae.Tests/src/Samples/Collections/VirtualizedListSample.cs
@@ -15,7 +15,7 @@ namespace Tesserae.Tests.Samples
         public VirtualizedListSample()
         {
             _content = SectionStack()
-                   .Title(SampleHeader(nameof(VirtualizedListSample)))
+                   .SampleTitle(nameof(VirtualizedListSample), UIcons.List, "A list that renders its items virtually")
                    .Section(Stack().Children(
                         SampleTitle("Overview"),
                         TextBlock("VirtualizedList is a high-performance component designed for rendering massive datasets—thousands or even tens of thousands of items—without sacrificing UI responsiveness."),

--- a/Tesserae.Tests/src/Samples/Components/AccordionSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/AccordionSample.cs
@@ -12,7 +12,7 @@ namespace Tesserae.Tests.Samples
         public AccordionSample()
         {
             _content = SectionStack()
-               .Title(SampleHeader(nameof(AccordionSample)))
+               .SampleTitle(nameof(AccordionSample), UIcons.Apps, "A collapsible content component")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("An accordion contains a list of expanders that can be toggled to reveal more information. They are useful for organizing content into manageable chunks and reducing vertical space usage when not all information needs to be visible at once."),

--- a/Tesserae.Tests/src/Samples/Components/ActionButtonSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/ActionButtonSample.cs
@@ -14,7 +14,7 @@ namespace Tesserae.Tests.Samples
         public ActionButtonSample()
         {
             _content = SectionStack()
-               .Title(SampleHeader(nameof(ActionButtonSample)))
+               .SampleTitle(nameof(ActionButtonSample), UIcons.Cursor, "A button that triggers an action")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("ActionButtons are a variation of the standard Button component that split the interaction into two distinct parts: a display area (typically the label and an icon) and a specific action area (typically a secondary icon on the right)."),

--- a/Tesserae.Tests/src/Samples/Components/AvatarSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/AvatarSample.cs
@@ -12,7 +12,7 @@ namespace Tesserae.Tests.Samples
         public AvatarSample()
         {
             _content = SectionStack()
-               .Title(SampleHeader(nameof(AvatarSample)))
+               .SampleTitle(nameof(AvatarSample), UIcons.User, "A component that represents a user")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("Avatars are used to represent users, teams, or entities in the system. They can display images, initials, and presence indicators."),

--- a/Tesserae.Tests/src/Samples/Components/BadgeSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/BadgeSample.cs
@@ -12,7 +12,7 @@ namespace Tesserae.Tests.Samples
         public BadgeSample()
         {
             _content = SectionStack()
-               .Title(SampleHeader(nameof(BadgeSample)))
+               .SampleTitle(nameof(BadgeSample), UIcons.Certificate, "A component to display a badge")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("Badges, Tags, and Chips are small visual elements used to categorize content, highlight status, or display metadata."),

--- a/Tesserae.Tests/src/Samples/Components/ButtonSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/ButtonSample.cs
@@ -14,7 +14,7 @@ namespace Tesserae.Tests.Samples
         public ButtonSample()
         {
             _content = SectionStack()
-               .Title(SampleHeader(nameof(ButtonSample)))
+               .SampleTitle(nameof(ButtonSample), UIcons.Cursor, "A control that triggers an action")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("Buttons are best used to enable a user to commit a change or complete steps in a task. They are typically found inside forms, dialogs, panels or pages. An example of their usage is confirming the deletion of a file in a confirmation dialog."),

--- a/Tesserae.Tests/src/Samples/Components/CarouselSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/CarouselSample.cs
@@ -20,7 +20,7 @@ namespace Tesserae.Tests.Samples
             var imgSlide3 = Image("https://cataas.com/cat").WS().H(300).Contain();
 
             _content = SectionStack()
-               .Title(SampleHeader(nameof(CarouselSample)))
+               .SampleTitle(nameof(CarouselSample), UIcons.Picture, "A slideshow component for cycling through elements")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("Carousels allow users to cycle through a set of related content, such as images, features, or messages. They are effective for showcasing highlights in a limited space."),

--- a/Tesserae.Tests/src/Samples/Components/ChatSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/ChatSample.cs
@@ -79,7 +79,7 @@ namespace Tesserae.Tests.Samples
             );
 
             _content = SectionStack()
-                .Title(SampleHeader(nameof(ChatSample)))
+                .SampleTitle(nameof(ChatSample), UIcons.Comments, "A component to display a chat")
                 .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("ChatArea and ChatMessage components allow building modern chat experiences with dynamic, animatable messages using DeltaComponent."),

--- a/Tesserae.Tests/src/Samples/Components/CheckBoxSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/CheckBoxSample.cs
@@ -13,7 +13,7 @@ namespace Tesserae.Tests.Samples
         public CheckBoxSample()
         {
             _content = SectionStack()
-               .Title(SampleHeader(nameof(CheckBoxSample)))
+               .SampleTitle(nameof(CheckBoxSample), UIcons.Checkbox, "A control that allows the user to select multiple options")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("CheckBoxes allow users to select one or more items from a set. They can also be used to turn an option on or off."),

--- a/Tesserae.Tests/src/Samples/Components/ChoiceGroupSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/ChoiceGroupSample.cs
@@ -13,7 +13,7 @@ namespace Tesserae.Tests.Samples
         public ChoiceGroupSample()
         {
             _content = SectionStack()
-               .Title(SampleHeader(nameof(ChoiceGroupSample)))
+               .SampleTitle(nameof(ChoiceGroupSample), UIcons.List, "A control to select a single option from a list")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("ChoiceGroups, also known as radio button groups, allow users to select exactly one option from a set of mutually exclusive choices."),

--- a/Tesserae.Tests/src/Samples/Components/ColorPickerSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/ColorPickerSample.cs
@@ -11,7 +11,7 @@ namespace Tesserae.Tests.Samples
         public ColorPickerSample()
         {
             _content = SectionStack()
-               .Title(SampleHeader(nameof(ColorPickerSample)))
+               .SampleTitle(nameof(ColorPickerSample), UIcons.Palette, "A control to pick a color")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("The ColorPicker allows users to select a color using the browser's native color selection widget. It returns the selected color as both a hex string and a Color object."),

--- a/Tesserae.Tests/src/Samples/Components/CommandBarSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/CommandBarSample.cs
@@ -12,7 +12,7 @@ namespace Tesserae.Tests.Samples
         public CommandBarSample()
         {
             _content = SectionStack()
-               .Title(SampleHeader(nameof(CommandBarSample)))
+               .SampleTitle(nameof(CommandBarSample), UIcons.MenuBurger, "A toolbar for housing commands")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("Command Bars provide a surface for common actions related to a specific context, such as a page or a selected item in a list."),

--- a/Tesserae.Tests/src/Samples/Components/CronEditorSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/CronEditorSample.cs
@@ -13,7 +13,7 @@ namespace Tesserae.Tests.Samples
         public CronEditorSample()
         {
             _content = SectionStack()
-                .Title(SampleHeader(nameof(CronEditorSample)))
+                .SampleTitle(nameof(CronEditorSample), UIcons.Clock, "A component to edit cron expressions")
                 .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("CronEditor allows users to schedule tasks using a simplified UI for daily schedules, with a fallback to raw cron expressions for advanced users.")

--- a/Tesserae.Tests/src/Samples/Components/DatePickerSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/DatePickerSample.cs
@@ -16,7 +16,7 @@ namespace Tesserae.Tests.Samples
             var to   = DateTime.Now.AddDays(7);
 
             _content = SectionStack()
-               .Title(SampleHeader(nameof(DatePickerSample)))
+               .SampleTitle(nameof(DatePickerSample), UIcons.Calendar, "A component to select a date")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("DatePickers allow users to select a specific date using a browser-native date selection widget. They ensure that the input is always a valid date format."),

--- a/Tesserae.Tests/src/Samples/Components/DateTimePickerSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/DateTimePickerSample.cs
@@ -16,7 +16,7 @@ namespace Tesserae.Tests.Samples
             var to   = DateTime.Now.AddDays(7);
 
             _content = SectionStack()
-               .Title(SampleHeader(nameof(DateTimePickerSample)))
+               .SampleTitle(nameof(DateTimePickerSample), UIcons.Calendar, "A control to pick a date and time")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("The DateTimePicker combines date and time selection into a single component, using the browser's native widget."),

--- a/Tesserae.Tests/src/Samples/Components/DeltaComponentSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/DeltaComponentSample.cs
@@ -137,7 +137,7 @@ namespace Tesserae.Tests.Samples
 
 
             _content = SectionStack()
-                .Title(SampleHeader(nameof(DeltaComponent)))
+                .SampleTitle(nameof(DeltaComponent), UIcons.Refresh, "A component that animates changes")
                 .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("DeltaComponent updates its DOM tree to match a new component's DOM tree using a diff algorithm. It detects text appends and adds them as new spans to avoid full re-rendering."),

--- a/Tesserae.Tests/src/Samples/Components/DropdownSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/DropdownSample.cs
@@ -19,7 +19,7 @@ namespace Tesserae.Tests.Samples
             validatedDropdown.Attach(dd => dd.IsInvalid = dd.SelectedItems.Length != 1 || dd.SelectedItems[0].Text != "Option 1");
 
             _content = SectionStack()
-               .Title(SampleHeader(nameof(DropdownSample)))
+               .SampleTitle(nameof(DropdownSample), UIcons.CaretDown, "A control to select an option from a dropdown")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("A Dropdown is a list in which the selected item is always visible, and the others are visible on demand by clicking a drop-down button."),

--- a/Tesserae.Tests/src/Samples/Components/EditableLabelSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/EditableLabelSample.cs
@@ -13,7 +13,7 @@ namespace Tesserae.Tests.Samples
         public EditableLabelSample()
         {
             _content = SectionStack()
-               .Title(SampleHeader(nameof(EditableLabelSample)))
+               .SampleTitle(nameof(EditableLabelSample), UIcons.Edit, "A label that can be edited")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("EditableLabels and EditableAreas allow users to view content as standard text and switch to an editing mode (input or textarea) upon interaction."),

--- a/Tesserae.Tests/src/Samples/Components/GridPickerSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/GridPickerSample.cs
@@ -65,7 +65,7 @@ namespace Tesserae.Tests.Samples
                 rowHeight: 24.px());
 
             _content = SectionStack()
-               .Title(SampleHeader(nameof(GridPickerSample)))
+               .SampleTitle(nameof(GridPickerSample), UIcons.Table, "A control to pick an item from a grid")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("The GridPicker component provides an interactive grid where each cell can cycle through a predefined number of states. It's highly customizable through its state formatting logic."),

--- a/Tesserae.Tests/src/Samples/Components/GridSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/GridSample.cs
@@ -22,7 +22,7 @@ namespace Tesserae.Tests.Samples
             Enumerable.Range(1, 10).ForEach(v => gridAutoSize.Add(Card(TextBlock($"Responsive Item {v}").TextCenter())));
 
             _content = SectionStack()
-               .Title(SampleHeader(nameof(GridSample)))
+               .SampleTitle(nameof(GridSample), UIcons.Table, "A component to display a grid")
                .Section(VStack().Children(
                     SampleTitle("Overview"),
                     TextBlock("The Grid component provides a powerful layout system based on CSS Grid. It allows you to define columns, rows, and gaps between items."),

--- a/Tesserae.Tests/src/Samples/Components/HorizontalSeparatorSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/HorizontalSeparatorSample.cs
@@ -13,7 +13,7 @@ namespace Tesserae.Tests.Samples
         public HorizontalSeparatorSample()
         {
             _content = SectionStack()
-               .Title(SampleHeader(nameof(HorizontalSeparatorSample)))
+               .SampleTitle(nameof(HorizontalSeparatorSample), UIcons.Minus, "A visual separator for components")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("A HorizontalSeparator visually divides content into groups. It can optionally contain text or other components to label the group it introduces."),

--- a/Tesserae.Tests/src/Samples/Components/LabelSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/LabelSample.cs
@@ -13,7 +13,7 @@ namespace Tesserae.Tests.Samples
         public LabelSample()
         {
             _content = SectionStack()
-               .Title(SampleHeader(nameof(LabelSample)))
+               .SampleTitle(nameof(LabelSample), UIcons.Tags, "A component to display a label")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("Labels provide a name or title for a component or a group of components. They are essential for accessibility and helping users understand the purpose of input fields."),

--- a/Tesserae.Tests/src/Samples/Components/MessageSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/MessageSample.cs
@@ -13,7 +13,7 @@ namespace Tesserae.Tests.Samples
         public MessageSample()
         {
             _content = SectionStack()
-               .Title(SampleHeader(nameof(MessageSample)))
+               .SampleTitle(nameof(MessageSample), UIcons.Envelope, "A component to display a message")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("The Message component is used to display static messages, alerts, or empty states. It supports an icon, title, text body, and an optional note area."),

--- a/Tesserae.Tests/src/Samples/Components/MetricSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/MetricSample.cs
@@ -12,7 +12,7 @@ namespace Tesserae.Tests.Samples
         public MetricSample()
         {
             content = SectionStack()
-               .Title(SampleHeader(nameof(MetricSample)))
+               .SampleTitle(nameof(MetricSample), UIcons.ChartHistogram, "A component to display a metric")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("A Metric component displays a key value alongside a title and an optional indicator of change.")))

--- a/Tesserae.Tests/src/Samples/Components/NavbarSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/NavbarSample.cs
@@ -26,7 +26,7 @@ namespace Tesserae.Tests.Samples
             navbar.AddFooter(new SidebarButton("footer", UIcons.Info, "About"));
 
             _content = SectionStack()
-               .Title(SampleHeader(nameof(NavbarSample)))
+               .SampleTitle(nameof(NavbarSample), UIcons.MapMarker, "A navigation bar component")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("A Sidebar rendered as a Navbar. Header items are inline, others are in a drawer."),

--- a/Tesserae.Tests/src/Samples/Components/NumberPickerSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/NumberPickerSample.cs
@@ -13,7 +13,7 @@ namespace Tesserae.Tests.Samples
         public NumberPickerSample()
         {
             _content = SectionStack()
-               .Title(SampleHeader(nameof(NumberPickerSample)))
+               .SampleTitle(nameof(NumberPickerSample), UIcons.SortAmountUp, "A control to pick a number")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("The NumberPicker provides an input field specifically for numeric values, leveraging the browser's native number input widget."),

--- a/Tesserae.Tests/src/Samples/Components/OmniBoxSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/OmniBoxSample.cs
@@ -91,7 +91,7 @@ namespace Tesserae.Tests.Samples
             });
 
             _content = SectionStack()
-               .Title(SampleHeader(nameof(OmniBoxSample)))
+               .SampleTitle(nameof(OmniBoxSample), UIcons.Search, "An omnibox search component")
                .Section(VStack().Children(
                     SampleTitle("Overview"),
                     toggle.MB(16),

--- a/Tesserae.Tests/src/Samples/Components/PaginationSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/PaginationSample.cs
@@ -14,7 +14,7 @@ namespace Tesserae.Tests.Samples
             var status = TextBlock("Showing page 1").Medium();
 
             _content = SectionStack()
-               .Title(SampleHeader(nameof(PaginationSample)))
+               .SampleTitle(nameof(PaginationSample), UIcons.AngleRight, "A component to navigate through pages")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("Pagination allows users to navigate through a large set of data by breaking it into smaller, manageable chunks called pages."),

--- a/Tesserae.Tests/src/Samples/Components/PickerSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/PickerSample.cs
@@ -15,7 +15,7 @@ namespace Tesserae.Tests.Samples
         public PickerSample()
         {
             _content = SectionStack()
-                   .Title(SampleHeader(nameof(PickerSample)))
+                   .SampleTitle(nameof(PickerSample), UIcons.Cursor, "A control to pick an item")
                    .Section(Stack().Children(
                         SampleTitle("Overview"),
                         TextBlock("Pickers are used to select one or more items, such as people or tags, from a large list. They provide a search-based interface with suggestions."),

--- a/Tesserae.Tests/src/Samples/Components/PlanSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/PlanSample.cs
@@ -49,7 +49,7 @@ namespace Tesserae.Tests.Samples
             plan3.Render().style.maxWidth = "800px";
 
             _content = SectionStack()
-                .Title(SampleHeader(nameof(PlanSample)))
+                .SampleTitle(nameof(PlanSample), UIcons.Map, "A component to display a plan")
                 .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("The Plan component displays a complex task with its sub-tasks and overall progress."),

--- a/Tesserae.Tests/src/Samples/Components/ResourceCardSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/ResourceCardSample.cs
@@ -17,7 +17,7 @@ namespace Tesserae.Tests.Samples
                 .WithNoResultsMessage(() => TextBlock("No models found").MediumPlus());
 
             _content = SectionStack()
-                .Title(SampleHeader(nameof(ResourceCardSample)))
+                .SampleTitle(nameof(ResourceCardSample), UIcons.IdCard, "A card to display a resource")
                 .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("ResourceCards are used to display a summary of a resource like an AI model, document, or service. They provide optional sections for title, subtitle, tags, description, date, icon, and a footer for commands."),

--- a/Tesserae.Tests/src/Samples/Components/SaveButtonSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/SaveButtonSample.cs
@@ -21,7 +21,7 @@ namespace Tesserae.Tests.Samples
             var manualButton = SaveButton().NothingToSave();
 
             _content = SectionStack()
-               .Title(SampleHeader(nameof(SaveButtonSample)))
+               .SampleTitle(nameof(SaveButtonSample), UIcons.Disk, "A button specialized for save operations")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("The SaveButton component is a wrapper around a Button that manages common saving states: Pending, Verifying, Saving, Saved, and Error.")

--- a/Tesserae.Tests/src/Samples/Components/SavingToastSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/SavingToastSample.cs
@@ -14,7 +14,7 @@ namespace Tesserae.Tests.Samples
         public SavingToastSample()
         {
             _content = SectionStack()
-               .Title(SampleHeader(nameof(SavingToastSample)))
+               .SampleTitle(nameof(SavingToastSample), UIcons.Disk, "A toast notification for save operations")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("The SavingToast component helps viewing the state of a saving operation (Saving, Saved, Error) with appropriate icons and colors.")

--- a/Tesserae.Tests/src/Samples/Components/SearchBoxSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/SearchBoxSample.cs
@@ -15,7 +15,7 @@ namespace Tesserae.Tests.Samples
             var searchAsYouType = TextBlock("Start typing in the 'Search as you type' box below...");
 
             _content = SectionStack()
-               .Title(SampleHeader(nameof(SearchBoxSample)))
+               .SampleTitle(nameof(SearchBoxSample), UIcons.Search, "A control to search")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("SearchBoxes provide an input field for searching through content, allowing users to locate specific items within the website or app."),

--- a/Tesserae.Tests/src/Samples/Components/SidebarSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/SidebarSample.cs
@@ -97,7 +97,7 @@ namespace Tesserae.Tests.Samples
 
 
             _content = SectionStack()
-               .Title(SampleHeader(nameof(SidebarSample)))
+               .SampleTitle(nameof(SidebarSample), UIcons.Apps, "A sidebar navigation component")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("A fully featured Sidebar with Search, Navigation, Buttons, and Separators."),

--- a/Tesserae.Tests/src/Samples/Components/SidebarSeparatorSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/SidebarSeparatorSample.cs
@@ -22,7 +22,7 @@ namespace Tesserae.Tests.Samples
             sidebar.AddContent(new SidebarButton("3", UIcons.Settings, "Settings"));
 
             _content = SectionStack()
-               .Title(SampleHeader(nameof(SidebarSeparatorSample)))
+               .SampleTitle(nameof(SidebarSeparatorSample), UIcons.Minus, "A visual separator for sidebar items")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("A separator for the Sidebar component to visually group items."),

--- a/Tesserae.Tests/src/Samples/Components/SkeletonSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/SkeletonSample.cs
@@ -12,7 +12,7 @@ namespace Tesserae.Tests.Samples
         public SkeletonSample()
         {
             _content = SectionStack()
-               .Title(SampleHeader(nameof(SkeletonSample)))
+               .SampleTitle(nameof(SkeletonSample), UIcons.Box, "A placeholder component for loading state")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("Skeleton loaders are used to provide a placeholder for content that is still loading. They help reduce the perceived load time and prevent layout shifts by reserving the space that the final content will occupy."),

--- a/Tesserae.Tests/src/Samples/Components/SliderSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/SliderSample.cs
@@ -17,7 +17,7 @@ namespace Tesserae.Tests.Samples
             var s2    = Slider(val: 20, min: 0, max: 100, step: 10).OnInput((s, e) => Toast().Information($"Value changed to {s.Value}"));
 
             _content = SectionStack()
-               .Title(SampleHeader(nameof(SliderSample)))
+               .SampleTitle(nameof(SliderSample), UIcons.SettingsSliders, "A control to select a value from a range")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("Sliders allow users to select a value from a continuous or discrete range of values by moving a thumb along a track."),

--- a/Tesserae.Tests/src/Samples/Components/SplitViewSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/SplitViewSample.cs
@@ -17,7 +17,7 @@ namespace Tesserae.Tests.Samples
 
             _content = SectionStack()
                .S()
-               .Title(SampleHeader(nameof(SplitViewSample)))
+               .SampleTitle(nameof(SplitViewSample), UIcons.Apps, "A component to split the view")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("SplitViews divide a surface into two areas, either horizontally or vertically. They are commonly used for master-detail layouts, navigation sidebars, or resizable workspace areas."),

--- a/Tesserae.Tests/src/Samples/Components/StepperSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/StepperSample.cs
@@ -12,7 +12,7 @@ namespace Tesserae.Tests.Samples
         public StepperSample()
         {
             _content = SectionStack()
-               .Title(SampleHeader(nameof(StepperSample)))
+               .SampleTitle(nameof(StepperSample), UIcons.ShoePrints, "A component to display a step-by-step process")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("Steppers (also known as Wizards) guide users through a multi-step process by breaking it down into smaller, logical chunks."),

--- a/Tesserae.Tests/src/Samples/Components/TaskBoardSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/TaskBoardSample.cs
@@ -79,7 +79,7 @@ namespace Tesserae.Tests.Samples
             var readOnlyToggle = Toggle("Read Only").OnChange((s, e) => board.ReadOnly(s.IsChecked));
 
             _content = SectionStack()
-               .Title(SampleHeader(nameof(TaskBoardSample)))
+               .SampleTitle(nameof(TaskBoardSample), UIcons.ClipboardList, "A board for managing tasks")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("TaskBoard provides a Trello-like interface with draggable columns and cards. Use it for Kanban boards and task management."),

--- a/Tesserae.Tests/src/Samples/Components/TextAreaSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/TextAreaSample.cs
@@ -13,7 +13,7 @@ namespace Tesserae.Tests.Samples
         public TextAreaSample()
         {
             _content = SectionStack()
-               .Title(SampleHeader(nameof(TextAreaSample)))
+               .SampleTitle(nameof(TextAreaSample), UIcons.AlignLeft, "A control to input multiple lines of text")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("TextAreas allow users to enter and edit multi-line text. They are commonly used for comments, descriptions, or any input that requires multiple lines of text.")))

--- a/Tesserae.Tests/src/Samples/Components/TextBlockSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/TextBlockSample.cs
@@ -13,7 +13,7 @@ namespace Tesserae.Tests.Samples
         public TextBlockSample()
         {
             _content = SectionStack()
-               .Title(SampleHeader(nameof(TextBlockSample)))
+               .SampleTitle(nameof(TextBlockSample), UIcons.Text, "A component to display text")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("TextBlock is the fundamental component for displaying text in Tesserae. It provides a consistent way to apply typography styles, sizes, and weights across your application."),

--- a/Tesserae.Tests/src/Samples/Components/TextBoxSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/TextBoxSample.cs
@@ -13,7 +13,7 @@ namespace Tesserae.Tests.Samples
         public TextBoxSample()
         {
             _content = SectionStack()
-               .Title(SampleHeader(nameof(TextBoxSample)))
+               .SampleTitle(nameof(TextBoxSample), UIcons.Text, "A control to input text")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("TextBoxes allow users to enter and edit text. They are used in forms, search queries, and anywhere text input is required."),

--- a/Tesserae.Tests/src/Samples/Components/TextBreadcrumbsSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/TextBreadcrumbsSample.cs
@@ -12,7 +12,7 @@ namespace Tesserae.Tests.Samples
         public TextBreadcrumbsSample()
         {
             _content = SectionStack()
-               .Title(SampleHeader(nameof(TextBreadcrumbsSample)))
+               .SampleTitle(nameof(TextBreadcrumbsSample), UIcons.AngleRight, "A breadcrumb navigation using text")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("TextBreadcrumbs are a navigational aid that indicates the current position within a hierarchy. They allow users to understand their context and easily navigate back to higher-level pages."),

--- a/Tesserae.Tests/src/Samples/Components/ToggleSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/ToggleSample.cs
@@ -13,7 +13,7 @@ namespace Tesserae.Tests.Samples
         public ToggleSample()
         {
             _content = SectionStack()
-               .Title(SampleHeader(nameof(ToggleSample)))
+               .SampleTitle(nameof(ToggleSample), UIcons.ToggleOn, "A control to toggle between two states")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("A Toggle represents a physical switch that allows users to choose between two mutually exclusive options, typically 'on' and 'off'."),

--- a/Tesserae.Tests/src/Samples/Components/TreeSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/TreeSample.cs
@@ -14,7 +14,7 @@ namespace Tesserae.Tests.Samples
         public TreeSample()
         {
             _content = SectionStack()
-               .Title(SampleHeader(nameof(TreeSample)))
+               .SampleTitle(nameof(TreeSample), UIcons.Sitemap, "A component that displays a hierarchical list")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("A tree displays hierarchical data. Nodes can be expanded or collapsed to reveal nested data."),

--- a/Tesserae.Tests/src/Samples/Progress/ProgressIndicatorSample.cs
+++ b/Tesserae.Tests/src/Samples/Progress/ProgressIndicatorSample.cs
@@ -15,7 +15,7 @@ namespace Tesserae.Tests.Samples
         public ProgressIndicatorSample()
         {
             _content = SectionStack()
-               .Title(SampleHeader(nameof(ProgressIndicatorSample)))
+               .SampleTitle(nameof(ProgressIndicatorSample), UIcons.Spinner, "A component to indicate progress")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("ProgressIndicators provide visual feedback for operations that take more than a few seconds. They show the current completion status and help set expectations for how much work remains. If the total amount of work is unknown, use the indeterminate state or a Spinner instead.")))

--- a/Tesserae.Tests/src/Samples/Progress/ProgressModalSample.cs
+++ b/Tesserae.Tests/src/Samples/Progress/ProgressModalSample.cs
@@ -61,7 +61,7 @@ namespace Tesserae.Tests.Samples
             }
 
             _content = SectionStack()
-               .Title(SampleHeader(nameof(ProgressModalSample)))
+               .SampleTitle(nameof(ProgressModalSample), UIcons.Spinner, "A modal dialog for progress")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("ProgressModal is a specialized modal overlay that combines a title, a message, and a progress indicator. It is used for long-running operations where it is important to block other user interactions until the task is complete, while keeping the user informed of the progress.")))

--- a/Tesserae.Tests/src/Samples/Progress/SpinnerSample.cs
+++ b/Tesserae.Tests/src/Samples/Progress/SpinnerSample.cs
@@ -15,7 +15,7 @@ namespace Tesserae.Tests.Samples
         public SpinnerSample()
         {
             _content = SectionStack()
-               .Title(SampleHeader(nameof(SpinnerSample)))
+               .SampleTitle(nameof(SpinnerSample), UIcons.Spinner, "A spinner component")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("Spinners are animated circular indicators used to show that a task is in progress when the exact duration is unknown. They are subtle, lightweight, and can be easily placed inline with content or centered within a container to provide feedback without disrupting the layout.")))

--- a/Tesserae.Tests/src/Samples/SamplesHelper.cs
+++ b/Tesserae.Tests/src/Samples/SamplesHelper.cs
@@ -4,17 +4,10 @@ namespace Tesserae.Tests.Samples
 {
     public static class SamplesHelper
     {
-        public static IComponent SampleHeader(string sampleType)
+        public static SectionStack SampleTitle(this SectionStack stack, string sampleType, UIcons icon, string subtitle)
         {
             var text = sampleType.Replace("Sample", "");
-
-            return Stack()
-               .Horizontal()
-               .WidthStretch()
-               .Children(
-                    TextBlock(text).XLarge().Bold(),
-                    Raw().Grow(1),
-                    Button().SetIcon(UIcons.SquareTerminal).SetTitle("View code for this sample").OnClick(() => ShowSampleCode(sampleType)));
+            return stack.Title(icon, text, subtitle, Button().SetIcon(UIcons.SquareTerminal).SetTitle("View code for this sample").OnClick(() => ShowSampleCode(sampleType)));
         }
 
         public static void ShowSampleCode(string sampleType)

--- a/Tesserae.Tests/src/Samples/Surfaces/CardPivotSample.cs
+++ b/Tesserae.Tests/src/Samples/Surfaces/CardPivotSample.cs
@@ -12,7 +12,7 @@ namespace Tesserae.Tests.Samples
         public CardPivotSample()
         {
             content = SectionStack()
-               .Title(SampleHeader(nameof(CardPivotSample)))
+               .SampleTitle(nameof(CardPivotSample), UIcons.Apps, "A pivot using cards")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("A CardPivot is a tabbed interface where the tabs are presented as connected cards with a shared border. It is useful for displaying selectable metrics that control the view below them.")))

--- a/Tesserae.Tests/src/Samples/Surfaces/ContextMenuSample.cs
+++ b/Tesserae.Tests/src/Samples/Surfaces/ContextMenuSample.cs
@@ -12,7 +12,7 @@ namespace Tesserae.Tests.Samples
         public ContextMenuSample()
         {
             _content = SectionStack()
-               .Title(SampleHeader(nameof(ContextMenuSample)))
+               .SampleTitle(nameof(ContextMenuSample), UIcons.Cursor, "A menu that appears on context")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("ContextMenu is a flyout component that displays a list of commands triggered by user interaction, such as a right-click or a button press."),

--- a/Tesserae.Tests/src/Samples/Surfaces/DialogSample.cs
+++ b/Tesserae.Tests/src/Samples/Surfaces/DialogSample.cs
@@ -18,7 +18,7 @@ namespace Tesserae.Tests.Samples
             var response = TextBlock();
 
             _content = SectionStack()
-               .Title(SampleHeader(nameof(DialogSample)))
+               .SampleTitle(nameof(DialogSample), UIcons.CommentAlt, "A dialog component")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("Dialogs are modal UI overlays that provide contextual information or require user action, such as confirmation or input. They are designed to capture the user's attention and typically block interaction with the rest of the application until they are dismissed.")))

--- a/Tesserae.Tests/src/Samples/Surfaces/FloatSample.cs
+++ b/Tesserae.Tests/src/Samples/Surfaces/FloatSample.cs
@@ -14,7 +14,7 @@ namespace Tesserae.Tests.Samples
         public FloatSample()
         {
             _content = SectionStack()
-               .Title(SampleHeader(nameof(FloatSample)))
+               .SampleTitle(nameof(FloatSample), UIcons.Apps, "A component to display floating content")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("Float components are used to place content in absolute-positioned overlays within a relative container. They allow for precise placement of UI elements, such as badges, help icons, or status indicators, without affecting the layout of surrounding components.")))

--- a/Tesserae.Tests/src/Samples/Surfaces/LayerSample.cs
+++ b/Tesserae.Tests/src/Samples/Surfaces/LayerSample.cs
@@ -17,7 +17,7 @@ namespace Tesserae.Tests.Samples
             var layerHost = LayerHost();
 
             _content = SectionStack()
-               .Title(SampleHeader(nameof(LayerSample)))
+               .SampleTitle(nameof(LayerSample), UIcons.Apps, "A component to display a layer")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("Layer is a technical component used to render content outside of its parent's DOM tree, typically at the end of the document body. This allows content to escape boundaries like 'overflow: hidden' or complex z-index stacks, ensuring that elements like tooltips, context menus, and modals always appear on top of other content.")))

--- a/Tesserae.Tests/src/Samples/Surfaces/ModalSample.cs
+++ b/Tesserae.Tests/src/Samples/Surfaces/ModalSample.cs
@@ -31,7 +31,7 @@ namespace Tesserae.Tests.Samples
                     Label("Open a dialog from here").Var(out var lbl).SetContent(Button("Open").OnClick((s, e) => Dialog("Dialog over Modal").Content(TextBlock("Hello World!")).YesNo(() => lbl.Text = "Yes", () => lbl.Text = "No")))));
 
             _content = SectionStack()
-               .Title(SampleHeader(nameof(ModalSample)))
+               .SampleTitle(nameof(ModalSample), UIcons.WindowMaximize, "A modal dialog component")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("Modals are large overlays used for tasks that require a separate context, such as creating or editing complex entities, or for displaying rich content that shouldn't clutter the main interface. They provide more space than Dialogs and can host a variety of components.")))

--- a/Tesserae.Tests/src/Samples/Surfaces/PanelSample.cs
+++ b/Tesserae.Tests/src/Samples/Surfaces/PanelSample.cs
@@ -38,7 +38,7 @@ namespace Tesserae.Tests.Samples
                 )).SetFooter(HStack().Children(Button("Footer Button 1").Primary(), Button("Footer Button 2")));
 
             _content = SectionStack()
-               .Title(SampleHeader(nameof(PanelSample)))
+               .SampleTitle(nameof(PanelSample), UIcons.WindowRestore, "A panel component")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("Panels are sliding overlays typically used for creation or management tasks, such as editing a user's profile or configuring settings. They provide a large, temporary surface that slides in from either the left or right side of the screen, keeping the user within the current context while providing space for complex forms or information.")))

--- a/Tesserae.Tests/src/Samples/Surfaces/PivotSample.cs
+++ b/Tesserae.Tests/src/Samples/Surfaces/PivotSample.cs
@@ -15,7 +15,7 @@ namespace Tesserae.Tests.Samples
         public PivotSample()
         {
             content = SectionStack()
-               .Title(SampleHeader(nameof(PivotSample)))
+               .SampleTitle(nameof(PivotSample), UIcons.Apps, "A navigation pivot")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("Pivots are used for navigating between different views or categories of content within the same context. They provide a compact way to switch between related data sets, such as different tabs in a settings page or different views of a list.")))

--- a/Tesserae.Tests/src/Samples/Surfaces/PivotSelectorSample.cs
+++ b/Tesserae.Tests/src/Samples/Surfaces/PivotSelectorSample.cs
@@ -15,7 +15,7 @@ namespace Tesserae.Tests.Samples
         public PivotSelectorSample()
         {
             content = SectionStack()
-               .Title(SampleHeader(nameof(PivotSelectorSample)))
+               .SampleTitle(nameof(PivotSelectorSample), UIcons.Cursor, "A control to select a pivot")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("PivotSelector is a variation of the Pivot component that uses a Dropdown for navigation. It is particularly effective for mobile-first designs or interfaces with a large number of tabs that would otherwise require excessive horizontal scrolling.")))

--- a/Tesserae.Tests/src/Samples/Surfaces/SectionStackSample.cs
+++ b/Tesserae.Tests/src/Samples/Surfaces/SectionStackSample.cs
@@ -16,7 +16,7 @@ namespace Tesserae.Tests.Samples
         {
             var stack = SectionStack();
 
-            _content = Stack().Children(SectionStack().Title(SampleHeader(nameof(SectionStackSample)))
+            _content = Stack().Children(SectionStack().SampleTitle(nameof(SectionStackSample), UIcons.Apps, "A stack with animated sections")
                    .Section(Stack().Children(
                         SampleTitle("Overview"),
                         TextBlock("SectionStack is a high-level layout component designed for creating long-form pages or detailed views. It organizes content into distinct vertical sections, typically with a header and footer, providing a consistent structure for complex information architectures.")))
@@ -34,6 +34,7 @@ namespace Tesserae.Tests.Samples
         private void SetChildren(SectionStack stack, int count)
         {
             stack.Clear();
+            stack.Title(UIcons.BoxOpen, "Dynamically Generated Sections", "These sections are added based on the slider value", Button("Clear").OnClick(() => stack.Clear()));
 
             for (int i = 0; i < count; i++)
             {

--- a/Tesserae.Tests/src/Samples/Surfaces/SegmentedPivotSample.cs
+++ b/Tesserae.Tests/src/Samples/Surfaces/SegmentedPivotSample.cs
@@ -12,7 +12,7 @@ namespace Tesserae.Tests.Samples
         public SegmentedPivotSample()
         {
             content = SectionStack()
-               .Title(SampleHeader(nameof(SegmentedPivotSample)))
+               .SampleTitle(nameof(SegmentedPivotSample), UIcons.Apps, "A segmented navigation pivot")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("A SegmentedPivot is a tabbed interface styled as a segmented control. It's best used for toggling between closely related views or filters where space is limited.")))

--- a/Tesserae.Tests/src/Samples/Surfaces/TabbedModalSample.cs
+++ b/Tesserae.Tests/src/Samples/Surfaces/TabbedModalSample.cs
@@ -19,7 +19,7 @@ namespace Tesserae.Tests.Samples
             _pivot = Pivot();
 
             content = SectionStack()
-               .Title(SampleHeader(nameof(TabbedModalSample)))
+               .SampleTitle(nameof(TabbedModalSample), UIcons.WindowMaximize, "A modal dialog with tabs")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("This sample demonstrates how to host Modals within a Pivot component, as well as how to use closeable tabs. Hosting a Modal within a Pivot allows it to embed its content while taking advantage of the Pivot's caching and lifecycle, and displaying a close button in the tab title automatically.")))

--- a/Tesserae.Tests/src/Samples/Surfaces/TutorialModalSample.cs
+++ b/Tesserae.Tests/src/Samples/Surfaces/TutorialModalSample.cs
@@ -16,7 +16,7 @@ namespace Tesserae.Tests.Samples
             var container = Raw();
 
             _content = SectionStack()
-               .Title(SampleHeader(nameof(TutorialModalSample)))
+               .SampleTitle(nameof(TutorialModalSample), UIcons.GraduationCap, "A modal dialog for tutorials")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("TutorialModal is a specialized modal designed for guided processes, such as onboarding or feature walkthroughs. It combines a large content area with a dedicated help panel and an optional illustrative image, providing a structured environment for users to learn while they interact.")))

--- a/Tesserae.Tests/src/Samples/Utilities/ColorsSample.cs
+++ b/Tesserae.Tests/src/Samples/Utilities/ColorsSample.cs
@@ -185,7 +185,7 @@ namespace Tesserae.Tests.Samples
             Theme.OnThemeChanged += () => window.setTimeout(_ => Render(), 1);
 
             _content = SectionStack()
-                .Title(SampleHeader(nameof(ColorsSample)))
+                .SampleTitle(nameof(ColorsSample), UIcons.Palette, "A utility to apply colors")
                 .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("Tesserae provides a comprehensive set of predefined colors that are part of the theme. These colors are accessible via the 'Theme.Colors' class and are designed to provide a consistent visual language across the application, with support for both light and dark modes.")))

--- a/Tesserae.Tests/src/Samples/Utilities/CommandPaletteSample.cs
+++ b/Tesserae.Tests/src/Samples/Utilities/CommandPaletteSample.cs
@@ -20,7 +20,7 @@ namespace Tesserae.Tests.Samples
                .OnClick(() => palette.Open());
 
             _content = SectionStack()
-               .Title(SampleHeader(nameof(CommandPaletteSample)))
+               .SampleTitle(nameof(CommandPaletteSample), UIcons.Keyboard, "A command palette utility")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("CommandPalette provides a fast and efficient way for users to navigate an application and trigger commands using only their keyboard. Inspired by modern editors and tools, it allows users to search through a list of actions and execute them with a single keystroke.")))

--- a/Tesserae.Tests/src/Samples/Utilities/DeferSample.cs
+++ b/Tesserae.Tests/src/Samples/Utilities/DeferSample.cs
@@ -17,7 +17,7 @@ namespace Tesserae.Tests.Samples
             var countSlider = Slider(5, 0, 10, 1);
 
             content = SectionStack()
-               .Title(SampleHeader(nameof(DeferSample)))
+               .SampleTitle(nameof(DeferSample), UIcons.Clock, "A utility to defer execution")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("Defer is a powerful utility for handling asynchronous UI rendering. It allows you to wrap a component that depends on an async task (like a network request). While the task is in progress, a loading message or a skeleton loader can be shown. Once the task completes, the actual component is seamlessly rendered in its place.")))

--- a/Tesserae.Tests/src/Samples/Utilities/DeferWithProgressSample.cs
+++ b/Tesserae.Tests/src/Samples/Utilities/DeferWithProgressSample.cs
@@ -17,7 +17,7 @@ namespace Tesserae.Tests.Samples
             var trigger = new SettableObservable<int>(0);
 
             content = SectionStack()
-               .Title(SampleHeader(nameof(DeferWithProgressSample)))
+               .SampleTitle(nameof(DeferWithProgressSample), UIcons.Clock, "A utility to defer execution with progress")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("DeferWithProgress extends Defer by providing a way to report progress during the async operation. This is useful for long-running tasks where you want to show a progress bar or status updates."),

--- a/Tesserae.Tests/src/Samples/Utilities/EmojiSample.cs
+++ b/Tesserae.Tests/src/Samples/Utilities/EmojiSample.cs
@@ -16,7 +16,7 @@ namespace Tesserae.Tests.Samples
         public EmojiSample()
         {
             _content = SectionStack().S()
-               .Title(SampleHeader(nameof(EmojiSample)))
+               .SampleTitle(nameof(EmojiSample), UIcons.Smile, "A utility to display emojis")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("Tesserae includes full support for Emojis via an integrated stylesheet and a strongly-typed enum. This allows you to easily add expressive icons to your application with complete C# IntelliSense support and consistent rendering.")))

--- a/Tesserae.Tests/src/Samples/Utilities/FileSelectorAndDropAreaSample.cs
+++ b/Tesserae.Tests/src/Samples/Utilities/FileSelectorAndDropAreaSample.cs
@@ -12,7 +12,7 @@ namespace Tesserae.Tests.Samples
         public FileSelectorAndDropAreaSample()
         {
             _content = SectionStack()
-               .Title(SampleHeader(nameof(FileSelectorAndDropAreaSample)))
+               .SampleTitle(nameof(FileSelectorAndDropAreaSample), UIcons.FileUpload, "A control to select and drop files")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("FileSelector and FileDropArea provide two different ways for users to upload files. FileSelector uses a standard button that opens the system file dialog, while FileDropArea provides a larger target area for users to drag and drop files directly into the application.")))

--- a/Tesserae.Tests/src/Samples/Utilities/GradientsSample.cs
+++ b/Tesserae.Tests/src/Samples/Utilities/GradientsSample.cs
@@ -45,7 +45,7 @@ namespace Tesserae.Tests.Samples
             Theme.OnThemeChanged += () => window.setTimeout(_ => Render(), 1);
 
             _content = SectionStack()
-                .Title(SampleHeader(nameof(GradientsSample)))
+                .SampleTitle(nameof(GradientsSample), UIcons.Palette, "A utility to apply gradients")
                 .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("Tesserae provides a comprehensive set of predefined gradients that are part of the theme. These gradients are accessible via the 'Theme.Gradients' class and are designed to provide a consistent visual language across the application, with support for both light and dark modes.")))

--- a/Tesserae.Tests/src/Samples/Utilities/NodeViewSample.cs
+++ b/Tesserae.Tests/src/Samples/Utilities/NodeViewSample.cs
@@ -82,7 +82,7 @@ namespace Tesserae.Tests.Samples
             textArea.OnBlur((ta, ev) => nodeView.SetState(ta.Text));
 
             content = SectionStack()
-               .Title(SampleHeader(nameof(NodeViewSample)))
+               .SampleTitle(nameof(NodeViewSample), UIcons.Sitemap, "A utility to display nodes")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("NodeView is a powerful utility for creating node-based visual editors and data flows. It allows you to define custom node types with various input and output interfaces, enabling users to build complex logic or data pipelines graphically.")))

--- a/Tesserae.Tests/src/Samples/Utilities/ThemeColorsSample.cs
+++ b/Tesserae.Tests/src/Samples/Utilities/ThemeColorsSample.cs
@@ -122,7 +122,7 @@ namespace Tesserae.Tests.Samples
             }, 1);
 
             _content = SectionStack()
-               .Title(SampleHeader(nameof(ThemeColorsSample)))
+               .SampleTitle(nameof(ThemeColorsSample), UIcons.Palette, "A utility to display theme colors")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("ThemeColors allows for real-time inspection and customization of the application's theme. It provides a detailed view of the primary, secondary, and semantic colors used throughout the UI, and allows you to experiment with different primary and background color combinations for both light and dark modes.")))

--- a/Tesserae.Tests/src/Samples/Utilities/TippySample.cs
+++ b/Tesserae.Tests/src/Samples/Utilities/TippySample.cs
@@ -20,7 +20,7 @@ namespace Tesserae.Tests.Samples
             var deferedWithChangingSize = DeferSync(size, sz => Button($"Height = {sz:n0}px").H(sz)).WS();
 
             content = SectionStack()
-               .Title(SampleHeader(nameof(TippySample)))
+               .SampleTitle(nameof(TippySample), UIcons.Comment, "A utility to display tippy tooltips")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("Tippy is the underlying engine for tooltips and popovers in Tesserae. It provides a flexible way to attach rich, interactive content to any component, with support for various animations, placements, and trigger events.")))

--- a/Tesserae.Tests/src/Samples/Utilities/ToastSample.cs
+++ b/Tesserae.Tests/src/Samples/Utilities/ToastSample.cs
@@ -14,7 +14,7 @@ namespace Tesserae.Tests.Samples
         public ToastSample()
         {
             _content = SectionStack()
-               .Title(SampleHeader(nameof(ToastSample)))
+               .SampleTitle(nameof(ToastSample), UIcons.Exclamation, "A utility to display toast notifications")
                .Section(Stack().WidthStretch().Children(
                     SampleTitle("Overview"),
                     TextBlock("Toasts are short-lived, non-intrusive notifications that provide feedback about an operation. They appear temporarily on the screen and then disappear automatically, making them ideal for success messages, warnings, or simple information updates.")))

--- a/Tesserae.Tests/src/Samples/Utilities/UIconsSample.cs
+++ b/Tesserae.Tests/src/Samples/Utilities/UIconsSample.cs
@@ -17,7 +17,7 @@ namespace Tesserae.Tests.Samples
         {
             //TODO: Add dropwdown to select icon weight
             _content = SectionStack().S()
-               .Title(SampleHeader(nameof(UIconsSample)))
+               .SampleTitle(nameof(UIconsSample), UIcons.Picture, "A utility to display icons")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("UIcons provide a massive collection of high-quality icons integrated directly into Tesserae. They are accessible through a strongly-typed enum, offering full IntelliSense support and ensuring that your application's iconography is consistent and easily maintainable.")))

--- a/Tesserae.Tests/src/Samples/Utilities/ValidatorSample.cs
+++ b/Tesserae.Tests/src/Samples/Utilities/ValidatorSample.cs
@@ -24,7 +24,7 @@ namespace Tesserae.Tests.Samples
             var dropdown = Dropdown().Items(DropdownItem(""), DropdownItem("Item 1"), DropdownItem("Item 2")).Required().Validation(dd => string.IsNullOrWhiteSpace(dd.SelectedText) ? "must select an item" : null, validator);
 
             content = SectionStack()
-               .Title(SampleHeader(nameof(ValidatorSample)))
+               .SampleTitle(nameof(ValidatorSample), UIcons.Check, "A utility to validate inputs")
                .Section(Stack().Children(
                     SampleTitle("Overview"),
                     TextBlock("Validator is a utility component that aggregates the validation state of multiple UI components. It provides a centralized way to monitor whether a form or a set of inputs is valid, making it easy to provide real-time feedback to users and prevent the submission of incorrect data.")))

--- a/Tesserae/h5.json
+++ b/Tesserae/h5.json
@@ -119,6 +119,7 @@
         "h5/assets/css/tss.nav.css",
         "h5/assets/css/tss.searchbox.css",
         "h5/assets/css/tss.omnibox.css",
+        "h5/assets/css/tss.sectiontitle.css",
         "h5/assets/css/tss.sectionstack.css",
         "h5/assets/css/tss.slider.css",
         "h5/assets/css/tss.spinner.css",

--- a/Tesserae/h5/assets/css/tss.sectiontitle.css
+++ b/Tesserae/h5/assets/css/tss.sectiontitle.css
@@ -1,0 +1,18 @@
+.tss-sectiontitle {
+    padding-bottom: 16px;
+    padding-top: 16px;
+}
+
+.tss-sectiontitle-icon {
+    font-size: 24px !important;
+    margin-right: 16px;
+    color: var(--tss-primary-color);
+}
+
+.tss-sectiontitle-title {
+    line-height: 1.2;
+}
+
+.tss-sectiontitle-subtitle {
+    line-height: 1.2;
+}

--- a/Tesserae/src/Base/UI.Components.cs
+++ b/Tesserae/src/Base/UI.Components.cs
@@ -362,6 +362,7 @@ namespace Tesserae
         /// Creates a <see cref="Tesserae.SectionStack"/> component.
         /// </summary>
         public static SectionStack SectionStack() => new SectionStack();
+        public static SectionTitle SectionTitle(UIcons icon, string title, string subtitle, params IComponent[] commands) => new SectionTitle(icon, title, subtitle, commands);
 
         /// <summary>
         /// Creates a <see cref="Tesserae.Float"/> component.

--- a/Tesserae/src/Components/SectionStackExtensions.cs
+++ b/Tesserae/src/Components/SectionStackExtensions.cs
@@ -35,8 +35,25 @@ namespace Tesserae
             return stack;
         }
 
+
+        /// <summary>
+        /// Adds a title to the stack using the SectionTitle component.
+        /// </summary>
+        /// <param name="stack">The stack.</param>
+        /// <param name="icon">The icon.</param>
+        /// <param name="title">The title.</param>
+        /// <param name="subtitle">The subtitle.</param>
+        /// <param name="commands">Optional commands to display on the right side.</param>
+        /// <returns>The stack instance.</returns>
+        public static SectionStack Title(this SectionStack stack, UIcons icon, string title, string subtitle, params IComponent[] commands)
+        {
+            stack.AddAnimatedTitle(UI.SectionTitle(icon, title, subtitle, commands));
+            return stack;
+        }
+
         /// <summary>
         /// Adds multiple sections to the stack.
+
         /// </summary>
         /// <param name="stack">The stack.</param>
         /// <param name="children">The components.</param>

--- a/Tesserae/src/Components/SectionTitle.cs
+++ b/Tesserae/src/Components/SectionTitle.cs
@@ -1,0 +1,58 @@
+using System.Linq;
+using static H5.Core.dom;
+using static Tesserae.UI;
+
+namespace Tesserae
+{
+    [H5.Name("tss.SectionTitle")]
+    public class SectionTitle : IComponent, IHasMarginPadding
+    {
+        private readonly HTMLElement _innerElement;
+        private readonly Stack _stack;
+
+        public SectionTitle(UIcons icon, string title, string subtitle, params IComponent[] commands)
+        {
+            var iconComponent = Icon(icon, size: TextSize.Large).Class("tss-sectiontitle-icon");
+            var titleBlock = TextBlock(title).MediumPlus().SemiBold().Class("tss-sectiontitle-title");
+            var subtitleBlock = TextBlock(subtitle).Small().Foreground(Theme.Secondary.Foreground).Class("tss-sectiontitle-subtitle");
+
+            var textStack = Stack().Vertical().Children(titleBlock, subtitleBlock).Class("tss-sectiontitle-textstack");
+
+            var leftSideStack = Stack().Horizontal().AlignItems(ItemAlign.Center).Children(iconComponent, textStack).Class("tss-sectiontitle-left");
+
+            _stack = Stack().Horizontal()
+                .AlignItems(ItemAlign.Center)
+                .WidthStretch()
+                .Class("tss-sectiontitle");
+
+            if (commands != null && commands.Length > 0)
+            {
+                var commandsStack = Stack().Horizontal().AlignItems(ItemAlign.Center).Children(commands).Class("tss-sectiontitle-commands");
+                _stack.Children(leftSideStack, Raw().Grow(1), commandsStack);
+            }
+            else
+            {
+                _stack.Children(leftSideStack, Raw().Grow(1));
+            }
+
+            _innerElement = _stack.Render();
+        }
+
+        public string Margin
+        {
+            get => _stack.Margin;
+            set => _stack.Margin = value;
+        }
+
+        public string Padding
+        {
+            get => _stack.Padding;
+            set => _stack.Padding = value;
+        }
+
+        public HTMLElement Render()
+        {
+            return _innerElement;
+        }
+    }
+}


### PR DESCRIPTION
Adds a new structured header component for complex layout structures and updates all library sample pages to use it, achieving better test UI consistency.

---
*PR created automatically by Jules for task [5621920954307289711](https://jules.google.com/task/5621920954307289711) started by @theolivenbaum*