### PR TITLE
feat(omnibox): support IComponent in InlineFilterChip

### DIFF
--- a/Tesserae.Tests/src/Samples/Components/OmniBoxSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/OmniBoxSample.cs
@@ -55,6 +55,7 @@ namespace Tesserae.Tests.Samples
 
             searchModeSample.InlineFilterChips.Add(new OmniBox.InlineFilterChip("Tag: Red", "var(--tss-danger-background-color)", "var(--tss-danger-foreground-color)"));
             searchModeSample.InlineFilterChips.Add(new OmniBox.InlineFilterChip("Author: Jules", onClick:(_)=> Toast().Success("hi!")));
+            searchModeSample.InlineFilterChips.Add(new OmniBox.InlineFilterChip(Button("IComponent")));
             searchModeSample.SetSearchRightText("124 results");
 
             attBtnForSearch.OnClick((s, e) => fileDropAreaOnSearch.OpenFileSelection());

--- a/Tesserae/src/Components/OmniBox.cs
+++ b/Tesserae/src/Components/OmniBox.cs
@@ -13,16 +13,23 @@ namespace Tesserae
 
         public class InlineFilterChip
         {
-            public string Name { get; }
-            public string Color { get; }
-            public string Background { get; }
-            public Action<MouseEvent> OnClick { get; }
+            internal string Name { get; }
+            internal string Color { get; }
+            internal string Background { get; }
+            internal Action<MouseEvent> OnClick { get; }
+            internal IComponent Content { get; }
 
             public InlineFilterChip(string name, string background = null, string color = null, Action<MouseEvent> onClick = null)
             {
                 Name = name;
                 Background = background;
                 Color = color;
+                OnClick = onClick;
+            }
+
+            public InlineFilterChip(IComponent content, Action<MouseEvent> onClick = null)
+            {
+                Content = content;
                 OnClick = onClick;
             }
         }
@@ -1094,7 +1101,15 @@ namespace Tesserae
                 if (!string.IsNullOrEmpty(chip.Background)) chipEl.style.background = chip.Background;
                 if (!string.IsNullOrEmpty(chip.Color)) chipEl.style.color = chip.Color;
 
-                var textEl = Span(_(text: chip.Name));
+                HTMLElement contentEl;
+                if (chip.Content is object)
+                {
+                    contentEl = chip.Content.Render();
+                }
+                else
+                {
+                    contentEl = Span(_(text: chip.Name));
+                }
 
                 var closeBtn = Div(_("tss-omnibox-inline-chip-close"));
                 closeBtn.appendChild(UI.Icon(UIcons.Cross).Render());
@@ -1115,7 +1130,7 @@ namespace Tesserae
                     chipEl.style.cursor = "pointer";
                 }
 
-                chipEl.appendChild(textEl);
+                chipEl.appendChild(contentEl);
                 chipEl.appendChild(closeBtn);
                 _searchInlineChipsContainer.appendChild(chipEl);
             }


### PR DESCRIPTION
This commit updates the `InlineFilterChip` implementation inside `OmniBox` to accept an `IComponent` instance as an alternative to simple text. It also scopes its properties as `internal` to prevent direct external mutation.

Tested via `dotnet build`.

---
*PR created automatically by Jules for task [4364001775934569921](https://jules.google.com/task/4364001775934569921) started by @theolivenbaum*