### PR TITLE
Enhance Expander component with OptionIcon and ChevronRight

### DIFF
--- a/Tesserae.Tests/src/Samples/Components/AccordionSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/AccordionSample.cs
@@ -37,8 +37,15 @@ namespace Tesserae.Tests.Samples
                         Expander("Section 3", TextBlock("Just set .AllowMultipleOpen(true) on the accordion.")))
                        .AllowMultipleOpen(true),
                     SampleSubTitle("Standalone Expander"),
-                    Expander("What is Tesserae?", TextBlock("Tesserae provides a fluent API for building UI components."))
-                       .Expanded())).SetTitle("Usage")));
+                    Expander("What is Tesserae?", TextBlock("Tesserae provides a fluent API for building UI components.")).Expanded(),
+                    SampleSubTitle("Expander with OptionIcon and ChevronRight"),
+                    Accordion(
+                        Expander("What does indexing do?", TextBlock("Indexing reads each document, extracts structured text, and stores it in a vector + keyword index so queries match in milliseconds.\n\nSource files stay where they are — only metadata leaves your machine.")).OptionIcon(UIcons.Info, Theme.Colors.Blue600, Theme.Colors.Blue100).ChevronRight().Expanded(),
+                        Expander("Where are my files stored?", TextBlock("")).OptionIcon(UIcons.Check, Theme.Colors.Green600, Theme.Colors.Green100).ChevronRight(),
+                        Expander("Why did my last build fail?", TextBlock("")).OptionIcon(UIcons.Exclamation, Theme.Colors.Orange600, Theme.Colors.Orange100).ChevronRight(),
+                        Expander("How do I rotate the IMAP token?", TextBlock("")).OptionIcon(UIcons.TriangleWarning, Theme.Colors.Red600, Theme.Colors.Red100).ChevronRight(),
+                        Expander("Can I use a custom embedding model?", TextBlock("")).OptionIcon(UIcons.Settings, Theme.Colors.Blue600, Theme.Colors.Blue100).ChevronRight()
+                    ).AllowMultipleOpen(false))).SetTitle("Usage")));
         }
 
         public HTMLElement Render() => _content.Render();

--- a/Tesserae/h5/assets/css/tss.expander.css
+++ b/Tesserae/h5/assets/css/tss.expander.css
@@ -49,3 +49,14 @@
     border-top: 1px solid var(--tss-default-border-color);
     padding: 12px 14px;
 }
+
+.tss-expander-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    border-radius: 8px;
+    font-size: 16px;
+    flex-shrink: 0;
+}

--- a/Tesserae/src/Components/Expander.cs
+++ b/Tesserae/src/Components/Expander.cs
@@ -10,6 +10,7 @@ namespace Tesserae
         private readonly HTMLElement       _header;
         private readonly HTMLElement       _headerContent;
         private readonly HTMLSpanElement   _title;
+        private readonly HTMLElement       _iconContainer;
         private readonly HTMLElement       _chevron;
         private readonly HTMLElement       _content;
         private          bool              _isExpanded;
@@ -23,7 +24,9 @@ namespace Tesserae
             var contentId = "tss-expander-content-" + Guid.NewGuid().ToString("N").Substring(0, 8);
 
             _title         = Span(_("tss-expander-title", text: title ?? string.Empty));
-            _headerContent = Div(_("tss-expander-header-content"), _title);
+            _iconContainer = Div(_("tss-expander-icon"));
+            _iconContainer.style.display = "none";
+            _headerContent = Div(_("tss-expander-header-content"), _iconContainer, _title);
             _chevron       = I(UIcons.AngleDown, cssClass: "tss-expander-chevron");
             _header        = Div(_("tss-expander-header", role: "button", ariaLabel: "Toggle section"), _chevron, _headerContent);
             _header.setAttribute("aria-controls", contentId);
@@ -81,9 +84,10 @@ namespace Tesserae
         {
             _title.innerText = title ?? string.Empty;
 
-            if (!_customHeader && _headerContent.firstChild != _title)
+            if (!_customHeader && _headerContent.lastChild != _title)
             {
                 ClearChildren(_headerContent);
+                _headerContent.appendChild(_iconContainer);
                 _headerContent.appendChild(_title);
             }
 
@@ -97,6 +101,7 @@ namespace Tesserae
             if (header == null)
             {
                 _customHeader = false;
+                _headerContent.appendChild(_iconContainer);
                 _headerContent.appendChild(_title);
             }
             else
@@ -117,6 +122,28 @@ namespace Tesserae
                 _content.appendChild(content.Render());
             }
 
+            return this;
+        }
+
+        public Expander OptionIcon(UIcons icon, string color = "", string background = "")
+        {
+            ClearChildren(_iconContainer);
+            _iconContainer.style.display = "flex";
+            if (!string.IsNullOrEmpty(color))
+            {
+                _iconContainer.style.color = color;
+            }
+            if (!string.IsNullOrEmpty(background))
+            {
+                _iconContainer.style.background = background;
+            }
+            _iconContainer.appendChild(I(icon));
+            return this;
+        }
+
+        public Expander ChevronRight()
+        {
+            _header.appendChild(_chevron);
             return this;
         }
 

--- a/start_server.sh
+++ b/start_server.sh
@@ -1,3 +1,0 @@
-cd Tesserae.Tests/bin/Debug/netstandard2.0/h5/
-npx http-server -p 8080 > ../../../../../server_output.log 2>&1 &
-echo $! > ../../../../../server_pid.txt


### PR DESCRIPTION
This commit enhances the `Expander` component by allowing it to display a custom option icon with customizable foreground and background colors. It also adds a fluent method to move the expansion chevron to the right side of the header.

These changes were verified visually and all existing tests continue to pass. The `AccordionSample` was updated to show a list of expanders functioning like an interactive FAQ or status list, mimicking the design provided in the initial requirements.

---
*PR created automatically by Jules for task [16579335936686713494](https://jules.google.com/task/16579335936686713494) started by @theolivenbaum*