### PR TITLE
Use 100svh for body height to avoid mobile chrome overlap

### DIFF
--- a/Tesserae/h5/assets/css/tss.body.css
+++ b/Tesserae/h5/assets/css/tss.body.css
@@ -5,6 +5,7 @@ body {
     border: 0;
     width: 100%;
     height: 100vh;
+    height: 100svh;
     min-width: 320px;
     line-height: 1.4;
     overflow-x: hidden;


### PR DESCRIPTION
On mobile, dynamic browser UI (address bar, nav controls) reduces the
visible viewport but 100vh stays fixed to the largest size, so content
gets hidden behind the chrome. The small viewport unit (svh) tracks the
shrunk viewport, keeping content fully visible. The 100vh line is kept
as a fallback for browsers that don't support svh.