### PR TITLE
Prevent duplicate search triggers in SearchBox.SearchAsYouType()

### DIFF
--- a/Tesserae/src/Components/SearchBox.cs
+++ b/Tesserae/src/Components/SearchBox.cs
@@ -21,6 +21,7 @@ namespace Tesserae
         public delegate void               SearchEventHandler(SearchBox sender, string value);
 
         private double _timeoutTriggerSearch = 0;
+        private string _lastSearchedValue    = string.Empty;
 
         public SearchBox(string placeholder = string.Empty)
         {
@@ -56,6 +57,7 @@ namespace Tesserae
             window.clearTimeout(_timeoutTriggerSearch);
             _timeoutTriggerSearch = window.setTimeout((_) =>
             {
+                _lastSearchedValue = InnerElement.value;
                 Searched?.Invoke(this, InnerElement.value);
             }, 50);
         }
@@ -223,6 +225,10 @@ namespace Tesserae
             OnKeyUp((s, e) =>
             {
                 if (e.altKey || e.ctrlKey || e.metaKey || e.key == "Enter" || e.key == "Escape")
+                {
+                    return;
+                }
+                if (InnerElement.value == _lastSearchedValue)
                 {
                     return;
                 }


### PR DESCRIPTION
## Summary
This change prevents the `SearchBox` component from triggering redundant search events when the input value hasn't actually changed, improving performance and reducing unnecessary event invocations in `SearchAsYouType()` mode.

## Key Changes
- Added `_lastSearchedValue` field to track the most recently searched input value
- Updated `TriggerSearch()` to store the current input value in `_lastSearchedValue` when the search event is invoked
- Added a guard clause in `SearchAsYouType()` to skip triggering search if the current input value matches the last searched value

## Implementation Details
The fix leverages a simple value comparison before calling `TriggerSearch()`. When a user types but the actual input value remains unchanged (e.g., due to rapid keystroke events or input validation), the search event is now skipped. This is particularly useful in `SearchAsYouType()` mode where frequent event triggers could impact performance or cause unnecessary API calls.

https://claude.ai/code/session_016XqH2TdLmzi5cCaDAk2hRF