### PR TITLE
Improve DX for NodeView

### DIFF
--- a/Tesserae.Tests/src/Samples/Utilities/NodeViewSample.cs
+++ b/Tesserae.Tests/src/Samples/Utilities/NodeViewSample.cs
@@ -39,38 +39,19 @@ namespace Tesserae.Tests.Samples
 
             var stateBuilder = NodeView.State();
 
-            var node1_id  = Guid.NewGuid().ToString();
-            var node1_inp = Guid.NewGuid().ToString();
-            var node1_out = Guid.NewGuid().ToString();
+            var node1 = stateBuilder.AddNode("Hello World", "My First Node", 100, 100)
+                .AddInput("inp", "Hello");
 
+            var node2 = stateBuilder.AddNode("Complex", "A Complex Node", 400, 100, 320)
+                .AddInput("text", "World")
+                .AddInput("int", 42)
+                .AddInput("num", 9.99)
+                .AddInput("btn", null)
+                .AddInput("chk", true)
+                .AddInput("sel", "B")
+                .AddInput("sld", 0.75);
 
-            stateBuilder.AddNode(node1_id, "Hello World", "My First Node", 100, 100, 200, nb => nb
-                .AddInput("inp",  node1_inp, "Hello")
-                .AddOutput("out", node1_out)
-            );
-
-            var node2_id      = Guid.NewGuid().ToString();
-            var node2_text_id = Guid.NewGuid().ToString(); 
-            var node2_int_id  = Guid.NewGuid().ToString();
-            var node2_num_id  = Guid.NewGuid().ToString();
-            var node2_btn_id  = Guid.NewGuid().ToString();
-            var node2_chk_id  = Guid.NewGuid().ToString();
-            var node2_sel_id  = Guid.NewGuid().ToString();
-            var node2_sld_id  = Guid.NewGuid().ToString();
-            var node2_out_id = Guid.NewGuid().ToString();
-
-            stateBuilder.AddNode(node2_id, "Complex", "A Complex Node", 400, 100, 320, nb => nb
-                .AddInput("text", node2_text_id , "World")
-                .AddInput("int",  node2_int_id  , 42)
-                .AddInput("num",  node2_num_id  , 9.99)
-                .AddInput("btn",  node2_btn_id  , null)
-                .AddInput("chk",  node2_chk_id  , true)
-                .AddInput("sel",  node2_sel_id  , "B")
-                .AddInput("sld",  node2_sld_id  , 0.75)
-                .AddOutput("out", node2_out_id )
-            );
-
-            stateBuilder.AddConnection(node1_out, node2_text_id);
+            node1.ConnectTo("out", node2, "text");
 
             nodeView.SetState(stateBuilder.Build());
 

--- a/Tesserae/src/Components/NodeView/NodeView.cs
+++ b/Tesserae/src/Components/NodeView/NodeView.cs
@@ -1114,15 +1114,22 @@ namespace Tesserae
         public class StateBuilder
         {
             private string _id = Guid.NewGuid().ToString();
-            private List<NodeState> _nodes = new List<NodeState>();
+            private List<NodeStateBuilder> _nodes = new List<NodeStateBuilder>();
             private List<ConnectionState> _connections = new List<ConnectionState>();
 
             public StateBuilder AddNode(string id, string type, string title, double x, double y, double width, Action<NodeStateBuilder> buildNode = null)
             {
-                var nsb = new NodeStateBuilder(id, type, title, x, y, width);
+                var nsb = new NodeStateBuilder(this, id, type, title, x, y, width);
                 buildNode?.Invoke(nsb);
-                _nodes.Add(nsb.Build());
+                _nodes.Add(nsb);
                 return this;
+            }
+
+            public NodeStateBuilder AddNode(string type, string title, double x, double y, double width = 200)
+            {
+                var nsb = new NodeStateBuilder(this, Guid.NewGuid().ToString(), type, title, x, y, width);
+                _nodes.Add(nsb);
+                return nsb;
             }
 
             public StateBuilder AddConnection(string fromInterfaceId, string toInterfaceId)
@@ -1138,10 +1145,16 @@ namespace Tesserae
 
             public NodeViewGraphState Build()
             {
+                var nodes = new List<NodeState>();
+                foreach (var nsb in _nodes)
+                {
+                    nodes.Add(nsb.Build());
+                }
+
                 return new NodeViewGraphState
                 {
                     id = _id,
-                    nodes = _nodes.ToObjectLiteralArray(),
+                    nodes = nodes.ToObjectLiteralArray(),
                     connections = _connections.ToObjectLiteralArray(),
                     inputs = new GraphInterfaceState[0],
                     outputs = new GraphInterfaceState[0],
@@ -1156,6 +1169,18 @@ namespace Tesserae
             private NodeState _node = new NodeState();
             private Dictionary<string, ValueState> _inputs = new Dictionary<string, ValueState>();
             private Dictionary<string, ValueState> _outputs = new Dictionary<string, ValueState>();
+            private StateBuilder _parent;
+
+            public NodeStateBuilder(StateBuilder parent, string id, string type, string title, double x, double y, double width)
+            {
+                _parent = parent;
+                _node.id = id;
+                _node.type = type;
+                _node.title = title;
+                _node.position = new PositionState { x = x, y = y };
+                _node.width = width;
+                _node.twoColumn = false;
+            }
 
             public NodeStateBuilder(string id, string type, string title, double x, double y, double width)
             {
@@ -1182,6 +1207,40 @@ namespace Tesserae
             public NodeStateBuilder AddOutput(string name, string interfaceId, object value = null)
             {
                 _outputs[name] = new ValueState { id = interfaceId, value = value };
+                return this;
+            }
+
+            public NodeStateBuilder AddInput(string name, object value = null)
+            {
+                _inputs[name] = new ValueState { id = Guid.NewGuid().ToString(), value = value };
+                return this;
+            }
+
+            public NodeStateBuilder AddOutput(string name, object value = null)
+            {
+                _outputs[name] = new ValueState { id = Guid.NewGuid().ToString(), value = value };
+                return this;
+            }
+
+            public string Input(string name)
+            {
+                if (_inputs.TryGetValue(name, out var value)) return value.id;
+                var id = Guid.NewGuid().ToString();
+                _inputs[name] = new ValueState { id = id, value = null };
+                return id;
+            }
+
+            public string Output(string name)
+            {
+                if (_outputs.TryGetValue(name, out var value)) return value.id;
+                var id = Guid.NewGuid().ToString();
+                _outputs[name] = new ValueState { id = id, value = null };
+                return id;
+            }
+
+            public NodeStateBuilder ConnectTo(string outputName, NodeStateBuilder targetNode, string inputName)
+            {
+                _parent?.AddConnection(Output(outputName), targetNode.Input(inputName));
                 return this;
             }
 


### PR DESCRIPTION
This PR improves the developer experience of the `NodeView` component by introducing a fluent API for building the node graph state.

Key changes:
- `StateBuilder` now returns a `NodeStateBuilder` instance when calling `AddNode`, allowing for method chaining.
- `NodeStateBuilder` can now automatically generate IDs for inputs and outputs when none are provided. This abstract away the need for explicit `Guid.NewGuid().ToString()` calls in the application code.
- Added a `ConnectTo(outputName, targetNode, inputName)` method on `NodeStateBuilder` which allows developers to connect nodes semantically by their port names.
- Updated `NodeViewSample` to use the new fluent API.

---
*PR created automatically by Jules for task [9731178909372987083](https://jules.google.com/task/9731178909372987083) started by @theolivenbaum*