### PR TITLE
feat(NodeView): Add dependency injection style for node definitions

### DIFF
--- a/Tesserae.Tests/src/Samples/Utilities/NodeViewSample.cs
+++ b/Tesserae.Tests/src/Samples/Utilities/NodeViewSample.cs
@@ -11,31 +11,58 @@ namespace Tesserae.Tests.Samples
     {
         private readonly IComponent content;
 
+        public class HelloWorldNode : INodeView
+        {
+            public string Name => "Hello World";
+            public void BuildNode(NodeView.InterfaceBuilder ib)
+            {
+                ib.AddInput("inp",  () => NodeView.Interfaces.TextInputInterface("Input", "Hi Input"))
+                  .AddOutput("out", () => NodeView.Interfaces.TextInputInterface("Output", "Hi Output"));
+            }
+        }
+
+        public class ComplexNode : INodeView
+        {
+            public string Name => "Complex";
+            public void BuildNode(NodeView.InterfaceBuilder ib)
+            {
+                ib.AddInput("text", () => NodeView.Interfaces.TextInterface("Input", "Hi Input"))
+                  .AddInput("int",  () => NodeView.Interfaces.IntegerInterface("Input", 123))
+                  .AddInput("num",  () => NodeView.Interfaces.NumberInterface("Input", 3.14))
+                  .AddInput("btn",  () => NodeView.Interfaces.ButtonInterface("Input", () => Toast().Information("Hi!")))
+                  .AddInput("chk",  () => NodeView.Interfaces.CheckboxInterface("Input", false))
+                  .AddInput("sel",  () => NodeView.Interfaces.SelectInterface("Input", "A", new ReadOnlyArray<string>(new[] { "A", "B", "C" })))
+                  .AddInput("sld",  () => NodeView.Interfaces.SliderInterface("Input", 0.5, 0, 1))
+                  .AddOutput("out", () => NodeView.Interfaces.TextInterface("Output", "Hi Output"));
+            }
+        }
+
+        public class DynamicNode : IDynamicNodeView
+        {
+            public string Name => "Dynamic";
+
+            public void BuildNode(NodeView.InterfaceBuilder ib)
+            {
+                ib.AddInput("inp", () => NodeView.Interfaces.IntegerInterface("Output Count", 1));
+            }
+
+            public void UpdateNode(NodeView.InputsState inputs, NodeView.OutputsState outputs, NodeView.InterfaceBuilder ib)
+            {
+                var inputCount = inputs["inp"].As<int>();
+                for(int i  = 0; i < inputCount; i++)
+                {
+                    ib.AddOutput($"out-{i}", () => NodeView.Interfaces.TextInterface($"out-{i}", i.ToString()));
+                }
+            }
+        }
+
         public NodeViewSample()
         {
             var nodeView    = NodeView().S();
 
-            nodeView.DefineNode("Hello World", ib => ib.AddInput("inp",  () => NodeView.Interfaces.TextInputInterface("Input", "Hi Input"))
-                                                       .AddOutput("out", () => NodeView.Interfaces.TextInputInterface("Output", "Hi Output")));
-
-            nodeView.DefineNode("Complex", ib => ib.AddInput("text", () => NodeView.Interfaces.TextInterface("Input", "Hi Input"))
-                                                   .AddInput("int",  () => NodeView.Interfaces.IntegerInterface("Input", 123))
-                                                   .AddInput("num",  () => NodeView.Interfaces.NumberInterface("Input", 3.14))
-                                                   .AddInput("btn",  () => NodeView.Interfaces.ButtonInterface("Input", () => Toast().Information("Hi!")))
-                                                   .AddInput("chk",  () => NodeView.Interfaces.CheckboxInterface("Input", false))
-                                                   .AddInput("sel",  () => NodeView.Interfaces.SelectInterface("Input", "A", new ReadOnlyArray<string>(new[] { "A", "B", "C" })))
-                                                   .AddInput("sld",  () => NodeView.Interfaces.SliderInterface("Input", 0.5, 0, 1))
-                                                   .AddOutput("out", () => NodeView.Interfaces.TextInterface("Output", "Hi Output")));
-
-            nodeView.DefineDynamicNode("Dynamic", ib => ib.AddInput("inp", () => NodeView.Interfaces.IntegerInterface("Output Count", 1)),
-                                                  (inputState, outputState, ib) =>
-                                                  {
-                                                      var inputCount = inputState["inp"].As<int>();
-                                                      for(int i  = 0; i < inputCount; i++)
-                                                      {
-                                                          ib.AddOutput($"out-{i}", () => NodeView.Interfaces.TextInterface($"out-{i}", i.ToString()));
-                                                      }
-                                                  });
+            nodeView.Register<HelloWorldNode>();
+            nodeView.Register<ComplexNode>();
+            nodeView.Register<DynamicNode>();
 
             var stateBuilder = NodeView.State();
 

--- a/Tesserae.Tests/src/Samples/Utilities/NodeViewSample.cs
+++ b/Tesserae.Tests/src/Samples/Utilities/NodeViewSample.cs
@@ -14,44 +14,39 @@ namespace Tesserae.Tests.Samples
         public class HelloWorldNode : INodeView
         {
             public string Name => "Hello World";
-            public void BuildNode(NodeView.InterfaceBuilder ib)
-            {
-                ib.AddInput("inp",  () => NodeView.Interfaces.TextInputInterface("Input", "Hi Input"))
-                  .AddOutput("out", () => NodeView.Interfaces.TextInputInterface("Output", "Hi Output"));
-            }
+            public INodeInput[] Inputs => new INodeInput[] { new NodeTextInput("inp", "Input", "Hi Input") };
+            public INodeOutput[] Outputs => new INodeOutput[] { new NodeTextInput("out", "Output", "Hi Output") };
         }
 
         public class ComplexNode : INodeView
         {
             public string Name => "Complex";
-            public void BuildNode(NodeView.InterfaceBuilder ib)
+            public INodeInput[] Inputs => new INodeInput[]
             {
-                ib.AddInput("text", () => NodeView.Interfaces.TextInterface("Input", "Hi Input"))
-                  .AddInput("int",  () => NodeView.Interfaces.IntegerInterface("Input", 123))
-                  .AddInput("num",  () => NodeView.Interfaces.NumberInterface("Input", 3.14))
-                  .AddInput("btn",  () => NodeView.Interfaces.ButtonInterface("Input", () => Toast().Information("Hi!")))
-                  .AddInput("chk",  () => NodeView.Interfaces.CheckboxInterface("Input", false))
-                  .AddInput("sel",  () => NodeView.Interfaces.SelectInterface("Input", "A", new ReadOnlyArray<string>(new[] { "A", "B", "C" })))
-                  .AddInput("sld",  () => NodeView.Interfaces.SliderInterface("Input", 0.5, 0, 1))
-                  .AddOutput("out", () => NodeView.Interfaces.TextInterface("Output", "Hi Output"));
-            }
+                new NodeText("text", "Input", "Hi Input"),
+                new NodeInteger("int", "Input", 123),
+                new NodeNumber("num", "Input", 3.14),
+                new NodeButton("btn", "Input", () => Toast().Information("Hi!")),
+                new NodeCheckbox("chk", "Input", false),
+                new NodeSelect("sel", "Input", "A", new ReadOnlyArray<string>(new[] { "A", "B", "C" })),
+                new NodeSlider("sld", "Input", 0.5, 0, 1)
+            };
+            public INodeOutput[] Outputs => new INodeOutput[] { new NodeText("out", "Output", "Hi Output") };
         }
 
         public class DynamicNode : IDynamicNodeView
         {
             public string Name => "Dynamic";
 
-            public void BuildNode(NodeView.InterfaceBuilder ib)
-            {
-                ib.AddInput("inp", () => NodeView.Interfaces.IntegerInterface("Output Count", 1));
-            }
+            public INodeInput[] Inputs => new INodeInput[] { new NodeInteger("inp", "Output Count", 1) };
+            public INodeOutput[] Outputs => null;
 
-            public void UpdateNode(NodeView.InputsState inputs, NodeView.OutputsState outputs, NodeView.InterfaceBuilder ib)
+            public void UpdateNode(NodeView.InputsState inputs, NodeView.OutputsState outputs, Action<INodeInput> addInput, Action<INodeOutput> addOutput)
             {
                 var inputCount = inputs["inp"].As<int>();
                 for(int i  = 0; i < inputCount; i++)
                 {
-                    ib.AddOutput($"out-{i}", () => NodeView.Interfaces.TextInterface($"out-{i}", i.ToString()));
+                    addOutput(new NodeText($"out-{i}", $"out-{i}", i.ToString()));
                 }
             }
         }

--- a/Tesserae.Tests/src/Samples/Utilities/NodeViewSample.cs
+++ b/Tesserae.Tests/src/Samples/Utilities/NodeViewSample.cs
@@ -14,8 +14,8 @@ namespace Tesserae.Tests.Samples
         public class HelloWorldNode : INodeView
         {
             public string Name => "Hello World";
-            public INodeInput[] Inputs => new INodeInput[] { new NodeTextInput("inp", "Input", "Hi Input") };
-            public INodeOutput[] Outputs => new INodeOutput[] { new NodeTextInput("out", "Output", "Hi Output") };
+            public INodeInput[] Inputs => new INodeInput[] { new NodeInput<string>("inp", "Input", "Hi Input") };
+            public INodeOutput[] Outputs => new INodeOutput[] { new NodeOutput<string>("out", "Output", "Hi Output") };
         }
 
         public class ComplexNode : INodeView
@@ -23,22 +23,22 @@ namespace Tesserae.Tests.Samples
             public string Name => "Complex";
             public INodeInput[] Inputs => new INodeInput[]
             {
-                new NodeText("text", "Input", "Hi Input"),
-                new NodeInteger("int", "Input", 123),
-                new NodeNumber("num", "Input", 3.14),
-                new NodeButton("btn", "Input", () => Toast().Information("Hi!")),
-                new NodeCheckbox("chk", "Input", false),
-                new NodeSelect("sel", "Input", "A", new ReadOnlyArray<string>(new[] { "A", "B", "C" })),
-                new NodeSlider("sld", "Input", 0.5, 0, 1)
+                new NodeInput<string>("text", "Input", "Hi Input"),
+                new NodeInput<int>("int", "Input", 123),
+                new NodeInput<double>("num", "Input", 3.14),
+                new NodeInput<Action>("btn", "Input", () => Toast().Information("Hi!")),
+                new NodeInput<bool>("chk", "Input", false),
+                new NodeSelectInput("sel", "Input", "A", new ReadOnlyArray<string>(new[] { "A", "B", "C" })),
+                new NodeSliderInput("sld", "Input", 0.5, 0, 1)
             };
-            public INodeOutput[] Outputs => new INodeOutput[] { new NodeText("out", "Output", "Hi Output") };
+            public INodeOutput[] Outputs => new INodeOutput[] { new NodeOutput<string>("out", "Output", "Hi Output") };
         }
 
         public class DynamicNode : IDynamicNodeView
         {
             public string Name => "Dynamic";
 
-            public INodeInput[] Inputs => new INodeInput[] { new NodeInteger("inp", "Output Count", 1) };
+            public INodeInput[] Inputs => new INodeInput[] { new NodeInput<int>("inp", "Output Count", 1) };
             public INodeOutput[] Outputs => null;
 
             public void UpdateNode(NodeView.InputsState inputs, NodeView.OutputsState outputs, Action<INodeInput> addInput, Action<INodeOutput> addOutput)
@@ -46,7 +46,7 @@ namespace Tesserae.Tests.Samples
                 var inputCount = inputs["inp"].As<int>();
                 for(int i  = 0; i < inputCount; i++)
                 {
-                    addOutput(new NodeText($"out-{i}", $"out-{i}", i.ToString()));
+                    addOutput(new NodeOutput<string>($"out-{i}", $"out-{i}", i.ToString()));
                 }
             }
         }

--- a/Tesserae/src/Components/NodeView/IDynamicNodeView.cs
+++ b/Tesserae/src/Components/NodeView/IDynamicNodeView.cs
@@ -4,6 +4,6 @@ namespace Tesserae
 {
     public interface IDynamicNodeView : INodeView
     {
-        void UpdateNode(NodeView.InputsState inputs, NodeView.OutputsState outputs, NodeView.InterfaceBuilder ib);
+        void UpdateNode(NodeView.InputsState inputs, NodeView.OutputsState outputs, Action<INodeInput> addInput, Action<INodeOutput> addOutput);
     }
 }

--- a/Tesserae/src/Components/NodeView/IDynamicNodeView.cs
+++ b/Tesserae/src/Components/NodeView/IDynamicNodeView.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace Tesserae
+{
+    public interface IDynamicNodeView : INodeView
+    {
+        void UpdateNode(NodeView.InputsState inputs, NodeView.OutputsState outputs, NodeView.InterfaceBuilder ib);
+    }
+}

--- a/Tesserae/src/Components/NodeView/INodeInterface.cs
+++ b/Tesserae/src/Components/NodeView/INodeInterface.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace Tesserae
+{
+    public interface INodeInput
+    {
+        string Name { get; }
+        NodeView.NodeInterface Build();
+    }
+
+    public interface INodeOutput
+    {
+        string Name { get; }
+        NodeView.NodeInterface Build();
+    }
+}

--- a/Tesserae/src/Components/NodeView/INodeInterface.cs
+++ b/Tesserae/src/Components/NodeView/INodeInterface.cs
@@ -13,4 +13,14 @@ namespace Tesserae
         string Name { get; }
         NodeView.NodeInterface Build();
     }
+
+    public interface INodeInput<T> : INodeInput
+    {
+        T DefaultValue { get; }
+    }
+
+    public interface INodeOutput<T> : INodeOutput
+    {
+        T DefaultValue { get; }
+    }
 }

--- a/Tesserae/src/Components/NodeView/INodeView.cs
+++ b/Tesserae/src/Components/NodeView/INodeView.cs
@@ -5,6 +5,7 @@ namespace Tesserae
     public interface INodeView
     {
         string Name { get; }
-        void BuildNode(NodeView.InterfaceBuilder ib);
+        INodeInput[] Inputs { get; }
+        INodeOutput[] Outputs { get; }
     }
 }

--- a/Tesserae/src/Components/NodeView/INodeView.cs
+++ b/Tesserae/src/Components/NodeView/INodeView.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace Tesserae
+{
+    public interface INodeView
+    {
+        string Name { get; }
+        void BuildNode(NodeView.InterfaceBuilder ib);
+    }
+}

--- a/Tesserae/src/Components/NodeView/NodeInterfaces.cs
+++ b/Tesserae/src/Components/NodeView/NodeInterfaces.cs
@@ -1,0 +1,171 @@
+using System;
+using H5;
+
+namespace Tesserae
+{
+    public class NodeTextInput : INodeInput, INodeOutput
+    {
+        public string Name { get; }
+        public string Title { get; }
+        public string DefaultValue { get; }
+        public bool AllowMultipleConnections { get; }
+        public bool SetPort { get; }
+
+        public NodeTextInput(string name, string title, string defaultValue = "", bool allowMultipleConnections = false, bool setPort = true)
+        {
+            Name = name;
+            Title = title;
+            DefaultValue = defaultValue;
+            AllowMultipleConnections = allowMultipleConnections;
+            SetPort = setPort;
+        }
+
+        public NodeView.NodeInterface Build() => NodeView.Interfaces.TextInputInterface(Title, DefaultValue, AllowMultipleConnections, SetPort);
+    }
+
+    public class NodeText : INodeInput, INodeOutput
+    {
+        public string Name { get; }
+        public string Title { get; }
+        public string DefaultValue { get; }
+        public bool AllowMultipleConnections { get; }
+        public bool SetPort { get; }
+
+        public NodeText(string name, string title, string defaultValue = "", bool allowMultipleConnections = false, bool setPort = true)
+        {
+            Name = name;
+            Title = title;
+            DefaultValue = defaultValue;
+            AllowMultipleConnections = allowMultipleConnections;
+            SetPort = setPort;
+        }
+
+        public NodeView.NodeInterface Build() => NodeView.Interfaces.TextInterface(Title, DefaultValue, AllowMultipleConnections, SetPort);
+    }
+
+    public class NodeInteger : INodeInput, INodeOutput
+    {
+        public string Name { get; }
+        public string Title { get; }
+        public int DefaultValue { get; }
+        public bool AllowMultipleConnections { get; }
+        public bool SetPort { get; }
+
+        public NodeInteger(string name, string title, int defaultValue = 0, bool allowMultipleConnections = false, bool setPort = true)
+        {
+            Name = name;
+            Title = title;
+            DefaultValue = defaultValue;
+            AllowMultipleConnections = allowMultipleConnections;
+            SetPort = setPort;
+        }
+
+        public NodeView.NodeInterface Build() => NodeView.Interfaces.IntegerInterface(Title, DefaultValue, AllowMultipleConnections, SetPort);
+    }
+
+    public class NodeNumber : INodeInput, INodeOutput
+    {
+        public string Name { get; }
+        public string Title { get; }
+        public double DefaultValue { get; }
+        public bool AllowMultipleConnections { get; }
+        public bool SetPort { get; }
+
+        public NodeNumber(string name, string title, double defaultValue = 0, bool allowMultipleConnections = false, bool setPort = true)
+        {
+            Name = name;
+            Title = title;
+            DefaultValue = defaultValue;
+            AllowMultipleConnections = allowMultipleConnections;
+            SetPort = setPort;
+        }
+
+        public NodeView.NodeInterface Build() => NodeView.Interfaces.NumberInterface(Title, DefaultValue, AllowMultipleConnections, SetPort);
+    }
+
+    public class NodeButton : INodeInput, INodeOutput
+    {
+        public string Name { get; }
+        public string Title { get; }
+        public Action OnClick { get; }
+        public bool AllowMultipleConnections { get; }
+        public bool SetPort { get; }
+
+        public NodeButton(string name, string title, Action onClick, bool allowMultipleConnections = false, bool setPort = true)
+        {
+            Name = name;
+            Title = title;
+            OnClick = onClick;
+            AllowMultipleConnections = allowMultipleConnections;
+            SetPort = setPort;
+        }
+
+        public NodeView.NodeInterface Build() => NodeView.Interfaces.ButtonInterface(Title, OnClick, AllowMultipleConnections, SetPort);
+    }
+
+    public class NodeCheckbox : INodeInput, INodeOutput
+    {
+        public string Name { get; }
+        public string Title { get; }
+        public bool DefaultValue { get; }
+        public bool AllowMultipleConnections { get; }
+        public bool SetPort { get; }
+
+        public NodeCheckbox(string name, string title, bool defaultValue = false, bool allowMultipleConnections = false, bool setPort = true)
+        {
+            Name = name;
+            Title = title;
+            DefaultValue = defaultValue;
+            AllowMultipleConnections = allowMultipleConnections;
+            SetPort = setPort;
+        }
+
+        public NodeView.NodeInterface Build() => NodeView.Interfaces.CheckboxInterface(Title, DefaultValue, AllowMultipleConnections, SetPort);
+    }
+
+    public class NodeSelect : INodeInput, INodeOutput
+    {
+        public string Name { get; }
+        public string Title { get; }
+        public string DefaultValue { get; }
+        public ReadOnlyArray<string> Values { get; }
+        public bool AllowMultipleConnections { get; }
+        public bool SetPort { get; }
+
+        public NodeSelect(string name, string title, string defaultValue, ReadOnlyArray<string> values, bool allowMultipleConnections = false, bool setPort = true)
+        {
+            Name = name;
+            Title = title;
+            DefaultValue = defaultValue;
+            Values = values;
+            AllowMultipleConnections = allowMultipleConnections;
+            SetPort = setPort;
+        }
+
+        public NodeView.NodeInterface Build() => NodeView.Interfaces.SelectInterface(Title, DefaultValue, Values, AllowMultipleConnections, SetPort);
+    }
+
+    public class NodeSlider : INodeInput, INodeOutput
+    {
+        public string Name { get; }
+        public string Title { get; }
+        public double DefaultValue { get; }
+        public double Min { get; }
+        public double Max { get; }
+        public bool AllowMultipleConnections { get; }
+        public bool SetPort { get; }
+
+        public NodeSlider(string name, string title, double defaultValue, double min, double max, bool allowMultipleConnections = false, bool setPort = true)
+        {
+            Name = name;
+            Title = title;
+            DefaultValue = defaultValue;
+            Min = min;
+            Max = max;
+            AllowMultipleConnections = allowMultipleConnections;
+            SetPort = setPort;
+        }
+
+        public NodeView.NodeInterface Build() => NodeView.Interfaces.SliderInterface(Title, DefaultValue, Min, Max, AllowMultipleConnections, SetPort);
+    }
+}

--- a/Tesserae/src/Components/NodeView/NodeInterfaces.cs
+++ b/Tesserae/src/Components/NodeView/NodeInterfaces.cs
@@ -3,15 +3,15 @@ using H5;
 
 namespace Tesserae
 {
-    public class NodeTextInput : INodeInput, INodeOutput
+    public class NodeInput<T> : INodeInput<T>
     {
         public string Name { get; }
         public string Title { get; }
-        public string DefaultValue { get; }
+        public T DefaultValue { get; }
         public bool AllowMultipleConnections { get; }
         public bool SetPort { get; }
 
-        public NodeTextInput(string name, string title, string defaultValue = "", bool allowMultipleConnections = false, bool setPort = true)
+        public NodeInput(string name, string title, T defaultValue = default, bool allowMultipleConnections = false, bool setPort = true)
         {
             Name = name;
             Title = title;
@@ -20,18 +20,44 @@ namespace Tesserae
             SetPort = setPort;
         }
 
-        public NodeView.NodeInterface Build() => NodeView.Interfaces.TextInputInterface(Title, DefaultValue, AllowMultipleConnections, SetPort);
+        public virtual NodeView.NodeInterface Build()
+        {
+            var type = typeof(T);
+
+            if (type == typeof(string))
+            {
+                return NodeView.Interfaces.TextInputInterface(Title, (string)(object)DefaultValue, AllowMultipleConnections, SetPort);
+            }
+            if (type == typeof(int))
+            {
+                return NodeView.Interfaces.IntegerInterface(Title, (int)(object)DefaultValue, AllowMultipleConnections, SetPort);
+            }
+            if (type == typeof(double))
+            {
+                return NodeView.Interfaces.NumberInterface(Title, (double)(object)DefaultValue, AllowMultipleConnections, SetPort);
+            }
+            if (type == typeof(bool))
+            {
+                return NodeView.Interfaces.CheckboxInterface(Title, (bool)(object)DefaultValue, AllowMultipleConnections, SetPort);
+            }
+            if (type == typeof(Action))
+            {
+                return NodeView.Interfaces.ButtonInterface(Title, (Action)(object)DefaultValue, AllowMultipleConnections, SetPort);
+            }
+
+            throw new ArgumentException($"Type {type.Name} is not supported for generic NodeInput without a specialized class.");
+        }
     }
 
-    public class NodeText : INodeInput, INodeOutput
+    public class NodeOutput<T> : INodeOutput<T>
     {
         public string Name { get; }
         public string Title { get; }
-        public string DefaultValue { get; }
+        public T DefaultValue { get; }
         public bool AllowMultipleConnections { get; }
         public bool SetPort { get; }
 
-        public NodeText(string name, string title, string defaultValue = "", bool allowMultipleConnections = false, bool setPort = true)
+        public NodeOutput(string name, string title, T defaultValue = default, bool allowMultipleConnections = false, bool setPort = true)
         {
             Name = name;
             Title = title;
@@ -40,132 +66,66 @@ namespace Tesserae
             SetPort = setPort;
         }
 
-        public NodeView.NodeInterface Build() => NodeView.Interfaces.TextInterface(Title, DefaultValue, AllowMultipleConnections, SetPort);
-    }
-
-    public class NodeInteger : INodeInput, INodeOutput
-    {
-        public string Name { get; }
-        public string Title { get; }
-        public int DefaultValue { get; }
-        public bool AllowMultipleConnections { get; }
-        public bool SetPort { get; }
-
-        public NodeInteger(string name, string title, int defaultValue = 0, bool allowMultipleConnections = false, bool setPort = true)
+        public virtual NodeView.NodeInterface Build()
         {
-            Name = name;
-            Title = title;
-            DefaultValue = defaultValue;
-            AllowMultipleConnections = allowMultipleConnections;
-            SetPort = setPort;
-        }
+            var type = typeof(T);
 
-        public NodeView.NodeInterface Build() => NodeView.Interfaces.IntegerInterface(Title, DefaultValue, AllowMultipleConnections, SetPort);
+            if (type == typeof(string))
+            {
+                return NodeView.Interfaces.TextInterface(Title, (string)(object)DefaultValue, AllowMultipleConnections, SetPort);
+            }
+            if (type == typeof(int))
+            {
+                return NodeView.Interfaces.IntegerInterface(Title, (int)(object)DefaultValue, AllowMultipleConnections, SetPort);
+            }
+            if (type == typeof(double))
+            {
+                return NodeView.Interfaces.NumberInterface(Title, (double)(object)DefaultValue, AllowMultipleConnections, SetPort);
+            }
+            if (type == typeof(bool))
+            {
+                return NodeView.Interfaces.CheckboxInterface(Title, (bool)(object)DefaultValue, AllowMultipleConnections, SetPort);
+            }
+            if (type == typeof(Action))
+            {
+                return NodeView.Interfaces.ButtonInterface(Title, (Action)(object)DefaultValue, AllowMultipleConnections, SetPort);
+            }
+
+            throw new ArgumentException($"Type {type.Name} is not supported for generic NodeOutput without a specialized class.");
+        }
     }
 
-    public class NodeNumber : INodeInput, INodeOutput
+    public class NodeSelectInput : NodeInput<string>
     {
-        public string Name { get; }
-        public string Title { get; }
-        public double DefaultValue { get; }
-        public bool AllowMultipleConnections { get; }
-        public bool SetPort { get; }
-
-        public NodeNumber(string name, string title, double defaultValue = 0, bool allowMultipleConnections = false, bool setPort = true)
-        {
-            Name = name;
-            Title = title;
-            DefaultValue = defaultValue;
-            AllowMultipleConnections = allowMultipleConnections;
-            SetPort = setPort;
-        }
-
-        public NodeView.NodeInterface Build() => NodeView.Interfaces.NumberInterface(Title, DefaultValue, AllowMultipleConnections, SetPort);
-    }
-
-    public class NodeButton : INodeInput, INodeOutput
-    {
-        public string Name { get; }
-        public string Title { get; }
-        public Action OnClick { get; }
-        public bool AllowMultipleConnections { get; }
-        public bool SetPort { get; }
-
-        public NodeButton(string name, string title, Action onClick, bool allowMultipleConnections = false, bool setPort = true)
-        {
-            Name = name;
-            Title = title;
-            OnClick = onClick;
-            AllowMultipleConnections = allowMultipleConnections;
-            SetPort = setPort;
-        }
-
-        public NodeView.NodeInterface Build() => NodeView.Interfaces.ButtonInterface(Title, OnClick, AllowMultipleConnections, SetPort);
-    }
-
-    public class NodeCheckbox : INodeInput, INodeOutput
-    {
-        public string Name { get; }
-        public string Title { get; }
-        public bool DefaultValue { get; }
-        public bool AllowMultipleConnections { get; }
-        public bool SetPort { get; }
-
-        public NodeCheckbox(string name, string title, bool defaultValue = false, bool allowMultipleConnections = false, bool setPort = true)
-        {
-            Name = name;
-            Title = title;
-            DefaultValue = defaultValue;
-            AllowMultipleConnections = allowMultipleConnections;
-            SetPort = setPort;
-        }
-
-        public NodeView.NodeInterface Build() => NodeView.Interfaces.CheckboxInterface(Title, DefaultValue, AllowMultipleConnections, SetPort);
-    }
-
-    public class NodeSelect : INodeInput, INodeOutput
-    {
-        public string Name { get; }
-        public string Title { get; }
-        public string DefaultValue { get; }
         public ReadOnlyArray<string> Values { get; }
-        public bool AllowMultipleConnections { get; }
-        public bool SetPort { get; }
 
-        public NodeSelect(string name, string title, string defaultValue, ReadOnlyArray<string> values, bool allowMultipleConnections = false, bool setPort = true)
+        public NodeSelectInput(string name, string title, string defaultValue, ReadOnlyArray<string> values, bool allowMultipleConnections = false, bool setPort = true)
+            : base(name, title, defaultValue, allowMultipleConnections, setPort)
         {
-            Name = name;
-            Title = title;
-            DefaultValue = defaultValue;
             Values = values;
-            AllowMultipleConnections = allowMultipleConnections;
-            SetPort = setPort;
         }
 
-        public NodeView.NodeInterface Build() => NodeView.Interfaces.SelectInterface(Title, DefaultValue, Values, AllowMultipleConnections, SetPort);
+        public override NodeView.NodeInterface Build()
+        {
+            return NodeView.Interfaces.SelectInterface(Title, DefaultValue, Values, AllowMultipleConnections, SetPort);
+        }
     }
 
-    public class NodeSlider : INodeInput, INodeOutput
+    public class NodeSliderInput : NodeInput<double>
     {
-        public string Name { get; }
-        public string Title { get; }
-        public double DefaultValue { get; }
         public double Min { get; }
         public double Max { get; }
-        public bool AllowMultipleConnections { get; }
-        public bool SetPort { get; }
 
-        public NodeSlider(string name, string title, double defaultValue, double min, double max, bool allowMultipleConnections = false, bool setPort = true)
+        public NodeSliderInput(string name, string title, double defaultValue, double min, double max, bool allowMultipleConnections = false, bool setPort = true)
+            : base(name, title, defaultValue, allowMultipleConnections, setPort)
         {
-            Name = name;
-            Title = title;
-            DefaultValue = defaultValue;
             Min = min;
             Max = max;
-            AllowMultipleConnections = allowMultipleConnections;
-            SetPort = setPort;
         }
 
-        public NodeView.NodeInterface Build() => NodeView.Interfaces.SliderInterface(Title, DefaultValue, Min, Max, AllowMultipleConnections, SetPort);
+        public override NodeView.NodeInterface Build()
+        {
+            return NodeView.Interfaces.SliderInterface(Title, DefaultValue, Min, Max, AllowMultipleConnections, SetPort);
+        }
     }
 }

--- a/Tesserae/src/Components/NodeView/NodeView.cs
+++ b/Tesserae/src/Components/NodeView/NodeView.cs
@@ -68,13 +68,38 @@ namespace Tesserae
         public NodeView Register<T>() where T : INodeView, new()
         {
             var node = new T();
+
+            Action<InterfaceBuilder> buildNode = ib =>
+            {
+                if (node.Inputs != null)
+                {
+                    foreach (var input in node.Inputs)
+                    {
+                        ib.AddInput(input.Name, () => input.Build());
+                    }
+                }
+
+                if (node.Outputs != null)
+                {
+                    foreach (var output in node.Outputs)
+                    {
+                        ib.AddOutput(output.Name, () => output.Build());
+                    }
+                }
+            };
+
             if (node is IDynamicNodeView dynamicNode)
             {
-                return DefineDynamicNode(node.Name, node.BuildNode, dynamicNode.UpdateNode);
+                return DefineDynamicNode(node.Name, buildNode, (inputs, outputs, ib) =>
+                {
+                    dynamicNode.UpdateNode(inputs, outputs,
+                        i => ib.AddInput(i.Name, () => i.Build()),
+                        o => ib.AddOutput(o.Name, () => o.Build()));
+                });
             }
             else
             {
-                return DefineNode(node.Name, node.BuildNode);
+                return DefineNode(node.Name, buildNode);
             }
         }
 

--- a/Tesserae/src/Components/NodeView/NodeView.cs
+++ b/Tesserae/src/Components/NodeView/NodeView.cs
@@ -61,6 +61,24 @@ namespace Tesserae
         }
 
         /// <summary>
+        /// Registers a new node type (static or dynamic) based on the provided class type that implements INodeView.
+        /// </summary>
+        /// <typeparam name="T">The node type.</typeparam>
+        /// <returns>The current instance of the type.</returns>
+        public NodeView Register<T>() where T : INodeView, new()
+        {
+            var node = new T();
+            if (node is IDynamicNodeView dynamicNode)
+            {
+                return DefineDynamicNode(node.Name, node.BuildNode, dynamicNode.UpdateNode);
+            }
+            else
+            {
+                return DefineNode(node.Name, node.BuildNode);
+            }
+        }
+
+        /// <summary>
         /// Defines a new static node type.
         /// </summary>
         /// <param name="nodeTypeName">The name of the node type.</param>


### PR DESCRIPTION
Improves the developer experience of NodeView by adding a dependency injection style syntax for defining nodes. This approach uses class implementations of the new `INodeView` and `IDynamicNodeView` interfaces and a `Register<T>` generic method in `NodeView` to provide better encapsulation and type-safety compared to the traditional lambda-based `DefineNode` methods. The sample has been updated to reflect the new best practice.

---
*PR created automatically by Jules for task [6795570562754956196](https://jules.google.com/task/6795570562754956196) started by @theolivenbaum*