### PR TITLE
MarkdownBlock: add OnAfterRender post-processing hook

### DIFF
--- a/Tesserae/src/Components/MarkdownBlock.cs
+++ b/Tesserae/src/Components/MarkdownBlock.cs
@@ -1,3 +1,4 @@
+using System;
 using static H5.Core.dom;
 using static Tesserae.UI;
 
@@ -10,7 +11,8 @@ namespace Tesserae
     [H5.Name("tss.mdb")]
     public class MarkdownBlock : ComponentBase<MarkdownBlock, HTMLElement>, ICanWrap
     {
-        private string _text;
+        private string                _text;
+        private Action<HTMLElement>   _onAfterRender;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MarkdownBlock"/> class.
@@ -31,6 +33,7 @@ namespace Tesserae
             {
                 _text                  = value ?? string.Empty;
                 InnerElement.innerHTML = Tesserae.Markdown.ConvertMarkdownSanitized(_text);
+                _onAfterRender?.Invoke(InnerElement);
             }
         }
 
@@ -42,6 +45,23 @@ namespace Tesserae
         {
             get => !InnerElement.classList.contains("tss-text-nowrap");
             set => InnerElement.UpdateClassIfNot(value, "tss-text-nowrap");
+        }
+
+        /// <summary>
+        /// Registers a callback invoked every time the Markdown source is re-parsed into the
+        /// inner HTML element. The callback receives the inner element so that callers can
+        /// post-process the rendered tree (e.g. wrap <c>&lt;code&gt;</c> blocks with custom
+        /// controls, rewrite links, attach copy buttons, ...).
+        ///
+        /// The callback is fired immediately with the current rendered content so the first
+        /// pass does not require the caller to also trigger an explicit render. Re-registering
+        /// replaces any previously-attached callback.
+        /// </summary>
+        public MarkdownBlock OnAfterRender(Action<HTMLElement> callback)
+        {
+            _onAfterRender = callback;
+            callback?.Invoke(InnerElement);
+            return this;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

Adds an opt-in `OnAfterRender(Action<HTMLElement>)` hook on `MarkdownBlock` that fires every time the markdown source is parsed into the inner element.

This lets callers post-process the rendered tree without having to subclass `MarkdownBlock` or duplicate the parse-and-sanitize pipeline. Concrete use case in `mosaik`: walk the freshly-rendered `<code>` blocks and wrap multi-line snippets with "Open in Canvas" controls so the chat surface can re-introduce the legacy `ChatAIView` canvas affordance on top of the new Tesserae-based chat.

## API

```csharp
var md = MarkdownBlock(text).OnAfterRender(el =>
{
    foreach (HTMLElement codeEl in el.querySelectorAll("code"))
    {
        // wrap, decorate, attach handlers, ...
    }
});
```

The callback is fired immediately with the current rendered content (so the first pass does not require an extra `Text =` assignment), and fires again every time `Text` is set.

## Notes

- No behavior change for existing callers — the hook is null by default.
- Streaming usage works as-is: each new `MarkdownBlock` instance can register its own hook; `DeltaComponent` continues to diff the resulting HTML.

## Test plan

- [ ] Render a static `MarkdownBlock`, verify `OnAfterRender` fires once with the parsed inner element.
- [ ] Assign `Text` again, verify the callback fires again on each re-parse.
- [ ] Re-register a different callback — only the latest one fires.

https://claude.ai/code/session_016BqxTR8QjK678rcfYN2o9d

---
_Generated by [Claude Code](https://claude.ai/code/session_016BqxTR8QjK678rcfYN2o9d)_