### PR TITLE
Fix dark-mode styles used by the OmniBox to highlight tokens

### DIFF
--- a/Tesserae.Tests/playwright/test_omnibox_tokens_dark_mode.py
+++ b/Tesserae.Tests/playwright/test_omnibox_tokens_dark_mode.py
@@ -1,0 +1,38 @@
+import pytest
+from playwright.sync_api import sync_playwright
+import time
+
+def test_omnibox_tokens_dark_mode():
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page()
+        page.goto('http://127.0.0.1:8080/#/view/Omni%20Box')
+
+        # Wait for rendering
+        page.wait_for_selector('.tss-omnibox-search-token-word')
+        time.sleep(1)
+
+        # Toggle dark mode on
+        page.evaluate('''() => {
+            document.body.classList.add('tss-dark-mode');
+        }''')
+        time.sleep(1)
+
+        # Take a screenshot to verify
+        page.screenshot(path="omnibox_darkmode.png")
+
+        # Verify word token background
+        word_bg_color = page.evaluate('''() => {
+            const token = document.querySelector('.tss-omnibox-search-token-word');
+            return window.getComputedStyle(token).backgroundColor;
+        }''')
+        # Check if it has the dark blue color (from var(--tss-colors-blue-900)) which might evaluate to its RGB
+        # Instead of checking explicit RGB, verify it's not the light blue rgb(219, 234, 254) which is --tss-colors-blue-100
+        # Light blue background in Chrome is often "rgb(219, 234, 254)" or similar, dark blue 900 is often "rgb(30, 58, 138)"
+        assert word_bg_color != 'rgb(219, 234, 254)'
+
+        browser.close()
+        print("Playwright test completed successfully.")
+
+if __name__ == "__main__":
+    test_omnibox_tokens_dark_mode()

--- a/Tesserae/h5/assets/css/tss.omnibox.css
+++ b/Tesserae/h5/assets/css/tss.omnibox.css
@@ -213,7 +213,19 @@
     color: var(--tss-colors-blue-500);
 }
 
+.tss-dark-mode .tss-omnibox-search-token-word {
+    color: var(--tss-colors-blue-100);
+    background: var(--tss-colors-blue-900);
+    outline-color: var(--tss-colors-blue-700);
+}
 
+.tss-dark-mode .tss-omnibox-search-token-operator-and,
+.tss-dark-mode .tss-omnibox-search-token-operator-or ,
+.tss-dark-mode .tss-omnibox-search-token-operator-not,
+.tss-dark-mode .tss-omnibox-search-token-paren,
+.tss-dark-mode .tss-omnibox-search-token-quote {
+    color: var(--tss-colors-blue-400);
+}
 
 .tss-omnibox-chat-input {
     width: 100%;


### PR DESCRIPTION
This adds proper `.tss-dark-mode` overrides within `tss.omnibox.css` to fix the overly bright light background of `SearchTokens` and logically colors operators, ensuring they are legible and adhere to dark mode aesthetics. A Playwright UI test was added to verify the visual state.

---
*PR created automatically by Jules for task [13453284280953651671](https://jules.google.com/task/13453284280953651671) started by @theolivenbaum*