### PR TITLE
Make CommandPalette global shortcut key configurable

### DIFF
--- a/Tesserae/src/Components/CommandPalette.cs
+++ b/Tesserae/src/Components/CommandPalette.cs
@@ -35,6 +35,11 @@ namespace Tesserae
         public bool EnableGlobalActionShortcuts { get; set; } = true;
         public bool HideOnAction { get; set; } = true;
 
+        /// <summary>
+        /// Key (combined with Ctrl/Cmd) that toggles the palette globally. Case-insensitive. Defaults to "k".
+        /// </summary>
+        public string GlobalShortcutKey { get; set; } = "k";
+
         public CommandPalette(IEnumerable<CommandPaletteAction> actions = null)
         {
             _searchInput = TextBox(_("tss-commandpalette-search", type: "search", placeholder: "Type a command"));
@@ -183,7 +188,9 @@ namespace Tesserae
                 return;
             }
 
-            if (EnableGlobalShortcut && (e.key == "k" || e.key == "K") && (e.metaKey || e.ctrlKey))
+            if (EnableGlobalShortcut && !string.IsNullOrEmpty(GlobalShortcutKey)
+                && string.Equals(e.key, GlobalShortcutKey, StringComparison.OrdinalIgnoreCase)
+                && (e.metaKey || e.ctrlKey))
             {
                 StopEvent(e);
                 Toggle();


### PR DESCRIPTION
## Summary
Make the CommandPalette's global keyboard shortcut configurable instead of hardcoded to "k".

## Changes
- Added `GlobalShortcutKey` property to `CommandPalette` class with a default value of "k"
- Updated the global shortcut key detection logic in `HandleGlobalKeyDown` to use the configurable property instead of hardcoded "k"/"K" comparison
- Implemented case-insensitive key matching using `StringComparison.OrdinalIgnoreCase`
- Added null/empty validation for the `GlobalShortcutKey` property

## Implementation Details
The shortcut detection now uses `string.Equals()` with `OrdinalIgnoreCase` comparison, allowing users to customize the global toggle key while maintaining backward compatibility (defaults to "k"). The implementation validates that `GlobalShortcutKey` is not null or empty before attempting the comparison.

https://claude.ai/code/session_01XvDb6grpVY4jWRugLeLPSd