### PR TITLE
show sidebar nav expand arrow on hover in place of the icon

### DIFF
--- a/Tesserae/h5/assets/css/tss.sidebar.css
+++ b/Tesserae/h5/assets/css/tss.sidebar.css
@@ -306,10 +306,6 @@
     min-width: 24px;
 }
 
-.tss-sidebar-nav-header.tss-sidebar-btn-open:not(.tss-sidebar-nav-header-empty) > .tss-btn i,
-.tss-sidebar-nav-header.tss-sidebar-btn-open:not(.tss-sidebar-nav-header-empty) > a > .tss-btn i,
-.tss-sidebar-nav-header.tss-sidebar-btn-open:not(.tss-sidebar-nav-header-empty) > .tss-btn > .tss-btn-with-image > .tss-image,
-.tss-sidebar-nav-header.tss-sidebar-btn-open:not(.tss-sidebar-nav-header-empty) > a > .tss-btn > .tss-btn-with-image > .tss-image,
 .tss-sidebar-nav-header.tss-sidebar-btn-open.tss-sidebar-nav-header-empty.tss-sidebar-nav-header-dot-if-empty > .tss-btn i,
 .tss-sidebar-nav-header.tss-sidebar-btn-open.tss-sidebar-nav-header-empty.tss-sidebar-nav-header-dot-if-empty > a > .tss-btn i,
 .tss-sidebar-nav-header.tss-sidebar-btn-open.tss-sidebar-nav-header-empty.tss-sidebar-nav-header-dot-if-empty > .tss-btn > .tss-btn-with-image > .tss-image,
@@ -319,6 +315,26 @@
 
 .tss-sidebar-nav-header.tss-sidebar-btn-open.tss-sidebar-nav-header-empty > .tss-sidebar-nav-arrow {
     display: none;
+}
+
+.tss-sidebar-nav-header.tss-sidebar-btn-open:not(.tss-sidebar-nav-header-empty) > .tss-sidebar-nav-arrow {
+    visibility: hidden;
+}
+
+.tss-sidebar-nav-header.tss-sidebar-btn-open:not(.tss-sidebar-nav-header-empty):hover > .tss-sidebar-nav-arrow,
+.tss-sidebar-nav-header.tss-sidebar-btn-open:not(.tss-sidebar-nav-header-empty):focus-within > .tss-sidebar-nav-arrow {
+    visibility: visible;
+}
+
+.tss-sidebar-nav-header.tss-sidebar-btn-open:not(.tss-sidebar-nav-header-empty):hover > .tss-btn > i,
+.tss-sidebar-nav-header.tss-sidebar-btn-open:not(.tss-sidebar-nav-header-empty):hover > a > .tss-btn > i,
+.tss-sidebar-nav-header.tss-sidebar-btn-open:not(.tss-sidebar-nav-header-empty):hover > .tss-btn > .tss-btn-with-image > .tss-image,
+.tss-sidebar-nav-header.tss-sidebar-btn-open:not(.tss-sidebar-nav-header-empty):hover > a > .tss-btn > .tss-btn-with-image > .tss-image,
+.tss-sidebar-nav-header.tss-sidebar-btn-open:not(.tss-sidebar-nav-header-empty):focus-within > .tss-btn > i,
+.tss-sidebar-nav-header.tss-sidebar-btn-open:not(.tss-sidebar-nav-header-empty):focus-within > a > .tss-btn > i,
+.tss-sidebar-nav-header.tss-sidebar-btn-open:not(.tss-sidebar-nav-header-empty):focus-within > .tss-btn > .tss-btn-with-image > .tss-image,
+.tss-sidebar-nav-header.tss-sidebar-btn-open:not(.tss-sidebar-nav-header-empty):focus-within > a > .tss-btn > .tss-btn-with-image > .tss-image {
+    visibility: hidden;
 }
 
 .tss-sidebar-nav-header.tss-sidebar-btn-open.tss-sidebar-nav-header-empty.tss-sidebar-nav-header-dot-if-empty > .tss-btn:before,


### PR DESCRIPTION
Instead of rendering the expand/collapse arrow next to the icon, the icon
now stays in its natural position and the arrow is revealed on hover (or
focus-within) by hiding the icon. This declutters the default state while
keeping the affordance discoverable.