### PR TITLE
Change Pivot tab switching from Ctrl+Tab to Ctrl+Alt+Arrow keys

### DIFF
--- a/Tesserae/src/Components/Pivot.cs
+++ b/Tesserae/src/Components/Pivot.cs
@@ -33,7 +33,7 @@ namespace Tesserae
         private readonly Button _scrollLeftBtn;
         private readonly Button _scrollRightBtn;
 
-        private Action<Event> _ctrlTabHandler;
+        private Action<Event> _tabSwitchHandler;
 
         // Fraction of the scroller's visible width to move per scroll-button click.
         private const double ScrollButtonStep = 0.7;
@@ -84,22 +84,23 @@ namespace Tesserae
         }
 
         /// <summary>
-        /// Enables Ctrl+Tab / Ctrl+Shift+Tab to cycle through tabs in order while
-        /// the pivot is mounted and focus is inside its container (or no element
-        /// is focused). Safe to call multiple times — the handler is only
-        /// registered once.
+        /// Enables Ctrl+Alt+Right / Ctrl+Alt+Left to cycle through tabs in order
+        /// while the pivot is mounted and focus is inside its container (or no
+        /// element is focused). Safe to call multiple times — the handler is
+        /// only registered once.
         /// </summary>
         public Pivot EnableCtrlTabSwitching()
         {
-            if (_ctrlTabHandler is object) return this;
+            if (_tabSwitchHandler is object) return this;
 
-            _ctrlTabHandler = ev =>
+            _tabSwitchHandler = ev =>
             {
                 if (!StylingContainer.IsMounted()) return;
                 if (_orderedTabs.Count <= 1) return;
 
                 var ke = ev.As<KeyboardEvent>();
-                if (ke.key != "Tab" || !ke.ctrlKey) return;
+                if (!ke.ctrlKey || !ke.altKey || ke.shiftKey || ke.metaKey) return;
+                if (ke.key != "ArrowRight" && ke.key != "ArrowLeft") return;
 
                 // Scope to focus within this pivot so multiple pivots on the
                 // same page don't fight, while still firing when nothing is
@@ -108,10 +109,10 @@ namespace Tesserae
                 if (active is object && active != document.body && !StylingContainer.contains(active)) return;
 
                 StopEvent(ev);
-                NavigateBy(ke.shiftKey ? -1 : 1);
+                NavigateBy(ke.key == "ArrowLeft" ? -1 : 1);
             };
 
-            window.addEventListener("keydown", _ctrlTabHandler);
+            window.addEventListener("keydown", _tabSwitchHandler);
             return this;
         }
 


### PR DESCRIPTION
## Summary
Updates the keyboard shortcut for cycling through Pivot tabs from `Ctrl+Tab` / `Ctrl+Shift+Tab` to `Ctrl+Alt+Right` / `Ctrl+Alt+Left`, providing a more intuitive and less conflict-prone key combination.

## Changes
- Renamed internal handler field from `_ctrlTabHandler` to `_tabSwitchHandler` for clarity
- Updated keyboard event detection logic:
  - Changed from checking `Tab` key with `ctrlKey` modifier to checking `ArrowRight`/`ArrowLeft` keys with `ctrlKey` and `altKey` modifiers
  - Added explicit rejection of `shiftKey` and `metaKey` to prevent unintended triggers
- Updated navigation direction logic to use arrow key direction instead of shift key state
- Updated method documentation to reflect the new keyboard shortcut

## Implementation Details
The new key combination (`Ctrl+Alt+Right` for next tab, `Ctrl+Alt+Left` for previous tab) is less likely to conflict with browser or OS shortcuts compared to `Ctrl+Tab`, which is commonly used for browser tab switching. The implementation maintains the same scoping behavior to prevent conflicts when multiple Pivots exist on the same page.

https://claude.ai/code/session_01QFDJxcM8bNrJU78Z8kyGsf