### PR TITLE
Fix VirtualizedList going blank on fast scroll

### DIFF
--- a/Tesserae/src/Components/VirtualizedList.cs
+++ b/Tesserae/src/Components/VirtualizedList.cs
@@ -285,43 +285,79 @@ namespace Tesserae
 
             var newPage = (int)Round(scrollPosition / _pageHeight.Size, MidpointRounding.AwayFromZero);
 
-            if ((newPage != _currentPage) && newPage > _pagesToVirtualizeLowerBoundary)
+            if (newPage != _currentPage)
             {
-                if (scrollDirection == ScrollDirection.Down)
+                // The per-step Down/Up branches assume the rendered window slid by exactly one
+                // page. On a fast scroll the viewport can jump several pages between events,
+                // so a one-page swap would leave the window disjoint from the viewport (which
+                // manifested as a blank list). Detect that case and rebuild the window instead.
+                if (Abs(newPage - _currentPage) > 1)
                 {
-                    RemoveFirstPageFromBasicListContainer();
-
-                    var newTopSpacingDivHeight = ((newPage - _pagesToVirtualizeLowerBoundary) * _pageHeight.Size).px();
-                    SetTopSpacingDivHeight(newTopSpacingDivHeight);
-
-                    var pageNumberToAdd = newPage + _pagesToVirtualizeUpperBoundary;
-                    CreatePageDownwards(RetrievePageFromCache(pageNumberToAdd));
-
-                    var newBottomSpacingDivHeight =
-                        ((_listPageCache.PagesCount - (newPage + _pagesToVirtualizeUpperBoundary)) * _pageHeight.Size).px();
-
-                    SetBottomSpacingDivHeight(newBottomSpacingDivHeight);
+                    RebuildRenderedPages(newPage);
                 }
-                else if (scrollDirection == ScrollDirection.Up)
+                else if (newPage > _pagesToVirtualizeLowerBoundary)
                 {
-                    RemoveLastPageFromBasicListContainer();
+                    if (scrollDirection == ScrollDirection.Down)
+                    {
+                        RemoveFirstPageFromBasicListContainer();
 
-                    var newTopSpacingDivHeight =
-                        ((newPage - (_pagesToVirtualizeUpperBoundary - 1)) * _pageHeight.Size).px();
-                    SetTopSpacingDivHeight(newTopSpacingDivHeight);
+                        var newTopSpacingDivHeight = ((newPage - _pagesToVirtualizeLowerBoundary) * _pageHeight.Size).px();
+                        SetTopSpacingDivHeight(newTopSpacingDivHeight);
 
-                    var pageNumberToAdd = newPage - _pagesToVirtualizeUpperBoundary;
-                    CreatePageUpwards(RetrievePageFromCache(pageNumberToAdd));
+                        var pageNumberToAdd = newPage + _pagesToVirtualizeUpperBoundary;
+                        CreatePageDownwards(RetrievePageFromCache(pageNumberToAdd));
 
-                    var newBottomSpacingDivHeight =
-                        ((_listPageCache.PagesCount - (newPage + _pagesToVirtualizeLowerBoundary)) * _pageHeight.Size).px();
+                        var newBottomSpacingDivHeight =
+                            ((_listPageCache.PagesCount - (newPage + _pagesToVirtualizeUpperBoundary)) * _pageHeight.Size).px();
 
-                    SetBottomSpacingDivHeight(newBottomSpacingDivHeight);
+                        SetBottomSpacingDivHeight(newBottomSpacingDivHeight);
+                    }
+                    else if (scrollDirection == ScrollDirection.Up)
+                    {
+                        RemoveLastPageFromBasicListContainer();
+
+                        var newTopSpacingDivHeight =
+                            ((newPage - (_pagesToVirtualizeUpperBoundary - 1)) * _pageHeight.Size).px();
+                        SetTopSpacingDivHeight(newTopSpacingDivHeight);
+
+                        var pageNumberToAdd = newPage - _pagesToVirtualizeUpperBoundary;
+                        CreatePageUpwards(RetrievePageFromCache(pageNumberToAdd));
+
+                        var newBottomSpacingDivHeight =
+                            ((_listPageCache.PagesCount - (newPage + _pagesToVirtualizeLowerBoundary)) * _pageHeight.Size).px();
+
+                        SetBottomSpacingDivHeight(newBottomSpacingDivHeight);
+                    }
                 }
             }
 
             _currentPage           = newPage;
             _currentScrollPosition = scrollPosition;
+        }
+
+        private void RebuildRenderedPages(int centerPage)
+        {
+            var rendered = GetRenderedPages();
+            for (var i = (int)rendered.length - 1; i >= 0; i--)
+            {
+                _basicListContainer.removeChild(rendered[i]);
+            }
+
+            var firstPage = Max(1, centerPage - _pagesToVirtualizeLowerBoundary + 1);
+            var lastPage  = Min(_listPageCache.PagesCount, centerPage + _pagesToVirtualizeUpperBoundary);
+
+            for (var pageNumber = firstPage; pageNumber <= lastPage; pageNumber++)
+            {
+                var page = RetrievePageFromCache(pageNumber);
+
+                if (page != null)
+                {
+                    _basicListContainer.insertBefore(page, _bottomSpacingDiv);
+                }
+            }
+
+            SetTopSpacingDivHeight(((firstPage - 1)                       * _pageHeight.Size).px());
+            SetBottomSpacingDivHeight(((_listPageCache.PagesCount - lastPage) * _pageHeight.Size).px());
         }
 
         private ScrollDirection GetScrollDirection(double scrollTop)

--- a/Tesserae/src/Components/VirtualizedList.cs
+++ b/Tesserae/src/Components/VirtualizedList.cs
@@ -316,15 +316,14 @@ namespace Tesserae
                     {
                         RemoveLastPageFromBasicListContainer();
 
-                        var newTopSpacingDivHeight =
-                            ((newPage - (_pagesToVirtualizeUpperBoundary - 1)) * _pageHeight.Size).px();
+                        var newTopSpacingDivHeight = ((newPage - _pagesToVirtualizeLowerBoundary) * _pageHeight.Size).px();
                         SetTopSpacingDivHeight(newTopSpacingDivHeight);
 
                         var pageNumberToAdd = newPage - _pagesToVirtualizeUpperBoundary;
                         CreatePageUpwards(RetrievePageFromCache(pageNumberToAdd));
 
                         var newBottomSpacingDivHeight =
-                            ((_listPageCache.PagesCount - (newPage + _pagesToVirtualizeLowerBoundary)) * _pageHeight.Size).px();
+                            ((_listPageCache.PagesCount - (newPage + _pagesToVirtualizeUpperBoundary)) * _pageHeight.Size).px();
 
                         SetBottomSpacingDivHeight(newBottomSpacingDivHeight);
                     }


### PR DESCRIPTION
## Summary

- The `VirtualizedList` scroll handler (used by the data hub's node-types list) only swaps one page per scroll event. On a fast scroll the viewport jumps several pages at once, so the rendered window detaches from the viewport and the user sees the empty spacer instead of any items.
- Detect multi-page jumps in `OnBasicListContainerScroll` and rebuild the rendered window around the new page via a new `RebuildRenderedPages` method (O(PagesToVirtualize) regardless of jump size). Also covers the case where a fast scroll lands near the top, where the per-step branch was previously gated off entirely.
- Fix an asymmetry in the slow-scroll Up branch: it computed `topSpacing` from `(upperBoundary - 1)` and `bottomSpacing` from `lowerBoundary`, while Down uses `lowerBoundary` and `upperBoundary`. The mismatch left total scroll height off by one page after a Down-then-Up sequence, producing visible top jitter. Up now uses the same boundaries as Down.

## Test plan

- [ ] Build `Tesserae` — passes locally with the h5 compiler.
- [ ] In the mosaik data hub, scroll the node types list slowly: rows track the viewport with no jitter at the top.
- [ ] Fast-scroll (drag the scrollbar or flick the wheel) from the top to the middle and to the bottom: rows render correctly at every landing position, no blank gaps.
- [ ] Fast-scroll back to the top: initial pages render.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VLFLDHbvNteRrwe1prwjhP)_