### PR TITLE
Fix blank mobile page and refine OmniBox send button states

### DIFF
--- a/Tesserae/h5/assets/css/tss.omnibox.css
+++ b/Tesserae/h5/assets/css/tss.omnibox.css
@@ -380,6 +380,39 @@
     background: var(--tss-colors-blue-200) !important;
 }
 
+/* Chat trigger (send) button */
+.tss-btn.tss-omnibox-chat-btn:not(.tss-disabled) {
+    background: var(--tss-secondary-background-color);
+    color: var(--tss-secondary-foreground-color);
+    border-color: transparent;
+    transition: background-color 0.15s ease-in-out, color 0.15s ease-in-out;
+}
+
+.tss-btn.tss-omnibox-chat-btn:not(.tss-disabled):hover {
+    background: var(--tss-default-border-color);
+    color: var(--tss-default-foreground-color);
+}
+
+.tss-btn.tss-omnibox-chat-btn.tss-omnibox-chat-btn-active:not(.tss-disabled):not(.tss-btn-danger) {
+    background: #000;
+    color: #fff;
+}
+
+.tss-btn.tss-omnibox-chat-btn.tss-omnibox-chat-btn-active:not(.tss-disabled):not(.tss-btn-danger):hover {
+    background: #222;
+    color: #fff;
+}
+
+.tss-dark-mode .tss-btn.tss-omnibox-chat-btn.tss-omnibox-chat-btn-active:not(.tss-disabled):not(.tss-btn-danger) {
+    background: #fff;
+    color: #000;
+}
+
+.tss-dark-mode .tss-btn.tss-omnibox-chat-btn.tss-omnibox-chat-btn-active:not(.tss-disabled):not(.tss-btn-danger):hover {
+    background: #e6e6e6;
+    color: #000;
+}
+
 /* Model selector button (chat footer) */
 .tss-btn.tss-omnibox-model-selector-btn {
     height: 28px;

--- a/Tesserae/src/Components/OmniBox.cs
+++ b/Tesserae/src/Components/OmniBox.cs
@@ -920,7 +920,11 @@ namespace Tesserae
                     }
                 });
 
-                _chatInput.addEventListener("input", (e) => Input?.Invoke(this, e));
+                _chatInput.addEventListener("input", (e) =>
+                {
+                    UpdateChatTriggerActiveState();
+                    Input?.Invoke(this, e);
+                });
                 _chatInput.addEventListener("keyup", (e) => KeyUp?.Invoke(this, e.As<KeyboardEvent>()));
                 _chatInput.addEventListener("keypress", (e) => KeyPress?.Invoke(this, e.As<KeyboardEvent>()));
                 _chatInput.addEventListener("focus", (e) => ReceivedFocus?.Invoke(this, e));
@@ -1916,6 +1920,16 @@ namespace Tesserae
             var val = _chatInput.value;
             Chatted?.Invoke(this, new ChatMessage() { Text = val });
             _chatInput.value = "";
+            UpdateChatTriggerActiveState();
+        }
+
+        private void UpdateChatTriggerActiveState()
+        {
+            if (_chatTriggerBtn == null || _chatInput == null) return;
+            var hasText = !string.IsNullOrEmpty(_chatInput.value) && !string.IsNullOrWhiteSpace(_chatInput.value);
+            var el = _chatTriggerBtn.Render();
+            if (hasText) el.classList.add("tss-omnibox-chat-btn-active");
+            else el.classList.remove("tss-omnibox-chat-btn-active");
         }
 
         private void TriggerStop()
@@ -2347,6 +2361,7 @@ namespace Tesserae
             set
             {
                 _chatInput.value = value;
+                UpdateChatTriggerActiveState();
                 Input?.Invoke(this, null);
             }
         }

--- a/Tesserae/src/Components/Sidebar/Sidebar.cs
+++ b/Tesserae/src/Components/Sidebar/Sidebar.cs
@@ -216,7 +216,7 @@ namespace Tesserae
                 var drawer = VStack().Class("tss-navbar-drawer")
                    .Children(
                         mobileHeader,
-                        VStack().Class("tss-sidebar-header tss-navbar-drawer-header").WS().NoShrink().Children(drawerHeader.Select(si => si.RenderOpen())),
+                        VStack().Class("tss-sidebar-header").Class("tss-navbar-drawer-header").WS().NoShrink().Children(drawerHeader.Select(si => si.RenderOpen())),
                         stackMiddle.Class("tss-sidebar-middle").WS().MinHeight(new UnitSize("fit-content")).MaxHeight(80.vh()).ScrollY().Children(middle.Select(si => AttachNavbarClose(si.RenderOpen()))),
                         VStack().Class("tss-sidebar-footer").WS().NoShrink().Children(footer.Select(si => AttachNavbarClose(si.RenderOpen())))
                     );


### PR DESCRIPTION
- Sidebar.AsNavbar passed a space-separated string to .Class() which
  threw a DOMTokenList error and aborted the page render on mobile;
  split into two Class() calls.
- Style the OmniBox chat trigger with a grey background when the input
  is empty, switching to black/white (light/dark) once there is text to
  send; toggle the active class on input and after sending.