### PR TITLE
CommandPalette: bind global keydown listener to host IComponent lifetime

### DIFF
--- a/Tesserae.Tests/src/Samples/Utilities/CommandPaletteSample.cs
+++ b/Tesserae.Tests/src/Samples/Utilities/CommandPaletteSample.cs
@@ -13,13 +13,14 @@ namespace Tesserae.Tests.Samples
 
         public CommandPaletteSample()
         {
-            var palette = new CommandPalette(BuildActions());
+            var stack = SectionStack().Secondary();
+            var palette = new CommandPalette(stack, BuildActions());
 
             var openButton = Button("Open Command Palette")
                .Primary()
                .OnClick(() => palette.Open());
 
-            _content = SectionStack().Secondary()
+            _content = stack
                .SampleTitle(typeof(CommandPaletteSample), UIcons.Keyboard, "A command palette utility")
                .FlatSection(Stack().Children(
                     Card(VStack().WS().Children(

--- a/Tesserae/src/Base/UI.Components.cs
+++ b/Tesserae/src/Base/UI.Components.cs
@@ -196,9 +196,12 @@ namespace Tesserae
         public static CommandBar CommandBar(params IComponent[] items) => new CommandBar(items);
 
         /// <summary>
-        /// Creates a <see cref="Tesserae.CommandPalette"/> component.
+        /// Creates a <see cref="Tesserae.CommandPalette"/> component bound to the
+        /// lifetime of <paramref name="host"/> (its global keyboard listener is
+        /// attached when <paramref name="host"/> mounts and removed when it is
+        /// unmounted).
         /// </summary>
-        public static CommandPalette CommandPalette(params CommandPaletteAction[] actions) => new CommandPalette(actions);
+        public static CommandPalette CommandPalette(IComponent host, params CommandPaletteAction[] actions) => new CommandPalette(host, actions);
 
         /// <summary>
         /// Creates a <see cref="Tesserae.CommandPaletteAction"/> definition.

--- a/Tesserae/src/Components/CommandPalette.cs
+++ b/Tesserae/src/Components/CommandPalette.cs
@@ -29,6 +29,9 @@ namespace Tesserae
         private string _currentParentId;
         private int _activeIndex = -1;
 
+        private readonly Action<Event> _globalKeyDownHandler;
+        private bool _globalListenerActive;
+
         public event Action<CommandPaletteAction> ActionExecuted;
 
         public bool EnableGlobalShortcut { get; set; } = true;
@@ -40,8 +43,17 @@ namespace Tesserae
         /// </summary>
         public string GlobalShortcutKey { get; set; } = "k";
 
-        public CommandPalette(IEnumerable<CommandPaletteAction> actions = null)
+        /// <summary>
+        /// Creates a CommandPalette whose global Ctrl/Cmd keyboard listener is bound
+        /// to the lifetime of <paramref name="host"/>: the listener is attached when
+        /// <paramref name="host"/> first mounts to the DOM and detached when it is
+        /// removed. This prevents the palette from leaking listeners (and continuing
+        /// to respond to its shortcut) after the owning view has been navigated away.
+        /// </summary>
+        public CommandPalette(IComponent host, IEnumerable<CommandPaletteAction> actions = null)
         {
+            if (host is null) throw new ArgumentNullException(nameof(host));
+
             _searchInput = TextBox(_("tss-commandpalette-search", type: "search", placeholder: "Type a command"));
             _searchInput.setAttribute("aria-label", "Command palette search");
             _searchInput.addEventListener("input", _ => RefreshResults());
@@ -54,7 +66,7 @@ namespace Tesserae
                     _searchInput.focus();
                 }
             });
-            _backButton = Button(_("tss-commandpalette-back tss-fontweight-semibold", type: "button", title: "Go Back"), 
+            _backButton = Button(_("tss-commandpalette-back tss-fontweight-semibold", type: "button", title: "Go Back"),
                                     Div(_("tss-commandpalette-icon"), I(_($"tss-commandpalette-icon-item {UIcons.AngleLeft}"))));
 
             _backButton.addEventListener("click", e =>
@@ -82,8 +94,22 @@ namespace Tesserae
             _contentHtml = Div(_("tss-commandpalette-container"), _overlay, _positioner);
 
             SetActions(actions);
-            window.addEventListener("keydown", HandleGlobalKeyDown);
-            
+
+            _globalKeyDownHandler = HandleGlobalKeyDown;
+            host.WhenMounted(() =>
+            {
+                if (_globalListenerActive) return;
+                window.addEventListener("keydown", _globalKeyDownHandler);
+                _globalListenerActive = true;
+                host.WhenRemoved(() =>
+                {
+                    if (!_globalListenerActive) return;
+                    window.removeEventListener("keydown", _globalKeyDownHandler);
+                    _globalListenerActive = false;
+                    if (IsVisible) Hide();
+                });
+            });
+
             InnerElement    = _contentHtml;
 
         }


### PR DESCRIPTION
## Summary
Bind the CommandPalette's global Ctrl/Cmd keyboard listener to the lifetime of a required `IComponent host`, so it stops responding once the owning view is navigated away from (and doesn't leak listeners across repeat visits).

## Changes
- `CommandPalette` constructor now requires `IComponent host`; throws `ArgumentNullException` if null.
- The `window.addEventListener("keydown", ...)` registration is moved out of the constructor and into `host.WhenMounted` / `host.WhenRemoved`, with a cached delegate so `removeEventListener` matches.
- On host unmount, if the palette overlay is currently visible it is also `Hide()`-ed so no orphaned overlay is left behind.
- `UI.CommandPalette(...)` factory updated to take `IComponent host` as its first argument.
- `CommandPaletteSample` updated to pass its own root stack as host.

## Notes
Breaking API change: any caller using `new CommandPalette(actions)` or `UI.CommandPalette(actions)` must now pass a host component. This is intentional — the previous behavior leaked one window-level keydown listener per instance and continued to fire after the owning view unmounted.

Follow-up to #178 (which only made the shortcut key configurable). Required by curiosity-ai/mosaik#1308 so Ctrl/Cmd+P only triggers while AdminBuildView is mounted.

https://claude.ai/code/session_01XvDb6grpVY4jWRugLeLPSd

---
_Generated by [Claude Code](https://claude.ai/code/session_01XvDb6grpVY4jWRugLeLPSd)_