### PR TITLE
Add trailing actions support to Tree items

### DIFF
--- a/Tesserae/h5/assets/css/tss.tree.css
+++ b/Tesserae/h5/assets/css/tss.tree.css
@@ -107,6 +107,24 @@
     text-overflow: ellipsis;
 }
 
+/* Trailing slot for caller-supplied buttons / menus on a tree row. Stays
+   collapsed when empty so the row layout is unchanged for items that
+   don't add actions. */
+.tss-tree-actions {
+    display: inline-flex;
+    align-items: center;
+    margin-left: 4px;
+    gap: 2px;
+}
+
+.tss-tree-actions:empty {
+    display: none;
+}
+
+.tss-tree-actions .tss-tree-action {
+    flex: 0 0 auto;
+}
+
 .tss-tree-children {
     list-style: none;
     margin: 0 0 0 16px;

--- a/Tesserae/src/Components/Tree.cs
+++ b/Tesserae/src/Components/Tree.cs
@@ -154,6 +154,7 @@ namespace Tesserae
             private          HTMLElement       _iconSpan;
             private readonly HTMLElement       _checkboxSpan;
             private readonly HTMLSpanElement   _textSpan;
+            private readonly HTMLDivElement    _actionsDiv;
             private readonly HTMLUListElement  _childContainer;
 
             private readonly List<Item> _childItems = new List<Item>();
@@ -192,6 +193,13 @@ namespace Tesserae
                 }
 
                 _headerDiv.appendChild(_textSpan);
+
+                // Trailing slot for caller-supplied buttons / menus (eg. "+" or
+                // "..." actions on a category row). The container is created
+                // unconditionally so consumers can populate it after construction
+                // without having to reach into the DOM directly.
+                _actionsDiv = Div(_("tss-tree-actions tss-default-component-no-margin"));
+                _headerDiv.appendChild(_actionsDiv);
 
                 InnerElement = Li(_("tss-tree-item", role: "treeitem"), _headerDiv, _childContainer);
                 InnerElement.setAttribute("aria-expanded",  "false");
@@ -383,6 +391,36 @@ namespace Tesserae
             public Item Items(params Item[] children)
             {
                 children.ForEach(x => Add(x));
+                return this;
+            }
+
+            /// <summary>
+            /// Adds one or more trailing action components (eg. a "+" button or
+            /// a "..." overflow menu) to the right edge of the header row.
+            /// Clicks on these elements are stopped from propagating, so they
+            /// don't toggle expansion or trigger the item's main OnClick.
+            /// </summary>
+            public Item Actions(params IComponent[] actions)
+            {
+                if (actions is null) return this;
+                foreach (var action in actions)
+                {
+                    if (action is null) continue;
+                    var rendered = action.Render();
+                    rendered.classList.add("tss-tree-action");
+                    rendered.addEventListener("click", e => StopEvent(e.As<Event>()));
+                    rendered.addEventListener("dblclick", e => StopEvent(e.As<Event>()));
+                    _actionsDiv.appendChild(rendered);
+                }
+                return this;
+            }
+
+            /// <summary>
+            /// Removes any previously-added trailing actions from the header.
+            /// </summary>
+            public Item ClearActions()
+            {
+                ClearChildren(_actionsDiv);
                 return this;
             }
 


### PR DESCRIPTION
## Summary
Adds support for displaying trailing action components (such as buttons or menus) on the right edge of tree item headers. This allows tree items to have contextual actions without cluttering the main item content.

## Changes
- **Tree.cs (Item class)**
  - Added `_actionsDiv` field to hold trailing action components
  - Initialize `_actionsDiv` in the constructor as an empty container with `tss-tree-actions` styling
  - Added `Actions(params IComponent[] actions)` method to append action components to the header, with automatic click/dblclick event stopping to prevent item expansion/selection
  - Added `ClearActions()` method to remove all previously-added actions

- **tss.tree.css**
  - Added `.tss-tree-actions` styles: inline-flex layout with centered alignment, 4px left margin, and 2px gap between actions
  - Added `.tss-tree-actions:empty` rule to hide the container when no actions are present (preserving row layout for items without actions)
  - Added `.tss-tree-actions .tss-tree-action` rule to prevent action items from shrinking

## Implementation Details
- The actions container is created unconditionally during item construction, allowing consumers to populate it after construction without direct DOM manipulation
- Event propagation is stopped on both click and double-click events to prevent unintended item selection or expansion when interacting with actions
- The CSS `:empty` pseudo-selector ensures the layout remains unchanged for tree items that don't use actions

https://claude.ai/code/session_016NSXiseEp8ABeQacxhcHGC