### PR TITLE
Simplify virtualization logic and fix viewport calculations

### DIFF
--- a/Tesserae/src/Components/SearchableGroupedList.cs
+++ b/Tesserae/src/Components/SearchableGroupedList.cs
@@ -194,7 +194,7 @@ namespace Tesserae
 
             var container = _defered.Render();
             double scrollTop = container.parentElement.scrollTop;
-            if (scrollTop > _virtualizedViewportMinTop || scrollTop < _virtualizedViewportMaxTop)
+            if (scrollTop < _virtualizedViewportMinTop || scrollTop > _virtualizedViewportMaxTop)
             {
                 RecomputeVisibleVirtualItemsInner();
             }
@@ -209,7 +209,7 @@ namespace Tesserae
             if (_virtualizedItemHeight is null || _virtualItems.Count == 0) return;
             var container = _defered.Render();
             double scrollTop = container.parentElement.scrollTop;
-            double containerHeight = container.parentElement.parentElement.scrollHeight;
+            double containerHeight = container.parentElement.clientHeight;
             if (containerHeight == 0) return;
 
             // We use the fixed height to calculate visible indices

--- a/Tesserae/src/Components/SearchableList.cs
+++ b/Tesserae/src/Components/SearchableList.cs
@@ -299,7 +299,7 @@ namespace Tesserae
             window.clearTimeout(_virtualizedTimeout);
             var container = _defered.Render();
             double scrollTop = container.parentElement.scrollTop;
-            if (scrollTop > _virtualizedViewportMinTop || scrollTop < _virtualizedViewportMaxTop)
+            if (scrollTop < _virtualizedViewportMinTop || scrollTop > _virtualizedViewportMaxTop)
             {
                 RecomputeVisibleVirtualItemsInner();
             }
@@ -314,7 +314,7 @@ namespace Tesserae
             if (_virtualizedItemHeight is null || _virtualItems.Count == 0) return;
             var container = _defered.Render();
             double scrollTop = container.parentElement.scrollTop;
-            double containerHeight = container.parentElement.parentElement.scrollHeight;
+            double containerHeight = container.parentElement.clientHeight;
             if (containerHeight == 0) return;
 
             // We use the fixed height to calculate visible indices

--- a/Tesserae/src/Components/VirtualizedList.cs
+++ b/Tesserae/src/Components/VirtualizedList.cs
@@ -31,7 +31,6 @@ namespace Tesserae
         private int              _currentPage;
         private UnitSize         _componentHeight;
         private UnitSize         _pageHeight;
-        private double           _currentScrollPosition;
 
         /// <summary>
         /// Initializes a new instance of the VirtualizedList class.
@@ -197,14 +196,6 @@ namespace Tesserae
                 component.Render());
         }
 
-        private void CreatePageUpwards(HTMLElement page)
-        {
-            CreatePage(page, pageToCreate =>
-            {
-                _topSpacingDiv.insertAdjacentElement(InsertPosition.afterend, pageToCreate);
-            });
-        }
-
         private void CreatePagesDownwards(IEnumerable<HTMLElement> pages)
         {
             foreach (var page in pages)
@@ -224,23 +215,6 @@ namespace Tesserae
         private NodeListOf<Element> GetRenderedPages()
         {
             return _basicListContainer.getElementsByClassName("tss-basiclist-page");
-        }
-
-        private void RemoveFirstPageFromBasicListContainer()
-        {
-            RemovePageFromBasicListContainer(GetRenderedPages(), 0);
-        }
-
-        private void RemoveLastPageFromBasicListContainer()
-        {
-            var pages = GetRenderedPages();
-
-            RemovePageFromBasicListContainer(pages, (int)pages.length - 1);
-        }
-
-        private void RemovePageFromBasicListContainer(NodeListOf<Element> pages, int index)
-        {
-            _basicListContainer.removeChild(pages[index]);
         }
 
         private void AttachOnLastComponentMountedEvent()
@@ -278,60 +252,17 @@ namespace Tesserae
 
         private void OnBasicListContainerScroll(object listener)
         {
-            var scrollTop       = _basicListContainer.scrollTop;
-            var scrollDirection = GetScrollDirection(scrollTop);
-
-            var scrollPosition = scrollTop;
-
-            var newPage = (int)Round(scrollPosition / _pageHeight.Size, MidpointRounding.AwayFromZero);
+            var newPage = (int)Round(_basicListContainer.scrollTop / _pageHeight.Size, MidpointRounding.AwayFromZero);
 
             if (newPage != _currentPage)
             {
-                // The per-step Down/Up branches assume the rendered window slid by exactly one
-                // page. On a fast scroll the viewport can jump several pages between events,
-                // so a one-page swap would leave the window disjoint from the viewport (which
-                // manifested as a blank list). Detect that case and rebuild the window instead.
-                if (Abs(newPage - _currentPage) > 1)
-                {
-                    RebuildRenderedPages(newPage);
-                }
-                else if (newPage > _pagesToVirtualizeLowerBoundary)
-                {
-                    if (scrollDirection == ScrollDirection.Down)
-                    {
-                        RemoveFirstPageFromBasicListContainer();
-
-                        var newTopSpacingDivHeight = ((newPage - _pagesToVirtualizeLowerBoundary) * _pageHeight.Size).px();
-                        SetTopSpacingDivHeight(newTopSpacingDivHeight);
-
-                        var pageNumberToAdd = newPage + _pagesToVirtualizeUpperBoundary;
-                        CreatePageDownwards(RetrievePageFromCache(pageNumberToAdd));
-
-                        var newBottomSpacingDivHeight =
-                            ((_listPageCache.PagesCount - (newPage + _pagesToVirtualizeUpperBoundary)) * _pageHeight.Size).px();
-
-                        SetBottomSpacingDivHeight(newBottomSpacingDivHeight);
-                    }
-                    else if (scrollDirection == ScrollDirection.Up)
-                    {
-                        RemoveLastPageFromBasicListContainer();
-
-                        var newTopSpacingDivHeight = ((newPage - _pagesToVirtualizeLowerBoundary) * _pageHeight.Size).px();
-                        SetTopSpacingDivHeight(newTopSpacingDivHeight);
-
-                        var pageNumberToAdd = newPage - _pagesToVirtualizeUpperBoundary;
-                        CreatePageUpwards(RetrievePageFromCache(pageNumberToAdd));
-
-                        var newBottomSpacingDivHeight =
-                            ((_listPageCache.PagesCount - (newPage + _pagesToVirtualizeUpperBoundary)) * _pageHeight.Size).px();
-
-                        SetBottomSpacingDivHeight(newBottomSpacingDivHeight);
-                    }
-                }
+                // Reconcile the whole rendered window around the page nearest the viewport on every
+                // change. A per-step add/remove is only valid mid-list with an already-aligned 5-page
+                // window; rebuilding handles the boundaries (top/bottom) and multi-page jumps
+                // uniformly, and reuses cached page elements so it stays cheap.
+                RebuildRenderedPages(newPage);
+                _currentPage = newPage;
             }
-
-            _currentPage           = newPage;
-            _currentScrollPosition = scrollPosition;
         }
 
         private void RebuildRenderedPages(int centerPage)
@@ -357,28 +288,6 @@ namespace Tesserae
 
             SetTopSpacingDivHeight(((firstPage - 1)                       * _pageHeight.Size).px());
             SetBottomSpacingDivHeight(((_listPageCache.PagesCount - lastPage) * _pageHeight.Size).px());
-        }
-
-        private ScrollDirection GetScrollDirection(double scrollTop)
-        {
-            if (scrollTop > _currentScrollPosition)
-            {
-                return ScrollDirection.Down;
-            }
-
-            if (scrollTop < _currentScrollPosition)
-            {
-                return ScrollDirection.Up;
-            }
-
-            return ScrollDirection.Neutral;
-        }
-
-        private enum ScrollDirection
-        {
-            Neutral = 0,
-            Up,
-            Down
         }
     }
 }

--- a/Tesserae/src/Components/VisibilitySensor.cs
+++ b/Tesserae/src/Components/VisibilitySensor.cs
@@ -94,11 +94,11 @@ namespace Tesserae
 
         private void CheckVisibility(object t)
         {
-            var viewport_top    = window.scrollY;
-            var viewport_bottom = window.scrollY + window.innerHeight;
-            var rect            = (DOMRect)InnerElement.getBoundingClientRect();
+            // getBoundingClientRect() is already viewport-relative, so it must be compared against
+            // the viewport (0 .. innerHeight), not the document scroll offset (window.scrollY).
+            var rect = (DOMRect)InnerElement.getBoundingClientRect();
 
-            if (rect.top > viewport_top && rect.bottom < viewport_bottom)
+            if (rect.top >= 0 && rect.bottom <= window.innerHeight)
             {
                 if (_maxCalls > 0)
                 {


### PR DESCRIPTION
## Summary
This PR refactors virtualization and viewport detection logic across multiple components to improve correctness and maintainability. The changes simplify scroll handling by removing complex per-step page management in favor of a uniform rebuild strategy, and fix viewport boundary calculations in visibility detection.

## Key Changes

### VirtualizedList.cs
- **Removed incremental scroll handling**: Eliminated `CreatePageUpwards()`, `RemoveFirstPageFromBasicListContainer()`, `RemoveLastPageFromBasicListContainer()`, and `RemovePageFromBasicListContainer()` methods that attempted per-step page swapping.
- **Simplified scroll event handler**: Replaced complex branching logic (detecting scroll direction and conditionally adding/removing pages) with a single `RebuildRenderedPages()` call on every page change.
- **Removed scroll tracking**: Deleted `_currentScrollPosition` field and `GetScrollDirection()` method with the `ScrollDirection` enum, as scroll direction is no longer needed.
- **Rationale**: The per-step approach only worked correctly mid-list with an already-aligned 5-page window. The new approach handles boundaries (top/bottom) and multi-page jumps uniformly while reusing cached page elements for efficiency.

### VisibilitySensor.cs
- **Fixed viewport comparison logic**: Changed from comparing `getBoundingClientRect()` results against `window.scrollY` (document scroll offset) to comparing against the viewport bounds (0 to `window.innerHeight`).
- **Corrected boundary conditions**: Updated from `rect.top > viewport_top && rect.bottom < viewport_bottom` to `rect.top >= 0 && rect.bottom <= window.innerHeight`.
- **Rationale**: `getBoundingClientRect()` returns viewport-relative coordinates, not document-relative, so it must be compared against viewport dimensions, not scroll offsets.

### SearchableGroupedList.cs & SearchableList.cs
- **Fixed viewport boundary check**: Corrected the condition from `scrollTop > _virtualizedViewportMinTop || scrollTop < _virtualizedViewportMaxTop` to `scrollTop < _virtualizedViewportMinTop || scrollTop > _virtualizedViewportMaxTop` (inverted logic).
- **Fixed container height measurement**: Changed from `container.parentElement.parentElement.scrollHeight` to `container.parentElement.clientHeight` to correctly measure the visible container height rather than the scrollable content height.
- **Rationale**: These fixes ensure the virtualization viewport is correctly detected when content scrolls out of view.

## Implementation Details
- All changes maintain backward compatibility at the public API level.
- The VirtualizedList refactor trades per-step optimization for correctness and simplicity; the rebuild approach is still efficient due to page element caching.
- Viewport calculations now correctly distinguish between document scroll offsets and viewport-relative coordinates.

https://claude.ai/code/session_015VhC1KuyjomAZwmYKVsJY2