### PR TITLE
OmniBox: add IsGenerating/Stopped stop-send toggle; ChatArea: expose scroll/focus/blur events

### DIFF
--- a/Tesserae/src/Components/Chat.cs
+++ b/Tesserae/src/Components/Chat.cs
@@ -15,6 +15,10 @@ namespace Tesserae
         private bool _stopAutoScroll = false;
         private string _bubbleBackground = null;
 
+        public event ComponentEventHandler<ChatArea, Event> Scrolled;
+        public event ComponentEventHandler<ChatArea, Event> ReceivedFocus;
+        public event ComponentEventHandler<ChatArea, Event> LostFocus;
+
         public ChatArea()
         {
             _messages = new ObservableList<IComponentWithID>();
@@ -25,7 +29,7 @@ namespace Tesserae
 
             _innerElement = Div(_("tss-chatarea"), _stack.Render());
 
-            _innerElement.onscroll = (e) =>
+            _innerElement.addEventListener("scroll", (e) =>
             {
                 // If user scrolls up (meaning not at the bottom), stop auto-scrolling
                 var scrollHeight = _innerElement.scrollHeight;
@@ -41,7 +45,30 @@ namespace Tesserae
                 {
                     _stopAutoScroll = false;
                 }
-            };
+
+                Scrolled?.Invoke(this, e);
+            });
+
+            _innerElement.addEventListener("focusin", (e) => ReceivedFocus?.Invoke(this, e));
+            _innerElement.addEventListener("focusout", (e) => LostFocus?.Invoke(this, e));
+        }
+
+        public ChatArea OnScroll(ComponentEventHandler<ChatArea, Event> onScroll)
+        {
+            Scrolled += onScroll;
+            return this;
+        }
+
+        public ChatArea OnFocus(ComponentEventHandler<ChatArea, Event> onFocus)
+        {
+            ReceivedFocus += onFocus;
+            return this;
+        }
+
+        public ChatArea OnBlur(ComponentEventHandler<ChatArea, Event> onBlur)
+        {
+            LostFocus += onBlur;
+            return this;
         }
 
         public ChatArea Background(string color)

--- a/Tesserae/src/Components/OmniBox.cs
+++ b/Tesserae/src/Components/OmniBox.cs
@@ -17,6 +17,7 @@ namespace Tesserae
                 InitialMode = initialMode ?? (mode == Mode.SearchAndChat ? Mode.Search : mode);
                 IconSearch = UIcons.Search;
                 IconChat = UIcons.PaperPlane;
+                IconStop = UIcons.StopCircle;
                 IconModeToggleSearch = UIcons.Search;
                 IconModeToggleChat = UIcons.Beacon;
                 TooltipModeToggleSearch = "Search";
@@ -32,6 +33,7 @@ namespace Tesserae
 
             public UIcons IconSearch { get; set; }
             public UIcons IconChat { get; set; }
+            public UIcons IconStop { get; set; }
             public UIcons IconModeToggleSearch { get; set; }
             public UIcons IconModeToggleChat { get; set; }
             public string TooltipModeToggleSearch { get; set; }
@@ -78,11 +80,16 @@ namespace Tesserae
         private string _tokenTypeMap = string.Empty;
         private readonly IconToggle<Mode> _modeToggle;
         private readonly bool _tokenIgnoreCase;
+        private bool _isGenerating = false;
+        private readonly UIcons _iconChat;
+        private readonly UIcons _iconStop;
 
         public delegate void SearchEventHandler(OmniBox sender, SearchQuery query);
         public delegate void ChatEventHandler(OmniBox sender, ChatMessage query);
+        public delegate void StopEventHandler(OmniBox sender);
         protected event SearchEventHandler Searched;
         protected event ChatEventHandler Chatted;
+        public event StopEventHandler Stopped;
 
         public event ComponentEventHandler<OmniBox, Event> Input;
         public event ComponentEventHandler<OmniBox, KeyboardEvent> KeyDown;
@@ -95,6 +102,8 @@ namespace Tesserae
         {
             _mode = config.Mode;
             _tokenIgnoreCase = config.TokenIgnoreCase;
+            _iconChat = config.IconChat;
+            _iconStop = config.IconStop;
 
             _activeMode = new SettableObservable<Mode>(config.InitialMode);
 
@@ -760,9 +769,19 @@ namespace Tesserae
 
         private void TriggerChat()
         {
+            if (_isGenerating)
+            {
+                TriggerStop();
+                return;
+            }
             var val = _chatInput.value;
             Chatted?.Invoke(this, new ChatMessage() { Text = val });
             _chatInput.value = "";
+        }
+
+        private void TriggerStop()
+        {
+            Stopped?.Invoke(this);
         }
 
         public OmniBox OnSearch(SearchEventHandler onSearch)
@@ -787,6 +806,41 @@ namespace Tesserae
         {
             Chatted += (s, q) => onChat(s, q.Text);
             return this;
+        }
+
+        public OmniBox OnStop(StopEventHandler onStop)
+        {
+            Stopped += onStop;
+            return this;
+        }
+
+        public OmniBox OnStop(Action<OmniBox> onStop)
+        {
+            Stopped += (s) => onStop(s);
+            return this;
+        }
+
+        public bool IsGenerating
+        {
+            get => _isGenerating;
+            set
+            {
+                if (_isGenerating == value) return;
+                _isGenerating = value;
+                if (_chatTriggerBtn != null)
+                {
+                    if (value)
+                    {
+                        _chatTriggerBtn.SetIcon(_iconStop);
+                        _container.classList.add("tss-omnibox-generating");
+                    }
+                    else
+                    {
+                        _chatTriggerBtn.SetIcon(_iconChat);
+                        _container.classList.remove("tss-omnibox-generating");
+                    }
+                }
+            }
         }
 
         public OmniBox OnInput(ComponentEventHandler<OmniBox, Event> onInput)


### PR DESCRIPTION
- OmniBox.Config gains IconStop (default UIcons.StopCircle)
- OmniBox.IsGenerating property: swaps chat-trigger button icon between send and stop, adds tss-omnibox-generating CSS class
- OmniBox.Stopped event + StopEventHandler delegate; TriggerChat() routes to TriggerStop() while generating so Enter and the button both fire Stopped instead of Chatted
- OmniBox.OnStop() fluent overloads
- ChatArea.Scrolled / ReceivedFocus / LostFocus events wired via addEventListener (scroll logic migrated from onscroll assignment)
- ChatArea.OnScroll() / OnFocus() / OnBlur() fluent helpers

https://claude.ai/code/session_01UGgLduryEdF82Df5aRgzF6