### PR TITLE
Add command buttons and context menu support to Tree items

### DIFF
--- a/Tesserae.Tests/src/Samples/Components/TreeSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/TreeSample.cs
@@ -71,15 +71,15 @@ namespace Tesserae.Tests.Samples
                     SampleSubTitle("Tree with Commands and Context Menu"),
                     new Tree().Items(
                         new Tree.Item("src", UIcons.Folder.ToString(),
-                            new SidebarCommand(UIcons.Plus).Tooltip("Add file").OnClick(() => window.alert("Add file clicked")),
-                            new SidebarCommand(UIcons.Refresh).Tooltip("Refresh").OnClick(() => window.alert("Refresh clicked"))
+                            new TreeCommand(UIcons.Plus).Tooltip("Add file").OnClick(() => window.alert("Add file clicked")),
+                            new TreeCommand(UIcons.Refresh).Tooltip("Refresh").OnClick(() => window.alert("Refresh clicked"))
                         ).Expanded().Items(
                             new Tree.Item("Program.cs", UIcons.File.ToString(),
-                                new SidebarCommand(UIcons.Pencil).Tooltip("Rename").OnClick(() => window.alert("Rename Program.cs")),
-                                new SidebarCommand(UIcons.Trash).Tooltip("Delete").OnClick(() => window.alert("Delete Program.cs"))
+                                new TreeCommand(UIcons.Pencil).Tooltip("Rename").OnClick(() => window.alert("Rename Program.cs")),
+                                new TreeCommand(UIcons.Trash).Tooltip("Delete").OnClick(() => window.alert("Delete Program.cs"))
                             ),
                             new Tree.Item("README.md", UIcons.File.ToString(),
-                                new SidebarCommand(UIcons.MenuDots).Tooltip("Context menu").HookToParentContextMenu().OnClick(() => window.alert("README.md context action (right-click or button)"))
+                                new TreeCommand(UIcons.MenuDots).Tooltip("Context menu").HookToParentContextMenu().OnClick(() => window.alert("README.md context action (right-click or button)"))
                             ),
                             new Tree.Item("notes.txt", UIcons.File.ToString()).OnContextMenu((s, e) =>
                             {

--- a/Tesserae.Tests/src/Samples/Components/TreeSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/TreeSample.cs
@@ -67,6 +67,26 @@ namespace Tesserae.Tests.Samples
                             new Tree.Item("Child C", UIcons.File.ToString()).Selected(),
                             new Tree.Item("Child D", UIcons.File.ToString())
                         )
+                    ),
+                    SampleSubTitle("Tree with Commands and Context Menu"),
+                    new Tree().Items(
+                        new Tree.Item("src", UIcons.Folder.ToString(),
+                            new SidebarCommand(UIcons.Plus).Tooltip("Add file").OnClick(() => window.alert("Add file clicked")),
+                            new SidebarCommand(UIcons.Refresh).Tooltip("Refresh").OnClick(() => window.alert("Refresh clicked"))
+                        ).Expanded().Items(
+                            new Tree.Item("Program.cs", UIcons.File.ToString(),
+                                new SidebarCommand(UIcons.Pencil).Tooltip("Rename").OnClick(() => window.alert("Rename Program.cs")),
+                                new SidebarCommand(UIcons.Trash).Tooltip("Delete").OnClick(() => window.alert("Delete Program.cs"))
+                            ),
+                            new Tree.Item("README.md", UIcons.File.ToString(),
+                                new SidebarCommand(UIcons.MenuDots).Tooltip("Context menu").HookToParentContextMenu().OnClick(() => window.alert("README.md context action (right-click or button)"))
+                            ),
+                            new Tree.Item("notes.txt", UIcons.File.ToString()).OnContextMenu((s, e) =>
+                            {
+                                e.preventDefault();
+                                window.alert("Right-clicked notes.txt");
+                            })
+                        )
                     )
                )).SetTitle("Usage")));
         }

--- a/Tesserae.Tests/src/Samples/Components/TreeSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/TreeSample.cs
@@ -85,7 +85,15 @@ namespace Tesserae.Tests.Samples
                             {
                                 e.preventDefault();
                                 window.alert("Right-clicked notes.txt");
-                            })
+                            }),
+                            new Tree.Item("config.json", UIcons.File.ToString(),
+                                new TreeCommand(UIcons.MenuBurger).Tooltip("More actions").OnClickMenu(() => new[]
+                                {
+                                    new TreeCommand(UIcons.Pencil).SetText("Rename").OnClick(() => window.alert("Rename config.json")),
+                                    new TreeCommand(UIcons.Copy).SetText("Duplicate").OnClick(() => window.alert("Duplicate config.json")),
+                                    new TreeCommand(UIcons.Trash).SetText("Delete").Danger().OnClick(() => window.alert("Delete config.json"))
+                                })
+                            )
                         )
                     )
                )).SetTitle("Usage")));

--- a/Tesserae/h5/assets/css/tss.tree.css
+++ b/Tesserae/h5/assets/css/tss.tree.css
@@ -140,3 +140,46 @@
 .tss-tree-item.tss-expanded > .tss-tree-children {
     display: flex;
 }
+
+.tss-tree-menu {
+    display: flex;
+    flex-direction: column;
+}
+
+.tss-tree-menu > .tss-tree-command,
+.tss-tree-menu > a > .tss-tree-command {
+    border: 1px solid transparent;
+    height: 36px !important;
+    min-height: unset;
+    border-radius: 0px;
+    margin: 0px;
+    padding: 0px 12px;
+    min-width: 52px !important;
+    justify-content: flex-start;
+}
+
+.tss-tree-menu > .tss-tree-command:not(.tss-btn-danger):not(.tss-btn-primary):not(.tss-btn-success),
+.tss-tree-menu > a > .tss-tree-command:not(.tss-btn-danger):not(.tss-btn-primary):not(.tss-btn-success) {
+    background: var(--tss-tooltip-background-color);
+    color: var(--tss-tooltip-foreground-color);
+    border-color: var(--tss-tooltip-background-color);
+}
+
+.tss-tree-menu > .tss-tree-command.tss-btn-default:not(.tss-btn-danger):not(.tss-btn-primary):not(.tss-btn-success):hover,
+.tss-tree-menu > a > .tss-tree-command.tss-btn-default:not(.tss-btn-danger):not(.tss-btn-primary):not(.tss-btn-success):hover {
+    color: var(--tss-default-background-hover-color);
+    background: var(--tss-default-foreground-hover-color);
+    border-color: var(--tss-default-foreground-color);
+}
+
+.tippy-box[data-theme~='tss-tree-tippy'] {
+    padding: 0px;
+    margin: 0px;
+    border-radius: 6px;
+    overflow: hidden;
+}
+
+.tippy-box[data-theme~='tss-tree-tippy'] .tippy-content {
+    padding: 0px;
+    margin: 0px;
+}

--- a/Tesserae/h5/assets/css/tss.tree.css
+++ b/Tesserae/h5/assets/css/tss.tree.css
@@ -120,7 +120,8 @@
     display: flex;
 }
 
-.tss-tree-commands > .tss-btn {
+.tss-tree-commands > .tss-tree-command,
+.tss-tree-commands > a > .tss-tree-command {
     min-height: unset;
     min-width: 20px;
     height: 20px;

--- a/Tesserae/h5/assets/css/tss.tree.css
+++ b/Tesserae/h5/assets/css/tss.tree.css
@@ -107,6 +107,26 @@
     text-overflow: ellipsis;
 }
 
+.tss-tree-commands {
+    display: none;
+    flex-wrap: nowrap;
+    margin-left: 4px;
+    z-index: 2;
+}
+
+.tss-tree-item-content:hover > .tss-tree-commands,
+.tss-tree-item-content.tss-selected > .tss-tree-commands,
+.tss-tree-item-content.tss-tree-commands-always-visible > .tss-tree-commands {
+    display: flex;
+}
+
+.tss-tree-commands > .tss-btn {
+    min-height: unset;
+    min-width: 20px;
+    height: 20px;
+    padding: 0 4px;
+}
+
 .tss-tree-children {
     list-style: none;
     margin: 0 0 0 16px;

--- a/Tesserae/src/Components/Tree.cs
+++ b/Tesserae/src/Components/Tree.cs
@@ -156,7 +156,7 @@ namespace Tesserae
             private readonly HTMLSpanElement   _textSpan;
             private readonly HTMLDivElement    _commandsDiv;
             private readonly HTMLUListElement  _childContainer;
-            private readonly SidebarCommand[]  _commands;
+            private readonly TreeCommand[]  _commands;
 
             private readonly List<Item> _childItems = new List<Item>();
             private bool _isExpanded;
@@ -178,13 +178,13 @@ namespace Tesserae
                 }
             }
 
-            public Item(string text = null, string icon = null, params SidebarCommand[] commands)
+            public Item(string text = null, string icon = null, params TreeCommand[] commands)
             {
                 _chevronSpan    = I(_("tss-tree-chevron " + UIcons.AngleRight.ToString()));
                 _textSpan       = Span(_("tss-tree-text", text: text));
                 _childContainer = Ul(_("tss-tree-children", role: "group"));
                 _checkboxSpan   = I(_("tss-tree-checkbox " + UIcons.Square.ToString()));
-                _commands       = commands ?? new SidebarCommand[0];
+                _commands       = commands ?? new TreeCommand[0];
 
                 _headerDiv = Div(_("tss-tree-item-content"), _chevronSpan, _checkboxSpan);
 

--- a/Tesserae/src/Components/Tree.cs
+++ b/Tesserae/src/Components/Tree.cs
@@ -154,7 +154,9 @@ namespace Tesserae
             private          HTMLElement       _iconSpan;
             private readonly HTMLElement       _checkboxSpan;
             private readonly HTMLSpanElement   _textSpan;
+            private readonly HTMLDivElement    _commandsDiv;
             private readonly HTMLUListElement  _childContainer;
+            private readonly SidebarCommand[]  _commands;
 
             private readonly List<Item> _childItems = new List<Item>();
             private bool _isExpanded;
@@ -176,12 +178,13 @@ namespace Tesserae
                 }
             }
 
-            public Item(string text = null, string icon = null)
+            public Item(string text = null, string icon = null, params SidebarCommand[] commands)
             {
                 _chevronSpan    = I(_("tss-tree-chevron " + UIcons.AngleRight.ToString()));
                 _textSpan       = Span(_("tss-tree-text", text: text));
                 _childContainer = Ul(_("tss-tree-children", role: "group"));
                 _checkboxSpan   = I(_("tss-tree-checkbox " + UIcons.Square.ToString()));
+                _commands       = commands ?? new SidebarCommand[0];
 
                 _headerDiv = Div(_("tss-tree-item-content"), _chevronSpan, _checkboxSpan);
 
@@ -193,6 +196,18 @@ namespace Tesserae
 
                 _headerDiv.appendChild(_textSpan);
 
+                _commandsDiv = Div(_("tss-tree-commands"));
+
+                if (_commands.Length > 0)
+                {
+                    foreach (var c in _commands)
+                    {
+                        _commandsDiv.appendChild(c.Render());
+                    }
+                }
+
+                _headerDiv.appendChild(_commandsDiv);
+
                 InnerElement = Li(_("tss-tree-item", role: "treeitem"), _headerDiv, _childContainer);
                 InnerElement.setAttribute("aria-expanded",  "false");
                 InnerElement.setAttribute("aria-selected",  "false");
@@ -201,7 +216,30 @@ namespace Tesserae
                 _chevronSpan.onclick = ChevronClickHandler;
                 _checkboxSpan.onclick = CheckboxClickHandler;
 
+                AttachContextMenu();
+
+                var hookContextMenu = _commands.FirstOrDefault(c => c.ShouldHookToContextMenu);
+
+                if (hookContextMenu is object)
+                {
+                    OnContextMenu((_, e) => hookContextMenu.RaiseOnClick(e));
+                }
+
                 UpdateChevronVisibility();
+            }
+
+            public Item CommandsAlwaysVisible(bool alwaysVisible = true)
+            {
+                if (alwaysVisible)
+                {
+                    _headerDiv.classList.add("tss-tree-commands-always-visible");
+                }
+                else
+                {
+                    _headerDiv.classList.remove("tss-tree-commands-always-visible");
+                }
+
+                return this;
             }
 
             public string Text

--- a/Tesserae/src/Components/TreeCommand.cs
+++ b/Tesserae/src/Components/TreeCommand.cs
@@ -1,0 +1,211 @@
+using System;
+using static H5.Core.dom;
+using static Tesserae.UI;
+
+namespace Tesserae
+{
+    /// <summary>
+    /// A Command component for use within a Tree item, typically appearing as a small action button.
+    /// </summary>
+    public class TreeCommand : IComponent
+    {
+        private readonly Button         _button;
+        private readonly IComponent     _renderedComponent;
+        private          Action<Button> _tooltip;
+        private          bool           _hookParentContextMenu;
+
+        internal bool ShouldHookToContextMenu => _hookParentContextMenu;
+
+        public TreeCommand(UIcons icon, UIconsWeight weight = UIconsWeight.Regular) : this(null, Button().SetIcon(icon, weight: weight)) { }
+        public TreeCommand(string href, UIcons icon, UIconsWeight weight = UIconsWeight.Regular) : this(href, Button().SetIcon(icon, weight: weight)) { }
+
+        public TreeCommand(Emoji  icon) : this(null, Button().SetIcon(icon)) { }
+        public TreeCommand(string href, Emoji  icon) : this(href, Button().SetIcon(icon)) { }
+
+        public TreeCommand(ISidebarIcon image) : this(null, image) { }
+        public TreeCommand(string href, ISidebarIcon image)
+        {
+            _button = Button().ReplaceContent(image).Class("tss-tree-command");
+            _renderedComponent = string.IsNullOrWhiteSpace(href) ? (IComponent)_button : UI.Link(href, _button, noUnderline: true);
+        }
+
+        private TreeCommand(Button buttonWithIcon) : this(null, buttonWithIcon) { }
+        private TreeCommand(string href, Button buttonWithIcon)
+        {
+            _button = buttonWithIcon.Class("tss-tree-command");
+            _renderedComponent = string.IsNullOrWhiteSpace(href) ? (IComponent)_button : UI.Link(href, _button, noUnderline: true);
+        }
+
+        /// <summary>
+        /// Sets the foreground color of the command button.
+        /// </summary>
+        public TreeCommand Foreground(string color)
+        {
+            _button.Foreground(color);
+            return this;
+        }
+
+        /// <summary>
+        /// Configures the command to hook into the parent tree item's context menu event.
+        /// </summary>
+        public TreeCommand HookToParentContextMenu()
+        {
+            _hookParentContextMenu = true;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the background color of the command button.
+        /// </summary>
+        public TreeCommand Background(string color)
+        {
+            _button.Background(color);
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the command to use the default style.
+        /// </summary>
+        public TreeCommand Default()
+        {
+            _button.IsPrimary = false;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the command to use the primary style.
+        /// </summary>
+        public TreeCommand Primary()
+        {
+            _button.IsPrimary = true;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the command to use the success style.
+        /// </summary>
+        public TreeCommand Success()
+        {
+            _button.IsSuccess = true;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the command to use the danger style.
+        /// </summary>
+        public TreeCommand Danger()
+        {
+            _button.IsDanger = true;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets a tooltip for the command.
+        /// </summary>
+        public TreeCommand Tooltip(string text)
+        {
+            _tooltip = (b) => b.Tooltip(text, placement: TooltipPlacement.Top);
+            RefreshTooltip();
+            return this;
+        }
+
+        /// <summary>
+        /// Sets a tooltip component for the command.
+        /// </summary>
+        public TreeCommand Tooltip(IComponent tooltip)
+        {
+            _tooltip = (b) => b.Tooltip(tooltip, placement: TooltipPlacement.Top);
+            RefreshTooltip();
+            return this;
+        }
+
+        /// <summary>
+        /// Sets a tooltip generator function for the command.
+        /// </summary>
+        public TreeCommand Tooltip(Func<IComponent> tooltip)
+        {
+            _tooltip = (b) => b.Tooltip(tooltip(), placement: TooltipPlacement.Top);
+            RefreshTooltip();
+            return this;
+        }
+
+        /// <summary>
+        /// Programmatically raises the click event.
+        /// </summary>
+        public TreeCommand RaiseOnClick(MouseEvent mouseEvent)
+        {
+            _button.RaiseOnClick(mouseEvent);
+            return this;
+        }
+
+        /// <summary>
+        /// Programmatically raises the context menu event.
+        /// </summary>
+        public TreeCommand RaiseOnContextMenu(MouseEvent mouseEvent)
+        {
+            _button.RaiseOnContextMenu(mouseEvent);
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a click event handler.
+        /// </summary>
+        public TreeCommand OnClick(Action action)
+        {
+            _button.OnClick(action);
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a context menu event handler.
+        /// </summary>
+        public TreeCommand OnContextMenu(Action action)
+        {
+            _button.OnContextMenu(action);
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a click event handler with button and mouse event arguments.
+        /// </summary>
+        public TreeCommand OnClick(Action<Button, MouseEvent> action)
+        {
+            _button.OnClick((b, e) => action(b, e));
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a context menu event handler with button and mouse event arguments.
+        /// </summary>
+        public TreeCommand OnContextMenu(Action<Button, MouseEvent> action)
+        {
+            _button.OnContextMenu((b, e) => action(b, e));
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the icon for the command.
+        /// </summary>
+        public TreeCommand SetIcon(UIcons icon, string color = "", UIconsWeight weight = UIconsWeight.Regular)
+        {
+            _button.SetIcon(icon, color, weight: weight);
+            return this;
+        }
+
+        /// <summary>
+        /// Sets an emoji icon for the command.
+        /// </summary>
+        public TreeCommand SetIcon(Emoji icon)
+        {
+            _button.SetIcon(icon);
+            return this;
+        }
+
+        internal void RefreshTooltip() => _tooltip?.Invoke(_button);
+
+        /// <summary>
+        /// Renders the tree command.
+        /// </summary>
+        public HTMLElement Render() => _renderedComponent.Render();
+    }
+}

--- a/Tesserae/src/Components/TreeCommand.cs
+++ b/Tesserae/src/Components/TreeCommand.cs
@@ -12,6 +12,7 @@ namespace Tesserae
         private readonly Button         _button;
         private readonly IComponent     _renderedComponent;
         private          Action<Button> _tooltip;
+        private          Func<TreeCommand[]> _menuGenerator;
         private          bool           _hookParentContextMenu;
 
         internal bool ShouldHookToContextMenu => _hookParentContextMenu;
@@ -130,6 +131,47 @@ namespace Tesserae
         }
 
         /// <summary>
+        /// Configures the command to show a menu when clicked.
+        /// </summary>
+        /// <param name="generator">A function that generates the tree commands for the menu.</param>
+        public TreeCommand OnClickMenu(Func<TreeCommand[]> generator)
+        {
+            _menuGenerator = generator;
+            _button.OnClick(() => ShowMenu());
+            return this;
+        }
+
+        /// <summary>
+        /// Shows the associated menu for the command.
+        /// </summary>
+        public void ShowMenu()
+        {
+            if (_menuGenerator is null) throw new NullReferenceException("Need to configure the menu first");
+
+            var items = _menuGenerator();
+
+            var menuDiv = Div(_("tss-tree-menu"));
+
+            foreach (var item in items)
+            {
+                menuDiv.appendChild(item.Render());
+            }
+
+            DomObserver.WhenMounted(menuDiv, () =>
+            {
+                _button.Render().parentElement.classList.add("tss-tree-command-menu-is-open");
+
+                DomObserver.WhenRemoved(menuDiv, () =>
+                {
+                    _button.Render().parentElement.classList.remove("tss-tree-command-menu-is-open");
+                    RefreshTooltip();
+                });
+            });
+
+            Tippy.ShowFor(_button.Render(), menuDiv, out Action hide, placement: TooltipPlacement.BottomStart, maxWidth: 500, delayHide: 1000, theme: "tss-tree-tippy");
+        }
+
+        /// <summary>
         /// Programmatically raises the click event.
         /// </summary>
         public TreeCommand RaiseOnClick(MouseEvent mouseEvent)
@@ -198,6 +240,15 @@ namespace Tesserae
         public TreeCommand SetIcon(Emoji icon)
         {
             _button.SetIcon(icon);
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the text label for the command.
+        /// </summary>
+        public TreeCommand SetText(string text)
+        {
+            _button.SetText(text);
             return this;
         }
 


### PR DESCRIPTION
## Summary
Extends the `Tree.Item` component to support inline command buttons and context menu integration, allowing developers to attach actions directly to tree nodes.

## Key Changes

- **Tree.Item constructor**: Now accepts a `params SidebarCommand[] commands` parameter to attach command buttons to items
- **Command rendering**: Commands are rendered into a new `_commandsDiv` container within the item header
- **Visibility control**: Added `CommandsAlwaysVisible(bool)` fluent method to control when command buttons are displayed (hover, selection, or always)
- **Context menu integration**: 
  - Commands can hook into the item's context menu via `ShouldHookToContextMenu` property
  - Hooked commands are triggered on right-click via `OnContextMenu` handler
- **Styling**: Added CSS rules in `tss.tree.css` to:
  - Hide commands by default
  - Show commands on hover, selection, or when `tss-tree-commands-always-visible` class is applied
  - Style command buttons with appropriate sizing and spacing
- **Sample**: Updated `TreeSample.cs` with a comprehensive example demonstrating:
  - Tree items with inline command buttons (Add, Refresh, Rename, Delete)
  - Context menu integration with `HookToParentContextMenu()`
  - Custom context menu handlers via `OnContextMenu`

## Implementation Details

Commands are stored as a `SidebarCommand[]` field and rendered during item construction. The context menu hook is set up conditionally if any command has `ShouldHookToContextMenu` enabled, allowing flexible command-driven interactions on tree nodes.

https://claude.ai/code/session_0148EqnrCad1qsPHgZTpEq43