### PR TITLE
feat(omnibox): add inline filter chips and right-aligned text support

### DIFF
--- a/Tesserae.Tests/playwright/omnibox.spec.py
+++ b/Tesserae.Tests/playwright/omnibox.spec.py
@@ -1,0 +1,57 @@
+import re
+import time
+from playwright.sync_api import Playwright, sync_playwright, expect
+
+def test_omnibox_inline_chips_and_right_text(playwright: Playwright) -> None:
+    browser = playwright.chromium.launch(headless=True)
+    context = browser.new_context()
+    page = context.new_page()
+
+    # Navigating via correct Hash Routing
+    page.goto("http://localhost:8080/#/view/Omni%20Box")
+
+    # Wait for rendering to complete
+    page.wait_for_timeout(2000)
+
+    # Locate the right text element
+    right_text = page.locator(".tss-omnibox-right-text").first
+    expect(right_text).to_be_visible()
+    expect(right_text).to_have_text("124 results")
+
+    # Locate the inline chips container
+    chips_container = page.locator(".tss-omnibox-inline-chips").first
+    expect(chips_container).to_be_visible()
+
+    # We added two chips in the sample
+    chips = page.locator(".tss-omnibox-inline-chips").first.locator(".tss-omnibox-inline-chip")
+    expect(chips).to_have_count(2)
+
+    expect(chips.nth(0)).to_contain_text("Tag: Red")
+    expect(chips.nth(1)).to_contain_text("Author: Jules")
+
+    # Click in the input to focus it
+    input_box = page.locator(".tss-omnibox-search-input").first
+    input_box.click()
+
+    # Move cursor to start of text
+    for i in range(50): # Ensure we're at index 0 (Left Arrow)
+        page.keyboard.press("ArrowLeft")
+
+    # Now we're at selectionStart=0, selectionEnd=0
+    # Press Backspace. The last chip (Author: Jules) should be removed
+    page.keyboard.press("Backspace")
+
+    # Expect only 1 chip remaining
+    expect(chips).to_have_count(1)
+    expect(chips.nth(0)).to_contain_text("Tag: Red")
+
+    # Press Backspace again. The remaining chip should be removed.
+    page.keyboard.press("Backspace")
+    expect(chips).to_have_count(0)
+
+    context.close()
+    browser.close()
+
+if __name__ == "__main__":
+    with sync_playwright() as p:
+        test_omnibox_inline_chips_and_right_text(p)

--- a/Tesserae.Tests/src/Samples/Components/OmniBoxSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/OmniBoxSample.cs
@@ -35,6 +35,10 @@ namespace Tesserae.Tests.Samples
             })
             .SetSearchText("potato AND ( tomato OR banana) AND NOT apple");
 
+            searchModeSample.InlineFilterChips.Add(new OmniBox.InlineFilterChip("Tag: Red", "var(--tss-danger-background-color)", "var(--tss-danger-foreground-color)"));
+            searchModeSample.InlineFilterChips.Add(new OmniBox.InlineFilterChip("Author: Jules"));
+            searchModeSample.SetSearchRightText("124 results");
+
             var chatModeSample = OmniBox(new OmniBox.Config(OmniBox.Mode.Chat)
             {
                 PlaceholderChat  =    "Ask me anything",
@@ -70,8 +74,6 @@ namespace Tesserae.Tests.Samples
             .WithHistory(async () => {
                 return new OmniBox.SearchQuery[0];
             });
-
-
 
             var toggle = Toggle("Disabled").OnChange((s, e) =>
             {

--- a/Tesserae/h5/assets/css/tss.omnibox.css
+++ b/Tesserae/h5/assets/css/tss.omnibox.css
@@ -269,3 +269,50 @@
 .tss-omnibox-container:not(.tss-omnibox-expanded).tss-omnibox-mode-chat .tss-omnibox-search-container {
     transition: min-height 0.15s ease-in-out;
 }
+.tss-omnibox-inline-chips {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    margin-left: 8px;
+    gap: 4px;
+}
+
+.tss-omnibox-inline-chip {
+    display: inline-flex;
+    align-items: center;
+    background-color: var(--tss-secondary-background-color);
+    color: var(--tss-secondary-foreground-color);
+    border-radius: var(--tss-border-radius-md);
+    padding: 2px 4px 2px 8px;
+    font-size: 12px;
+    height: 24px;
+    white-space: nowrap;
+}
+
+.tss-omnibox-inline-chip-close {
+    cursor: pointer;
+    margin-left: 4px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    width: 16px;
+    height: 16px;
+    transition: background-color 0.2s;
+}
+.tss-omnibox-inline-chip-close:hover {
+    background-color: var(--tss-danger-background-color);
+    color: var(--tss-danger-foreground-color);
+}
+.tss-omnibox-inline-chip-close i {
+    font-size: 10px;
+}
+
+.tss-omnibox-right-text {
+    display: flex;
+    align-items: center;
+    margin-right: 8px;
+    color: var(--tss-secondary-foreground-color);
+    font-size: 12px;
+    white-space: nowrap;
+}

--- a/Tesserae/h5/assets/css/tss.omnibox.css
+++ b/Tesserae/h5/assets/css/tss.omnibox.css
@@ -275,6 +275,8 @@
     align-items: center;
     margin-left: 8px;
     gap: 4px;
+    background: var(--tss-secondary-background-color);
+    border-right: 1px solid var(--tss-default-border-color);
 }
 
 .tss-omnibox-inline-chip {
@@ -300,6 +302,7 @@
     height: 16px;
     transition: background-color 0.2s;
 }
+
 .tss-omnibox-inline-chip-close:hover {
     background-color: var(--tss-danger-background-color);
     color: var(--tss-danger-foreground-color);

--- a/Tesserae/h5/assets/css/tss.omnibox.css
+++ b/Tesserae/h5/assets/css/tss.omnibox.css
@@ -86,6 +86,7 @@
     align-items: stretch;
     width: 100%;
     height: 36px;
+    border-radius: var(--tss-border-radius-md);
 }
 
 .tss-omnibox-chat-container,
@@ -119,6 +120,7 @@
     display: flex;
     overflow: hidden;
     cursor: text;
+
 }
 
 .tss-omnibox-search-input {
@@ -275,11 +277,14 @@
     align-items: center;
     padding-left: 4px;
     padding-right: 4px;
-    margin-right: 4px;
     gap: 4px;
     background: var(--tss-secondary-background-color);
     border-right: 1px solid var(--tss-default-border-color);
 }
+
+    .tss-omnibox-inline-chips:empty {
+        display: none;
+    }
 
 .tss-omnibox-inline-chip {
     display: inline-flex;

--- a/Tesserae/h5/assets/css/tss.omnibox.css
+++ b/Tesserae/h5/assets/css/tss.omnibox.css
@@ -273,7 +273,9 @@
     display: flex;
     flex-direction: row;
     align-items: center;
-    margin-left: 8px;
+    padding-left: 4px;
+    padding-right: 4px;
+    margin-right: 4px;
     gap: 4px;
     background: var(--tss-secondary-background-color);
     border-right: 1px solid var(--tss-default-border-color);

--- a/Tesserae/src/Components/OmniBox.cs
+++ b/Tesserae/src/Components/OmniBox.cs
@@ -9,6 +9,21 @@ namespace Tesserae
     [H5.Name("tss.OmniBox")]
     public class OmniBox : IComponent, IHasBackgroundColor, ITabIndex
     {
+
+        public class InlineFilterChip
+        {
+            public string Name { get; set; }
+            public string Color { get; set; }
+            public string Background { get; set; }
+
+            public InlineFilterChip(string name, string background = null, string color = null)
+            {
+                Name = name;
+                Background = background;
+                Color = color;
+            }
+        }
+
         public class Config
         {
             public Config(Mode mode, Mode? initialMode = null)
@@ -66,6 +81,11 @@ namespace Tesserae
         private readonly HTMLDivElement   _container;
         private readonly HTMLDivElement   _searchContainer;
         private readonly HTMLInputElement _searchInput;
+
+        public ObservableList<InlineFilterChip> InlineFilterChips { get; }
+        private readonly HTMLDivElement _searchInlineChipsContainer;
+        private readonly HTMLDivElement _searchRightTextContainer;
+
         private readonly HTMLDivElement   _searchTokensContainer;
         private readonly HTMLDivElement   _searchInputContainer;
         private readonly Button      _searchHistoryBtn;
@@ -122,6 +142,14 @@ namespace Tesserae
 
             if (_mode == Mode.Search || _mode == Mode.SearchAndChat)
             {
+
+                InlineFilterChips = new ObservableList<InlineFilterChip>();
+                _searchInlineChipsContainer = Div(_("tss-omnibox-inline-chips"));
+                _searchRightTextContainer = Div(_("tss-omnibox-right-text"));
+                _searchRightTextContainer.style.display = "none";
+
+                InlineFilterChips.Observe(RenderInlineChips);
+
                 _searchInput = TextBox(_("tss-omnibox-search-input", type: "text", placeholder: config.PlaceholderSearch ?? ""));
                 _searchInput.autocomplete = "off";
                 _searchInput.spellcheck = false;
@@ -137,11 +165,11 @@ namespace Tesserae
 
                 if (_mode == Mode.Search)
                 {
-                    _searchContainer = Div(_("tss-omnibox-search-container"), _searchHistoryBtn.Render(), _searchInputContainer, _searchClearBtn.Render(), _searchTriggerBtn.Render());
+                    _searchContainer = Div(_("tss-omnibox-search-container"), _searchHistoryBtn.Render(), _searchInlineChipsContainer, _searchInputContainer, _searchRightTextContainer, _searchClearBtn.Render(), _searchTriggerBtn.Render());
                 }
                 else
                 {
-                    _searchContainer = Div(_("tss-omnibox-search-container"), _searchInputContainer);
+                    _searchContainer = Div(_("tss-omnibox-search-container"), _searchInlineChipsContainer, _searchInputContainer, _searchRightTextContainer);
                     _footer.appendChild(_searchHistoryBtn.Render());
                     footerEnd.Add(_searchClearBtn);
                     footerEnd.Add(_searchTriggerBtn);
@@ -161,9 +189,20 @@ namespace Tesserae
                     {
                         TriggerSearch();
                     }
+
                     else if (ke.key == "Backspace")
                     {
                         var cursorPos = _searchInput.selectionStart;
+                        if (cursorPos == 0 && _searchInput.selectionEnd == 0)
+                        {
+                            if (InlineFilterChips.Count > 0)
+                            {
+                                InlineFilterChips.RemoveAt(InlineFilterChips.Count - 1);
+                                e.preventDefault();
+                                return;
+                            }
+                        }
+
                         if (cursorPos > 0 && cursorPos == _searchInput.selectionEnd)
                         {
                             // Check if the character to be deleted is a non-breaking space
@@ -973,6 +1012,48 @@ namespace Tesserae
         public HTMLElement Render()
         {
             return _container;
+        }
+
+
+        public OmniBox SetSearchRightText(string text)
+        {
+            if (string.IsNullOrEmpty(text))
+            {
+                _searchRightTextContainer.textContent = "";
+                _searchRightTextContainer.style.display = "none";
+            }
+            else
+            {
+                _searchRightTextContainer.textContent = text;
+                _searchRightTextContainer.style.display = "flex";
+            }
+            return this;
+        }
+
+        private void RenderInlineChips(IReadOnlyList<InlineFilterChip> chips)
+        {
+            ClearChildren(_searchInlineChipsContainer);
+            foreach (var chip in chips)
+            {
+                var chipEl = Div(_("tss-omnibox-inline-chip"));
+                if (!string.IsNullOrEmpty(chip.Background)) chipEl.style.background = chip.Background;
+                if (!string.IsNullOrEmpty(chip.Color)) chipEl.style.color = chip.Color;
+
+                var textEl = Span(_(text: chip.Name));
+
+                var closeBtn = Div(_("tss-omnibox-inline-chip-close"));
+                closeBtn.appendChild(UI.Icon(UIcons.Cross).Render());
+
+                closeBtn.onclick = (e) =>
+                {
+                    InlineFilterChips.Remove(chip);
+                    e.stopPropagation();
+                };
+
+                chipEl.appendChild(textEl);
+                chipEl.appendChild(closeBtn);
+                _searchInlineChipsContainer.appendChild(chipEl);
+            }
         }
 
         public OmniBox SetSearchText(string text)


### PR DESCRIPTION
This commit introduces two new UI enhancements to the `OmniBox` component specifically designed for its search functionalities:
1. **Inline Filter Chips**: Users can now add filter chips directly to the left of the search caret. These chips can be seamlessly removed via the UI 'X' button or using a natural Backspace flow when the text cursor is empty and positioned at index `0`.
2. **Right-Side Result Text**: Developers can now optionally render a text summary on the right side of the box (e.g. "124 results") which scales elegantly.

Tested locally and validated with a Playwright e2e test scenario.

---
*PR created automatically by Jules for task [3730531740299416971](https://jules.google.com/task/3730531740299416971) started by @theolivenbaum*