### PR TITLE
mark wheel listeners passive, drop pivot rAF loop, lazy DomObserver

### DIFF
--- a/Tesserae/h5/assets/css/tss.pivot.css
+++ b/Tesserae/h5/assets/css/tss.pivot.css
@@ -114,6 +114,13 @@
     overflow: hidden;
     pointer-events: none;
     border-radius: 4px;
+    transition: left 0.5s cubic-bezier(0.2, 0, 0, 1),
+                width 0.5s cubic-bezier(0.2, 0, 0, 1);
+    will-change: left, width;
+}
+
+.tss-pivot-line.tss-pivot-line-instant {
+    transition: none;
 }
 
 .tss-pivot-tab-closeable {

--- a/Tesserae/src/Components/Dropdown.cs
+++ b/Tesserae/src/Components/Dropdown.cs
@@ -276,7 +276,9 @@ namespace Tesserae
                 _contentHtml.addEventListener("click",       OnWindowClick);
                 _contentHtml.addEventListener("dblclick",    OnWindowClick);
                 _contentHtml.addEventListener("contextmenu", OnWindowClick);
-                _contentHtml.addEventListener("wheel",       OnWindowClick);
+                // OnWindowClick doesn't preventDefault, so mark the wheel listener
+                // passive to avoid blocking scroll and silence the browser warning.
+                _contentHtml.addEventListener("wheel",       (Action<Event>)OnWindowClick, new AddEventListenerOptions { passive = true });
 
                 if (_itemsSource is object)
                 {

--- a/Tesserae/src/Components/Pivot.cs
+++ b/Tesserae/src/Components/Pivot.cs
@@ -27,11 +27,6 @@ namespace Tesserae
         public           string      SelectedTab => _currentSelectedID ?? _initiallySelectedID;
         private HTMLElement _selectedNav;
         private HTMLElement _hoveredNav;
-        private double _t0 = 0;
-        private double _currentWidth = 0;
-        private double _currentLeft = 0;
-        private double _targetWidth;
-        private double _targetLeft;
         private bool _firstRender = false;
         private ResizeObserver _ro;
         private readonly Button _moreBtn;
@@ -129,7 +124,9 @@ namespace Tesserae
         private void AttachScrollerEvents()
         {
             // Convert vertical wheel motion (typical mouse) into horizontal scrolling.
-            _scroller.addEventListener("wheel", e =>
+            // This listener calls preventDefault() so it must be non-passive; mark it
+            // explicitly so the browser doesn't have to guess.
+            _scroller.addEventListener("wheel", (Action<Event>)(e =>
             {
                 var we = e.As<WheelEvent>();
                 if (Math.Abs(we.deltaY) > Math.Abs(we.deltaX))
@@ -137,7 +134,7 @@ namespace Tesserae
                     _scroller.scrollLeft += we.deltaY;
                     e.preventDefault();
                 }
-            });
+            }), new AddEventListenerOptions { passive = false });
 
             _scroller.addEventListener("scroll", e => UpdateScrollButtons());
 
@@ -461,53 +458,27 @@ namespace Tesserae
 
         private void TriggerAnimation()
         {
-            _t0 = -1;
-            window.requestAnimationFrame((t) => AnimateLine(t));
-        }
+            var target = _hoveredNav ?? _selectedNav;
+            if (target is null) return;
 
-        private void AnimateLine(double time)
-        {
-            if (_t0 < 0)
-            {
-                var target = _hoveredNav ?? _selectedNav;
-
-                if (target is null) { return; }
-
-                _t0 = time;
-                // offsetLeft/offsetWidth are relative to the titlebar, which is the
-                // line's offsetParent (it's position: relative). This stays correct
-                // regardless of scroll position.
-                _targetWidth = target.offsetWidth;
-                _targetLeft  = target.offsetLeft;
-            }
-
-            var f = (time - _t0) / 500; //500ms animation
-
+            // offsetLeft/offsetWidth are relative to the titlebar, which is the line's
+            // offsetParent (it's position: relative). This stays correct regardless of
+            // scroll position. CSS transitions on .tss-pivot-line interpolate width/left.
             if (_firstRender)
             {
-                f            = 1;
+                // Snap to position on first render so the line doesn't animate in from 0/0.
+                _line.classList.add("tss-pivot-line-instant");
+                _line.style.width = target.offsetWidth + "px";
+                _line.style.left  = target.offsetLeft  + "px";
+                // Read offsetWidth to flush the layout before re-enabling the transition.
+                var _flush = _line.offsetWidth;
+                _line.classList.remove("tss-pivot-line-instant");
                 _firstRender = false;
+                return;
             }
 
-            if (f > 1)
-            {
-                f = 1;
-            }
-
-            _currentWidth     += (_targetWidth - _currentWidth) * f;
-            _currentLeft      += (_targetLeft  - _currentLeft)  * f;
-
-            if (Math.Abs(_currentLeft - _targetLeft) > 1 || Math.Abs(_currentWidth - _targetWidth) > 1)
-            {
-                _line.style.width =  _currentWidth + "px";
-                _line.style.left  =  _currentLeft  + "px";
-                window.requestAnimationFrame((t) => AnimateLine(t));
-            }
-            else
-            {
-                _line.style.width =  _targetWidth + "px";
-                _line.style.left  =  _targetLeft  + "px";
-            }
+            _line.style.width = target.offsetWidth + "px";
+            _line.style.left  = target.offsetLeft  + "px";
         }
 
         internal sealed class Tab

--- a/Tesserae/src/Helpers/HTML/DomObserver.cs
+++ b/Tesserae/src/Helpers/HTML/DomObserver.cs
@@ -16,77 +16,20 @@ namespace Tesserae
 
         private class ElementAndCallback
         {
-            // Tri-state cache for the WeakRef feature probe: Unknown until we've tested,
-            // then either Available or NotAvailable. Using an int + consts avoids the
-            // Nullable<bool> boxing that h5 emits for bool?.
-            private const int WeakRefUnknown      = 0;
-            private const int WeakRefNotAvailable = 1;
-            private const int WeakRefAvailable    = 2;
-
-            private static int _weakrefState;
+            // WeakRef is available in every evergreen browser (Chrome 84+, Firefox 79+,
+            // Safari 14.1+), so we use it unconditionally.
             private static int _count;
 
-            private static bool IsAvailable()
-            {
-                if (_weakrefState != WeakRefUnknown) return _weakrefState == WeakRefAvailable;
-
-                try
-                {
-                    Script.Write("let ref = new WeakRef({0})", new object());
-                    _weakrefState = WeakRefAvailable;
-                }
-                catch
-                {
-                    _weakrefState = WeakRefNotAvailable;
-                }
-
-                return _weakrefState == WeakRefAvailable;
-            }
-
-            public HTMLElement ElementOrNullIfCollected => dereference();
-
-            private HTMLElement dereference()
-            {
-                if (IsAvailable())
-                {
-                    return Script.Write<HTMLElement>("{0}.ref.deref()", this);
-                }
-                else
-                {
-                    return Script.Write<HTMLElement>("{0}.ref", this);
-                }
-            }
-
-            public Action CallbackOrNullIfCollected => dereferenceCallback();
-
-            private Action dereferenceCallback()
-            {
-                if (IsAvailable())
-                {
-                    return Script.Write<Action>("{0}.callbackref.deref()", this);
-                }
-                else
-                {
-                    return Script.Write<Action>("{0}.callbackref", this);
-                }
-            }
+            public HTMLElement ElementOrNullIfCollected  => Script.Write<HTMLElement>("{0}.ref.deref()",         this);
+            public Action      CallbackOrNullIfCollected => Script.Write<Action>     ("{0}.callbackref.deref()", this);
 
             public ElementAndCallback(HTMLElement element, Action callback)
             {
-                if (IsAvailable())
-                {
-                    _count++;
-
-                    if (_count < 0) { _count = 0; }
-                    Script.Write("{0}['callbackRefN' + {2}] = {1}",    element, callback, _count); //We need to store the callback reference on the object otherwise it can be collected before the element
-                    Script.Write("{0}.ref = new WeakRef({1})",         this,    element);
-                    Script.Write("{0}.callbackref = new WeakRef({1})", this,    callback);
-                }
-                else
-                {
-                    Script.Write("{0}.ref = {1}",         this, element);
-                    Script.Write("{0}.callbackref = {1}", this, callback);
-                }
+                _count++;
+                if (_count < 0) { _count = 0; }
+                Script.Write("{0}['callbackRefN' + {2}] = {1}",    element, callback, _count); //We need to store the callback reference on the object otherwise it can be collected before the element
+                Script.Write("{0}.ref = new WeakRef({1})",         this,    element);
+                Script.Write("{0}.callbackref = new WeakRef({1})", this,    callback);
             }
         }
 

--- a/Tesserae/src/Helpers/HTML/DomObserver.cs
+++ b/Tesserae/src/Helpers/HTML/DomObserver.cs
@@ -9,28 +9,38 @@ namespace Tesserae
     [H5.Name("tss.domObs")]
     public static class DomObserver
     {
-        private static List<ElementAndCallback> _elementsToTrackMountingOf;
-        private static List<ElementAndCallback> _elementsToTrackRemovalOf;
+        private static readonly List<ElementAndCallback> _elementsToTrackMountingOf;
+        private static readonly List<ElementAndCallback> _elementsToTrackRemovalOf;
+        private static readonly MutationObserver         _observer;
+        private static bool                              _isObserving;
 
         private class ElementAndCallback
         {
-            private static bool? _weakrefAvailable;
-            private static int   _count;
+            // Tri-state cache for the WeakRef feature probe: Unknown until we've tested,
+            // then either Available or NotAvailable. Using an int + consts avoids the
+            // Nullable<bool> boxing that h5 emits for bool?.
+            private const int WeakRefUnknown      = 0;
+            private const int WeakRefNotAvailable = 1;
+            private const int WeakRefAvailable    = 2;
+
+            private static int _weakrefState;
+            private static int _count;
+
             private static bool IsAvailable()
             {
-                if (_weakrefAvailable.HasValue) return _weakrefAvailable.Value;
+                if (_weakrefState != WeakRefUnknown) return _weakrefState == WeakRefAvailable;
 
                 try
                 {
                     Script.Write("let ref = new WeakRef({0})", new object());
-                    _weakrefAvailable = true;
+                    _weakrefState = WeakRefAvailable;
                 }
                 catch
                 {
-                    _weakrefAvailable = false;
+                    _weakrefState = WeakRefNotAvailable;
                 }
 
-                return _weakrefAvailable.Value;
+                return _weakrefState == WeakRefAvailable;
             }
 
             public HTMLElement ElementOrNullIfCollected => dereference();
@@ -85,20 +95,38 @@ namespace Tesserae
             _elementsToTrackMountingOf = new List<ElementAndCallback>();
             _elementsToTrackRemovalOf  = new List<ElementAndCallback>();
 
-            var observer = new MutationObserver((mutationRecords, _) =>
+            _observer = new MutationObserver((mutationRecords, _) =>
             {
                 //First check all unmounted rules as they might modify the dom, then the mounted ones
                 CheckUnmounted(mutationRecords);
                 CheckMounted(mutationRecords);
+                StopObservingIfNothingToTrack();
             });
+        }
 
-            observer.observe(document.body, new MutationObserverInit { childList = true, subtree = true });
+        // The MutationObserver receives every childList change on document.body. When
+        // nothing is tracked, that's wasted work, so we start the observer lazily and
+        // stop it as soon as both tracking lists drain.
+        private static void StartObservingIfNeeded()
+        {
+            if (_isObserving) return;
+            _observer.observe(document.body, new MutationObserverInit { childList = true, subtree = true });
+            _isObserving = true;
+        }
+
+        private static void StopObservingIfNothingToTrack()
+        {
+            if (!_isObserving) return;
+            if (_elementsToTrackMountingOf.Count > 0 || _elementsToTrackRemovalOf.Count > 0) return;
+            _observer.disconnect();
+            _isObserving = false;
         }
 
         public static void CleanUnusedReferences()
         {
             _elementsToTrackMountingOf.RemoveAll(e => e.ElementOrNullIfCollected is null);
             _elementsToTrackRemovalOf.RemoveAll(e => e.ElementOrNullIfCollected is null);
+            StopObservingIfNothingToTrack();
         }
 
         private static void CheckMounted(MutationRecord[] mutationRecords)
@@ -106,30 +134,37 @@ namespace Tesserae
             if (_elementsToTrackMountingOf.Count == 0)
                 return;
 
-            var elementsMountedThatWeCareAbout = new List<ElementAndCallback>();
+            HashSet<ElementAndCallback> matched = null;
 
             foreach (var mutationRecord in mutationRecords)
             {
-                foreach (var mountedElement in mutationRecord.addedNodes)
+                var addedNodes = mutationRecord.addedNodes;
+                if (addedNodes.length == 0) continue;
+
+                foreach (var mountedElement in addedNodes)
                 {
-                    foreach (var elementToTrackMountingOf in _elementsToTrackMountingOf)
+                    for (int i = 0; i < _elementsToTrackMountingOf.Count; i++)
                     {
-                        var element = elementToTrackMountingOf.ElementOrNullIfCollected;
+                        var entry   = _elementsToTrackMountingOf[i];
+                        var element = entry.ElementOrNullIfCollected;
 
                         if (element != null && element.IsEqualToOrIsChildOf(mountedElement))
                         {
-                            elementsMountedThatWeCareAbout.Add(elementToTrackMountingOf);
+                            if (matched is null) matched = new HashSet<ElementAndCallback>();
+                            matched.Add(entry);
                         }
                     }
                 }
             }
-            if (elementsMountedThatWeCareAbout.Count == 0) return;
 
-            _elementsToTrackMountingOf = _elementsToTrackMountingOf.Except(elementsMountedThatWeCareAbout).Where(e => e.ElementOrNullIfCollected is object && e.CallbackOrNullIfCollected is object).ToList();
+            if (matched is null) return;
+
+            // Remove matched and collected entries in a single pass.
+            _elementsToTrackMountingOf.RemoveAll(e => matched.Contains(e) || e.ElementOrNullIfCollected is null || e.CallbackOrNullIfCollected is null);
 
             window.requestAnimationFrame(_ =>
             {
-                foreach (var entry in elementsMountedThatWeCareAbout)
+                foreach (var entry in matched)
                 {
                     var element = entry.ElementOrNullIfCollected;
 
@@ -152,11 +187,14 @@ namespace Tesserae
             if (_elementsToTrackRemovalOf.Count == 0)
                 return;
 
-            var elementsRemovedThatWeCareAbout = new List<ElementAndCallback>();
+            HashSet<ElementAndCallback> matched = null;
 
             foreach (var mutationRecord in mutationRecords)
             {
-                foreach (var removedElement in mutationRecord.removedNodes)
+                var removedNodes = mutationRecord.removedNodes;
+                if (removedNodes.length == 0) continue;
+
+                foreach (var removedElement in removedNodes)
                 {
                     // 2019-10-28 DWR: The intent behind the NotifyWhenRemoved method is to fire a callback when an element is removed from the document, so that any related tidy-up / disposal
                     // may be performed. However, this will also be fired if an element (or one of its ancestors) is RE-rendered somewhere and that's not really what we want, so if the element
@@ -174,28 +212,27 @@ namespace Tesserae
                         continue;
                     }
 
-                    foreach (var elementToTrackRemovalOf in _elementsToTrackRemovalOf)
+                    for (int i = 0; i < _elementsToTrackRemovalOf.Count; i++)
                     {
-                        var element = elementToTrackRemovalOf.ElementOrNullIfCollected;
+                        var entry   = _elementsToTrackRemovalOf[i];
+                        var element = entry.ElementOrNullIfCollected;
 
                         if (element is object && element.IsEqualToOrIsChildOf(removedElement))
                         {
-                            elementsRemovedThatWeCareAbout.Add(elementToTrackRemovalOf);
+                            if (matched is null) matched = new HashSet<ElementAndCallback>();
+                            matched.Add(entry);
                         }
                     }
                 }
             }
 
-            if (elementsRemovedThatWeCareAbout.Count == 0)
-            {
-                return;
-            }
+            if (matched is null) return;
 
-            _elementsToTrackRemovalOf = _elementsToTrackRemovalOf.Except(elementsRemovedThatWeCareAbout).Where(e => e.ElementOrNullIfCollected is object && e.CallbackOrNullIfCollected is object).ToList();
+            _elementsToTrackRemovalOf.RemoveAll(e => matched.Contains(e) || e.ElementOrNullIfCollected is null || e.CallbackOrNullIfCollected is null);
 
             window.requestAnimationFrame(_ =>
             {
-                foreach (var entry in elementsRemovedThatWeCareAbout)
+                foreach (var entry in matched)
                 {
                     var element = entry.ElementOrNullIfCollected;
 
@@ -236,6 +273,7 @@ namespace Tesserae
             else
             {
                 _elementsToTrackMountingOf.Add(new ElementAndCallback(element, callback));
+                StartObservingIfNeeded();
             }
         }
 
@@ -258,6 +296,7 @@ namespace Tesserae
             // an element before its initial render / adding-to-the-DOM and so that check has had to be removed (as, in that case, the element would not be mounted because it hasn't been
             // added yet, not because it WAS added to the DOM and had already been removed again)
             _elementsToTrackRemovalOf.Add(new ElementAndCallback(element, callback));
+            StartObservingIfNeeded();
         }
     }
 }


### PR DESCRIPTION
- Dropdown's wheel listener doesn't preventDefault, so mark it passive
  to silence the scroll-blocking warning. Pivot's wheel listener must
  stay non-passive (it converts vertical wheel to horizontal scroll),
  so mark it passive: false explicitly.
- Replace Pivot's requestAnimationFrame line animation with a CSS
  transition; the JS handler now only writes the target width/left and
  the GPU handles interpolation. First-render snap is preserved via
  the tss-pivot-line-instant class.
- DomObserver now lazy-starts its MutationObserver and disconnects
  when both tracking lists drain, so apps that don't currently track
  anything pay nothing for body-wide mutation notifications. Hot path
  drops the Except/Where/ToList allocations in favour of RemoveAll,
  and dedupes matches via a HashSet so a single element matched by
  multiple mutation records fires its callback once.
- Replace ElementAndCallback's Nullable<bool> feature probe with an
  int tri-state plus consts to avoid Nullable boxing.