### PR TITLE
Rewrite Pivot to use a horizontal scrolling tab strip

### DIFF
--- a/Tesserae.Tests/src/Samples/Surfaces/PivotSample.cs
+++ b/Tesserae.Tests/src/Samples/Surfaces/PivotSample.cs
@@ -51,8 +51,29 @@ namespace Tesserae.Tests.Samples
                        .Pivot("tab6", PivotTitle("Tab 6"), () => ItemsList(GetSomeItems(5)).PB(16), cached: true)
                        .Pivot("tab7", PivotTitle("Tab 7"), () => ItemsList(GetSomeItems(5)).PB(16), cached: true)
                        .Pivot("tab8", PivotTitle("Tab 8"), () => ItemsList(GetSomeItems(5)).PB(16), cached: true))
-                    .Right(TextBlock("👈 resize this area to see the overflow adjusting which tabs to show").WS().BreakSpaces())
+                    .Right(TextBlock("👈 resize this area to scroll the tab strip — use the chevrons, the mouse wheel, or arrow / Home / End keys, and click the ⋯ button for an All Tabs menu").WS().BreakSpaces()),
+                    SampleSubTitle("Many Tabs with Long Titles"),
+                    GetManyTabsPivot()
                 )).SetTitle("Usage")));
+        }
+
+        private Pivot GetManyTabsPivot()
+        {
+            var titles = new[]
+            {
+                "Project Overview", "Recent Activity", "Pull Requests", "Code Review",
+                "Build Pipelines", "Test Results", "Deployments", "Issue Tracker",
+                "Documentation", "Team Members", "Performance Metrics", "Security Audits",
+                "Release Notes", "Settings & Preferences", "Integrations", "Audit Log"
+            };
+            var pivot = Pivot().H(220);
+            for (int i = 0; i < titles.Length; i++)
+            {
+                var idx = i;
+                pivot = pivot.Pivot($"many-{idx}", PivotTitle(titles[idx]),
+                                    () => TextBlock($"Content for: {titles[idx]}").P(16), cached: true);
+            }
+            return pivot;
         }
 
         private Pivot GetPivot()

--- a/Tesserae/h5/assets/css/tss.mobile.css
+++ b/Tesserae/h5/assets/css/tss.mobile.css
@@ -194,11 +194,6 @@ body.tss-mobile .tippy-box {
     max-width: min(340px, 95vw) !important;
 }
 
-/* ─── Pivot — allow wrapping on mobile ───────────────────────────────────── */
-body.tss-mobile .tss-pivot-titlebar {
-    flex-wrap: wrap !important;
-}
-
 /* ─── Pagination — smaller controls ─────────────────────────────────────── */
 body.tss-mobile .tss-pagination .tss-btn {
     min-width: 36px !important;

--- a/Tesserae/h5/assets/css/tss.pivot.css
+++ b/Tesserae/h5/assets/css/tss.pivot.css
@@ -1,4 +1,4 @@
-﻿/* Tabs */
+/* Tabs */
 .tss-pivot {
     margin: 0;
     padding: 0;
@@ -9,77 +9,89 @@
     position: relative;
 }
 
-.tss-pivot-titlebar {
-    display: inline-flex;
+.tss-pivot-titlebar-wrapper {
+    display: flex;
     flex-direction: row;
     flex-wrap: nowrap;
     flex-shrink: 0;
     flex-grow: 0;
+    align-items: stretch;
+    width: 100%;
+    background: var(--tss-secondary-background-color);
+}
+
+.tss-pivot-titlebar-scroller {
+    position: relative;
+    flex: 1 1 auto;
+    min-width: 0; /* allow the scroller to shrink below its content size */
+    overflow-x: auto;
+    overflow-y: hidden;
+    scrollbar-width: none; /* Firefox: hide native scrollbar (scroll buttons handle it) */
+    -ms-overflow-style: none;
+}
+
+.tss-pivot-titlebar-scroller::-webkit-scrollbar {
+    display: none;
+}
+
+.tss-pivot-titlebar {
+    position: relative;
+    display: flex;
+    flex-direction: row;
+    flex-wrap: nowrap;
+    /* Stretch to fill the scroller when tabs are narrower (so justify-content works)
+       and grow with the content when tabs overflow (enabling horizontal scroll). */
+    min-width: 100%;
+    width: max-content;
     font-size: 14px;
     font-weight: 400;
     box-shadow: none;
-    margin-top: 0px;
-    margin-right: 0px;
-    margin-bottom: 0px;
-    margin-left: 0px;
-    padding-top: 0px;
-    padding-right: 0px;
-    padding-bottom: 0px;
-    padding-left: 0px;
+    margin: 0;
+    padding: 0;
     box-sizing: border-box;
-    position: relative;
     color: rgb(0, 120, 212);
     white-space: nowrap;
-    background: var(--tss-secondary-background-color);
-    width: 100%;
-    overflow:hidden;
 }
 
     .tss-pivot-titlebar > * {
         background: var(--tss-secondary-background-color);
         border: 0px;
         margin: 0px;
-        flex-shrink:1;
-        min-width: min-content;        
+        flex-shrink: 0;
     }
 
 
     .tss-pivot-titlebar > .tss-pivot-selected-title {
         font-weight: var(--tss-font-weight-semibold);
         background: var(--tss-default-background-color);
-        flex-shrink: 0;
     }
 
         .tss-pivot-titlebar > .tss-pivot-selected-title > span {
             font-weight: var(--tss-font-weight-semibold);
             background: var(--tss-default-background-color);
-            flex-shrink: 0;
         }
 
         .tss-pivot-titlebar > .tss-pivot-selected-title:hover > span {
             background-color: unset;
             border-color: unset;
         }
-        
+
         .tss-pivot-titlebar > .tss-pivot-selected-title > div {
             font-weight: var(--tss-font-weight-semibold);
             background: var(--tss-default-background-color);
-            flex-shrink: 0;
         }
 
-.tss-pivot-titlebar-more {
-
+.tss-pivot-titlebar-more,
+.tss-pivot-titlebar-scroll-left,
+.tss-pivot-titlebar-scroll-right {
+    flex-shrink: 0;
+    flex-grow: 0;
+    align-self: stretch;
 }
 
 .tss-pivot-titlebar-scroll-left i,
 .tss-pivot-titlebar-scroll-right i {
     font-size: 10px;
-}
-
-.tss-pivot-titlebar-hide-if-single > .tss-pivot-selected-title:only-child,
-.tss-pivot-titlebar-hide-if-single > .tss-pivot-titlebar-scroll-left
-.tss-pivot-titlebar-hide-if-single > .tss-pivot-titlebar-scroll-right {
-    display: none;
 }
 
 .tss-pivot-content {
@@ -92,21 +104,16 @@
 }
 
 .tss-pivot-line {
+    position: absolute;
+    bottom: 0;
+    left: 0;
     height: 4px;
-    margin-top: -2px;
-    z-index: 1;
     width: 0px;
-    flex-shrink: 0;
-    flex-grow: 0;
+    z-index: 1;
     background-color: var(--tss-primary-background-hover-color);
     overflow: hidden;
     pointer-events: none;
     border-radius: 4px;
-}
-
-
-.tss-pivot-titlebar-hidden-overflow {
-    display: none;
 }
 
 .tss-pivot-tab-closeable {

--- a/Tesserae/src/Components/Pivot.cs
+++ b/Tesserae/src/Components/Pivot.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using static H5.Core.dom;
@@ -18,10 +18,12 @@ namespace Tesserae
         private readonly HTMLElement _renderedTabs;
         private readonly HTMLElement _renderedContent;
         private readonly HTMLElement _line;
-        private readonly HTMLDivElement _scrollCommands;
+        private readonly HTMLElement _scroller;
+        private readonly HTMLElement _titlebarWrapper;
         private          string      _initiallySelectedID;
         private          string      _currentSelectedID;
         private          bool        _isRendered = false;
+        private          bool        _hideIfSingle = false;
         public           string      SelectedTab => _currentSelectedID ?? _initiallySelectedID;
         private HTMLElement _selectedNav;
         private HTMLElement _hoveredNav;
@@ -30,19 +32,34 @@ namespace Tesserae
         private double _currentLeft = 0;
         private double _targetWidth;
         private double _targetLeft;
-        private double _left0;
         private bool _firstRender = false;
         private ResizeObserver _ro;
         private readonly Button _moreBtn;
+        private readonly Button _scrollLeftBtn;
+        private readonly Button _scrollRightBtn;
 
+        // Fraction of the scroller's visible width to move per scroll-button click.
+        private const double ScrollButtonStep = 0.7;
 
         public Pivot()
         {
-            _moreBtn          = Button().SetIcon(UIcons.MenuDots).NoMinSize().W(32).HS().NoPadding().Class("tss-pivot-titlebar-more").OnClick(() => ShowMoreTabs());
-            _line             = Div(_("tss-pivot-line"));
-            _renderedTabs     = Div(_("tss-pivot-titlebar", role: "tablist"));
-            _renderedContent  = Div(_("tss-pivot-content", role: "tabpanel"));
-            StylingContainer = Div(_("tss-pivot"), _renderedTabs, _line, _renderedContent);
+            _scrollLeftBtn  = Button().SetIcon(UIcons.AngleLeft).NoMinSize().W(32).HS().NoPadding().Class("tss-pivot-titlebar-scroll-left").OnClick(() => ScrollByAmount(-_scroller.clientWidth * ScrollButtonStep));
+            _scrollRightBtn = Button().SetIcon(UIcons.AngleRight).NoMinSize().W(32).HS().NoPadding().Class("tss-pivot-titlebar-scroll-right").OnClick(() => ScrollByAmount(_scroller.clientWidth * ScrollButtonStep));
+            _moreBtn        = Button().SetIcon(UIcons.MenuDots).NoMinSize().W(32).HS().NoPadding().Class("tss-pivot-titlebar-more").OnClick(() => ShowAllTabs());
+
+            _renderedTabs    = Div(_("tss-pivot-titlebar", role: "tablist"));
+            _line            = Div(_("tss-pivot-line"));
+            _renderedTabs.appendChild(_line); // line sits inside titlebar so it scrolls with tabs
+            _scroller        = Div(_("tss-pivot-titlebar-scroller"), _renderedTabs);
+            _titlebarWrapper = Div(_("tss-pivot-titlebar-wrapper"),
+                                   _scrollLeftBtn.Render(),
+                                   _scroller,
+                                   _scrollRightBtn.Render(),
+                                   _moreBtn.Render());
+            _renderedContent = Div(_("tss-pivot-content", role: "tabpanel"));
+            StylingContainer = Div(_("tss-pivot"), _titlebarWrapper, _renderedContent);
+
+            AttachScrollerEvents();
         }
 
         public HTMLElement StylingContainer { get; }
@@ -64,13 +81,14 @@ namespace Tesserae
 
         public Pivot HideIfSingle()
         {
-            _renderedTabs.classList.add("tss-pivot-titlebar-hide-if-single");
+            _hideIfSingle = true;
+            UpdateTitlebarVisibility();
             return this;
         }
 
         public void RefreshPivotSizes()
         {
-            RefreshTabsOverflow();
+            UpdateScrollState();
             TriggerAnimation();
         }
 
@@ -92,97 +110,126 @@ namespace Tesserae
             }
             title.setAttribute("role", "tab");
             title.setAttribute("aria-selected", "false");
+            title.tabIndex = -1;
             _renderedTitles.Add(tab, title);
             AttachEvents(tab.Id, title);
-            _renderedTabs.appendChild(title);
+            _renderedTabs.insertBefore(title, _line); // keep _line as last child
 
             if (_isRendered && _orderedTabs.Count == 1)
             {
                 Select(tab.Id);
             }
 
-            RefreshTabsOverflow();
+            UpdateTitlebarVisibility();
+            UpdateScrollState();
 
             return this;
         }
 
-        private void RefreshTabsOverflow(HTMLElement willSelect = null)
+        private void AttachScrollerEvents()
         {
-            if (!StylingContainer.IsMounted()) return; //Nothing to do yet
-
-            if (_moreBtn.IsMounted())
+            // Convert vertical wheel motion (typical mouse) into horizontal scrolling.
+            _scroller.addEventListener("wheel", e =>
             {
-                _moreBtn.Render().remove();
-            }
-
-            var orderedTitles = _orderedTabs.Select(t => _renderedTitles[t]).ToArray();
-
-            foreach (var rendered in orderedTitles)
-            {
-                rendered.classList.remove("tss-pivot-titlebar-hidden-overflow");
-            }
-
-            if (orderedTitles.Length == 0) return;
-
-            var availableWidth = _renderedTabs.getBoundingClientRect().As<DOMRect>().width;
-            var widths         = orderedTitles.Select(e => e.getBoundingClientRect().As<DOMRect>().width).ToArray();
-
-            // If every tab fits in full, no More button is needed.
-            if (widths.Sum() <= availableWidth) return;
-
-            const double moreWidth = 40;
-            var maxWidth = availableWidth - moreWidth;
-
-            // The selected tab must always remain visible — reserve its width first.
-            int selectedIdx = willSelect != null ? Array.IndexOf(orderedTitles, willSelect) : -1;
-            if (selectedIdx < 0)
-            {
-                for (int i = 0; i < orderedTitles.Length; i++)
+                var we = e.As<WheelEvent>();
+                if (Math.Abs(we.deltaY) > Math.Abs(we.deltaX))
                 {
-                    if (orderedTitles[i].classList.contains("tss-pivot-selected-title"))
-                    {
-                        selectedIdx = i;
-                        break;
-                    }
+                    _scroller.scrollLeft += we.deltaY;
+                    e.preventDefault();
                 }
-            }
+            });
 
-            double curWidth = selectedIdx >= 0 ? widths[selectedIdx] : 0;
+            _scroller.addEventListener("scroll", e => UpdateScrollButtons());
 
-            // A tab is only shown if its full width fits; otherwise it goes into the More menu.
-            for (int i = 0; i < orderedTitles.Length; i++)
+            // ARIA tablist keyboard navigation. Arrow keys move and activate the
+            // adjacent tab, Home/End jump to the first/last tab.
+            _renderedTabs.addEventListener("keydown", e =>
             {
-                if (i == selectedIdx) continue;
-                if (curWidth + widths[i] <= maxWidth)
+                var ke = e.As<KeyboardEvent>();
+                if (ke.key == "ArrowLeft" || ke.key == "ArrowRight" || ke.key == "Home" || ke.key == "End")
                 {
-                    curWidth += widths[i];
+                    StopEvent(e);
+                    NavigateWithKey(ke.key);
                 }
-                else
-                {
-                    orderedTitles[i].classList.add("tss-pivot-titlebar-hidden-overflow");
-                }
-            }
-
-            _renderedTabs.appendChild(_moreBtn.Render());
+            });
         }
 
-        private void ShowMoreTabs()
+        private void NavigateWithKey(string key)
         {
-            var elementsToClone = _renderedTabs.querySelectorAll(".tss-pivot-titlebar-hidden-overflow").Select(n => n.As<HTMLElement>()).ToArray();
-            var cloned = elementsToClone.Select(n => n.cloneNode(true).As<HTMLElement>()).ToArray();
-            var items = new ContextMenu.Item[cloned.Length];
-            for (int i = 0; i < cloned.Length; i++)
+            if (_orderedTabs.Count == 0) return;
+
+            int currentIdx = _orderedTabs.FindIndex(t => t.Id == _currentSelectedID);
+            if (currentIdx < 0) currentIdx = 0;
+
+            int nextIdx = currentIdx;
+            switch (key)
             {
-                var iLocal = i;
-                HTMLElement c = cloned[i];
-                c.classList.remove("tss-pivot-titlebar-hidden-overflow");
-                items[i] = ContextMenuItem(Raw(c)).OnClick(() =>
-                {
-                    RefreshTabsOverflow(elementsToClone[iLocal]);
-                    elementsToClone[iLocal].click();
-                });
+                case "ArrowLeft":  nextIdx = (currentIdx - 1 + _orderedTabs.Count) % _orderedTabs.Count; break;
+                case "ArrowRight": nextIdx = (currentIdx + 1) % _orderedTabs.Count;                     break;
+                case "Home":       nextIdx = 0;                                                          break;
+                case "End":        nextIdx = _orderedTabs.Count - 1;                                     break;
             }
 
+            if (nextIdx != currentIdx)
+            {
+                var nextTab = _orderedTabs[nextIdx];
+                Select(nextTab.Id);
+                if (_renderedTitles.TryGetValue(nextTab, out var nextTitle))
+                {
+                    nextTitle.focus();
+                }
+            }
+        }
+
+        private void ScrollByAmount(double dx)
+        {
+            _scroller.scrollLeft += dx;
+        }
+
+        private void UpdateScrollState()
+        {
+            if (!StylingContainer.IsMounted()) return;
+            UpdateScrollButtons();
+            UpdateMoreVisibility();
+        }
+
+        private void UpdateScrollButtons()
+        {
+            var canScrollLeft  = _scroller.scrollLeft > 0;
+            var canScrollRight = _scroller.scrollLeft + _scroller.clientWidth < _scroller.scrollWidth - 1; // -1 for sub-pixel rounding
+            _scrollLeftBtn.Render().style.display  = canScrollLeft  ? "" : "none";
+            _scrollRightBtn.Render().style.display = canScrollRight ? "" : "none";
+        }
+
+        private void UpdateMoreVisibility()
+        {
+            _moreBtn.Render().style.display = _orderedTabs.Count > 0 ? "" : "none";
+        }
+
+        private void UpdateTitlebarVisibility()
+        {
+            var hide = _hideIfSingle && _orderedTabs.Count <= 1;
+            _titlebarWrapper.style.display = hide ? "none" : "";
+        }
+
+        private void ShowAllTabs()
+        {
+            var items = new ContextMenu.Item[_orderedTabs.Count];
+            for (int i = 0; i < _orderedTabs.Count; i++)
+            {
+                var tab     = _orderedTabs[i];
+                var title   = _renderedTitles[tab];
+                var clone   = title.cloneNode(true).As<HTMLElement>();
+                clone.classList.remove("tss-pivot-titlebar-hidden-overflow");
+                // The cloned close icon is non-functional inside the menu; strip it
+                // so the user gets a clean title row.
+                foreach (var x in clone.querySelectorAll(".tss-pivot-tab-close").ToList())
+                {
+                    x.As<HTMLElement>().remove();
+                }
+                var id = tab.Id;
+                items[i] = ContextMenuItem(Raw(clone)).OnClick(() => Select(id));
+            }
             ContextMenu().Items(items).ShowFor(_moreBtn);
         }
 
@@ -214,6 +261,9 @@ namespace Tesserae
                 }
 
                 tab.OnClosed?.Invoke();
+
+                UpdateTitlebarVisibility();
+                UpdateScrollState();
             }
         }
 
@@ -308,6 +358,7 @@ namespace Tesserae
 
             _currentSelectedID = tab.Id;
             UpdateTitleStyles(title);
+            ScrollIntoView(title);
             TriggerAnimation();
 
             var pne = new PivotNavigateEvent(_currentSelectedID, tab.Id);
@@ -315,6 +366,23 @@ namespace Tesserae
             _navigated?.Invoke(this, pne);
 
             return this;
+        }
+
+        private void ScrollIntoView(HTMLElement target)
+        {
+            if (!_scroller.IsMounted()) return;
+            var tabLeft  = (double)target.offsetLeft;
+            var tabRight = tabLeft + target.offsetWidth;
+            var viewLeft = _scroller.scrollLeft;
+            var viewRight = viewLeft + _scroller.clientWidth;
+            if (tabLeft < viewLeft)
+            {
+                _scroller.scrollLeft = tabLeft;
+            }
+            else if (tabRight > viewRight)
+            {
+                _scroller.scrollLeft = tabRight - _scroller.clientWidth;
+            }
         }
 
         private void ClearChildrenExceptCached()
@@ -340,11 +408,13 @@ namespace Tesserae
                 {
                     v.classList.add("tss-pivot-selected-title");
                     v.setAttribute("aria-selected", "true");
+                    v.tabIndex = 0;
                 }
                 else
                 {
                     v.classList.remove("tss-pivot-selected-title");
                     v.setAttribute("aria-selected", "false");
+                    v.tabIndex = -1;
                 }
             }
             _selectedNav = title;
@@ -364,7 +434,7 @@ namespace Tesserae
 
                 _ro = new ResizeObserver((entries, obs) =>
                 {
-                    RefreshTabsOverflow(); 
+                    UpdateScrollState();
                     TriggerAnimation();
                 });
 
@@ -372,15 +442,17 @@ namespace Tesserae
 
                 DomObserver.WhenMounted(StylingContainer, () =>
                 {
-                    RefreshTabsOverflow();
+                    UpdateScrollState();
+                    if (_selectedNav != null) ScrollIntoView(_selectedNav);
                     TriggerAnimation();
                     //Also do on a timeout to account for animations on modals
                     window.setTimeout((_) => {
-                        RefreshTabsOverflow();
+                        UpdateScrollState();
+                        if (_selectedNav != null) ScrollIntoView(_selectedNav);
                         TriggerAnimation();
                     }, 1000);
                 });
-                
+
                 DomObserver.WhenRemoved(StylingContainer, () => _ro.unobserve(StylingContainer));
             }
 
@@ -402,10 +474,11 @@ namespace Tesserae
                 if (target is null) { return; }
 
                 _t0 = time;
-                var r = target.getBoundingClientRect().As<DOMRect>();
-                _left0       = _renderedTabs.getBoundingClientRect().As<DOMRect>().left;
-                _targetWidth = r.width;
-                _targetLeft  = r.left;
+                // offsetLeft/offsetWidth are relative to the titlebar, which is the
+                // line's offsetParent (it's position: relative). This stays correct
+                // regardless of scroll position.
+                _targetWidth = target.offsetWidth;
+                _targetLeft  = target.offsetLeft;
             }
 
             var f = (time - _t0) / 500; //500ms animation
@@ -421,10 +494,10 @@ namespace Tesserae
                 f = 1;
             }
 
-            _currentWidth          += (_targetWidth - _currentWidth) * f;
-            _currentLeft           += (_targetLeft  - _currentLeft)  * f;
-            _line.style.width      =  _currentWidth          + "px";
-            _line.style.marginLeft =  (_currentLeft - _left0) + "px";
+            _currentWidth     += (_targetWidth - _currentWidth) * f;
+            _currentLeft      += (_targetLeft  - _currentLeft)  * f;
+            _line.style.width =  _currentWidth + "px";
+            _line.style.left  =  _currentLeft  + "px";
 
             if (Math.Abs(_currentLeft - _targetLeft) > 1e-5 || Math.Abs(_currentWidth - _targetWidth) > 1e-5)
             {

--- a/Tesserae/src/Components/Pivot.cs
+++ b/Tesserae/src/Components/Pivot.cs
@@ -109,17 +109,12 @@ namespace Tesserae
         private void RefreshTabsOverflow(HTMLElement willSelect = null)
         {
             if (!StylingContainer.IsMounted()) return; //Nothing to do yet
-            
+
             if (_moreBtn.IsMounted())
             {
                 _moreBtn.Render().remove();
             }
 
-            var moreWidth = 40;
-            var maxWidth = _renderedTabs.getBoundingClientRect().As<DOMRect>().width - moreWidth;
-            double curWidth = 0;
-            bool hasMore = false;
-            
             var orderedTitles = _orderedTabs.Select(t => _renderedTitles[t]).ToArray();
 
             foreach (var rendered in orderedTitles)
@@ -127,26 +122,48 @@ namespace Tesserae
                 rendered.classList.remove("tss-pivot-titlebar-hidden-overflow");
             }
 
-            orderedTitles = orderedTitles.OrderBy(e => (e == willSelect  || (willSelect is null && e.classList.contains("tss-pivot-selected-title"))) ? 0 : 1).ToArray();
+            if (orderedTitles.Length == 0) return;
 
-            foreach (var rendered in orderedTitles)
+            var availableWidth = _renderedTabs.getBoundingClientRect().As<DOMRect>().width;
+            var widths         = orderedTitles.Select(e => e.getBoundingClientRect().As<DOMRect>().width).ToArray();
+
+            // If every tab fits in full, no More button is needed.
+            if (widths.Sum() <= availableWidth) return;
+
+            const double moreWidth = 40;
+            var maxWidth = availableWidth - moreWidth;
+
+            // The selected tab must always remain visible — reserve its width first.
+            int selectedIdx = willSelect != null ? Array.IndexOf(orderedTitles, willSelect) : -1;
+            if (selectedIdx < 0)
             {
-                curWidth += rendered.getBoundingClientRect().As<DOMRect>().width;
-                if (curWidth > maxWidth)
+                for (int i = 0; i < orderedTitles.Length; i++)
                 {
-                    rendered.classList.add("tss-pivot-titlebar-hidden-overflow");
-                    hasMore = true;
+                    if (orderedTitles[i].classList.contains("tss-pivot-selected-title"))
+                    {
+                        selectedIdx = i;
+                        break;
+                    }
+                }
+            }
+
+            double curWidth = selectedIdx >= 0 ? widths[selectedIdx] : 0;
+
+            // A tab is only shown if its full width fits; otherwise it goes into the More menu.
+            for (int i = 0; i < orderedTitles.Length; i++)
+            {
+                if (i == selectedIdx) continue;
+                if (curWidth + widths[i] <= maxWidth)
+                {
+                    curWidth += widths[i];
                 }
                 else
                 {
-                    rendered.classList.remove("tss-pivot-titlebar-hidden-overflow");
+                    orderedTitles[i].classList.add("tss-pivot-titlebar-hidden-overflow");
                 }
             }
 
-            if (hasMore)
-            {
-                _renderedTabs.appendChild(_moreBtn.Render());
-            }
+            _renderedTabs.appendChild(_moreBtn.Render());
         }
 
         private void ShowMoreTabs()


### PR DESCRIPTION
## Summary

Replaces the old hide-overflow Pivot model with a single horizontal scrolling strip, while keeping the public API intact.

- **One horizontal row** — tabs never wrap or get hidden.
- **Horizontal scrolling** — mouse wheel (vertical wheel maps to horizontal scroll), left/right chevron buttons (auto-shown only when scrolling in that direction is possible), and ARIA tablist keyboard navigation (Arrow keys, Home, End) with a roving tabindex. The active tab is auto-scrolled into view on selection.
- **All Tabs (⋯) menu** — always available and lists *every* open tab, not just hidden ones.
- **Active-tab indicator** — now lives inside the titlebar, positioned from `offsetLeft / offsetWidth`, so it tracks the selected tab correctly under any scroll position.
- **HideIfSingle** moved from a CSS `:only-child` rule (which broke once the indicator became a child of the titlebar) to explicit titlebar visibility kept in sync with `Add` / `RemoveTab`.
- Removed the `flex-wrap: wrap` mobile override — the scrolling strip is the intended behaviour on every viewport.

The first commit on the branch is a narrower fix to the original `RefreshTabsOverflow` logic; it's superseded by the full rewrite in the second commit but kept in history for context.

## Sample updates

`PivotSample.cs`:

- Reworded the "Tab Overflow" caption to point at the chevrons / wheel / arrow keys / ⋯ menu.
- Added a "Many Tabs with Long Titles" sample (16 descriptive workspace-style titles) to exercise the scroll/keyboard/All Tabs paths visually.

## Test plan

- [ ] Open the Pivot sample page; confirm the existing "Normal / Justified / Centered" pivots still render correctly when all tabs fit.
- [ ] In "Tab Overflow", drag the splitter narrower and verify:
  - [ ] Tabs stay in one row and never wrap.
  - [ ] The right chevron appears once content overflows; left chevron appears once scrolled.
  - [ ] Clicking the chevrons scrolls the strip; scrolling to the ends hides the corresponding chevron.
  - [ ] Mouse-wheel over the strip scrolls it horizontally.
  - [ ] Focus a tab, then Arrow-Left / Arrow-Right / Home / End move and select neighbouring tabs; the active tab is brought into view.
  - [ ] The ⋯ button shows *all* 8 tabs; clicking one selects it and scrolls it into view.
- [ ] In "Many Tabs with Long Titles", confirm the strip scrolls smoothly across all 16 tabs and the ⋯ menu lists them all.
- [ ] Confirm `Justified()` and `Centered()` still spread / center tabs when they fit, and fall through to scrolling when they don't.
- [ ] `HideIfSingle()` still hides the strip when only one tab remains.

https://claude.ai/code/session_011ng4w4pPg7HPqmUbQNkLws