### PR TITLE
add Tesserae.Benchmark.Tests harness and Tesserae.Benchmark.Measure profiler

### DIFF
--- a/Tesserae.Benchmark.Measure/BenchmarkOptions.cs
+++ b/Tesserae.Benchmark.Measure/BenchmarkOptions.cs
@@ -1,0 +1,158 @@
+namespace Tesserae.Benchmark.Measure;
+
+internal sealed class BenchmarkOptions
+{
+    public string HarnessPath { get; set; } = string.Empty;
+    public string OutputDirectory { get; set; } = string.Empty;
+    public TimeSpan Duration { get; set; } = TimeSpan.FromMinutes(3);
+    public int CpuSamplingIntervalMicros { get; set; } = 100;
+    public int HeapSamplingIntervalBytes { get; set; } = 32 * 1024;
+    public TimeSpan SamplePerSample { get; set; } = TimeSpan.FromMilliseconds(750);
+    public TimeSpan MemoryProbeInterval { get; set; } = TimeSpan.FromSeconds(2);
+    public bool Headed { get; set; }
+    public int Port { get; set; }
+    public bool SkipBuild { get; set; }
+    public int TopMethods { get; set; } = 30;
+    public int TopAllocators { get; set; } = 30;
+    public bool UseMinified { get; set; }
+    public string? SampleFilter { get; set; }
+
+    public static BenchmarkOptions Parse(string[] args)
+    {
+        var o = new BenchmarkOptions();
+
+        var here = AppContext.BaseDirectory;
+
+        // Default harness lookup: walk up from bin/ until we find the sibling
+        // Tesserae.Benchmark.Tests project, then point at its h5 output. This
+        // makes `dotnet run` work out of the box from a normal checkout.
+        var defaultHarness = FindDefaultHarness(here);
+        if (defaultHarness != null) o.HarnessPath = defaultHarness;
+
+        o.OutputDirectory = Path.Combine(Environment.CurrentDirectory, "benchmark-report-" + DateTime.Now.ToString("yyyyMMdd-HHmmss"));
+
+        for (int i = 0; i < args.Length; i++)
+        {
+            switch (args[i])
+            {
+                case "--harness":
+                case "-h":
+                    o.HarnessPath = args[++i];
+                    break;
+                case "--output":
+                case "-o":
+                    o.OutputDirectory = args[++i];
+                    break;
+                case "--duration":
+                case "-d":
+                    o.Duration = ParseDuration(args[++i]);
+                    break;
+                case "--cpu-interval-us":
+                    o.CpuSamplingIntervalMicros = int.Parse(args[++i]);
+                    break;
+                case "--heap-interval-bytes":
+                    o.HeapSamplingIntervalBytes = int.Parse(args[++i]);
+                    break;
+                case "--sample-time":
+                    o.SamplePerSample = ParseDuration(args[++i]);
+                    break;
+                case "--memory-interval":
+                    o.MemoryProbeInterval = ParseDuration(args[++i]);
+                    break;
+                case "--port":
+                case "-p":
+                    o.Port = int.Parse(args[++i]);
+                    break;
+                case "--headed":
+                    o.Headed = true;
+                    break;
+                case "--skip-build":
+                    o.SkipBuild = true;
+                    break;
+                case "--minified":
+                    o.UseMinified = true;
+                    break;
+                case "--top-methods":
+                    o.TopMethods = int.Parse(args[++i]);
+                    break;
+                case "--top-allocators":
+                    o.TopAllocators = int.Parse(args[++i]);
+                    break;
+                case "--samples":
+                    o.SampleFilter = args[++i];
+                    break;
+                case "--help":
+                case "-?":
+                    PrintHelp();
+                    Environment.Exit(0);
+                    break;
+                default:
+                    Console.Error.WriteLine($"Unknown option: {args[i]}");
+                    PrintHelp();
+                    Environment.Exit(1);
+                    break;
+            }
+        }
+
+        return o;
+    }
+
+    private static string? FindDefaultHarness(string startDir)
+    {
+        var dir = new DirectoryInfo(startDir);
+        for (int i = 0; i < 8 && dir != null; i++, dir = dir.Parent)
+        {
+            var candidate = Path.Combine(dir.FullName, "Tesserae.Benchmark.Tests", "bin", "Debug", "netstandard2.0", "h5");
+            if (Directory.Exists(candidate) && File.Exists(Path.Combine(candidate, "index.html")))
+                return candidate;
+        }
+        // If not yet built, return the expected location so we can build into it.
+        dir = new DirectoryInfo(startDir);
+        for (int i = 0; i < 8 && dir != null; i++, dir = dir.Parent)
+        {
+            if (Directory.Exists(Path.Combine(dir.FullName, "Tesserae.Benchmark.Tests")))
+                return Path.Combine(dir.FullName, "Tesserae.Benchmark.Tests", "bin", "Debug", "netstandard2.0", "h5");
+        }
+        return null;
+    }
+
+    private static TimeSpan ParseDuration(string s)
+    {
+        s = s.Trim();
+        if (s.EndsWith("ms")) return TimeSpan.FromMilliseconds(double.Parse(s[..^2]));
+        if (s.EndsWith("s"))  return TimeSpan.FromSeconds(double.Parse(s[..^1]));
+        if (s.EndsWith("m"))  return TimeSpan.FromMinutes(double.Parse(s[..^1]));
+        if (s.EndsWith("h"))  return TimeSpan.FromHours(double.Parse(s[..^1]));
+        return TimeSpan.FromSeconds(double.Parse(s));
+    }
+
+    public static void PrintHelp()
+    {
+        Console.WriteLine("""
+Tesserae.Benchmark.Measure - Playwright/CDP-based performance profiler for Tesserae.Benchmark.Tests.
+
+Usage:
+  dotnet run --project Tesserae.Benchmark.Measure -- [options]
+
+Options:
+  --harness <path>           Path to the built Tesserae.Benchmark.Tests h5 output directory.
+                             (defaults to ../Tesserae.Benchmark.Tests/bin/Debug/netstandard2.0/h5)
+  --output <path>            Directory to write reports into (default: ./benchmark-report-<ts>)
+  --duration <time>          Total measurement window (default: 3m). Accepts 250ms, 30s, 3m, 1h.
+  --sample-time <time>       How long to keep each sample mounted (default: 750ms).
+  --memory-interval <time>   Cadence of heap-usage probes (default: 2s).
+  --cpu-interval-us <us>     V8 CPU sampler interval in microseconds (default: 100).
+  --heap-interval-bytes <n>  V8 heap sampling interval in bytes (default: 32768).
+  --port <port>              Local HTTP port (default: random free port).
+  --headed                   Run Chromium with a visible window for inspection.
+  --skip-build               Don't rebuild Tesserae.Benchmark.Tests before measuring.
+  --minified                 Load app.min.js + tss.min.js for a release-shaped profile.
+  --top-methods <n>          Hot-methods table size (default: 30).
+  --top-allocators <n>       Top-allocators table size (default: 30).
+  --samples <regex>          Only cycle samples whose names match this regex.
+
+Output: writes cpu-profile.json, heap-profile.json, memory-trace.csv, report.md,
+        and report.json into the output directory.
+""");
+    }
+}

--- a/Tesserae.Benchmark.Measure/BenchmarkReport.cs
+++ b/Tesserae.Benchmark.Measure/BenchmarkReport.cs
@@ -1,0 +1,19 @@
+namespace Tesserae.Benchmark.Measure;
+
+internal sealed record BenchmarkReport(
+    DateTimeOffset                StartedUtc,
+    DateTimeOffset                FinishedUtc,
+    string                        HarnessUrl,
+    int                           SamplesCycled,
+    int                           TotalRenders,
+    int                           TotalInteractions,
+    int                           Failures,
+    IReadOnlyList<SampleStats>    SampleStats,
+    double                        CpuProfileDurationMs,
+    int                           CpuSampleCount,
+    long                          HeapSampledBytes,
+    IReadOnlyList<HotMethod>      HotMethods,
+    IReadOnlyList<TopAllocator>   TopAllocators,
+    IReadOnlyList<MemoryProbe>    MemoryProbes,
+    LeakDiagnosis                 LeakDiagnosis,
+    IReadOnlyList<string>         ConsoleErrors);

--- a/Tesserae.Benchmark.Measure/BenchmarkRunner.cs
+++ b/Tesserae.Benchmark.Measure/BenchmarkRunner.cs
@@ -1,0 +1,316 @@
+using System.Diagnostics;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Microsoft.Playwright;
+
+namespace Tesserae.Benchmark.Measure;
+
+internal sealed class BenchmarkRunner
+{
+    private readonly BenchmarkOptions _options;
+    private readonly string _baseUrl;
+
+    public BenchmarkRunner(BenchmarkOptions options, string baseUrl)
+    {
+        _options = options;
+        _baseUrl = baseUrl;
+    }
+
+    public async Task<BenchmarkReport> RunAsync(CancellationToken cancellationToken)
+    {
+        Directory.CreateDirectory(_options.OutputDirectory);
+
+        Console.WriteLine("[playwright] launching chromium");
+
+        using var playwright = await Playwright.CreateAsync();
+
+        var launchOptions = new BrowserTypeLaunchOptions
+        {
+            Headless = !_options.Headed,
+            // Disabling extensions / background networking gives us a quieter
+            // baseline and keeps non-app code out of the CPU profile.
+            Args = new[]
+            {
+                "--disable-extensions",
+                "--disable-background-networking",
+                "--disable-component-update",
+                "--disable-default-apps",
+                "--disable-sync",
+                "--no-first-run",
+                "--no-default-browser-check",
+                "--js-flags=--expose-gc",
+                "--enable-precise-memory-info"
+            }
+        };
+
+        await using var browser = await playwright.Chromium.LaunchAsync(launchOptions);
+        var context = await browser.NewContextAsync(new BrowserNewContextOptions
+        {
+            ViewportSize = new ViewportSize { Width = 1280, Height = 800 }
+        });
+        var page    = await context.NewPageAsync();
+        var cdp     = await context.NewCDPSessionAsync(page);
+
+        var consoleErrors = new List<string>();
+        page.PageError += (_, e) => consoleErrors.Add(e);
+        page.Console   += (_, msg) =>
+        {
+            if (msg.Type == "error" || msg.Type == "warning")
+                consoleErrors.Add($"[{msg.Type}] {msg.Text}");
+        };
+
+        var landingUrl = _options.UseMinified
+            ? $"{_baseUrl}/index.html?min=1"  // index.html doesn't actually do anything with this — kept as a marker for the report.
+            : $"{_baseUrl}/index.html";
+
+        Console.WriteLine($"[playwright] navigating to {landingUrl}");
+        await page.GotoAsync(landingUrl, new PageGotoOptions { WaitUntil = WaitUntilState.NetworkIdle, Timeout = 30000 });
+
+        // Wait until the harness publishes its API.
+        await page.WaitForFunctionAsync("() => window.tssBenchmark && window.tssBenchmark.ready === true", null, new PageWaitForFunctionOptions { Timeout = 30000 });
+
+        var samples = await page.EvaluateAsync<string[]>("() => window.tssBenchmark.samples");
+        if (samples == null || samples.Length == 0)
+            throw new InvalidOperationException("Harness exposed no samples.");
+
+        if (!string.IsNullOrEmpty(_options.SampleFilter))
+        {
+            var re = new Regex(_options.SampleFilter, RegexOptions.IgnoreCase);
+            samples = samples.Where(s => re.IsMatch(s)).ToArray();
+            if (samples.Length == 0)
+                throw new InvalidOperationException($"Filter '{_options.SampleFilter}' matched zero samples.");
+        }
+
+        Console.WriteLine($"[playwright] harness exposes {samples.Length} samples");
+
+        // --- enable profilers ---------------------------------------------------
+        await cdp.SendAsync("Performance.enable");
+        await cdp.SendAsync("Profiler.enable");
+        await cdp.SendAsync("HeapProfiler.enable");
+
+        await cdp.SendAsync("Profiler.setSamplingInterval", new Dictionary<string, object>
+        {
+            ["interval"] = _options.CpuSamplingIntervalMicros
+        });
+
+        // Force a baseline GC so the heap profile / leak diagnosis aren't
+        // dominated by load-time scaffolding.
+        await cdp.SendAsync("HeapProfiler.collectGarbage");
+        await Task.Delay(250, cancellationToken);
+
+        await cdp.SendAsync("Profiler.start");
+        await cdp.SendAsync("HeapProfiler.startSampling", new Dictionary<string, object>
+        {
+            ["samplingInterval"] = _options.HeapSamplingIntervalBytes
+        });
+
+        // --- main measurement loop ---------------------------------------------
+        var probes = new List<MemoryProbe>();
+        var sampleStats = new Dictionary<string, SampleStats>();
+
+        var runStart = DateTimeOffset.UtcNow;
+        var deadline = runStart + _options.Duration;
+        var lastProbe = runStart - _options.MemoryProbeInterval;
+
+        int cursor = 0;
+        int totalRenders = 0;
+        int totalExercises = 0;
+
+        Console.WriteLine($"[run] cycling samples for {_options.Duration:c}");
+
+        while (DateTimeOffset.UtcNow < deadline && !cancellationToken.IsCancellationRequested)
+        {
+            var sampleName = samples[cursor];
+            cursor = (cursor + 1) % samples.Length;
+
+            var sampleStart = Stopwatch.StartNew();
+
+            try
+            {
+                // Drive the harness via routing — the page's router observes the
+                // hash and rebuilds the DOM, which is exactly what we want to
+                // measure.
+                await page.EvaluateAsync("name => window.tssBenchmark.render(name)", sampleName);
+
+                // Give the DOM a chance to settle before exercising it.
+                await page.WaitForFunctionAsync("name => window.tssBenchmark.current() === name", sampleName, new PageWaitForFunctionOptions { Timeout = 10000 });
+
+                // Lightweight per-sample interactions implemented inside the harness.
+                var interactions = await page.EvaluateAsync<int>("() => window.tssBenchmark.exercise()");
+
+                await Task.Delay(_options.SamplePerSample, cancellationToken);
+
+                totalRenders++;
+                totalExercises++;
+
+                if (!sampleStats.TryGetValue(sampleName, out var stat))
+                    sampleStats[sampleName] = stat = new SampleStats(sampleName);
+                stat.Renders++;
+                stat.Interactions += interactions;
+                stat.WallTimeMs   += sampleStart.Elapsed.TotalMilliseconds;
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"[run] sample {sampleName} failed: {ex.Message}");
+                if (!sampleStats.TryGetValue(sampleName, out var stat))
+                    sampleStats[sampleName] = stat = new SampleStats(sampleName);
+                stat.Failures++;
+            }
+
+            // Sample memory probes on their own cadence so we don't tie them
+            // 1-to-1 to renders (some samples are much slower than others).
+            if (DateTimeOffset.UtcNow - lastProbe >= _options.MemoryProbeInterval)
+            {
+                lastProbe = DateTimeOffset.UtcNow;
+                var probe = await CollectMemoryProbe(page, cdp, sampleName);
+                probes.Add(probe);
+                if (probes.Count == 1 || probes.Count % 10 == 0)
+                {
+                    Console.WriteLine($"[mem ] {DateTime.Now:HH:mm:ss} usedHeap={MemoryTrace.Format(probe.UsedJsHeapBytes)} nodes={probe.NodeCount} listeners={probe.ListenerCount} sample={sampleName}");
+                }
+            }
+        }
+
+        Console.WriteLine($"[run ] done — {totalRenders} renders across {sampleStats.Count} samples");
+
+        // Final post-GC probe to make leak detection less noisy.
+        await cdp.SendAsync("HeapProfiler.collectGarbage");
+        await Task.Delay(500, cancellationToken);
+        probes.Add(await CollectMemoryProbe(page, cdp, "<final-after-gc>"));
+
+        // --- stop profilers + collect raw output -------------------------------
+        Console.WriteLine("[stop] collecting profiles");
+        var cpuJson  = ExtractProfileJson(await cdp.SendAsync("Profiler.stop"));
+        var heapJson = ExtractProfileJson(await cdp.SendAsync("HeapProfiler.stopSampling"));
+
+        File.WriteAllText(Path.Combine(_options.OutputDirectory, "cpu-profile.json"),  cpuJson);
+        File.WriteAllText(Path.Combine(_options.OutputDirectory, "heap-profile.json"), heapJson);
+
+        var cpuProfile  = JsonSerializer.Deserialize<V8CpuProfile>(cpuJson)  ?? new V8CpuProfile();
+        var heapProfile = JsonSerializer.Deserialize<V8HeapProfile>(heapJson) ?? new V8HeapProfile();
+
+        var hotMethods    = CpuProfileAnalyzer.AnalyzeHotMethods(cpuProfile, _options.TopMethods);
+        var topAllocators = HeapProfileAnalyzer.AnalyzeAllocators(heapProfile, _options.TopAllocators);
+        var leak          = MemoryTrace.Diagnose(probes);
+
+        var report = new BenchmarkReport(
+            StartedUtc:          runStart,
+            FinishedUtc:         DateTimeOffset.UtcNow,
+            HarnessUrl:          landingUrl,
+            SamplesCycled:       sampleStats.Count,
+            TotalRenders:        totalRenders,
+            TotalInteractions:   sampleStats.Values.Sum(s => s.Interactions),
+            Failures:            sampleStats.Values.Sum(s => s.Failures),
+            SampleStats:         sampleStats.Values.OrderBy(s => s.Name).ToList(),
+            CpuProfileDurationMs: (cpuProfile.EndTime - cpuProfile.StartTime) / 1000.0,
+            CpuSampleCount:      cpuProfile.Samples?.Count ?? 0,
+            HeapSampledBytes:    HeapProfileAnalyzer.TotalSampledBytes(heapProfile),
+            HotMethods:          hotMethods,
+            TopAllocators:       topAllocators,
+            MemoryProbes:        probes,
+            LeakDiagnosis:       leak,
+            ConsoleErrors:       consoleErrors.Distinct().Take(50).ToList());
+
+        WriteMemoryCsv(probes);
+
+        await context.CloseAsync();
+        return report;
+    }
+
+    private async Task<MemoryProbe> CollectMemoryProbe(IPage page, ICDPSession cdp, string sampleName)
+    {
+        long usedHeap   = 0;
+        long totalHeap  = 0;
+        long nodes      = 0;
+        long listeners  = 0;
+        long documents  = 0;
+        long frames     = 0;
+        long jsListeners = 0;
+
+        try
+        {
+            var metricsResp = await cdp.SendAsync("Performance.getMetrics");
+            if (metricsResp != null && metricsResp.Value.TryGetProperty("metrics", out var arr))
+            {
+                foreach (var m in arr.EnumerateArray())
+                {
+                    var name  = m.GetProperty("name").GetString();
+                    var value = m.GetProperty("value").GetDouble();
+                    switch (name)
+                    {
+                        case "JSHeapUsedSize":   usedHeap   = (long)value; break;
+                        case "JSHeapTotalSize":  totalHeap  = (long)value; break;
+                        case "Nodes":            nodes      = (long)value; break;
+                        case "Documents":        documents  = (long)value; break;
+                        case "Frames":           frames     = (long)value; break;
+                        case "JSEventListeners": jsListeners = (long)value; break;
+                    }
+                }
+            }
+        }
+        catch { }
+
+        try
+        {
+            var counters = await cdp.SendAsync("Memory.getDOMCounters");
+            if (counters != null)
+            {
+                if (counters.Value.TryGetProperty("nodes", out var n)) nodes = n.GetInt64();
+                if (counters.Value.TryGetProperty("jsEventListeners", out var l)) listeners = l.GetInt64();
+                if (counters.Value.TryGetProperty("documents", out var d)) documents = d.GetInt64();
+            }
+        }
+        catch { }
+
+        if (listeners == 0) listeners = jsListeners;
+
+        if (usedHeap == 0)
+        {
+            try { usedHeap = await page.EvaluateAsync<long>("() => (performance.memory && performance.memory.usedJSHeapSize) ? Math.floor(performance.memory.usedJSHeapSize) : 0"); }
+            catch { }
+        }
+
+        return new MemoryProbe(
+            Timestamp:           DateTimeOffset.UtcNow,
+            CurrentSample:       sampleName,
+            UsedJsHeapBytes:     usedHeap,
+            TotalJsHeapBytes:    totalHeap,
+            NodeCount:           nodes,
+            ListenerCount:       listeners,
+            DocumentCount:       documents,
+            FrameCount:          frames,
+            JsEventListenerCount: jsListeners);
+    }
+
+    private void WriteMemoryCsv(IReadOnlyList<MemoryProbe> probes)
+    {
+        var path = Path.Combine(_options.OutputDirectory, "memory-trace.csv");
+        using var w = new StreamWriter(path);
+        w.WriteLine("timestamp,sample,used_js_heap_bytes,total_js_heap_bytes,nodes,listeners,documents,frames,js_event_listeners");
+        foreach (var p in probes)
+        {
+            w.WriteLine($"{p.Timestamp:O},{Csv(p.CurrentSample)},{p.UsedJsHeapBytes},{p.TotalJsHeapBytes},{p.NodeCount},{p.ListenerCount},{p.DocumentCount},{p.FrameCount},{p.JsEventListenerCount}");
+        }
+    }
+
+    private static string Csv(string s) =>
+        s.Contains(',') || s.Contains('"') ? "\"" + s.Replace("\"", "\"\"") + "\"" : s;
+
+    private static string ExtractProfileJson(JsonElement? response)
+    {
+        if (!response.HasValue) return "{}";
+        if (response.Value.TryGetProperty("profile", out var profile))
+            return profile.GetRawText();
+        return response.Value.GetRawText();
+    }
+}
+
+internal sealed class SampleStats
+{
+    public SampleStats(string name) { Name = name; }
+    public string Name { get; }
+    public int Renders { get; set; }
+    public int Interactions { get; set; }
+    public int Failures { get; set; }
+    public double WallTimeMs { get; set; }
+}

--- a/Tesserae.Benchmark.Measure/CpuProfileAnalyzer.cs
+++ b/Tesserae.Benchmark.Measure/CpuProfileAnalyzer.cs
@@ -1,0 +1,111 @@
+namespace Tesserae.Benchmark.Measure;
+
+internal sealed record HotMethod(
+    string FunctionName,
+    string ScriptUrl,
+    int    LineNumber,
+    double SelfTimeMs,
+    double TotalTimeMs,
+    int    SampleHits);
+
+internal static class CpuProfileAnalyzer
+{
+    // Aggregates a V8 CPU profile into a sorted list of self-hot methods.
+    // V8 reports timeDeltas in microseconds and assigns each sample to the
+    // node currently on top of the call stack — accumulating those deltas
+    // gives us self time; propagating each sample's delta up its ancestor
+    // chain gives us total time.
+    public static IReadOnlyList<HotMethod> AnalyzeHotMethods(V8CpuProfile profile, int top)
+    {
+        if (profile.Samples == null || profile.TimeDeltas == null || profile.Samples.Count == 0)
+            return Array.Empty<HotMethod>();
+
+        var byId      = profile.Nodes.ToDictionary(n => n.Id);
+        var selfMicros = new Dictionary<int, long>();
+        var totalMicros = new Dictionary<int, long>();
+        var hits      = new Dictionary<int, int>();
+
+        var parentOf = BuildParentMap(profile);
+
+        var count = Math.Min(profile.Samples.Count, profile.TimeDeltas.Count);
+        for (int i = 0; i < count; i++)
+        {
+            var sampleId  = profile.Samples[i];
+            var delta     = profile.TimeDeltas[i];
+            if (delta < 0) delta = 0;
+
+            selfMicros[sampleId] = selfMicros.GetValueOrDefault(sampleId) + delta;
+            hits[sampleId]       = hits.GetValueOrDefault(sampleId) + 1;
+
+            var cursor = sampleId;
+            var seen   = new HashSet<int>();
+            while (cursor != 0 && seen.Add(cursor))
+            {
+                totalMicros[cursor] = totalMicros.GetValueOrDefault(cursor) + delta;
+                if (!parentOf.TryGetValue(cursor, out var parent)) break;
+                cursor = parent;
+            }
+        }
+
+        return selfMicros
+            .Where(kv => byId.ContainsKey(kv.Key))
+            .Select(kv =>
+            {
+                var node = byId[kv.Key];
+                if (IsSyntheticNode(node)) return null;
+                return new HotMethod(
+                    FunctionName: PrettifyFunctionName(node.CallFrame.FunctionName),
+                    ScriptUrl:    StripBaseUrl(node.CallFrame.Url),
+                    LineNumber:   node.CallFrame.LineNumber,
+                    SelfTimeMs:   kv.Value / 1000.0,
+                    TotalTimeMs:  totalMicros.GetValueOrDefault(kv.Key) / 1000.0,
+                    SampleHits:   hits.GetValueOrDefault(kv.Key));
+            })
+            .Where(h => h != null)
+            .Cast<HotMethod>()
+            .OrderByDescending(h => h.SelfTimeMs)
+            .Take(top)
+            .ToList();
+    }
+
+    private static Dictionary<int, int> BuildParentMap(V8CpuProfile profile)
+    {
+        var map = new Dictionary<int, int>();
+        foreach (var node in profile.Nodes)
+        {
+            if (node.Children == null) continue;
+            foreach (var child in node.Children)
+                map[child] = node.Id;
+        }
+        return map;
+    }
+
+    private static bool IsSyntheticNode(V8CpuNode node)
+    {
+        var name = node.CallFrame.FunctionName;
+        return name == "(root)"
+            || name == "(idle)"
+            || name == "(program)"
+            || name == "(garbage collector)";
+    }
+
+    private static string PrettifyFunctionName(string name)
+    {
+        if (string.IsNullOrEmpty(name)) return "(anonymous)";
+        return name;
+    }
+
+    private static string StripBaseUrl(string url)
+    {
+        if (string.IsNullOrEmpty(url)) return "";
+        // We serve everything off http://localhost:PORT/ — collapse that prefix
+        // so report rows stay readable.
+        int idx = url.IndexOf("//");
+        if (idx >= 0)
+        {
+            int slash = url.IndexOf('/', idx + 2);
+            if (slash >= 0) return url[slash..];
+        }
+        return url;
+    }
+}

--- a/Tesserae.Benchmark.Measure/HarnessBuilder.cs
+++ b/Tesserae.Benchmark.Measure/HarnessBuilder.cs
@@ -1,0 +1,67 @@
+using System.Diagnostics;
+
+namespace Tesserae.Benchmark.Measure;
+
+internal static class HarnessBuilder
+{
+    public static async Task BuildAsync(string harnessOutputDir)
+    {
+        var projectFile = ResolveProjectFile(harnessOutputDir);
+        if (projectFile == null)
+        {
+            Console.WriteLine($"[build] Could not locate Tesserae.Benchmark.Tests.csproj near {harnessOutputDir}, skipping build.");
+            return;
+        }
+
+        Console.WriteLine($"[build] dotnet build {projectFile}");
+
+        var psi = new ProcessStartInfo("dotnet", $"build \"{projectFile}\" -nologo -v:minimal")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError  = true,
+            UseShellExecute        = false
+        };
+
+        // h5-compiler is a global tool installed under ~/.dotnet/tools but the
+        // current shell may not have that on PATH (Claude Code remote envs).
+        var toolsDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".dotnet", "tools");
+        if (Directory.Exists(toolsDir))
+        {
+            var sep  = OperatingSystem.IsWindows() ? ";" : ":";
+            var path = psi.EnvironmentVariables["PATH"] ?? "";
+            if (!path.Split(sep).Contains(toolsDir))
+                psi.EnvironmentVariables["PATH"] = string.IsNullOrEmpty(path) ? toolsDir : $"{path}{sep}{toolsDir}";
+        }
+
+        using var p = Process.Start(psi)!;
+
+        var stdoutTask = p.StandardOutput.ReadToEndAsync();
+        var stderrTask = p.StandardError.ReadToEndAsync();
+
+        await p.WaitForExitAsync();
+
+        var stdout = await stdoutTask;
+        var stderr = await stderrTask;
+
+        if (p.ExitCode != 0)
+        {
+            Console.WriteLine(stdout);
+            Console.Error.WriteLine(stderr);
+            throw new InvalidOperationException($"Building harness failed with exit code {p.ExitCode}.");
+        }
+
+        Console.WriteLine("[build] succeeded.");
+    }
+
+    private static string? ResolveProjectFile(string harnessOutputDir)
+    {
+        // harnessOutputDir is typically .../Tesserae.Benchmark.Tests/bin/Debug/netstandard2.0/h5
+        var dir = new DirectoryInfo(harnessOutputDir);
+        for (int i = 0; i < 6 && dir != null; i++, dir = dir.Parent)
+        {
+            var candidate = Path.Combine(dir.FullName, "Tesserae.Benchmark.Tests.csproj");
+            if (File.Exists(candidate)) return candidate;
+        }
+        return null;
+    }
+}

--- a/Tesserae.Benchmark.Measure/HeapProfileAnalyzer.cs
+++ b/Tesserae.Benchmark.Measure/HeapProfileAnalyzer.cs
@@ -1,0 +1,70 @@
+namespace Tesserae.Benchmark.Measure;
+
+internal sealed record TopAllocator(
+    string FunctionName,
+    string ScriptUrl,
+    int    LineNumber,
+    long   SelfBytes,
+    long   TotalBytes,
+    int    SampleCount);
+
+internal static class HeapProfileAnalyzer
+{
+    public static IReadOnlyList<TopAllocator> AnalyzeAllocators(V8HeapProfile profile, int top)
+    {
+        var rows = new List<TopAllocator>();
+        Walk(profile.Head, rows);
+
+        return rows
+            .Where(r => r.SelfBytes > 0)
+            .OrderByDescending(r => r.SelfBytes)
+            .Take(top)
+            .ToList();
+    }
+
+    private static long Walk(V8HeapNode node, List<TopAllocator> rows)
+    {
+        long subtotal = node.SelfSize;
+        foreach (var child in node.Children)
+            subtotal += Walk(child, rows);
+
+        if (!IsSyntheticNode(node))
+        {
+            rows.Add(new TopAllocator(
+                FunctionName: PrettifyFunctionName(node.CallFrame.FunctionName),
+                ScriptUrl:    StripBaseUrl(node.CallFrame.Url),
+                LineNumber:   node.CallFrame.LineNumber,
+                SelfBytes:    node.SelfSize,
+                TotalBytes:   subtotal,
+                SampleCount:  0));
+        }
+
+        return subtotal;
+    }
+
+    public static long TotalSampledBytes(V8HeapProfile profile) =>
+        profile.Samples.Sum(s => s.Size);
+
+    private static bool IsSyntheticNode(V8HeapNode node)
+    {
+        var name = node.CallFrame.FunctionName;
+        return name == "(root)"
+            || name == "(GC)"
+            || (string.IsNullOrEmpty(name) && string.IsNullOrEmpty(node.CallFrame.Url));
+    }
+
+    private static string PrettifyFunctionName(string name) =>
+        string.IsNullOrEmpty(name) ? "(anonymous)" : name;
+
+    private static string StripBaseUrl(string url)
+    {
+        if (string.IsNullOrEmpty(url)) return "";
+        int idx = url.IndexOf("//");
+        if (idx >= 0)
+        {
+            int slash = url.IndexOf('/', idx + 2);
+            if (slash >= 0) return url[slash..];
+        }
+        return url;
+    }
+}

--- a/Tesserae.Benchmark.Measure/MemoryTrace.cs
+++ b/Tesserae.Benchmark.Measure/MemoryTrace.cs
@@ -1,0 +1,118 @@
+namespace Tesserae.Benchmark.Measure;
+
+internal sealed record MemoryProbe(
+    DateTimeOffset Timestamp,
+    string         CurrentSample,
+    long           UsedJsHeapBytes,
+    long           TotalJsHeapBytes,
+    long           NodeCount,
+    long           ListenerCount,
+    long           DocumentCount,
+    long           FrameCount,
+    long           JsEventListenerCount);
+
+internal sealed record LeakDiagnosis(
+    long   FirstUsedHeapBytes,
+    long   LastUsedHeapBytes,
+    long   FirstNodeCount,
+    long   LastNodeCount,
+    long   FirstListenerCount,
+    long   LastListenerCount,
+    double HeapGrowthBytesPerMin,
+    double NodeGrowthPerMin,
+    double ListenerGrowthPerMin,
+    double RSquaredHeap,
+    string Verdict);
+
+internal static class MemoryTrace
+{
+    public static LeakDiagnosis Diagnose(IReadOnlyList<MemoryProbe> probes)
+    {
+        if (probes.Count < 2)
+        {
+            return new LeakDiagnosis(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "insufficient data");
+        }
+
+        var first = probes[0];
+        var last  = probes[^1];
+
+        // Linear regression on (elapsedSeconds, usedHeap) to compute growth rate and goodness-of-fit.
+        var times  = probes.Select(p => (p.Timestamp - first.Timestamp).TotalSeconds).ToArray();
+        var heaps  = probes.Select(p => (double)p.UsedJsHeapBytes).ToArray();
+
+        var (slope, _, r2) = LinearRegression(times, heaps);
+
+        var nodeSlope = LinearRegression(times, probes.Select(p => (double)p.NodeCount).ToArray()).slope;
+        var listSlope = LinearRegression(times, probes.Select(p => (double)p.ListenerCount).ToArray()).slope;
+
+        var heapPerMin = slope     * 60.0;
+        var nodePerMin = nodeSlope * 60.0;
+        var listPerMin = listSlope * 60.0;
+
+        // Heuristic verdict. The thresholds intentionally err on the side of
+        // flagging something so reviewers see the trend; final attribution is
+        // expected to come from comparing this against a baseline run.
+        string verdict;
+        if (heapPerMin > 4 * 1024 * 1024 && r2 > 0.6)
+            verdict = $"likely leak: heap grew {Format(heapPerMin)}/min (R²={r2:F2})";
+        else if (nodePerMin > 500 && r2 > 0.4)
+            verdict = $"detached-DOM suspected: +{nodePerMin:F0} DOM nodes/min";
+        else if (listPerMin > 200 && r2 > 0.4)
+            verdict = $"listener leak suspected: +{listPerMin:F0} listeners/min";
+        else if (heapPerMin > 1 * 1024 * 1024)
+            verdict = $"mild growth: heap +{Format(heapPerMin)}/min (R²={r2:F2})";
+        else
+            verdict = $"stable: heap drift {Format(heapPerMin)}/min";
+
+        return new LeakDiagnosis(
+            FirstUsedHeapBytes:   first.UsedJsHeapBytes,
+            LastUsedHeapBytes:    last.UsedJsHeapBytes,
+            FirstNodeCount:       first.NodeCount,
+            LastNodeCount:        last.NodeCount,
+            FirstListenerCount:   first.ListenerCount,
+            LastListenerCount:    last.ListenerCount,
+            HeapGrowthBytesPerMin: heapPerMin,
+            NodeGrowthPerMin:      nodePerMin,
+            ListenerGrowthPerMin:  listPerMin,
+            RSquaredHeap:          r2,
+            Verdict:               verdict);
+    }
+
+    private static (double slope, double intercept, double r2) LinearRegression(double[] x, double[] y)
+    {
+        int n = x.Length;
+        if (n < 2) return (0, 0, 0);
+
+        double sumX = 0, sumY = 0;
+        for (int i = 0; i < n; i++) { sumX += x[i]; sumY += y[i]; }
+        var meanX = sumX / n;
+        var meanY = sumY / n;
+
+        double num = 0, denX = 0, denY = 0;
+        for (int i = 0; i < n; i++)
+        {
+            var dx = x[i] - meanX;
+            var dy = y[i] - meanY;
+            num  += dx * dy;
+            denX += dx * dx;
+            denY += dy * dy;
+        }
+
+        if (denX == 0) return (0, meanY, 0);
+
+        var slope     = num / denX;
+        var intercept = meanY - slope * meanX;
+        var r2        = denY == 0 ? 1.0 : (num * num) / (denX * denY);
+        return (slope, intercept, r2);
+    }
+
+    public static string Format(double bytes)
+    {
+        var sign = bytes < 0 ? "-" : "+";
+        var abs  = Math.Abs(bytes);
+        if (abs >= 1024 * 1024 * 1024) return $"{sign}{abs / (1024.0 * 1024.0 * 1024.0):F2} GiB";
+        if (abs >= 1024 * 1024)        return $"{sign}{abs / (1024.0 * 1024.0):F2} MiB";
+        if (abs >= 1024)               return $"{sign}{abs / 1024.0:F2} KiB";
+        return $"{sign}{abs:F0} B";
+    }
+}

--- a/Tesserae.Benchmark.Measure/Program.cs
+++ b/Tesserae.Benchmark.Measure/Program.cs
@@ -1,0 +1,72 @@
+using Microsoft.Playwright;
+
+namespace Tesserae.Benchmark.Measure;
+
+internal static class Program
+{
+    private static async Task<int> Main(string[] args)
+    {
+        var options = BenchmarkOptions.Parse(args);
+
+        if (string.IsNullOrEmpty(options.HarnessPath))
+        {
+            Console.Error.WriteLine("Could not locate Tesserae.Benchmark.Tests harness. Pass --harness <path>.");
+            return 2;
+        }
+
+        if (!options.SkipBuild)
+        {
+            try
+            {
+                await HarnessBuilder.BuildAsync(options.HarnessPath);
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"Failed to build harness: {ex.Message}");
+                return 3;
+            }
+        }
+
+        if (!Directory.Exists(options.HarnessPath) || !File.Exists(Path.Combine(options.HarnessPath, "index.html")))
+        {
+            Console.Error.WriteLine($"Harness output not found at {options.HarnessPath}. Pass --harness or omit --skip-build.");
+            return 4;
+        }
+
+        // Make sure Playwright's bundled browsers are installed. This is a
+        // no-op on subsequent runs and just prints a hint on the first run.
+        var exitCode = Microsoft.Playwright.Program.Main(new[] { "install", "chromium" });
+        if (exitCode != 0)
+        {
+            Console.Error.WriteLine($"Playwright browser install returned exit code {exitCode}. Continuing anyway.");
+        }
+
+        await using var server = await StaticFileServer.StartAsync(options.HarnessPath, options.Port);
+        Console.WriteLine($"[server] serving {options.HarnessPath} on {server.BaseUrl}");
+
+        var cts = new CancellationTokenSource();
+        Console.CancelKeyPress += (_, e) =>
+        {
+            e.Cancel = true;
+            cts.Cancel();
+        };
+
+        try
+        {
+            var runner = new BenchmarkRunner(options, server.BaseUrl);
+            var report = await runner.RunAsync(cts.Token);
+            ReportWriter.Write(report, options);
+            return 0;
+        }
+        catch (OperationCanceledException)
+        {
+            Console.Error.WriteLine("Cancelled.");
+            return 130;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Benchmark failed: {ex}");
+            return 1;
+        }
+    }
+}

--- a/Tesserae.Benchmark.Measure/ReportWriter.cs
+++ b/Tesserae.Benchmark.Measure/ReportWriter.cs
@@ -1,0 +1,129 @@
+using System.Text;
+using System.Text.Json;
+
+namespace Tesserae.Benchmark.Measure;
+
+internal static class ReportWriter
+{
+    public static void Write(BenchmarkReport report, BenchmarkOptions options)
+    {
+        Directory.CreateDirectory(options.OutputDirectory);
+
+        var markdown = BuildMarkdown(report, options);
+        File.WriteAllText(Path.Combine(options.OutputDirectory, "report.md"), markdown);
+
+        var json = JsonSerializer.Serialize(report, new JsonSerializerOptions { WriteIndented = true });
+        File.WriteAllText(Path.Combine(options.OutputDirectory, "report.json"), json);
+
+        Console.WriteLine();
+        Console.WriteLine(markdown);
+        Console.WriteLine();
+        Console.WriteLine($"[done] artifacts written to {options.OutputDirectory}");
+    }
+
+    private static string BuildMarkdown(BenchmarkReport r, BenchmarkOptions options)
+    {
+        var b = new StringBuilder();
+
+        b.AppendLine("# Tesserae benchmark report");
+        b.AppendLine();
+        b.AppendLine($"- Started: `{r.StartedUtc:u}`  ");
+        b.AppendLine($"- Finished: `{r.FinishedUtc:u}`  ");
+        b.AppendLine($"- Wall time: `{(r.FinishedUtc - r.StartedUtc):c}`  ");
+        b.AppendLine($"- Harness: `{r.HarnessUrl}`  ");
+        b.AppendLine($"- CPU sampling interval: `{options.CpuSamplingIntervalMicros} µs`  ");
+        b.AppendLine($"- Heap sampling interval: `{options.HeapSamplingIntervalBytes} bytes`  ");
+        b.AppendLine($"- Time per sample: `{options.SamplePerSample.TotalMilliseconds:F0} ms`  ");
+        b.AppendLine();
+
+        b.AppendLine("## Summary");
+        b.AppendLine();
+        b.AppendLine($"- Samples cycled: **{r.SamplesCycled}**");
+        b.AppendLine($"- Total renders: **{r.TotalRenders}**");
+        b.AppendLine($"- Total interactions fired: **{r.TotalInteractions}**");
+        b.AppendLine($"- Failures: **{r.Failures}**");
+        b.AppendLine($"- CPU sample count: **{r.CpuSampleCount}** over {r.CpuProfileDurationMs:F0} ms");
+        b.AppendLine($"- Heap sampled bytes: **{MemoryTrace.Format(r.HeapSampledBytes)}**");
+        b.AppendLine();
+
+        b.AppendLine("## Memory leak diagnosis");
+        b.AppendLine();
+        var leak = r.LeakDiagnosis;
+        b.AppendLine($"> **{leak.Verdict}**");
+        b.AppendLine();
+        b.AppendLine("|                   | first probe | last probe | growth/min |");
+        b.AppendLine("|-------------------|-------------|------------|------------|");
+        b.AppendLine($"| Used JS heap     | {MemoryTrace.Format(leak.FirstUsedHeapBytes)} | {MemoryTrace.Format(leak.LastUsedHeapBytes)} | {MemoryTrace.Format(leak.HeapGrowthBytesPerMin)} (R²={leak.RSquaredHeap:F2}) |");
+        b.AppendLine($"| DOM nodes        | {leak.FirstNodeCount} | {leak.LastNodeCount} | {leak.NodeGrowthPerMin:+0.#;-0.#;0} |");
+        b.AppendLine($"| JS listeners     | {leak.FirstListenerCount} | {leak.LastListenerCount} | {leak.ListenerGrowthPerMin:+0.#;-0.#;0} |");
+        b.AppendLine();
+
+        b.AppendLine($"## Hot methods (top {r.HotMethods.Count} by self CPU time)");
+        b.AppendLine();
+        if (r.HotMethods.Count == 0)
+        {
+            b.AppendLine("_No CPU samples captured._");
+        }
+        else
+        {
+            b.AppendLine("| # | Function | Self ms | Total ms | Hits | Source |");
+            b.AppendLine("|---|----------|--------:|---------:|-----:|--------|");
+            int rank = 1;
+            foreach (var m in r.HotMethods)
+            {
+                b.AppendLine($"| {rank++} | `{Sanitize(m.FunctionName)}` | {m.SelfTimeMs:F1} | {m.TotalTimeMs:F1} | {m.SampleHits} | `{Sanitize(m.ScriptUrl)}:{m.LineNumber}` |");
+            }
+        }
+        b.AppendLine();
+
+        b.AppendLine($"## Top allocators (top {r.TopAllocators.Count} by self bytes)");
+        b.AppendLine();
+        if (r.TopAllocators.Count == 0)
+        {
+            b.AppendLine("_No heap allocation samples captured._");
+        }
+        else
+        {
+            b.AppendLine("| # | Function | Self | Subtree | Source |");
+            b.AppendLine("|---|----------|-----:|--------:|--------|");
+            int rank = 1;
+            foreach (var a in r.TopAllocators)
+            {
+                b.AppendLine($"| {rank++} | `{Sanitize(a.FunctionName)}` | {MemoryTrace.Format(a.SelfBytes)} | {MemoryTrace.Format(a.TotalBytes)} | `{Sanitize(a.ScriptUrl)}:{a.LineNumber}` |");
+            }
+        }
+        b.AppendLine();
+
+        b.AppendLine("## Per-sample stats");
+        b.AppendLine();
+        b.AppendLine("| Sample | Renders | Interactions | Wall ms | Failures |");
+        b.AppendLine("|--------|--------:|-------------:|--------:|---------:|");
+        foreach (var s in r.SampleStats)
+        {
+            b.AppendLine($"| {Sanitize(s.Name)} | {s.Renders} | {s.Interactions} | {s.WallTimeMs:F0} | {s.Failures} |");
+        }
+        b.AppendLine();
+
+        if (r.ConsoleErrors.Count > 0)
+        {
+            b.AppendLine("## Console errors / warnings");
+            b.AppendLine();
+            foreach (var err in r.ConsoleErrors)
+            {
+                b.AppendLine($"- `{Sanitize(err)}`");
+            }
+            b.AppendLine();
+        }
+
+        b.AppendLine("## Artifacts");
+        b.AppendLine();
+        b.AppendLine("- `cpu-profile.json` — open with chrome://inspect, DevTools Performance tab, or Speedscope");
+        b.AppendLine("- `heap-profile.json` — V8 sampling allocation profile, open in Chrome DevTools Memory tab (\"Load profile\")");
+        b.AppendLine("- `memory-trace.csv` — per-probe time series for trend plotting");
+        b.AppendLine("- `report.json` — machine-readable view of this report");
+        return b.ToString();
+    }
+
+    private static string Sanitize(string s) =>
+        string.IsNullOrEmpty(s) ? "" : s.Replace("|", "\\|").Replace("`", "'");
+}

--- a/Tesserae.Benchmark.Measure/StaticFileServer.cs
+++ b/Tesserae.Benchmark.Measure/StaticFileServer.cs
@@ -1,0 +1,90 @@
+using System.Net;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.StaticFiles;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Tesserae.Benchmark.Measure;
+
+internal sealed class StaticFileServer : IAsyncDisposable
+{
+    private readonly WebApplication _app;
+
+    public string BaseUrl { get; }
+
+    private StaticFileServer(WebApplication app, string baseUrl)
+    {
+        _app    = app;
+        BaseUrl = baseUrl;
+    }
+
+    public static async Task<StaticFileServer> StartAsync(string rootDirectory, int port)
+    {
+        if (!Directory.Exists(rootDirectory))
+            throw new DirectoryNotFoundException($"Harness directory not found: {rootDirectory}");
+
+        var builder = WebApplication.CreateBuilder();
+        builder.Logging.ClearProviders();
+        builder.WebHost.UseKestrel(options =>
+        {
+            options.Listen(IPAddress.Loopback, port);
+        });
+
+        var app = builder.Build();
+
+        var provider = new FileExtensionContentTypeProvider();
+        provider.Mappings[".js"]    = "application/javascript; charset=utf-8";
+        provider.Mappings[".css"]   = "text/css; charset=utf-8";
+        provider.Mappings[".map"]   = "application/json";
+        provider.Mappings[".woff2"] = "font/woff2";
+
+        var fileProvider = new PhysicalFileProvider(rootDirectory);
+
+        app.UseDefaultFiles(new DefaultFilesOptions
+        {
+            FileProvider = fileProvider,
+            DefaultFileNames = new List<string> { "index.html" }
+        });
+
+        app.UseStaticFiles(new StaticFileOptions
+        {
+            FileProvider     = fileProvider,
+            ContentTypeProvider = provider,
+            ServeUnknownFileTypes = true,
+            DefaultContentType    = "application/octet-stream",
+            OnPrepareResponse = ctx =>
+            {
+                // Disable caching so consecutive runs always see fresh assets.
+                ctx.Context.Response.Headers["Cache-Control"] = "no-store, no-cache, must-revalidate";
+                ctx.Context.Response.Headers["Pragma"]        = "no-cache";
+            }
+        });
+
+        await app.StartAsync();
+
+        var actualPort = port;
+        if (actualPort == 0)
+        {
+            // Kestrel chose a free port — read it back from the server addresses feature.
+            var server = app.Services.GetRequiredService<Microsoft.AspNetCore.Hosting.Server.IServer>();
+            var feature = server.Features.Get<Microsoft.AspNetCore.Hosting.Server.Features.IServerAddressesFeature>();
+            var addr = feature?.Addresses.FirstOrDefault();
+            if (addr != null)
+            {
+                var uri = new Uri(addr);
+                actualPort = uri.Port;
+            }
+        }
+
+        return new StaticFileServer(app, $"http://localhost:{actualPort}");
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _app.StopAsync();
+        await _app.DisposeAsync();
+    }
+}

--- a/Tesserae.Benchmark.Measure/Tesserae.Benchmark.Measure.csproj
+++ b/Tesserae.Benchmark.Measure/Tesserae.Benchmark.Measure.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <LangVersion>latest</LangVersion>
+    <RootNamespace>Tesserae.Benchmark.Measure</RootNamespace>
+    <AssemblyName>Tesserae.Benchmark.Measure</AssemblyName>
+    <RollForward>LatestMajor</RollForward>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.Playwright" Version="1.49.0" />
+  </ItemGroup>
+</Project>

--- a/Tesserae.Benchmark.Measure/V8Profile.cs
+++ b/Tesserae.Benchmark.Measure/V8Profile.cs
@@ -1,0 +1,55 @@
+using System.Text.Json.Serialization;
+
+namespace Tesserae.Benchmark.Measure;
+
+// Subset of the V8 CPU profile schema produced by Profiler.stop (CDP).
+// https://chromedevtools.github.io/devtools-protocol/tot/Profiler/#type-Profile
+internal sealed class V8CpuProfile
+{
+    [JsonPropertyName("nodes")]      public List<V8CpuNode> Nodes { get; set; } = new();
+    [JsonPropertyName("startTime")]  public long   StartTime  { get; set; }
+    [JsonPropertyName("endTime")]    public long   EndTime    { get; set; }
+    [JsonPropertyName("samples")]    public List<int>?  Samples    { get; set; }
+    [JsonPropertyName("timeDeltas")] public List<int>?  TimeDeltas { get; set; }
+}
+
+internal sealed class V8CpuNode
+{
+    [JsonPropertyName("id")]        public int       Id        { get; set; }
+    [JsonPropertyName("callFrame")] public CallFrame CallFrame { get; set; } = new();
+    [JsonPropertyName("hitCount")]  public int       HitCount  { get; set; }
+    [JsonPropertyName("children")]  public List<int>? Children { get; set; }
+    [JsonPropertyName("deoptReason")] public string? DeoptReason { get; set; }
+}
+
+internal sealed class CallFrame
+{
+    [JsonPropertyName("functionName")] public string FunctionName { get; set; } = "";
+    [JsonPropertyName("scriptId")]     public string ScriptId     { get; set; } = "";
+    [JsonPropertyName("url")]          public string Url          { get; set; } = "";
+    [JsonPropertyName("lineNumber")]   public int    LineNumber   { get; set; }
+    [JsonPropertyName("columnNumber")] public int    ColumnNumber { get; set; }
+}
+
+// Subset of the V8 sampling heap profile schema produced by HeapProfiler.stopSampling.
+// https://chromedevtools.github.io/devtools-protocol/tot/HeapProfiler/#type-SamplingHeapProfile
+internal sealed class V8HeapProfile
+{
+    [JsonPropertyName("head")]    public V8HeapNode Head     { get; set; } = new();
+    [JsonPropertyName("samples")] public List<V8HeapSample> Samples { get; set; } = new();
+}
+
+internal sealed class V8HeapNode
+{
+    [JsonPropertyName("callFrame")] public CallFrame      CallFrame { get; set; } = new();
+    [JsonPropertyName("selfSize")]  public long           SelfSize  { get; set; }
+    [JsonPropertyName("id")]        public int            Id        { get; set; }
+    [JsonPropertyName("children")]  public List<V8HeapNode> Children { get; set; } = new();
+}
+
+internal sealed class V8HeapSample
+{
+    [JsonPropertyName("size")]    public long Size    { get; set; }
+    [JsonPropertyName("nodeId")]  public int  NodeId  { get; set; }
+    [JsonPropertyName("ordinal")] public long Ordinal { get; set; }
+}

--- a/Tesserae.Benchmark.Tests/Tesserae.Benchmark.Tests.csproj
+++ b/Tesserae.Benchmark.Tests/Tesserae.Benchmark.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="h5.Target/26.3.64912">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <DefineConstants>H5</DefineConstants>
+    <MinifyLocalVariables>true</MinifyLocalVariables>
+    <AssemblyName>tss-benchmark</AssemblyName>
+    <RootNamespace>Tesserae.Benchmark.Tests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="h5" Version="26.2.64514" />
+    <PackageReference Include="h5.core" Version="26.4.580" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Tesserae\Tesserae.csproj" />
+    <ProjectReference Include="..\Tesserae.Tests\Tesserae.Tests.csproj" />
+  </ItemGroup>
+</Project>

--- a/Tesserae.Benchmark.Tests/h5.json
+++ b/Tesserae.Benchmark.Tests/h5.json
@@ -1,0 +1,30 @@
+{
+  "output": "$(OutDir)/h5/",
+  "fileName": "app.js",
+  "html": {
+    "disabled": false,
+    "title": "Tesserae Benchmark Harness"
+  },
+  "resources": [],
+  "cleanOutputFolderBeforeBuildPattern": "*.js|*.css|*.dontload",
+  "console": { "enabled": false },
+  "loader": { "type": "Global" },
+  "sourceMap": { "enabled": true },
+  "reflection": {
+    "disabled": false,
+    "target": "inline"
+  },
+  "generateTypeScript": false,
+  "report": { "enabled": false },
+  "rules": {
+    "anonymousType": "Plain",
+    "arrayIndex": "Managed",
+    "autoProperty": "Plain",
+    "boxing": "Managed",
+    "externalCast": "Plain",
+    "inlineComment": "Plain",
+    "integer": "Managed",
+    "lambda": "Plain",
+    "useShortForms": true
+  }
+}

--- a/Tesserae.Benchmark.Tests/src/App.cs
+++ b/Tesserae.Benchmark.Tests/src/App.cs
@@ -1,0 +1,424 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using H5;
+using H5.Core;
+using Tesserae;
+using Tesserae.Tests;
+using Tesserae.Tests.Samples;
+using static H5.Core.dom;
+using static Tesserae.UI;
+
+namespace Tesserae.Benchmark.Tests
+{
+    // Harness used by Tesserae.Benchmark.Measure to drive performance measurements.
+    //
+    // It exposes every sample defined in Tesserae.Tests as an isolated route
+    // (#/sample/{Name}) and publishes a small JS API on `window.tssBenchmark`
+    // that the Playwright driver uses to enumerate samples and trigger
+    // lightweight in-page interactions (clicks, typing, toggles) without
+    // pulling in any sidebar / sample-picker chrome that would otherwise
+    // pollute the CPU and allocation profiles.
+    internal static class App
+    {
+        private static Dictionary<string, Type> _samplesByName;
+        private static HTMLElement _hostElement;
+        private static HTMLElement _statusElement;
+        private static string _currentSample;
+        private static int _renderCount;
+        private static int _exerciseCount;
+
+        private static void Main()
+        {
+            document.body.style.margin   = "0";
+            document.body.style.padding  = "0";
+            document.body.style.overflow = "hidden";
+
+            BuildShell();
+            DiscoverSamples();
+            RegisterRoutes();
+            ExposeBenchmarkApi();
+
+            Router.Initialize();
+            Router.Refresh(onDone: Router.ForceMatchCurrent);
+
+            SetStatus("ready");
+        }
+
+        private static void BuildShell()
+        {
+            _statusElement                  = document.createElement("div");
+            _statusElement.id               = "tss-benchmark-status";
+            _statusElement.style.position   = "fixed";
+            _statusElement.style.top        = "0";
+            _statusElement.style.left       = "0";
+            _statusElement.style.right      = "0";
+            _statusElement.style.height     = "20px";
+            _statusElement.style.padding    = "2px 8px";
+            _statusElement.style.background = "#111";
+            _statusElement.style.color      = "#0f0";
+            _statusElement.style.fontFamily = "ui-monospace, Consolas, monospace";
+            _statusElement.style.fontSize   = "11px";
+            _statusElement.style.lineHeight = "20px";
+            _statusElement.style.zIndex     = "99999";
+            _statusElement.textContent      = "initializing";
+            document.body.appendChild(_statusElement);
+
+            _hostElement                  = document.createElement("div");
+            _hostElement.id               = "tss-benchmark-host";
+            _hostElement.style.position   = "absolute";
+            _hostElement.style.top        = "24px";
+            _hostElement.style.left       = "0";
+            _hostElement.style.right      = "0";
+            _hostElement.style.bottom     = "0";
+            _hostElement.style.overflow   = "auto";
+            document.body.appendChild(_hostElement);
+        }
+
+        private static void DiscoverSamples()
+        {
+            var samples = typeof(ISample).Assembly.GetTypes()
+                .Where(t => typeof(ISample).IsAssignableFrom(t)
+                    && typeof(IComponent).IsAssignableFrom(t)
+                    && !t.IsInterface
+                    && !t.IsAbstract)
+                .OrderBy(t => t.Name, StringComparer.Ordinal)
+                .ToArray();
+
+            _samplesByName = samples.ToDictionary(t => t.Name, t => t);
+            console.log("tss-benchmark: discovered " + _samplesByName.Count + " samples");
+        }
+
+        private static void RegisterRoutes()
+        {
+            Router.Register("benchmark-home", "/", _ => RenderHome());
+
+            foreach (var name in _samplesByName.Keys)
+            {
+                var captured = name;
+                Router.Register(
+                    "benchmark-sample-" + captured,
+                    "#/sample/" + captured,
+                    _ => RenderSample(captured));
+            }
+        }
+
+        private static void RenderHome()
+        {
+            ClearHost();
+            _currentSample = null;
+
+            var info = document.createElement("div");
+            info.style.padding    = "16px";
+            info.style.fontFamily = "system-ui, sans-serif";
+            info.style.fontSize   = "14px";
+            info.style.color      = "#444";
+
+            var title = document.createElement("h2");
+            title.textContent = "Tesserae Benchmark Harness";
+            info.appendChild(title);
+
+            var p = document.createElement("p");
+            p.textContent = _samplesByName.Count + " samples discovered. Navigate via #/sample/{Name} or call window.tssBenchmark.render(name).";
+            info.appendChild(p);
+
+            _hostElement.appendChild(info);
+            SetStatus("home");
+        }
+
+        private static void RenderSample(string name)
+        {
+            ClearHost();
+            _currentSample = name;
+
+            if (!_samplesByName.TryGetValue(name, out var type))
+            {
+                _hostElement.textContent = "Unknown sample: " + name;
+                SetStatus("unknown:" + name);
+                return;
+            }
+
+            try
+            {
+                var component = Activator.CreateInstance(type) as IComponent;
+
+                if (component == null)
+                {
+                    _hostElement.textContent = "Sample " + name + " did not return an IComponent";
+                    SetStatus("invalid:" + name);
+                    return;
+                }
+
+                _hostElement.appendChild(component.Render());
+                _renderCount++;
+                SetStatus("rendered:" + name);
+            }
+            catch (Exception ex)
+            {
+                _hostElement.textContent = "Failed to render " + name + ": " + ex.Message;
+                console.warn("tss-benchmark: render failed for " + name + " - " + ex.Message);
+                SetStatus("error:" + name);
+            }
+        }
+
+        private static void ClearHost()
+        {
+            while (_hostElement.firstChild != null)
+            {
+                _hostElement.removeChild(_hostElement.firstChild);
+            }
+
+            // Close any drifting overlays/toasts left behind by the previous sample so
+            // they don't accumulate across the run and skew the memory profile.
+            CloseLeftovers();
+        }
+
+        private static void CloseLeftovers()
+        {
+            string[] overlaySelectors = new[]
+            {
+                ".tss-toast",
+                ".tss-modal-overlay",
+                ".tss-modal",
+                ".tss-dialog-overlay",
+                ".tss-dialog",
+                ".tss-panel-overlay",
+                ".tss-panel",
+                ".tss-context-menu",
+                ".tss-tooltip",
+                ".tss-tutorial-overlay",
+                ".tss-command-palette",
+                ".tippy-box"
+            };
+
+            for (int s = 0; s < overlaySelectors.Length; s++)
+            {
+                var found = document.querySelectorAll(overlaySelectors[s]);
+                for (int i = 0; i < found.length; i++)
+                {
+                    try
+                    {
+                        var el = found[i].As<HTMLElement>();
+                        if (el.parentNode != null) el.parentNode.removeChild(el);
+                    }
+                    catch { }
+                }
+            }
+        }
+
+        // Trigger a few low-risk interactions on whatever sample is currently
+        // mounted: click a handful of visible buttons, fill the first text
+        // inputs, toggle the first checkbox/switch, change the first dropdown.
+        // Returns the number of distinct interactions that fired so the
+        // measurement driver can verify the call did something.
+        private static int Exercise()
+        {
+            if (_currentSample == null) return 0;
+
+            int interactions = 0;
+
+            interactions += ClickSafeButtons(maxClicks: 3);
+            interactions += FillTextInputs("benchmark-" + _exerciseCount, maxFills: 2);
+            interactions += ToggleCheckboxes(maxToggles: 1);
+            interactions += ChangeSelects(maxChanges: 1);
+            interactions += FocusBlurFirstInput();
+
+            _exerciseCount++;
+            SetStatus("exercised:" + _currentSample + ":" + interactions);
+            return interactions;
+        }
+
+        private static int ClickSafeButtons(int maxClicks)
+        {
+            var nodes = _hostElement.querySelectorAll("button");
+            int clicked = 0;
+
+            for (int i = 0; i < nodes.length && clicked < maxClicks; i++)
+            {
+                var b = nodes[i].As<HTMLButtonElement>();
+
+                if (b.disabled) continue;
+                if (!IsVisible(b)) continue;
+
+                var label = (b.textContent ?? string.Empty).ToLower();
+
+                if (label.Contains("delete")
+                 || label.Contains("remove")
+                 || label.Contains("destroy")
+                 || label.Contains("sign out")
+                 || label.Contains("logout")) continue;
+
+                try
+                {
+                    b.click();
+                    clicked++;
+                }
+                catch { }
+            }
+
+            return clicked;
+        }
+
+        private static int FillTextInputs(string value, int maxFills)
+        {
+            var nodes = _hostElement.querySelectorAll("input, textarea");
+            int filled = 0;
+
+            for (int i = 0; i < nodes.length && filled < maxFills; i++)
+            {
+                var el = nodes[i];
+
+                if (!IsVisible(el.As<HTMLElement>())) continue;
+
+                var tagName = el.As<HTMLElement>().tagName;
+                var type    = (el["type"] as string) ?? "";
+
+                bool acceptable = tagName == "TEXTAREA"
+                               || type == ""
+                               || type == "text"
+                               || type == "search"
+                               || type == "email"
+                               || type == "url";
+
+                if (!acceptable) continue;
+
+                try
+                {
+                    el["value"] = value;
+                    DispatchEvent(el.As<Element>(), "input");
+                    DispatchEvent(el.As<Element>(), "change");
+                    filled++;
+                }
+                catch { }
+            }
+
+            return filled;
+        }
+
+        private static int ToggleCheckboxes(int maxToggles)
+        {
+            var nodes = _hostElement.querySelectorAll("input[type='checkbox'], [role='switch'], .tss-toggle, .tss-checkbox");
+            int toggled = 0;
+
+            for (int i = 0; i < nodes.length && toggled < maxToggles; i++)
+            {
+                var el = nodes[i].As<HTMLElement>();
+
+                if (!IsVisible(el)) continue;
+
+                try
+                {
+                    el.click();
+                    toggled++;
+                }
+                catch { }
+            }
+
+            return toggled;
+        }
+
+        private static int ChangeSelects(int maxChanges)
+        {
+            var nodes = _hostElement.querySelectorAll("select");
+            int changed = 0;
+
+            for (int i = 0; i < nodes.length && changed < maxChanges; i++)
+            {
+                var select = nodes[i].As<HTMLSelectElement>();
+
+                if (!IsVisible(select)) continue;
+                if (select.options.length < 2) continue;
+
+                try
+                {
+                    select.selectedIndex = (select.selectedIndex + 1) % (int)select.options.length;
+                    DispatchEvent(select, "input");
+                    DispatchEvent(select, "change");
+                    changed++;
+                }
+                catch { }
+            }
+
+            return changed;
+        }
+
+        private static int FocusBlurFirstInput()
+        {
+            var nodes = _hostElement.querySelectorAll("input, textarea, [contenteditable='true']");
+
+            for (int i = 0; i < nodes.length; i++)
+            {
+                var el = nodes[i].As<HTMLElement>();
+
+                if (!IsVisible(el)) continue;
+
+                try
+                {
+                    el.focus();
+                    el.blur();
+                    return 1;
+                }
+                catch { }
+            }
+
+            return 0;
+        }
+
+        private static bool IsVisible(HTMLElement el)
+        {
+            if (el == null) return false;
+            if (el.offsetParent == null && el.tagName != "BODY") return false;
+
+            var rect = el.getBoundingClientRect().As<DOMRect>();
+            return rect.width > 0 && rect.height > 0;
+        }
+
+        private static void DispatchEvent(Element el, string type)
+        {
+            var evt = document.createEvent("Event");
+            evt.initEvent(type, true, true);
+            el.dispatchEvent(evt);
+        }
+
+        private static void SetStatus(string text)
+        {
+            _statusElement.textContent = "tss-benchmark: " + text + " (renders=" + _renderCount + ", exercises=" + _exerciseCount + ")";
+            Script.Write("window.__tssBenchmarkStatus = {0};", text);
+        }
+
+        private static void ExposeBenchmarkApi()
+        {
+            // Pre-serialize the sample list once so the driver can enumerate it deterministically.
+            var samplesJson = "[" + string.Join(",", _samplesByName.Keys.Select(k => "\"" + EscapeJson(k) + "\"")) + "]";
+
+            Script.Write("if (!window.tssBenchmark) window.tssBenchmark = new Object();");
+            Script.Write("window.tssBenchmark.ready = true;");
+            Script.Write("window.tssBenchmark.samples = JSON.parse({0});", samplesJson);
+            Script.Write("window.tssBenchmark.render = {0};",     (Action<string>)RenderSampleViaApi);
+            Script.Write("window.tssBenchmark.exercise = {0};",   (Func<int>)Exercise);
+            Script.Write("window.tssBenchmark.current = {0};",    (Func<string>)(() => _currentSample));
+            Script.Write("window.tssBenchmark.renderCount = {0};",   (Func<int>)(() => _renderCount));
+            Script.Write("window.tssBenchmark.exerciseCount = {0};", (Func<int>)(() => _exerciseCount));
+        }
+
+        private static void RenderSampleViaApi(string name)
+        {
+            // Update URL state for human-friendly debugging, but always force
+            // a fresh render — Router.Push is a no-op when the hash is
+            // unchanged, which would silently skip repeated renders of the
+            // same sample (a common case for soak-style benchmark runs).
+            var path = "#/sample/" + name;
+            if (window.location.hash != path)
+            {
+                Router.Replace(path);
+            }
+            RenderSample(name);
+        }
+
+        private static string EscapeJson(string s)
+        {
+            return s.Replace("\\", "\\\\").Replace("\"", "\\\"");
+        }
+    }
+}

--- a/Tesserae.sln
+++ b/Tesserae.sln
@@ -21,6 +21,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Build.UpdateInterfaceIcons", "Build.UpdateInterfaceIcons\Build.UpdateInterfaceIcons.csproj", "{084992F7-74EB-4123-989C-86CDFE8BDBC4}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tesserae.Benchmark.Tests", "Tesserae.Benchmark.Tests\Tesserae.Benchmark.Tests.csproj", "{B9A55B25-1B6E-4F0E-9C8F-7C2F1E10B001}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tesserae.Benchmark.Measure", "Tesserae.Benchmark.Measure\Tesserae.Benchmark.Measure.csproj", "{B9A55B25-1B6E-4F0E-9C8F-7C2F1E10B002}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -43,6 +47,14 @@ Global
 		{084992F7-74EB-4123-989C-86CDFE8BDBC4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{084992F7-74EB-4123-989C-86CDFE8BDBC4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{084992F7-74EB-4123-989C-86CDFE8BDBC4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B9A55B25-1B6E-4F0E-9C8F-7C2F1E10B001}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B9A55B25-1B6E-4F0E-9C8F-7C2F1E10B001}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B9A55B25-1B6E-4F0E-9C8F-7C2F1E10B001}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B9A55B25-1B6E-4F0E-9C8F-7C2F1E10B001}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B9A55B25-1B6E-4F0E-9C8F-7C2F1E10B002}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B9A55B25-1B6E-4F0E-9C8F-7C2F1E10B002}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B9A55B25-1B6E-4F0E-9C8F-7C2F1E10B002}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B9A55B25-1B6E-4F0E-9C8F-7C2F1E10B002}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Tesserae.Benchmark.Tests is a minimal h5 harness that mounts each
ISample under #/sample/{Name} and publishes a window.tssBenchmark API
(samples, render, exercise, current) so the driver can navigate by
routing alone without dragging in the regular sidebar chrome.

Tesserae.Benchmark.Measure is a net10 console app that serves the
harness over Kestrel, drives Playwright/Chromium through the sample
list, and captures (separately) a V8 CPU sampling profile, a V8
heap allocation profile, and a periodic memory/DOM-counter trace via
CDP. It writes cpu-profile.json, heap-profile.json, memory-trace.csv,
plus a report.md / report.json with the top hot methods, top
allocators, per-sample stats, and a linear-regression leak verdict.