### PR TITLE
Improve NodeView state builder developer experience

### DIFF
--- a/Tesserae.Tests/src/Samples/Utilities/NodeViewSample.cs
+++ b/Tesserae.Tests/src/Samples/Utilities/NodeViewSample.cs
@@ -39,38 +39,21 @@ namespace Tesserae.Tests.Samples
 
             var stateBuilder = NodeView.State();
 
-            var node1_id  = Guid.NewGuid().ToString();
-            var node1_inp = Guid.NewGuid().ToString();
-            var node1_out = Guid.NewGuid().ToString();
-
-
-            stateBuilder.AddNode(node1_id, "Hello World", "My First Node", 100, 100, 200, nb => nb
-                .AddInput("inp",  node1_inp, "Hello")
-                .AddOutput("out", node1_out)
+            var node1 = stateBuilder.AddNode("Hello World", "My First Node", 100, 100, 200, nb => nb
+                .SetInput("inp", "Hello")
             );
 
-            var node2_id      = Guid.NewGuid().ToString();
-            var node2_text_id = Guid.NewGuid().ToString(); 
-            var node2_int_id  = Guid.NewGuid().ToString();
-            var node2_num_id  = Guid.NewGuid().ToString();
-            var node2_btn_id  = Guid.NewGuid().ToString();
-            var node2_chk_id  = Guid.NewGuid().ToString();
-            var node2_sel_id  = Guid.NewGuid().ToString();
-            var node2_sld_id  = Guid.NewGuid().ToString();
-            var node2_out_id = Guid.NewGuid().ToString();
-
-            stateBuilder.AddNode(node2_id, "Complex", "A Complex Node", 400, 100, 320, nb => nb
-                .AddInput("text", node2_text_id , "World")
-                .AddInput("int",  node2_int_id  , 42)
-                .AddInput("num",  node2_num_id  , 9.99)
-                .AddInput("btn",  node2_btn_id  , null)
-                .AddInput("chk",  node2_chk_id  , true)
-                .AddInput("sel",  node2_sel_id  , "B")
-                .AddInput("sld",  node2_sld_id  , 0.75)
-                .AddOutput("out", node2_out_id )
+            var node2 = stateBuilder.AddNode("Complex", "A Complex Node", 400, 100, 320, nb => nb
+                .SetInput("text", "World")
+                .SetInput("int",  42)
+                .SetInput("num",  9.99)
+                .SetInput("btn",  null)
+                .SetInput("chk",  true)
+                .SetInput("sel",  "B")
+                .SetInput("sld",  0.75)
             );
 
-            stateBuilder.AddConnection(node1_out, node2_text_id);
+            stateBuilder.Connect(node1.Output("out"), node2.Input("text"));
 
             nodeView.SetState(stateBuilder.Build());
 

--- a/Tesserae/src/Components/NodeView/NodeView.cs
+++ b/Tesserae/src/Components/NodeView/NodeView.cs
@@ -1114,15 +1114,23 @@ namespace Tesserae
         public class StateBuilder
         {
             private string _id = Guid.NewGuid().ToString();
-            private List<NodeState> _nodes = new List<NodeState>();
+            private List<NodeStateBuilder> _nodes = new List<NodeStateBuilder>();
             private List<ConnectionState> _connections = new List<ConnectionState>();
 
             public StateBuilder AddNode(string id, string type, string title, double x, double y, double width, Action<NodeStateBuilder> buildNode = null)
             {
                 var nsb = new NodeStateBuilder(id, type, title, x, y, width);
                 buildNode?.Invoke(nsb);
-                _nodes.Add(nsb.Build());
+                _nodes.Add(nsb);
                 return this;
+            }
+
+            public NodeStateBuilder AddNode(string type, string title, double x, double y, double width = 200, Action<NodeStateBuilder> buildNode = null)
+            {
+                var nsb = new NodeStateBuilder(Guid.NewGuid().ToString(), type, title, x, y, width);
+                buildNode?.Invoke(nsb);
+                _nodes.Add(nsb);
+                return nsb;
             }
 
             public StateBuilder AddConnection(string fromInterfaceId, string toInterfaceId)
@@ -1136,12 +1144,23 @@ namespace Tesserae
                 return this;
             }
 
+            public StateBuilder Connect(string fromInterfaceId, string toInterfaceId)
+            {
+                return AddConnection(fromInterfaceId, toInterfaceId);
+            }
+
             public NodeViewGraphState Build()
             {
+                var nodes = new List<NodeState>();
+                foreach (var n in _nodes)
+                {
+                    nodes.Add(n.Build());
+                }
+
                 return new NodeViewGraphState
                 {
                     id = _id,
-                    nodes = _nodes.ToObjectLiteralArray(),
+                    nodes = nodes.ToObjectLiteralArray(),
                     connections = _connections.ToObjectLiteralArray(),
                     inputs = new GraphInterfaceState[0],
                     outputs = new GraphInterfaceState[0],
@@ -1182,6 +1201,52 @@ namespace Tesserae
             public NodeStateBuilder AddOutput(string name, string interfaceId, object value = null)
             {
                 _outputs[name] = new ValueState { id = interfaceId, value = value };
+                return this;
+            }
+
+            public string Input(string name)
+            {
+                if (!_inputs.TryGetValue(name, out var valueState))
+                {
+                    valueState = new ValueState { id = Guid.NewGuid().ToString(), value = null };
+                    _inputs[name] = valueState;
+                }
+                return valueState.id;
+            }
+
+            public string Output(string name)
+            {
+                if (!_outputs.TryGetValue(name, out var valueState))
+                {
+                    valueState = new ValueState { id = Guid.NewGuid().ToString(), value = null };
+                    _outputs[name] = valueState;
+                }
+                return valueState.id;
+            }
+
+            public NodeStateBuilder SetInput(string name, object value = null)
+            {
+                if (_inputs.TryGetValue(name, out var valueState))
+                {
+                    valueState.value = value;
+                }
+                else
+                {
+                    _inputs[name] = new ValueState { id = Guid.NewGuid().ToString(), value = value };
+                }
+                return this;
+            }
+
+            public NodeStateBuilder SetOutput(string name, object value = null)
+            {
+                if (_outputs.TryGetValue(name, out var valueState))
+                {
+                    valueState.value = value;
+                }
+                else
+                {
+                    _outputs[name] = new ValueState { id = Guid.NewGuid().ToString(), value = value };
+                }
                 return this;
             }
 


### PR DESCRIPTION
This commit significantly improves the DX of defining workflows programmatically using the NodeView component. By abstracting the generation and tracking of UUIDs for interfaces during the build step, developers can now set inputs, outputs, and establish connections via fluent methods without manually instantiating or assigning IDs. The NodeView sample page has been rewritten to demonstrate these improvements.

---
*PR created automatically by Jules for task [17799930752290814380](https://jules.google.com/task/17799930752290814380) started by @theolivenbaum*