### PR TITLE
Change Tree.Item icon parameter from string to UIcons?

### DIFF
--- a/Tesserae.Tests/src/Samples/Components/TreeSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/TreeSample.cs
@@ -23,70 +23,70 @@ namespace Tesserae.Tests.Samples
                     Card(VStack().WS().Children(
                     SampleSubTitle("Basic Synchronous Tree"),
                     new Tree().Items(
-                        new Tree.Item("samples/ConsoleApp...", UIcons.Folder.ToString()).Expanded().Items(
-                            new Tree.Item("ConsoleApp1.csproj", UIcons.File.ToString()).Selected(),
-                            new Tree.Item("Program.cs", UIcons.File.ToString())
+                        new Tree.Item("samples/ConsoleApp...", UIcons.Folder).Expanded().Items(
+                            new Tree.Item("ConsoleApp1.csproj", UIcons.File).Selected(),
+                            new Tree.Item("Program.cs", UIcons.File)
                         ),
-                        new Tree.Item("src", UIcons.Folder.ToString()).Expanded().Items(
-                            new Tree.Item("MarkdownRende...", UIcons.Folder.ToString()).Expanded().Items(
-                                new Tree.Item("MarkdownConve...", UIcons.File.ToString()),
-                                new Tree.Item("Slides", UIcons.Folder.ToString()).Expanded().Items(
-                                    new Tree.Item("Blocks", UIcons.Folder.ToString()).Expanded().Items(
-                                        new Tree.Item("HeadingRe...", UIcons.File.ToString()),
-                                        new Tree.Item("HeadingRe...", UIcons.File.ToString())
+                        new Tree.Item("src", UIcons.Folder).Expanded().Items(
+                            new Tree.Item("MarkdownRende...", UIcons.Folder).Expanded().Items(
+                                new Tree.Item("MarkdownConve...", UIcons.File),
+                                new Tree.Item("Slides", UIcons.Folder).Expanded().Items(
+                                    new Tree.Item("Blocks", UIcons.Folder).Expanded().Items(
+                                        new Tree.Item("HeadingRe...", UIcons.File),
+                                        new Tree.Item("HeadingRe...", UIcons.File)
                                     ),
-                                    new Tree.Item("SlideDocume...", UIcons.File.ToString())
+                                    new Tree.Item("SlideDocume...", UIcons.File)
                                 )
                             ),
-                            new Tree.Item("MarkdownRende...", UIcons.Folder.ToString()).Expanded().Items(
-                                new Tree.Item("MarkdownRende...", UIcons.File.ToString()),
-                                new Tree.Item("Program.cs", UIcons.File.ToString())
+                            new Tree.Item("MarkdownRende...", UIcons.Folder).Expanded().Items(
+                                new Tree.Item("MarkdownRende...", UIcons.File),
+                                new Tree.Item("Program.cs", UIcons.File)
                             ),
-                            new Tree.Item("MarkdownRenderer...", UIcons.File.ToString())
+                            new Tree.Item("MarkdownRenderer...", UIcons.File)
                         )
                     ),
                     SampleSubTitle("Asynchronous Tree"),
                     new Tree().Items(
-                        new Tree.Item("Lazy Loaded Folder", UIcons.Folder.ToString()).ItemsAsync(async () =>
+                        new Tree.Item("Lazy Loaded Folder", UIcons.Folder).ItemsAsync(async () =>
                         {
                             await Task.Delay(1000);
                             return new[]
                             {
-                                new Tree.Item("Async Child 1", UIcons.File.ToString()),
-                                new Tree.Item("Async Child 2", UIcons.File.ToString())
+                                new Tree.Item("Async Child 1", UIcons.File),
+                                new Tree.Item("Async Child 2", UIcons.File)
                             };
                         })
                     ),
                     SampleSubTitle("Selectable Tree"),
                     new Tree().SelectionEnabled().Items(
-                        new Tree.Item("Root 1", UIcons.Folder.ToString()).Expanded().Items(
-                            new Tree.Item("Child A", UIcons.File.ToString()),
-                            new Tree.Item("Child B", UIcons.File.ToString())
+                        new Tree.Item("Root 1", UIcons.Folder).Expanded().Items(
+                            new Tree.Item("Child A", UIcons.File),
+                            new Tree.Item("Child B", UIcons.File)
                         ),
-                        new Tree.Item("Root 2", UIcons.Folder.ToString()).Expanded().Items(
-                            new Tree.Item("Child C", UIcons.File.ToString()).Selected(),
-                            new Tree.Item("Child D", UIcons.File.ToString())
+                        new Tree.Item("Root 2", UIcons.Folder).Expanded().Items(
+                            new Tree.Item("Child C", UIcons.File).Selected(),
+                            new Tree.Item("Child D", UIcons.File)
                         )
                     ),
                     SampleSubTitle("Tree with Commands and Context Menu"),
                     new Tree().Items(
-                        new Tree.Item("src", UIcons.Folder.ToString(),
+                        new Tree.Item("src", UIcons.Folder,
                             new TreeCommand(UIcons.Plus).Tooltip("Add file").OnClick(() => window.alert("Add file clicked")),
                             new TreeCommand(UIcons.Refresh).Tooltip("Refresh").OnClick(() => window.alert("Refresh clicked"))
                         ).Expanded().Items(
-                            new Tree.Item("Program.cs", UIcons.File.ToString(),
+                            new Tree.Item("Program.cs", UIcons.File,
                                 new TreeCommand(UIcons.Pencil).Tooltip("Rename").OnClick(() => window.alert("Rename Program.cs")),
                                 new TreeCommand(UIcons.Trash).Tooltip("Delete").OnClick(() => window.alert("Delete Program.cs"))
                             ),
-                            new Tree.Item("README.md", UIcons.File.ToString(),
+                            new Tree.Item("README.md", UIcons.File,
                                 new TreeCommand(UIcons.MenuDots).Tooltip("Context menu").HookToParentContextMenu().OnClick(() => window.alert("README.md context action (right-click or button)"))
                             ),
-                            new Tree.Item("notes.txt", UIcons.File.ToString()).OnContextMenu((s, e) =>
+                            new Tree.Item("notes.txt", UIcons.File).OnContextMenu((s, e) =>
                             {
                                 e.preventDefault();
                                 window.alert("Right-clicked notes.txt");
                             }),
-                            new Tree.Item("config.json", UIcons.File.ToString(),
+                            new Tree.Item("config.json", UIcons.File,
                                 new TreeCommand(UIcons.MenuBurger).Tooltip("More actions").OnClickMenu(() => new[]
                                 {
                                     new TreeCommand(UIcons.Pencil).SetText("Rename").OnClick(() => window.alert("Rename config.json")),

--- a/Tesserae/src/Components/Tree.cs
+++ b/Tesserae/src/Components/Tree.cs
@@ -152,6 +152,7 @@ namespace Tesserae
             private readonly HTMLDivElement    _headerDiv;
             private readonly HTMLElement       _chevronSpan;
             private          HTMLElement       _iconSpan;
+            private          UIcons?           _icon;
             private readonly HTMLElement       _checkboxSpan;
             private readonly HTMLSpanElement   _textSpan;
             private readonly HTMLDivElement    _commandsDiv;
@@ -178,7 +179,7 @@ namespace Tesserae
                 }
             }
 
-            public Item(string text = null, string icon = null, params TreeCommand[] commands)
+            public Item(string text = null, UIcons? icon = null, params TreeCommand[] commands)
             {
                 _chevronSpan    = I(_("tss-tree-chevron " + UIcons.AngleRight.ToString()));
                 _textSpan       = Span(_("tss-tree-text", text: text));
@@ -188,9 +189,10 @@ namespace Tesserae
 
                 _headerDiv = Div(_("tss-tree-item-content"), _chevronSpan, _checkboxSpan);
 
-                if (!string.IsNullOrEmpty(icon))
+                if (icon.HasValue)
                 {
-                    _iconSpan = I(_("tss-tree-icon " + icon));
+                    _icon = icon.Value;
+                    _iconSpan = I(_("tss-tree-icon " + icon.Value.ToString()));
                     _headerDiv.appendChild(_iconSpan);
                 }
 
@@ -248,12 +250,13 @@ namespace Tesserae
                 set => _textSpan.innerText = value;
             }
 
-            public string Icon
+            public UIcons? Icon
             {
-                get => _iconSpan?.className.Replace("tss-tree-icon ", "");
+                get => _icon;
                 set
                 {
-                    if (string.IsNullOrEmpty(value))
+                    _icon = value;
+                    if (!value.HasValue)
                     {
                         if (_iconSpan != null)
                         {
@@ -265,12 +268,12 @@ namespace Tesserae
                     {
                         if (_iconSpan == null)
                         {
-                            _iconSpan = I(_("tss-tree-icon " + value));
+                            _iconSpan = I(_("tss-tree-icon " + value.Value.ToString()));
                             _headerDiv.insertBefore(_iconSpan, _textSpan);
                         }
                         else
                         {
-                            _iconSpan.className = "tss-tree-icon " + value;
+                            _iconSpan.className = "tss-tree-icon " + value.Value.ToString();
                         }
                     }
                 }
@@ -435,7 +438,7 @@ namespace Tesserae
                     {
                         alreadyRun = true;
 
-                        var loading = new Item("Loading...", UIcons.Spinner.ToString());
+                        var loading = new Item("Loading...", UIcons.Spinner);
                         Add(loading);
 
                         Task.Run(async () =>


### PR DESCRIPTION
Match the convention used by other components (CommandBarItem, Dropdown.Item)
so callers can pass UIcons.Folder directly instead of UIcons.Folder.ToString().

https://claude.ai/code/session_01UXf917TMtCLxEjdeX1eGk1