### PR TITLE
add ToolCall and ToolsUsed components for AI chat interfaces

### DIFF
--- a/Tesserae.Tests/src/Samples/Components/ChatSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/ChatSample.cs
@@ -77,6 +77,26 @@ namespace Tesserae.Tests.Samples
             chatArea.Add(ChatMessage(TextBlock("Hello there!"), Avatar(null, "U")).RightAligned().MaxWidth());
             chatArea.Add(ChatMessage(TextBlock("Hi! How can I help you today?"), Avatar(null, "AI")).MaxWidth());
 
+            // Demonstrate an AI message that uses a single tool inline via ToolCall.
+            chatArea.Add(ChatMessage(VStack().WS().Children(
+                ToolCall(UIcons.Eye, "Read /home/user/project/src/App.tsx", () => TextBlock("import React from 'react';\n\nexport default function App() {\n    return <div>Hello</div>;\n}").BreakSpaces()),
+                TextBlock("I just read App.tsx — it's a minimal React component. Want me to add routing?").PT(8)
+            ), Avatar(null, "AI")).MaxWidth());
+
+            // Demonstrate an AI message that used many tools, summarized via ToolsUsed.
+            chatArea.Add(ChatMessage(VStack().WS().Children(
+                ToolsUsed(
+                    ToolCall(UIcons.Terminal, "Bash ls -la && git status",                       () => TextBlock("On branch main\nnothing to commit, working tree clean").BreakSpaces()),
+                    ToolCall(UIcons.Eye,      "Read /home/user/project/README.md",              () => TextBlock("# Project\n\nA sample app.").BreakSpaces()),
+                    ToolCall(UIcons.Search,   "Grep \"TODO\" src/",                              () => TextBlock("src/App.tsx:14: // TODO: add routing").BreakSpaces()),
+                    ToolCall(UIcons.Terminal, "Bash dotnet build",                                () => TextBlock("Build succeeded.\n    0 Warning(s)\n    0 Error(s)").BreakSpaces()),
+                    ToolCall(UIcons.Eye,      "Read /home/user/project/src/index.tsx",          () => TextBlock("import { createRoot } from 'react-dom/client';\n...").BreakSpaces()),
+                    ToolCall(UIcons.Tools,    "ToolSearch routing",                              () => TextBlock("Found: react-router-dom v6")),
+                    ToolCall(UIcons.ListCheck, "Update todos").NotExpandable()
+                ).SetSummary("Ran 4 commands, read 2 files, used a tool"),
+                TextBlock("I scanned the project, ran the build, and looked at routing options. Here's what I found:").PT(8)
+            ), Avatar(null, "AI")).MaxWidth());
+
             input = OmniBox(new OmniBox.Config(OmniBox.Mode.Chat)
             {
                 PlaceholderChat = "Ask anything...",

--- a/Tesserae.Tests/src/Samples/Components/ToolCallSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/ToolCallSample.cs
@@ -1,0 +1,53 @@
+using static H5.Core.dom;
+using static Tesserae.UI;
+using static Tesserae.Tests.Samples.SamplesHelper;
+
+namespace Tesserae.Tests.Samples
+{
+    [SampleDetails(Group = "Components", Order = 102, Icon = UIcons.Tools)]
+    public class ToolCallSample : IComponent, ISample
+    {
+        private readonly IComponent _content;
+
+        public ToolCallSample()
+        {
+            _content = SectionStack().Secondary()
+                .SampleTitle(typeof(ToolCallSample), UIcons.Tools, "Inline tool-call indicators and a multi-tool summary popup")
+                .FlatSection(Stack().Children(
+                    Card(VStack().WS().Children(
+                        TextBlock("ToolCall renders a single tool invocation inline. It behaves like an accordion: a compact header with an icon and label, expanding to reveal arbitrary content the first time it is clicked (the content component is created lazily)."),
+                        TextBlock("ToolsUsed groups many ToolCalls behind a compact summary. Clicking it opens a popup with the list of tools on the left; selecting one slides to the detail view on the right, with a back button to return to the list.")
+                    )).SetTitle("Overview")))
+                .FlatSection(Stack().Children(
+                    Card(VStack().WS().Children(
+                        SampleSubTitle("Inline ToolCall"),
+                        TextBlock("A single expandable tool call. The content factory only runs when the user first expands it."),
+                        ToolCall(UIcons.Terminal, "Bash ls -la && git status", () => TextBlock("total 16\ndrwxr-xr-x  3 user user 4096 Jan 1 12:00 .\n\nOn branch main\nnothing to commit, working tree clean").BreakSpaces()),
+                        ToolCall(UIcons.Eye, "Read /home/user/project/README.md", () => TextBlock("# My Project\n\nA sample project demonstrating the ToolCall component.\n\n## Usage\n\n...").BreakSpaces()).Expanded(),
+                        ToolCall(UIcons.Search, "Grep \"useEffect\" src/", () => TextBlock("src/App.tsx:5: import { useEffect } from 'react';\nsrc/hooks/useData.ts:1: import { useEffect, useState } from 'react';").BreakSpaces()),
+                        ToolCall(UIcons.ListCheck, "Update todos").NotExpandable(),
+
+                        SampleSubTitle("ToolsUsed summary popup"),
+                        TextBlock("When an AI uses many tools, surface a compact summary that opens a list/detail popup, similar to a master-detail navigation on mobile."),
+                        ToolsUsed(
+                            ToolCall(UIcons.Terminal, "Bash ls -la && git status && git branch --show-current", () => TextBlock("total 348\ndrwxr-xr-x ...\nOn branch claude/add-tool-components\nnothing to commit, working tree clean").BreakSpaces()),
+                            ToolCall(UIcons.Terminal, "Bash cat Needle.slnx && echo \"---\" && ls src/ && ...", () => TextBlock("<Solution>...\n---\nNeedle/\nNeedle.Tests/").BreakSpaces()),
+                            ToolCall(UIcons.Terminal, "Bash ls src/Needle/ && echo \"---\" && ls tests/N...", () => TextBlock("Inference/\nModel/\nTokenizer/\n---\nIntegration/\nUnit/").BreakSpaces()),
+                            ToolCall(UIcons.Eye, "Read /home/user/needle/README.md", () => TextBlock("# Needle\n\nA tiny ML library written in C#.").BreakSpaces()),
+                            ToolCall(UIcons.Terminal, "Bash cat src/Needle/Needle.csproj && echo \"---\"", () => TextBlock("<Project Sdk=\"Microsoft.NET.Sdk\">...</Project>").BreakSpaces()),
+                            ToolCall(UIcons.Terminal, "Bash find src/Needle -type f | head -50", () => TextBlock("src/Needle/Needle.csproj\nsrc/Needle/Inference/Runner.cs\n...").BreakSpaces()),
+                            ToolCall(UIcons.Terminal, "Bash find tests -type f && echo \"---\" && find n...", () => TextBlock("tests/Needle/Integration/RunnerTests.cs\n---").BreakSpaces()),
+                            ToolCall(UIcons.Eye, "Read /home/user/needle/src/Needle/Inference/Run...", () => TextBlock("namespace Needle.Inference;\n\npublic class Runner { ... }").BreakSpaces()),
+                            ToolCall(UIcons.Eye, "Read /home/user/needle/src/Needle/Weights/Weigh...", () => TextBlock("namespace Needle.Weights;\n\npublic class Weights { ... }").BreakSpaces()),
+                            ToolCall(UIcons.Eye, "Read /home/user/needle/src/Needle/Model/NeedleM...", () => TextBlock("namespace Needle.Model;\n\npublic class NeedleModel { ... }").BreakSpaces()),
+                            ToolCall(UIcons.Tools, "ToolSearch max_results, query", () => TextBlock("Found 3 candidate tools matching query 'tokenizer'.")),
+                            ToolCall(UIcons.ListCheck, "Update todos").NotExpandable(),
+                            ToolCall(UIcons.Eye, "Read /home/user/needle/needle/model/run.py", () => TextBlock("import torch\n\ndef run(model, x): ...").BreakSpaces()),
+                            ToolCall(UIcons.Eye, "Read /home/user/needle/src/Needle/Tokenizer/Nee...", () => TextBlock("namespace Needle.Tokenizer;\n\npublic class NeedleTokenizer { ... }").BreakSpaces())
+                        ).SetSummary("Ran 14 commands, read 9 files, used a tool").SetTitle("Tools used")
+                    )).SetTitle("Usage")));
+        }
+
+        public HTMLElement Render() => _content.Render();
+    }
+}

--- a/Tesserae/h5.json
+++ b/Tesserae/h5.json
@@ -149,6 +149,7 @@
         "h5/assets/css/tss.uptime.css",
         "h5/assets/css/baklava.css",
         "h5/assets/css/tss.chat.css",
+        "h5/assets/css/tss.toolcall.css",
         "h5/assets/css/tss.rating.css",
         "h5/assets/css/tss.progressring.css",
         "h5/assets/css/tss.colorpalette.css",

--- a/Tesserae/h5/assets/css/tss.toolcall.css
+++ b/Tesserae/h5/assets/css/tss.toolcall.css
@@ -1,0 +1,280 @@
+/* ToolCall — inline accordion-like tool call indicator */
+
+.tss-toolcall {
+    display: inline-flex;
+    flex-direction: column;
+    border: 1px solid var(--tss-default-border-color);
+    border-radius: 8px;
+    background: var(--tss-default-background-color);
+    overflow: hidden;
+    max-width: 100%;
+    box-sizing: border-box;
+}
+
+.tss-toolcall-header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 6px 10px;
+    cursor: pointer;
+    user-select: none;
+    font-size: 13px;
+    color: var(--tss-colors-neutral-700, #374151);
+}
+
+.tss-toolcall-header:hover {
+    background: var(--tss-default-background-hover-color);
+}
+
+.tss-toolcall-header.tss-toolcall-not-expandable {
+    cursor: default;
+}
+
+.tss-toolcall-header.tss-toolcall-not-expandable:hover {
+    background: transparent;
+}
+
+.tss-toolcall-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 22px;
+    height: 22px;
+    border-radius: 6px;
+    background: var(--tss-colors-neutral-100, #f3f4f6);
+    color: var(--tss-colors-neutral-700, #374151);
+    flex-shrink: 0;
+    font-size: 13px;
+}
+
+.tss-toolcall-text {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-family: var(--tss-monospace-font-family, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+    font-size: 12px;
+}
+
+.tss-toolcall-chevron {
+    transition: transform 200ms ease;
+    font-size: 12px;
+    color: var(--tss-colors-neutral-500, #6b7280);
+    flex-shrink: 0;
+}
+
+.tss-toolcall.tss-expanded .tss-toolcall-chevron {
+    transform: rotate(180deg);
+}
+
+.tss-toolcall-content {
+    border-top: 1px solid var(--tss-default-border-color);
+    padding: 10px 12px;
+    background: var(--tss-default-background-color);
+}
+
+/* ToolsUsed — clickable summary that opens a list/detail modal */
+
+.tss-toolsused {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    padding: 6px 12px;
+    border-radius: 999px;
+    border: 1px solid var(--tss-default-border-color);
+    background: var(--tss-default-background-color);
+    cursor: pointer;
+    user-select: none;
+    color: var(--tss-colors-neutral-800, #1f2937);
+    font-size: 13px;
+}
+
+.tss-toolsused:hover {
+    background: var(--tss-default-background-hover-color);
+}
+
+.tss-toolsused-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 22px;
+    height: 22px;
+    border-radius: 50%;
+    background: var(--tss-colors-neutral-100, #f3f4f6);
+    color: var(--tss-colors-neutral-700, #374151);
+    flex-shrink: 0;
+    font-size: 13px;
+}
+
+.tss-toolsused-text {
+    flex: 1;
+    font-weight: var(--tss-font-weight-medium, 500);
+}
+
+.tss-toolsused-chevron {
+    color: var(--tss-colors-neutral-500, #6b7280);
+    font-size: 12px;
+}
+
+/* ToolsUsed modal layout */
+
+.tss-toolsused-modal .tss-modal-content {
+    padding: 0;
+    overflow: hidden;
+    min-width: 380px;
+    max-width: 90vw;
+    width: 480px;
+    box-sizing: border-box;
+}
+
+.tss-toolsused-modal-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex: 1;
+    min-width: 0;
+}
+
+.tss-toolsused-back {
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    width: 28px;
+    height: 28px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    padding: 0;
+    color: var(--tss-colors-neutral-700, #374151);
+}
+
+.tss-toolsused-back:hover {
+    background: var(--tss-default-background-hover-color);
+}
+
+.tss-toolsused-modal-detail-icon {
+    width: 26px;
+    height: 26px;
+    border-radius: 6px;
+    background: var(--tss-colors-neutral-100, #f3f4f6);
+    color: var(--tss-colors-neutral-700, #374151);
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    font-size: 13px;
+}
+
+.tss-toolsused-modal-title,
+.tss-toolsused-modal-detail-title {
+    font-weight: var(--tss-font-weight-semibold, 600);
+    font-size: 15px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    flex: 1;
+    min-width: 0;
+}
+
+.tss-toolsused-modal-detail-title {
+    font-family: var(--tss-monospace-font-family, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+    font-weight: var(--tss-font-weight-medium, 500);
+}
+
+.tss-toolsused-modal-body {
+    position: relative;
+    overflow: hidden;
+    width: 100%;
+    height: 60vh;
+    max-height: 480px;
+}
+
+.tss-toolsused-modal-slider {
+    display: flex;
+    width: 200%;
+    height: 100%;
+    transform: translateX(0);
+    transition: transform 250ms ease;
+}
+
+.tss-toolsused-modal-slider.tss-toolsused-no-anim {
+    transition: none;
+}
+
+.tss-toolsused-modal-slider.tss-toolsused-show-detail {
+    transform: translateX(-50%);
+}
+
+.tss-toolsused-modal-panel {
+    width: 50%;
+    height: 100%;
+    overflow-y: auto;
+    overflow-x: hidden;
+    box-sizing: border-box;
+    flex-shrink: 0;
+}
+
+.tss-toolsused-modal-list {
+    padding: 8px 0;
+}
+
+.tss-toolsused-list-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 16px;
+    cursor: pointer;
+    user-select: none;
+    border-bottom: 1px solid var(--tss-default-border-color);
+}
+
+.tss-toolsused-list-row:last-child {
+    border-bottom: none;
+}
+
+.tss-toolsused-list-row:hover {
+    background: var(--tss-default-background-hover-color);
+}
+
+.tss-toolsused-list-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    border-radius: 6px;
+    background: var(--tss-colors-neutral-100, #f3f4f6);
+    color: var(--tss-colors-neutral-700, #374151);
+    flex-shrink: 0;
+    font-size: 13px;
+}
+
+.tss-toolsused-list-text {
+    flex: 1;
+    font-family: var(--tss-monospace-font-family, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+    font-size: 13px;
+    color: var(--tss-colors-neutral-800, #1f2937);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.tss-toolsused-list-chevron {
+    color: var(--tss-colors-neutral-400, #9ca3af);
+    font-size: 12px;
+}
+
+.tss-toolsused-modal-detail {
+    padding: 16px;
+}
+
+.tss-toolsused-modal-detail-content {
+    height: 100%;
+    overflow: auto;
+}
+
+.tss-toolsused-empty {
+    color: var(--tss-colors-neutral-500, #6b7280);
+    font-style: italic;
+    padding: 12px;
+}

--- a/Tesserae/src/Base/UI.Components.cs
+++ b/Tesserae/src/Base/UI.Components.cs
@@ -761,6 +761,25 @@ namespace Tesserae
         public static ChatMessage ChatMessage(IComponent content, IComponent avatar = null, IComponent commands = null) => new ChatMessage(content, avatar, commands);
 
         /// <summary>
+        /// Creates a <see cref="Tesserae.ToolCall"/> component that renders an
+        /// inline tool-call indicator. The provided <paramref name="contentFactory"/>
+        /// is invoked lazily the first time the user expands the tool call.
+        /// </summary>
+        public static ToolCall ToolCall(UIcons icon, string text, Func<IComponent> contentFactory = null) => new ToolCall(icon, text, contentFactory);
+
+        /// <summary>
+        /// Creates a <see cref="Tesserae.ToolCall"/> component with an already
+        /// materialized content component.
+        /// </summary>
+        public static ToolCall ToolCall(UIcons icon, string text, IComponent content) => new ToolCall(icon, text, content);
+
+        /// <summary>
+        /// Creates a <see cref="Tesserae.ToolsUsed"/> summary that opens a
+        /// list/detail popup when clicked.
+        /// </summary>
+        public static ToolsUsed ToolsUsed(params ToolCall[] tools) => new ToolsUsed(tools);
+
+        /// <summary>
         /// Creates a <see cref="Tesserae.Toast"/> component.
         /// </summary>
         public static Toast Toast() => new Toast();

--- a/Tesserae/src/Components/ToolCall.cs
+++ b/Tesserae/src/Components/ToolCall.cs
@@ -1,0 +1,405 @@
+using System;
+using System.Collections.Generic;
+using static H5.Core.dom;
+using static Tesserae.UI;
+
+namespace Tesserae
+{
+    /// <summary>
+    /// Inline tool-call indicator that expands accordion-style to show the
+    /// associated content. The content component is created lazily the first
+    /// time the user expands the tool call.
+    /// </summary>
+    [H5.Name("tss.ToolCall")]
+    public sealed class ToolCall : ComponentBase<ToolCall, HTMLElement>
+    {
+        private readonly HTMLElement      _header;
+        private readonly HTMLElement      _iconContainer;
+        private readonly HTMLElement      _textContainer;
+        private readonly HTMLElement      _chevron;
+        private readonly HTMLElement      _content;
+        private          UIcons           _icon;
+        private          string           _text;
+        private          Func<IComponent> _contentFactory;
+        private          IComponent       _renderedContent;
+        private          bool             _isExpanded;
+        private          bool             _expandable = true;
+        private          Action<ToolCall> _onToggle;
+
+        public ToolCall(UIcons icon, string text, Func<IComponent> contentFactory = null)
+        {
+            _icon           = icon;
+            _text           = text ?? string.Empty;
+            _contentFactory = contentFactory;
+
+            _iconContainer = Div(_("tss-toolcall-icon"), I(icon));
+            _textContainer = Div(_("tss-toolcall-text", text: _text));
+            _chevron       = I(UIcons.AngleDown, cssClass: "tss-toolcall-chevron");
+
+            _header = Div(_("tss-toolcall-header", role: "button", ariaLabel: "Toggle tool call"),
+                          _iconContainer, _textContainer, _chevron);
+
+            _content = Div(_("tss-toolcall-content"));
+            _content.style.display = "none";
+
+            InnerElement = Div(_("tss-toolcall"), _header, _content);
+
+            _header.addEventListener("click", _ =>
+            {
+                if (_expandable) Toggle();
+            });
+        }
+
+        public ToolCall(UIcons icon, string text, IComponent content)
+            : this(icon, text, content != null ? (Func<IComponent>)(() => content) : null)
+        {
+        }
+
+        public UIcons  Icon            => _icon;
+        public string  Text            => _text;
+        public bool    IsExpanded      => _isExpanded;
+        public bool    HasContent      => _contentFactory != null;
+
+        /// <summary>
+        /// Returns a fresh IComponent built from the content factory, or null
+        /// if no factory was provided. Used by <see cref="ToolsUsed"/> to
+        /// render the detail pane independently of this inline view.
+        /// </summary>
+        public IComponent CreateContent()
+        {
+            return _contentFactory?.Invoke();
+        }
+
+        public ToolCall SetContent(Func<IComponent> contentFactory)
+        {
+            _contentFactory  = contentFactory;
+            _renderedContent = null;
+            ClearChildren(_content);
+            if (_isExpanded)
+            {
+                EnsureContentRendered();
+            }
+            return this;
+        }
+
+        public ToolCall SetContent(IComponent content)
+        {
+            return SetContent(content != null ? (Func<IComponent>)(() => content) : null);
+        }
+
+        public ToolCall SetText(string text)
+        {
+            _text = text ?? string.Empty;
+            _textContainer.innerText = _text;
+            return this;
+        }
+
+        public ToolCall SetIcon(UIcons icon)
+        {
+            _icon = icon;
+            ClearChildren(_iconContainer);
+            _iconContainer.appendChild(I(icon));
+            return this;
+        }
+
+        public ToolCall NotExpandable()
+        {
+            _expandable = false;
+            _chevron.style.display = "none";
+            _header.classList.add("tss-toolcall-not-expandable");
+            return this;
+        }
+
+        public ToolCall Expanded(bool value = true)
+        {
+            if (value) Expand();
+            else Collapse();
+            return this;
+        }
+
+        public ToolCall Expand()
+        {
+            if (_isExpanded || !_expandable) return this;
+            _isExpanded = true;
+            EnsureContentRendered();
+            UpdateExpandedState();
+            _onToggle?.Invoke(this);
+            return this;
+        }
+
+        public ToolCall Collapse()
+        {
+            if (!_isExpanded) return this;
+            _isExpanded = false;
+            UpdateExpandedState();
+            _onToggle?.Invoke(this);
+            return this;
+        }
+
+        public ToolCall Toggle()
+        {
+            return _isExpanded ? Collapse() : Expand();
+        }
+
+        public ToolCall OnToggle(Action<ToolCall> onToggle)
+        {
+            _onToggle += onToggle;
+            return this;
+        }
+
+        private void EnsureContentRendered()
+        {
+            if (_renderedContent != null) return;
+            if (_contentFactory == null) return;
+
+            _renderedContent = _contentFactory();
+            if (_renderedContent != null)
+            {
+                _content.appendChild(_renderedContent.Render());
+            }
+        }
+
+        private void UpdateExpandedState()
+        {
+            InnerElement.UpdateClassIf(_isExpanded, "tss-expanded");
+            _content.style.display = _isExpanded ? "block" : "none";
+            _header.setAttribute("aria-expanded", _isExpanded ? "true" : "false");
+        }
+
+        public override HTMLElement Render()
+        {
+            return InnerElement;
+        }
+    }
+
+    /// <summary>
+    /// Compact summary of multiple tool calls that opens a popup showing the
+    /// list of tools on the left. Clicking a tool slides the list to the left
+    /// and shows that tool's content on the right with a back button to
+    /// return to the list.
+    /// </summary>
+    [H5.Name("tss.ToolsUsed")]
+    public sealed class ToolsUsed : ComponentBase<ToolsUsed, HTMLElement>
+    {
+        private readonly HTMLElement      _summaryIcon;
+        private readonly HTMLElement      _summaryText;
+        private readonly List<ToolCall>   _tools;
+        private          string           _summaryLabel;
+        private          UIcons           _summaryIconKind = UIcons.Tools;
+        private          string           _modalTitle      = "Tools used";
+        private          Modal            _modal;
+        private          HTMLElement      _slider;
+        private          HTMLElement      _listPanel;
+        private          HTMLElement      _detailPanel;
+        private          HTMLElement      _detailContent;
+        private          HTMLElement      _detailTitle;
+        private          HTMLElement      _detailIconHolder;
+        private          HTMLElement      _backButton;
+        private          HTMLElement      _titleEl;
+
+        public ToolsUsed(IEnumerable<ToolCall> tools = null)
+        {
+            _tools = new List<ToolCall>();
+
+            _summaryIcon = Div(_("tss-toolsused-icon"), I(_summaryIconKind));
+            _summaryText = Div(_("tss-toolsused-text"));
+            var chevron  = I(UIcons.AngleRight, cssClass: "tss-toolsused-chevron");
+
+            InnerElement = Div(_("tss-toolsused", role: "button", ariaLabel: "Show tools used"),
+                               _summaryIcon, _summaryText, chevron);
+
+            InnerElement.addEventListener("click", _ => Show());
+
+            if (tools != null)
+            {
+                foreach (var t in tools)
+                {
+                    Add(t);
+                }
+            }
+
+            UpdateSummary();
+        }
+
+        public ToolsUsed Add(ToolCall tool)
+        {
+            if (tool == null) return this;
+            _tools.Add(tool);
+            UpdateSummary();
+            return this;
+        }
+
+        public ToolsUsed AddRange(IEnumerable<ToolCall> tools)
+        {
+            if (tools == null) return this;
+            foreach (var t in tools) Add(t);
+            return this;
+        }
+
+        public ToolsUsed Add(UIcons icon, string text, Func<IComponent> contentFactory)
+        {
+            return Add(new ToolCall(icon, text, contentFactory));
+        }
+
+        public ToolsUsed Add(UIcons icon, string text, IComponent content)
+        {
+            return Add(new ToolCall(icon, text, content));
+        }
+
+        public ToolsUsed Clear()
+        {
+            _tools.Clear();
+            UpdateSummary();
+            return this;
+        }
+
+        public ToolsUsed SetSummary(string label)
+        {
+            _summaryLabel = label;
+            UpdateSummary();
+            return this;
+        }
+
+        public ToolsUsed SetIcon(UIcons icon)
+        {
+            _summaryIconKind = icon;
+            ClearChildren(_summaryIcon);
+            _summaryIcon.appendChild(I(icon));
+            return this;
+        }
+
+        public ToolsUsed SetTitle(string title)
+        {
+            _modalTitle = title ?? string.Empty;
+            if (_titleEl != null && _backButton != null && _backButton.style.visibility == "hidden")
+            {
+                _titleEl.innerText = _modalTitle;
+            }
+            return this;
+        }
+
+        public ToolsUsed Show()
+        {
+            BuildModalIfNeeded();
+            RebuildList();
+            ShowList(animate: false);
+            _modal.Show();
+            return this;
+        }
+
+        public ToolsUsed Hide()
+        {
+            _modal?.Hide();
+            return this;
+        }
+
+        private void UpdateSummary()
+        {
+            if (!string.IsNullOrEmpty(_summaryLabel))
+            {
+                _summaryText.innerText = _summaryLabel;
+                return;
+            }
+            _summaryText.innerText = _tools.Count == 1
+                ? "Used 1 tool"
+                : $"Used {_tools.Count} tools";
+        }
+
+        private void BuildModalIfNeeded()
+        {
+            if (_modal != null) return;
+
+            _titleEl          = Div(_("tss-toolsused-modal-title"));
+            _detailTitle      = Div(_("tss-toolsused-modal-detail-title"));
+            _detailIconHolder = Div(_("tss-toolsused-modal-detail-icon"));
+            _detailIconHolder.style.display = "none";
+
+            _backButton = Button(_("tss-toolsused-back", type: "button", ariaLabel: "Back to list"), I(UIcons.AngleLeft));
+            _backButton.addEventListener("click", _ => ShowList(animate: true));
+            _backButton.style.visibility = "hidden";
+
+            var header = Div(_("tss-toolsused-modal-header"),
+                             _backButton,
+                             _detailIconHolder,
+                             _titleEl,
+                             _detailTitle);
+
+            _listPanel     = Div(_("tss-toolsused-modal-panel tss-toolsused-modal-list"));
+            _detailContent = Div(_("tss-toolsused-modal-detail-content"));
+            _detailPanel   = Div(_("tss-toolsused-modal-panel tss-toolsused-modal-detail"), _detailContent);
+
+            _slider = Div(_("tss-toolsused-modal-slider"), _listPanel, _detailPanel);
+
+            _modal = Modal(Raw(header));
+            _modal.Content = Raw(Div(_("tss-toolsused-modal-body"), _slider));
+            _modal.NoFooter();
+            _modal.CanLightDismiss = true;
+            _modal.InnerElement.classList.add("tss-toolsused-modal");
+        }
+
+        private void RebuildList()
+        {
+            ClearChildren(_listPanel);
+            for (int i = 0; i < _tools.Count; i++)
+            {
+                var tool = _tools[i];
+
+                var iconEl  = Div(_("tss-toolsused-list-icon"), I(tool.Icon));
+                var labelEl = Div(_("tss-toolsused-list-text", text: tool.Text));
+                var chevron = I(UIcons.AngleRight, cssClass: "tss-toolsused-list-chevron");
+                var row     = Div(_("tss-toolsused-list-row", role: "button"), iconEl, labelEl, chevron);
+
+                var capturedTool = tool;
+                row.addEventListener("click", _ => ShowDetail(capturedTool));
+
+                _listPanel.appendChild(row);
+            }
+        }
+
+        private void ShowList(bool animate)
+        {
+            ClearChildren(_detailContent);
+            _slider.classList.remove("tss-toolsused-show-detail");
+            _backButton.style.visibility       = "hidden";
+            _detailIconHolder.style.display    = "none";
+            ClearChildren(_detailIconHolder);
+            _detailTitle.innerText             = string.Empty;
+            _titleEl.innerText                 = _modalTitle;
+
+            if (!animate)
+            {
+                _slider.classList.add("tss-toolsused-no-anim");
+                window.setTimeout(__ => _slider.classList.remove("tss-toolsused-no-anim"), 30);
+            }
+        }
+
+        private void ShowDetail(ToolCall tool)
+        {
+            ClearChildren(_detailContent);
+
+            var content = tool.CreateContent();
+            if (content != null)
+            {
+                _detailContent.appendChild(content.Render());
+            }
+            else
+            {
+                _detailContent.appendChild(Div(_("tss-toolsused-empty", text: "No content")));
+            }
+
+            _titleEl.innerText      = string.Empty;
+            _detailTitle.innerText  = tool.Text;
+            ClearChildren(_detailIconHolder);
+            _detailIconHolder.style.display = "flex";
+            _detailIconHolder.appendChild(I(tool.Icon));
+
+            _backButton.style.visibility = "visible";
+            _slider.classList.add("tss-toolsused-show-detail");
+        }
+
+        public override HTMLElement Render()
+        {
+            return InnerElement;
+        }
+    }
+}


### PR DESCRIPTION
ToolCall renders an inline tool invocation as a compact, accordion-like
indicator with lazy content rendering. ToolsUsed groups many ToolCalls
behind a single summary chip that opens a list/detail popup, sliding
between the list of tools and each tool's content.

Includes a dedicated sample page and integration into the Chat sample.