### PR TITLE
Fix OmniBox query parsing to not split tokens on mid-word dash

### DIFF
--- a/Tesserae/src/Components/OmniBox.cs
+++ b/Tesserae/src/Components/OmniBox.cs
@@ -1316,16 +1316,31 @@ namespace Tesserae
                     }
                     continue;
                 }
-                if (c == '!' || c == '-')
+                if (c == '!')
                 {
                     tokens.Add(new SearchToken(SearchToken.TokenType.Not, c.ToString()));
                     i++;
                     continue;
                 }
+                if (c == '-')
+                {
+                    // A '-' only acts as a negation operator when it sits at a token boundary,
+                    // i.e. at the start of the input, after whitespace, or after an opening
+                    // parenthesis. A '-' that is preceded by a non-whitespace character is part
+                    // of the word so that ranges like "53-223" stay a single token.
+                    bool isBoundary = i == 0 || char.IsWhiteSpace(input[i - 1]) || input[i - 1] == '(';
+                    if (isBoundary)
+                    {
+                        tokens.Add(new SearchToken(SearchToken.TokenType.Not, c.ToString()));
+                        i++;
+                        continue;
+                    }
+                    // otherwise fall through and treat the '-' as part of a word
+                }
 
                 // Word token
                 int wordStart = i;
-                while (i < input.Length && !char.IsWhiteSpace(input[i]) && input[i] != '(' && input[i] != ')' && input[i] != '"' && input[i] != '\'' && input[i] != '&' && input[i] != '|' && input[i] != '!' && input[i] != '-')
+                while (i < input.Length && !char.IsWhiteSpace(input[i]) && input[i] != '(' && input[i] != ')' && input[i] != '"' && input[i] != '\'' && input[i] != '&' && input[i] != '|' && input[i] != '!')
                 {
                     i++;
                 }


### PR DESCRIPTION
## Problem

In `OmniBox.ParseQuery`, every `-` was treated as a negation (NOT) operator, and the word-reading loop broke on `-`. As a result, ranges like `53-223` were tokenized as three tokens: `53`, `-` (NOT), `223`, instead of a single token.

## Fix

A `-` now only acts as a negation operator when it sits at a token boundary — at the start of the input, after whitespace, or after an opening parenthesis. A `-` preceded by a non-whitespace character is treated as part of the word, and the word loop no longer breaks on `-`.

This keeps negation queries like `foo -bar` and `-apple` working, while `53-223` stays a single token.

## Verified behaviour

| Input | Result |
|---|---|
| `53-223` | single word ✓ |
| `(53-223)` | single word in parens ✓ |
| `53 - 223` | `53`, NOT, `223` (whitespace → splits) ✓ |
| `foo -bar` | negation of `bar` preserved ✓ |
| `-apple` | leading negation preserved ✓ |
| `a-b-c` | single word ✓ |

The `!` operator and all boolean/quote/paren parsing are unchanged. Project builds cleanly with the h5 compiler.

https://claude.ai/code/session_01CH8YZSpZyTo6F9HyeR97d1

---
_Generated by [Claude Code](https://claude.ai/code/session_01CH8YZSpZyTo6F9HyeR97d1)_