### PR TITLE
Fix Timeline component styling

### DIFF
--- a/Tesserae.Tests/src/Samples/Collections/TimelineSample.cs
+++ b/Tesserae.Tests/src/Samples/Collections/TimelineSample.cs
@@ -27,23 +27,51 @@ namespace Tesserae.Tests.Samples
                .FlatSection(Stack().Children(
                     Card(VStack().WS().Children(
                     SampleSubTitle("Default Staggered Timeline"),
-                    Timeline().Children(GetSomeItems(6)).Height(300.px()).MB(32),
+                    BuildTimeline(Timeline()).Height(400.px()).MB(32),
                     SampleSubTitle("Same Side Alignment"),
-                    Timeline().SameSide().Children(GetSomeItems(6)).Height(300.px()).MB(32),
+                    BuildTimeline(Timeline().SameSide()).Height(400.px()).MB(32),
                     SampleSubTitle("Constrained Width"),
-                    Timeline().TimelineWidth(400.px()).Children(GetSomeItems(6)).Height(300.px())
+                    BuildTimeline(Timeline().TimelineWidth(400.px())).Height(400.px())
                 )).SetTitle("Usage")));
         }
 
         public HTMLElement Render() => _content.Render();
 
-        private IComponent[] GetSomeItems(int count)
+        private Timeline BuildTimeline(Timeline timeline)
         {
-            return Enumerable.Range(1, count).Select(n =>
-                VStack().Children(
-                    TextBlock($"Event {n}").SemiBold(),
-                    TextBlock($"{DateTime.Today.AddHours(-n):t} - Description of the event happens here.").Small()
-                )).ToArray();
+            timeline.Add(VStack().Children(
+                HStack().WS().JustifyContent(ItemJustify.Between).Children(
+                    TextBlock("Build #4182 succeeded").SemiBold(),
+                    TextBlock("2m ago").Small().Foreground(Theme.Secondary.Foreground)
+                ),
+                TextBlock("All 47 tests passing on master.").Small().Foreground(Theme.Secondary.Foreground).PT(8)
+            ), Theme.Success.Background);
+
+            timeline.Add(VStack().Children(
+                HStack().WS().JustifyContent(ItemJustify.Between).Children(
+                    TextBlock("Anna pushed to master").SemiBold(),
+                    TextBlock("14m ago").Small().Foreground(Theme.Secondary.Foreground)
+                ),
+                TextBlock("Merge #312: Add ProgressRing component (3 files changed).").Small().Foreground(Theme.Secondary.Foreground).PT(8)
+            ), Theme.Primary.Background);
+
+            timeline.Add(VStack().Children(
+                HStack().WS().JustifyContent(ItemJustify.Between).Children(
+                    TextBlock("Build #4181 failed").SemiBold(),
+                    TextBlock("1h ago").Small().Foreground(Theme.Secondary.Foreground)
+                ),
+                TextBlock("2 of 47 tests failed in Tesserae.Tests/Buttons.").Small().Foreground(Theme.Secondary.Foreground).PT(8)
+            ), Theme.Danger.Background);
+
+            timeline.Add(VStack().Children(
+                HStack().WS().JustifyContent(ItemJustify.Between).Children(
+                    TextBlock("Index rebuilt").SemiBold(),
+                    TextBlock("yesterday").Small().Foreground(Theme.Secondary.Foreground)
+                ),
+                TextBlock("4,182 documents reindexed from curiosity-prod.").Small().Foreground(Theme.Secondary.Foreground).PT(8)
+            ), Theme.Default.DarkBorder);
+
+            return timeline;
         }
     }
 }

--- a/Tesserae/h5/assets/css/tss.timeline.css
+++ b/Tesserae/h5/assets/css/tss.timeline.css
@@ -1,7 +1,7 @@
-﻿/* Timeline */
+/* Timeline */
 
 .tss-timeline-owner {
-    background: var(--tss-secondary-background-color) linear-gradient(var(--tss-default-background-color), var(--tss-default-background-color)) no-repeat center/4px 100%;
+    background: transparent linear-gradient(var(--tss-default-border-color), var(--tss-default-border-color)) no-repeat center/2px 100%;
     overflow-y: auto;
     overflow-x: hidden;
     height: 100%;
@@ -19,7 +19,7 @@
 /* Container around content */
 .tss-timeline-container {
     padding: 10px 40px;
-    min-height:60px;
+    min-height: 60px;
     position: relative;
     width: 50%;
 }
@@ -30,13 +30,13 @@
         position: absolute;
         width: 16px;
         height: 16px;
-        right: -13px;
+        box-sizing: border-box;
+        right: -8px;
         background-color: var(--tss-default-background-color);
-        border: 3px solid var(--tss-default-background-color);
-        top: 22px;
+        border: 2px solid var(--tss-timeline-circle-color, var(--tss-default-border-color));
+        top: 24px;
         border-radius: 50%;
         z-index: 2;
-        box-shadow: var(--tss-box-shadow);
     }
 
     /* Place the container to the left */
@@ -49,65 +49,27 @@
         left: 50%;
     }
 
-    /* Add arrows to the left container (pointing right) */
-    .tss-timeline-container.tss-left::before {
-        content: "";
-        position: absolute;
-        width: 0;
-        height: 0;
-        top: 38px;
-        right: 29px;
-        box-sizing: border-box;
-        z-index: 1;
-        border: 6px solid black;
-        border-color: transparent transparent var(--tss-default-background-color) var(--tss-default-background-color);
-        transform-origin: 0 0;
-        transform: rotate(225deg);
-        box-shadow: -1px 0.6px 2px 0 var(--tss-shadow-color-to);
-    }
-
-    /* Add arrows to the right container (pointing left) */
-    .tss-timeline-container.tss-right::before {
-        content: "";
-        position: absolute;
-        width: 0;
-        height: 0;
-        top: 21px;
-        left: 40px;
-        box-sizing: border-box;
-        z-index: 1;
-        border: 6px solid black;
-        border-color: transparent transparent var(--tss-default-background-color) var(--tss-default-background-color);
-        transform-origin: 0 0;
-        transform: rotate(45deg);
-        box-shadow: -1px 0.6px 2px 0 var(--tss-shadow-color-to);
-    }
-
     /* Fix the circle for containers on the right side */
     .tss-timeline-container.tss-right::after {
-        left: -3px;
+        left: -8px;
     }
 
     /* The actual content */
     .tss-timeline-container .tss-timeline-content {
-        padding: 20px 30px;
+        padding: 12px 16px;
         position: relative;
         background: var(--tss-default-background-color);
-        border-radius: 2px;
+        border-radius: 4px;
         background-clip: padding-box;
         -webkit-box-shadow: var(--tss-card-shadow);
         box-shadow: var(--tss-card-shadow);
+        border: 1px solid var(--tss-default-border-color);
         isolation: isolate;
     }
 
-/* Place the timelime to the left */
-.tss-timeline-owner.tss-left .tss-timeline::after {
-    left: 31px;
-}
-
 /* Full-width containers */
 .tss-timeline-owner.tss-left {
-    background: var(--tss-secondary-background-color) linear-gradient(var(--tss-default-background-color), var(--tss-default-background-color)) no-repeat 20px 0px/4px 100%;
+    background: transparent linear-gradient(var(--tss-default-border-color), var(--tss-default-border-color)) no-repeat 20px 0px/2px 100%;
 }
 
     .tss-timeline-owner.tss-left .tss-timeline {
@@ -116,33 +78,16 @@
 
     .tss-timeline-owner.tss-left > .tss-timeline > .tss-timeline-container {
         width: 100%;
-        padding-left: 70px;
-        padding-right: 25px;
+        padding-left: 48px;
+        padding-right: 20px;
     }
-
-    /* Make sure that all arrows are pointing leftwards */
-        .tss-timeline-owner.tss-left > .tss-timeline > .tss-timeline-container::before {
-            content: "";
-            position: absolute;
-            width: 0;
-            height: 0;
-            top: 21px;
-            left: 70px;
-            box-sizing: border-box;
-            z-index: 1;
-            border: 6px solid black;
-            border-color: transparent transparent var(--tss-default-background-color) var(--tss-default-background-color);
-            transform-origin: 0 0;
-            transform: rotate(45deg);
-            box-shadow: -1px 0.6px 2px 0 var(--tss-shadow-color-to);
-        }
 
         /* Make sure all circles are at the same spot */
         .tss-timeline-owner.tss-left > .tss-timeline > .tss-timeline-container.tss-left::after {
-            left: 15px;
+            left: 13px;
         }
         .tss-timeline-owner.tss-left > .tss-timeline > .tss-timeline-container.tss-right::after {
-            left: 15px;
+            left: 13px;
         }
 
         /* Make all right containers behave like the left ones */

--- a/Tesserae/src/Components/Timeline.cs
+++ b/Tesserae/src/Components/Timeline.cs
@@ -54,7 +54,18 @@ namespace Tesserae
         /// <param name="component">The component to add.</param>
         public void Add(IComponent component)
         {
-            _timeline.appendChild(Wrap(component));
+            _timeline.appendChild(Wrap(component, null));
+            Rebase(false);
+        }
+
+        /// <summary>
+        /// Adds a component to the timeline with a specified color.
+        /// </summary>
+        /// <param name="component">The component to add.</param>
+        /// <param name="color">The color of the timeline circle.</param>
+        public void Add(IComponent component, string color)
+        {
+            _timeline.appendChild(Wrap(component, color));
             Rebase(false);
         }
 
@@ -129,9 +140,14 @@ namespace Tesserae
             }
         }
 
-        private HTMLElement Wrap(IComponent component)
+        private HTMLElement Wrap(IComponent component, string color = null)
         {
-            return Div(_("tss-timeline-container"), Div(_("tss-timeline-content"), component.Render()));
+            var container = Div(_("tss-timeline-container"), Div(_("tss-timeline-content"), component.Render()));
+            if (!string.IsNullOrEmpty(color))
+            {
+                container.style.setProperty("--tss-timeline-circle-color", color);
+            }
+            return container;
         }
 
         /// <summary>


### PR DESCRIPTION
The Timeline component styles have been adjusted to match provided visual reference. Padding has been reduced, triangle arrows linking the nodes to their descriptions have been removed, the shadow usage has been simplified, and the line colors now respect the default themes seamlessly interacting with light and dark modes. I updated `TimelineSample.cs` to show these updates correctly with a mocked list using default theme variables.

---
*PR created automatically by Jules for task [17064459104823707698](https://jules.google.com/task/17064459104823707698) started by @theolivenbaum*