### PR TITLE
SplitView: fix resize calculation when RightIsSmaller

### DIFF
--- a/Tesserae/src/Components/SplitView.cs
+++ b/Tesserae/src/Components/SplitView.cs
@@ -74,16 +74,19 @@ namespace Tesserae
             double      width = 0;
             DOMRect     rect;
             HTMLElement current;
+            bool        currentIsRight;
 
             el.onmousedown += (me) =>
             {
                 if (_splitContainer.classList.contains("tss-split-right"))
                 {
-                    current = _rightComponent.Render();
+                    current        = _rightComponent.Render();
+                    currentIsRight = true;
                 }
                 else
                 {
-                    current = _leftComponent.Render();
+                    current        = _leftComponent.Render();
+                    currentIsRight = false;
                 }
                 rect               =  _splitContainer.getBoundingClientRect().As<DOMRect>();
                 window.onmousemove += Resize;
@@ -93,7 +96,8 @@ namespace Tesserae
 
             void Resize(MouseEvent me)
             {
-                width                    = Math.Min(rect.width - 16, Math.Max(16, (me.clientX - rect.left)));
+                double raw = currentIsRight ? (rect.right - me.clientX) : (me.clientX - rect.left);
+                width                    = Math.Min(rect.width - 16, Math.Max(16, raw));
                 current.style.width      = width + "px";
                 current.style.flexGrow   = "0";
                 current.style.flexShrink = "1";


### PR DESCRIPTION
## Summary

Fixes a bug in `SplitView` when the view is configured with `RightIsSmaller(...)` and the user drags the splitter.

The drag handler in `HookDragEvents` always computed the new width as `clientX - rect.left` — i.e. distance from the container's **left** edge:

```csharp
width = Math.Min(rect.width - 16, Math.Max(16, (me.clientX - rect.left)));
current.style.width = width + "px";
```

That formula is correct when the **left** panel is the one being resized (`LeftIsSmaller` → `tss-split-left`), but it is inverted when `tss-split-right` is set and `current` is the right panel:

- moving the splitter toward the right made the right panel grow instead of shrink, and
- the value passed to `onResizeEnd` was the distance from the container's left edge, not the right panel's actual width.

The fix tracks which side is being resized and computes the new width relative to the appropriate edge:

```csharp
double raw = currentIsRight ? (rect.right - me.clientX) : (me.clientX - rect.left);
```

## Test plan
- [ ] Build with `dotnet build` (passes locally).
- [ ] In a sample using `LeftIsSmaller(...)`, drag the splitter — left panel resizes as before.
- [ ] In a sample using `RightIsSmaller(...)`, drag the splitter — right panel now shrinks/grows in the expected direction and `onResizeEnd` receives the right panel's width.

---
_Generated by [Claude Code](https://claude.ai/code/session_017SBqp4fvygNnr1q5PjHsZ6)_