### PR TITLE
Add Toggle extension method for SettableObservable<bool> and refactor

### DIFF
--- a/Tesserae/src/Components/Sidebar/Sidebar.cs
+++ b/Tesserae/src/Components/Sidebar/Sidebar.cs
@@ -172,7 +172,7 @@ namespace Tesserae
 
             if (_isNavbar)
             {
-                var hamburger = Button().Class("tss-navbar-burger").SetIcon(UIcons.MenuBurger).OnClick(() => _closed.Value = !_closed.Value);
+                var hamburger = Button().Class("tss-navbar-burger").SetIcon(UIcons.MenuBurger).OnClick(() => _closed.Toggle());
 
                 var drawer = VStack().Class("tss-navbar-drawer")
                    .Children(
@@ -233,7 +233,7 @@ namespace Tesserae
         /// <returns>The current instance of the type.</returns>
         public Sidebar Toggle()
         {
-            _closed.Value = !_closed.Value;
+            _closed.Toggle();
             return this;
         }
 

--- a/Tesserae/src/Components/Sidebar/SidebarNav.cs
+++ b/Tesserae/src/Components/Sidebar/SidebarNav.cs
@@ -141,7 +141,7 @@ namespace Tesserae
 
             _arrow.OnClick(() =>
             {
-                _collapsed.Value = !_collapsed.Value;
+                _collapsed.Toggle();
             });
         }
 
@@ -213,7 +213,7 @@ namespace Tesserae
         /// <returns>The current instance of the type.</returns>
         public SidebarNav Toggle()
         {
-            _collapsed.Value = !_collapsed.Value;
+            _collapsed.Toggle();
             return this;
         }
 

--- a/Tesserae/src/Helpers/SettableObservable.cs
+++ b/Tesserae/src/Helpers/SettableObservable.cs
@@ -16,5 +16,14 @@ namespace Tesserae
         /// <param name="comparer">An optional equality comparer.</param>
         /// <returns>A new SettableObservable instance.</returns>
         public static SettableObservable<T> For<T>(T value, IEqualityComparer<T> comparer = null) => new SettableObservable<T>(value, comparer);
+
+        /// <summary>
+        /// Toggles the boolean value of the SettableObservable.
+        /// </summary>
+        /// <param name="observable">The observable boolean.</param>
+        public static void Toggle(this SettableObservable<bool> observable)
+        {
+            observable.Value = !observable.Value;
+        }
     }
 }


### PR DESCRIPTION
This adds an extension method `Toggle` to `SettableObservable<bool>` which simply inverts its inner `Value`. It also refactors `Sidebar.cs` and `SidebarNav.cs` to use this new extension.

---
*PR created automatically by Jules for task [15516146699523650281](https://jules.google.com/task/15516146699523650281) started by @theolivenbaum*