### PR TITLE
Add Form component and credential management API support

### DIFF
--- a/Tesserae/src/Base/UI.Components.cs
+++ b/Tesserae/src/Base/UI.Components.cs
@@ -338,7 +338,15 @@ namespace Tesserae
         /// </summary>
         /// <returns></returns>
         public static Stack VStack() => new Stack(Tesserae.Stack.Orientation.Vertical);
-        
+
+        /// <summary>
+        /// Creates a <see cref="Tesserae.Form"/> component that renders as a real
+        /// <c>&lt;form&gt;</c> element so password managers can detect the submission and scope
+        /// credentials to the current origin.
+        /// </summary>
+        public static Form Form() => new Form();
+
+
         /// <summary>
         /// Creates a <see cref="Tesserae.SortableStack"/> component.
         /// </summary>

--- a/Tesserae/src/Components/Form.cs
+++ b/Tesserae/src/Components/Form.cs
@@ -1,0 +1,124 @@
+using H5;
+using static H5.Core.dom;
+using static Tesserae.UI;
+
+namespace Tesserae
+{
+    /// <summary>
+    /// A &lt;form&gt; container. Wrapping login inputs in a real form (with <see cref="Action"/> and
+    /// proper <c>autocomplete</c> hints on the inputs) is what lets browser and third-party password
+    /// managers detect the submission, scope saved credentials to the current origin (subdomain
+    /// included) instead of falling back to registrable-domain heuristics, and prompt the user to
+    /// save or update the password.
+    /// </summary>
+    [H5.Name("tss.Form")]
+    public class Form : IContainer<Form, IComponent>, IHasMarginPadding
+    {
+        private readonly HTMLFormElement _form;
+
+        private event ComponentEventHandler<Form, Event> Submitted;
+
+        public Form()
+        {
+            _form = FormE(_("tss-form"));
+
+            // Default to "POST" so password managers treat this as a credential submission target
+            // (GET forms are usually treated as search). Consumers can override via SetMethod.
+            _form.method = "post";
+
+            // Prevent the browser's default navigation - the login is performed via fetch/XHR in
+            // OnSubmit handlers. We still raise the submit event so the browser's built-in
+            // password manager observes a real form submission and can offer to save credentials.
+            _form.addEventListener("submit", e =>
+            {
+                e.preventDefault();
+                Submitted?.Invoke(this, e);
+            });
+        }
+
+        /// <summary>
+        /// The form's submission URL. Should be a same-origin URL (absolute or relative) on the
+        /// current subdomain — this is the strongest hint a password manager has for scoping the
+        /// saved credential to <c>location.host</c> rather than to the registrable domain.
+        /// </summary>
+        public string Action
+        {
+            get => _form.action;
+            set => _form.action = value ?? string.Empty;
+        }
+
+        /// <summary>The form's HTTP method (defaults to <c>post</c>).</summary>
+        public string Method
+        {
+            get => _form.method;
+            set => _form.method = string.IsNullOrEmpty(value) ? "post" : value;
+        }
+
+        /// <summary>The form's <c>name</c> attribute.</summary>
+        public string FormName
+        {
+            get => _form.name;
+            set => _form.name = value ?? string.Empty;
+        }
+
+        /// <summary>
+        /// The form-level <c>autocomplete</c> attribute (<c>on</c> / <c>off</c>). Leave unset to
+        /// inherit the browser default. Setting this to <c>off</c> disables saving for the whole
+        /// form, which is the opposite of what a sign-in form usually wants.
+        /// </summary>
+        public string AutoComplete
+        {
+            get => _form.getAttribute("autocomplete");
+            set
+            {
+                if (string.IsNullOrEmpty(value))
+                {
+                    _form.removeAttribute("autocomplete");
+                }
+                else
+                {
+                    _form.setAttribute("autocomplete", value);
+                }
+            }
+        }
+
+        public string Margin  { get => _form.style.margin;  set => _form.style.margin  = value; }
+        public string Padding { get => _form.style.padding; set => _form.style.padding = value; }
+
+        public Form SetAction(string action)         { Action       = action; return this; }
+        public Form SetMethod(string method)         { Method       = method; return this; }
+        public Form SetName(string name)             { FormName     = name;   return this; }
+        public Form SetAutoComplete(string value)    { AutoComplete = value;  return this; }
+
+        /// <summary>
+        /// Attaches a handler invoked when the form is submitted (via Enter on a child input or
+        /// a <c>&lt;button type="submit"&gt;</c> inside the form). The native browser navigation
+        /// is always cancelled.
+        /// </summary>
+        public Form OnSubmit(ComponentEventHandler<Form, Event> onSubmit)
+        {
+            Submitted += onSubmit;
+            return this;
+        }
+
+        /// <summary>
+        /// Programmatically request submission (mirrors pressing Enter inside the form).
+        /// Uses <c>HTMLFormElement.requestSubmit()</c> when available so that validation runs and
+        /// the <c>submit</c> event fires; otherwise falls back to dispatching a synthetic event.
+        /// </summary>
+        public Form Submit()
+        {
+            Script.Write("if (typeof {0}.requestSubmit === 'function') { {0}.requestSubmit(); } else { {0}.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true })); }", _form);
+            return this;
+        }
+
+        public void Add(IComponent component) => _form.appendChild(component.Render());
+
+        public void Clear() => ClearChildren(_form);
+
+        public void Replace(IComponent newComponent, IComponent oldComponent)
+            => _form.replaceChild(newComponent.Render(), oldComponent.Render());
+
+        public HTMLElement Render() => _form;
+    }
+}

--- a/Tesserae/src/Components/TextBox.cs
+++ b/Tesserae/src/Components/TextBox.cs
@@ -142,6 +142,43 @@ namespace Tesserae
             return this;
         }
 
+        /// <summary>Sets the text box input type to <c>email</c>.</summary>
+        public TextBox Email()
+        {
+            InnerElement.type = "email";
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the <c>name</c> attribute on the underlying input. Password managers and
+        /// browser autofill heuristics use this to identify the field's role (e.g. <c>username</c>,
+        /// <c>password</c>, <c>email</c>) and to scope saved credentials to the current origin.
+        /// </summary>
+        public TextBox Name(string name)
+        {
+            InnerElement.name = name ?? string.Empty;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the <c>autocomplete</c> attribute on the underlying input. Use values from the
+        /// WHATWG autofill spec (<c>username</c>, <c>email</c>, <c>current-password</c>,
+        /// <c>new-password</c>, <c>one-time-code</c>, <c>off</c>, ...). Password managers rely on
+        /// this hint to distinguish sign-in flows from password-creation flows.
+        /// </summary>
+        public TextBox AutoComplete(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                InnerElement.removeAttribute("autocomplete");
+            }
+            else
+            {
+                InnerElement.setAttribute("autocomplete", value);
+            }
+            return this;
+        }
+
         /// <summary>Removes the border from the text box.</summary>
         public TextBox NoBorder()
         {

--- a/Tesserae/src/Helpers/CredentialStore.cs
+++ b/Tesserae/src/Helpers/CredentialStore.cs
@@ -1,0 +1,156 @@
+using System;
+using System.Threading.Tasks;
+using H5;
+using static H5.Core.dom;
+
+namespace Tesserae
+{
+    /// <summary>
+    /// Thin wrapper around the <a href="https://developer.mozilla.org/docs/Web/API/Credential_Management_API">Credential
+    /// Management API</a>'s <c>navigator.credentials.store(new PasswordCredential(...))</c>.
+    ///
+    /// <para>
+    /// After a successful sign-in, call <see cref="StorePasswordAsync"/> to ask the browser's
+    /// password manager to remember the credentials. The credential is stored against
+    /// <c>window.location.origin</c> — including the current subdomain — rather than against the
+    /// registrable domain that browser heuristics default to when no API is used. That matters when
+    /// a workspace is served from <c>tenant-a.example.com</c> and you do not want the credential
+    /// auto-filled on <c>tenant-b.example.com</c>.
+    /// </para>
+    ///
+    /// <para>
+    /// The API is only available on secure contexts (HTTPS / localhost) and in browsers that
+    /// expose it; on unsupported environments <see cref="StorePasswordAsync"/> resolves to
+    /// <c>false</c> instead of throwing.
+    /// </para>
+    /// </summary>
+    [H5.Name("tss.CredentialStore")]
+    public static class CredentialStore
+    {
+        /// <summary>
+        /// Returns true if the current browser exposes <c>navigator.credentials</c> and the
+        /// <c>PasswordCredential</c> constructor.
+        /// </summary>
+        public static bool IsSupported =>
+            Script.Write<bool>("(typeof navigator !== 'undefined' && navigator.credentials && typeof window.PasswordCredential === 'function')");
+
+        /// <summary>
+        /// Asks the browser to store a username/password credential for the current origin.
+        /// </summary>
+        /// <param name="username">The username or email the user signed in with.</param>
+        /// <param name="password">The password the user signed in with.</param>
+        /// <param name="name">Optional human-readable account label shown in the browser's password UI.</param>
+        /// <param name="iconURL">Optional icon URL shown in the browser's password UI.</param>
+        /// <returns>
+        /// <c>true</c> if the credential was handed off to the browser (the user may still decline
+        /// the save prompt); <c>false</c> if the API is unavailable or the call failed.
+        /// </returns>
+        public static Task<bool> StorePasswordAsync(string username, string password, string name = null, string iconURL = null)
+        {
+            var tcs = new TaskCompletionSource<bool>();
+
+            if (string.IsNullOrEmpty(username) || string.IsNullOrEmpty(password) || !IsSupported)
+            {
+                tcs.SetResult(false);
+                return tcs.Task;
+            }
+
+            // We bind the delegate to a single C# local so H5 emits one JS variable reference per
+            // substitution slot (instead of re-inlining the lambda as an anonymous function
+            // literal at each call site, which is a syntax-ambiguous expression-statement).
+            Action<bool> done = ok => tcs.SetResult(ok);
+
+            Script.Write(@"
+                try {
+                    var __init = { id: {0}, password: {1} };
+                    if ({2}) { __init.name = {2}; }
+                    if ({3}) { __init.iconURL = {3}; }
+                    var __cred = new window.PasswordCredential(__init);
+                    navigator.credentials.store(__cred).then(
+                        function () { {4}(true); },
+                        function () { {4}(false); }
+                    );
+                } catch (__e) {
+                    {4}(false);
+                }
+            ", username, password, name, iconURL, done);
+
+            return tcs.Task;
+        }
+
+        /// <summary>
+        /// Asks the browser if it has a previously-stored credential for the current origin and,
+        /// if so, returns its <c>id</c> (typically the username) and <c>password</c>. Returns
+        /// <c>(null, null)</c> when nothing was returned (user dismissed the picker, no credential
+        /// stored, or the API is unsupported).
+        ///
+        /// <para>
+        /// Pass <paramref name="mediation"/> = <c>"silent"</c> to avoid showing the account chooser
+        /// UI (returns a credential only if the browser is confident there is exactly one), or
+        /// <c>"optional"</c> (default) to let the browser prompt the user.
+        /// </para>
+        /// </summary>
+        public static Task<(string id, string password)> TryGetStoredPasswordAsync(string mediation = "optional")
+        {
+            var tcs = new TaskCompletionSource<(string, string)>();
+
+            if (!IsSupported)
+            {
+                tcs.SetResult((null, null));
+                return tcs.Task;
+            }
+
+            Action<string, string> done = (id, pw) => tcs.SetResult((id, pw));
+
+            Script.Write(@"
+                try {
+                    navigator.credentials.get({ password: true, mediation: {0} }).then(
+                        function (__cred) {
+                            if (__cred && __cred.type === 'password') {
+                                {1}(__cred.id, __cred.password);
+                            } else {
+                                {1}(null, null);
+                            }
+                        },
+                        function () { {1}(null, null); }
+                    );
+                } catch (__e) {
+                    {1}(null, null);
+                }
+            ", mediation, done);
+
+            return tcs.Task;
+        }
+
+        /// <summary>
+        /// Hints to the browser that the user signed out, so the next call to
+        /// <c>navigator.credentials.get</c> will not silently auto-sign-in. Safe to call on
+        /// browsers without the API (no-op).
+        /// </summary>
+        public static Task PreventSilentAccessAsync()
+        {
+            var tcs = new TaskCompletionSource<bool>();
+
+            if (!IsSupported)
+            {
+                tcs.SetResult(true);
+                return tcs.Task;
+            }
+
+            Action<bool> done = _ => tcs.SetResult(true);
+
+            Script.Write(@"
+                try {
+                    navigator.credentials.preventSilentAccess().then(
+                        function () { {0}(true); },
+                        function () { {0}(false); }
+                    );
+                } catch (__e) {
+                    {0}(true);
+                }
+            ", done);
+
+            return tcs.Task;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds support for browser-native credential management and form submission handling, enabling password managers to properly detect sign-in flows and scope saved credentials to the current origin (including subdomain).

## Key Changes

- **New `Form` component** (`Tesserae/src/Components/Form.cs`): A real `<form>` element wrapper that:
  - Defaults to POST method (password manager hint for credential submission)
  - Prevents default navigation while allowing the submit event to fire (so password managers observe the submission)
  - Exposes `Action`, `Method`, `FormName`, and `AutoComplete` properties
  - Provides `OnSubmit()` handler and `Submit()` method for programmatic submission
  - Implements `IContainer<Form, IComponent>` and `IHasMarginPadding` for consistency with other Tesserae components

- **New `CredentialStore` helper** (`Tesserae/src/Helpers/CredentialStore.cs`): Thin wrapper around the Credential Management API:
  - `StorePasswordAsync()`: Asks the browser to save username/password after successful sign-in
  - `TryGetStoredPasswordAsync()`: Retrieves previously-stored credentials with optional mediation mode
  - `PreventSilentAccessAsync()`: Hints to the browser that the user signed out
  - Gracefully degrades on unsupported browsers (returns false/null instead of throwing)
  - Scopes credentials to `window.location.origin` (subdomain-aware) rather than registrable domain heuristics

- **Enhanced `TextBox` component** (`Tesserae/src/Components/TextBox.cs`):
  - Added `Email()` method to set input type to `email`
  - Added `Name(string)` method to set the `name` attribute (used by password managers for field identification)
  - Added `AutoComplete(string)` method to set the `autocomplete` attribute (e.g., `username`, `current-password`, `new-password`)

- **Updated `UI.Components.cs`**: Added `Form()` factory method following Tesserae conventions

## Implementation Details

- The `Form` component uses `HTMLFormElement.requestSubmit()` when available for proper validation and event firing, with fallback to synthetic event dispatch
- `CredentialStore` uses H5's `Script.Write()` to safely invoke browser APIs with proper error handling and callback binding
- All credential management operations are async (`Task<T>`) to match browser API patterns
- The implementation is only available on secure contexts (HTTPS/localhost) and gracefully handles unsupported browsers

https://claude.ai/code/session_01479qYqYc7emKkZ1w9t3wgi