### PR TITLE
Fix SaveButton state check timing in click handlers

### DIFF
--- a/Tesserae/src/Components/SaveButton.cs
+++ b/Tesserae/src/Components/SaveButton.cs
@@ -140,15 +140,21 @@ namespace Tesserae
 
         public SaveButton OnClick(Action action)
         {
-            if (_state != State.PendingSave) return this;
-            _button.OnClick(action);
+            _button.OnClick(() =>
+            {
+                if (_state != State.PendingSave) return;
+                action();
+            });
             return this;
         }
-        
+
         public SaveButton OnClickSpinWhile(Func<Task> actionAsync)
         {
-            if (_state != State.PendingSave) return this;
-            _button.OnClickSpinWhile(actionAsync);
+            _button.OnClickSpinWhile(async () =>
+            {
+                if (_state != State.PendingSave) return;
+                await actionAsync();
+            });
             return this;
         }
 


### PR DESCRIPTION
## Summary
Refactored `SaveButton.OnClick()` and `OnClickSpinWhile()` methods to defer the `PendingSave` state check until the button is actually clicked, rather than checking at registration time.

## Key Changes
- **OnClick()**: Wrapped the action in a lambda that checks `_state != State.PendingSave` before executing, allowing the state to be validated at click time rather than at handler registration time
- **OnClickSpinWhile()**: Applied the same pattern to the async handler, wrapping `actionAsync` in an async lambda with deferred state validation
- Both methods now always call the underlying button's handler registration methods, returning `this` for fluent chaining consistency

## Implementation Details
This change ensures that the `PendingSave` state is evaluated when the user actually clicks the button, not when the handler is registered. This allows the button's state to change between handler registration and the actual click event, making the component more flexible and responsive to state transitions.

https://claude.ai/code/session_01B2XJzER5UqkJLjhf4bzwxi