### PR TITLE
Move sidebar search box into hamburger drawer on mobile

### DIFF
--- a/Tesserae.Tests/src/App.cs
+++ b/Tesserae.Tests/src/App.cs
@@ -87,12 +87,9 @@ namespace Tesserae.Tests
 
             sidebar.AddHeader(new SidebarText("header", "Tesserae", "TSS", textSize: TextSize.XLarge, textWeight: TextWeight.Bold));
 
-            if (!Theme.IsMobile)
-            {
-                var searchBox = new SidebarSearchBox("search", "Search...");
-                searchBox.OnSearch((term) => sidebar.Search(term));
-                sidebar.AddHeader(searchBox);
-            }
+            var searchBox = new SidebarSearchBox("search", "Search...");
+            searchBox.OnSearch((term) => sidebar.Search(term));
+            sidebar.AddHeader(searchBox);
 
             var contentArea = DeferSync(currentPage, page => page is null
                 ? (IComponent)CenteredCardWithBackground(Message("Welcome to Tesserae", "Select a component to see more details").Icon(UIcons.Search))

--- a/Tesserae.Tests/src/Samples/SamplesHelper.cs
+++ b/Tesserae.Tests/src/Samples/SamplesHelper.cs
@@ -9,13 +9,13 @@ namespace Tesserae.Tests.Samples
         public static SectionStack SampleTitle(this SectionStack stack, Type sampleType, UIcons icon, string subtitle)
         {
             var text = Sample.FormatSampleName(sampleType);
-            return stack.Title(SectionTitle(icon, text, subtitle, Button("Documentation").SetIcon(UIcons.Books).OnClick(() => window.location.href = "https://docs.curiosity.ai/tesserae/"), Button("View Code").SetIcon(UIcons.SquareTerminal).Tooltip("View source-code for this sample page").OnClick(() => ShowSampleCode(sampleType.Name))).NoWrap());
+            return stack.Title(icon, text, subtitle, Button("Documentation").SetIcon(UIcons.Books).OnClick(() => window.location.href = "https://docs.curiosity.ai/tesserae/"), Button("View Code").SetIcon(UIcons.SquareTerminal).Tooltip("View source-code for this sample page").OnClick(() => ShowSampleCode(sampleType.Name)));
         }
 
         public static SectionStack SampleTitle(this SectionStack stack, string sampleType, UIcons icon, string subtitle)
         {
             var text = Sample.FormatSampleName(sampleType);
-            return stack.Title(SectionTitle(icon, text, subtitle, Button("Documentation").SetIcon(UIcons.Books).OnClick(() => window.location.href = "https://docs.curiosity.ai/tesserae/"), Button("View Code").SetIcon(UIcons.SquareTerminal).Tooltip("View source-code for this sample page").OnClick(() => ShowSampleCode(sampleType))).NoWrap());
+            return stack.Title(icon, text, subtitle, Button("Documentation").SetIcon(UIcons.Books).OnClick(() => window.location.href = "https://docs.curiosity.ai/tesserae/"), Button("View Code").SetIcon(UIcons.SquareTerminal).Tooltip("View source-code for this sample page").OnClick(() => ShowSampleCode(sampleType)));
         }
 
         public static void ShowSampleCode(string sampleType)

--- a/Tesserae.Tests/src/Samples/SamplesHelper.cs
+++ b/Tesserae.Tests/src/Samples/SamplesHelper.cs
@@ -9,13 +9,13 @@ namespace Tesserae.Tests.Samples
         public static SectionStack SampleTitle(this SectionStack stack, Type sampleType, UIcons icon, string subtitle)
         {
             var text = Sample.FormatSampleName(sampleType);
-            return stack.Title(icon, text, subtitle, Button("Documentation").SetIcon(UIcons.Books).OnClick(() => window.location.href = "https://docs.curiosity.ai/tesserae/"), Button("View Code").SetIcon(UIcons.SquareTerminal).Tooltip("View source-code for this sample page").OnClick(() => ShowSampleCode(sampleType.Name)));
+            return stack.Title(SectionTitle(icon, text, subtitle, Button("Documentation").SetIcon(UIcons.Books).OnClick(() => window.location.href = "https://docs.curiosity.ai/tesserae/"), Button("View Code").SetIcon(UIcons.SquareTerminal).Tooltip("View source-code for this sample page").OnClick(() => ShowSampleCode(sampleType.Name))).NoWrap());
         }
 
         public static SectionStack SampleTitle(this SectionStack stack, string sampleType, UIcons icon, string subtitle)
         {
             var text = Sample.FormatSampleName(sampleType);
-            return stack.Title(icon, text, subtitle, Button("Documentation").SetIcon(UIcons.Books).OnClick(() => window.location.href = "https://docs.curiosity.ai/tesserae/"), Button("View Code").SetIcon(UIcons.SquareTerminal).Tooltip("View source-code for this sample page").OnClick(() => ShowSampleCode(sampleType)));
+            return stack.Title(SectionTitle(icon, text, subtitle, Button("Documentation").SetIcon(UIcons.Books).OnClick(() => window.location.href = "https://docs.curiosity.ai/tesserae/"), Button("View Code").SetIcon(UIcons.SquareTerminal).Tooltip("View source-code for this sample page").OnClick(() => ShowSampleCode(sampleType))).NoWrap());
         }
 
         public static void ShowSampleCode(string sampleType)

--- a/Tesserae/src/Components/SectionTitle.cs
+++ b/Tesserae/src/Components/SectionTitle.cs
@@ -7,12 +7,14 @@ namespace Tesserae
     [H5.Name("tss.SectionTitle")]
     public class SectionTitle : IComponent, IHasMarginPadding
     {
-        private readonly Stack _stack;
+        private readonly Stack     _stack;
+        private readonly TextBlock _titleBlock;
 
         public SectionTitle(UIcons icon, string title, string subtitle, params IComponent[] commands)
         {
             var iconComponent = Icon(icon, size: TextSize.Large).Class("tss-sectiontitle-icon");
             var titleBlock    = TextBlock(title).MediumPlus().Bold().Class("tss-sectiontitle-title");
+            _titleBlock       = titleBlock;
 
             var subtitleBlock = TextBlock(subtitle).WS().SmallPlus().Foreground(Theme.Secondary.Foreground).Class("tss-sectiontitle-subtitle");
 
@@ -46,5 +48,12 @@ namespace Tesserae
         }
 
         public HTMLElement Render() => _stack.Render();
+
+        /// <summary>Disables wrapping on the title TextBlock.</summary>
+        public SectionTitle NoWrap()
+        {
+            _titleBlock.NoWrap();
+            return this;
+        }
     }
 }

--- a/Tesserae/src/Components/SectionTitle.cs
+++ b/Tesserae/src/Components/SectionTitle.cs
@@ -7,14 +7,12 @@ namespace Tesserae
     [H5.Name("tss.SectionTitle")]
     public class SectionTitle : IComponent, IHasMarginPadding
     {
-        private readonly Stack     _stack;
-        private readonly TextBlock _titleBlock;
+        private readonly Stack _stack;
 
         public SectionTitle(UIcons icon, string title, string subtitle, params IComponent[] commands)
         {
             var iconComponent = Icon(icon, size: TextSize.Large).Class("tss-sectiontitle-icon");
-            var titleBlock    = TextBlock(title).MediumPlus().Bold().Class("tss-sectiontitle-title");
-            _titleBlock       = titleBlock;
+            var titleBlock    = TextBlock(title).MediumPlus().Bold().NoWrap().Class("tss-sectiontitle-title");
 
             var subtitleBlock = TextBlock(subtitle).WS().SmallPlus().Foreground(Theme.Secondary.Foreground).Class("tss-sectiontitle-subtitle");
 
@@ -48,12 +46,5 @@ namespace Tesserae
         }
 
         public HTMLElement Render() => _stack.Render();
-
-        /// <summary>Disables wrapping on the title TextBlock.</summary>
-        public SectionTitle NoWrap()
-        {
-            _titleBlock.NoWrap();
-            return this;
-        }
     }
 }

--- a/Tesserae/src/Components/Sidebar/Sidebar.cs
+++ b/Tesserae/src/Components/Sidebar/Sidebar.cs
@@ -208,9 +208,15 @@ namespace Tesserae
                     Button().Class("tss-navbar-mobile-close").SetIcon(UIcons.Cross).OnClick(() => _closed.Value = true)
                 );
 
+                // In navbar/mobile mode, search boxes belong inside the drawer so users can
+                // search the sample list from the hamburger menu instead of the top bar.
+                var topBarHeader  = header.Where(si => !(si is SidebarSearchBox)).ToList();
+                var drawerHeader  = header.Where(si =>   si is SidebarSearchBox ).ToList();
+
                 var drawer = VStack().Class("tss-navbar-drawer")
                    .Children(
                         mobileHeader,
+                        VStack().Class("tss-sidebar-header tss-navbar-drawer-header").WS().NoShrink().Children(drawerHeader.Select(si => si.RenderOpen())),
                         stackMiddle.Class("tss-sidebar-middle").WS().MinHeight(new UnitSize("fit-content")).MaxHeight(80.vh()).ScrollY().Children(middle.Select(si => AttachNavbarClose(si.RenderOpen()))),
                         VStack().Class("tss-sidebar-footer").WS().NoShrink().Children(footer.Select(si => AttachNavbarClose(si.RenderOpen())))
                     );
@@ -225,7 +231,7 @@ namespace Tesserae
                 }
 
                 _sidebar.Children(
-                    HStack().Class("tss-sidebar-header").W(10).Grow().NoShrink().Children(header.Select(si => si.RenderOpen())),
+                    HStack().Class("tss-sidebar-header").W(10).Grow().NoShrink().Children(topBarHeader.Select(si => si.RenderOpen())),
                     Stack().Grow(),
                     hamburger,
                     drawer


### PR DESCRIPTION
Restores the SidebarSearchBox in the sample app for both desktop and
mobile. In navbar/mobile mode, search box header items now render inside
the hamburger drawer instead of the top bar, and are not wrapped with
the auto-close click handler so the user can type into them without
collapsing the drawer. Search routes back to Sidebar.Search which
filters the middle items, so it works the same in either mode.

Also adds a NoWrap option to SectionTitle and applies it to the sample
page titles so long sample names don't wrap awkwardly.