### PR TITLE
Generalize Plan component with statuses, substeps, and data-driven SetModel

### DIFF
--- a/Tesserae.Tests/src/Samples/Components/PlanSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/PlanSample.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 using static H5.Core.dom;
 using static Tesserae.UI;
@@ -13,6 +14,7 @@ namespace Tesserae.Tests.Samples
 
         public PlanSample()
         {
+            // --- Section 1: existing fluent API (unchanged behavior) ---
             var plan1 = Plan("SCIM user provisioning deep dive")
                 .HeaderCommands(Button("Update").NoBorder().Rounded())
                 .AddTask("Collect official SCIM RFCs and specifications from IETF and RFC repositories.", true)
@@ -22,7 +24,7 @@ namespace Tesserae.Tests.Samples
                 .AddTask("Compile technical explanation covering endpoints, auth, schemas, and examples.", false)
                 .FooterMessage("Finalizing details for licenses and attribution...")
                 .FooterCommands(TextBlock("117 searches").Small().SemiBold())
-                .Progress(1, 5) // Determinate style as per screenshot
+                .Progress(1, 5)
                 .Stop()
                 .MaxWidth(800.px());
 
@@ -48,19 +50,107 @@ namespace Tesserae.Tests.Samples
 
             plan3.Render().style.maxWidth = "800px";
 
+            // --- Section 2: data-driven / streaming updates ---
+            // A single Plan instance cycled through Pending -> Running ->
+            // Completed / Failed / Canceled. Each click calls SetModel on the
+            // same instance, demonstrating in-place DOM reconciliation.
+            var streamedPlan = Plan("Deep research: SCIM provisioning")
+                .HideStartStopButton()
+                .MaxWidth(800.px());
+            streamedPlan.Render().style.maxWidth = "800px";
+
+            // Initial model
+            streamedPlan.SetModel(BuildModel(PlanStatus.Pending, runningStep: -1));
+
+            var pendingBtn   = Button("Pending").OnClick(() => streamedPlan.SetModel(BuildModel(PlanStatus.Pending, runningStep: -1)));
+            var runningBtn   = Button("Running").OnClick(() => streamedPlan.SetModel(BuildModel(PlanStatus.Running, runningStep: 1)));
+            var completedBtn = Button("Completed").OnClick(() => streamedPlan.SetModel(BuildModel(PlanStatus.Completed, runningStep: -1, allComplete: true)));
+            var failedBtn    = Button("Failed").OnClick(() => streamedPlan.SetModel(BuildModel(PlanStatus.Failed, runningStep: 1, failStep: 2)));
+            var canceledBtn  = Button("Canceled").OnClick(() => streamedPlan.SetModel(BuildModel(PlanStatus.Canceled, runningStep: -1)));
+
+            var streamedControls = HStack().Gap(8.px()).Children(
+                pendingBtn, runningBtn, completedBtn, failedBtn, canceledBtn
+            );
+
             _content = SectionStack().Secondary()
                 .SampleTitle(typeof(PlanSample), UIcons.Map, "A component to display a plan")
                 .FlatSection(Stack().Children(
                     Card(VStack().WS().Children(
-                    TextBlock("The Plan component displays a complex task with its sub-tasks and overall progress."))).SetTitle("Overview"),
+                        TextBlock("The Plan component displays a complex task with its sub-tasks and overall progress."))).SetTitle("Overview"),
                     Card(VStack().WS().Children(
-                    TextBlock("Default usage showing a running plan with partial progress.").SemiBold().PT(16).PB(8),
-                    plan1,
-                    TextBlock("A completed plan, with the stop button hidden.").SemiBold().PT(16).PB(8),
-                    plan2,
-                    TextBlock("A plan with indeterminate progress.").SemiBold().PT(16).PB(8),
-                    plan3
-                )).SetTitle("Usage")));
+                        TextBlock("Default usage showing a running plan with partial progress.").SemiBold().PT(16).PB(8),
+                        plan1,
+                        TextBlock("A completed plan, with the stop button hidden.").SemiBold().PT(16).PB(8),
+                        plan2,
+                        TextBlock("A plan with indeterminate progress.").SemiBold().PT(16).PB(8),
+                        plan3
+                    )).SetTitle("Usage"),
+                    Card(VStack().WS().Children(
+                        TextBlock("The same Plan instance is updated by calling SetModel(model) — DOM nodes are reused across updates so animations, focus and scroll position are preserved.").PT(16).PB(8),
+                        streamedControls,
+                        TextBlock("").PT(8),
+                        streamedPlan
+                    )).SetTitle("Data-driven / streaming updates")
+                ));
+        }
+
+        private static PlanModel BuildModel(PlanStatus planStatus, int runningStep, bool allComplete = false, int failStep = -1)
+        {
+            // Stable ids — the reconciler will reuse DOM nodes across calls.
+            var steps = new List<PlanStepModel>
+            {
+                new PlanStepModel { Id = "s-collect",   Index = 0, Title = "Collect official SCIM RFCs",     Status = PlanStatus.Pending },
+                new PlanStepModel { Id = "s-survey",   Index = 1, Title = "Survey identity providers",      Status = PlanStatus.Pending },
+                new PlanStepModel { Id = "s-payloads", Index = 2, Title = "Gather sample payloads",         Status = PlanStatus.Pending },
+                new PlanStepModel { Id = "s-impl",     Index = 3, Title = "Identify open-source libraries", Status = PlanStatus.Pending },
+                new PlanStepModel { Id = "s-write",    Index = 4, Title = "Write the explanation",          Status = PlanStatus.Pending },
+            };
+
+            if (allComplete)
+            {
+                foreach (var s in steps) s.Status = PlanStatus.Completed;
+            }
+            else if (runningStep >= 0)
+            {
+                // Steps before runningStep are completed, step at runningStep is running.
+                for (int i = 0; i < runningStep && i < steps.Count; i++) steps[i].Status = PlanStatus.Completed;
+                if (runningStep < steps.Count)
+                {
+                    steps[runningStep].Status = PlanStatus.Running;
+                    steps[runningStep].Progress = 0.6f;
+                    steps[runningStep].CurrentStage = "fetching documents...";
+                    steps[runningStep].Substeps = new List<PlanSubstepModel>
+                    {
+                        new PlanSubstepModel { Id = "sub-okta",  Title = "okta.com",   Status = PlanStatus.Completed, Message = "scim/v2/Users (200)" },
+                        new PlanSubstepModel { Id = "sub-azure", Title = "azure.com",  Status = PlanStatus.Running,   Message = "fetching..." },
+                        new PlanSubstepModel { Id = "sub-jump",  Title = "jumpcloud.com", Status = PlanStatus.Pending },
+                    };
+                }
+            }
+
+            if (failStep >= 0 && failStep < steps.Count)
+            {
+                steps[failStep].Status = PlanStatus.Failed;
+                steps[failStep].CurrentStage = "HTTP 503 from upstream";
+            }
+
+            int completed = 0;
+            foreach (var s in steps) if (s.Status == PlanStatus.Completed) completed++;
+
+            return new PlanModel
+            {
+                Id = "deep-research-1",
+                Title = "Deep research: SCIM provisioning",
+                Status = planStatus,
+                Progress = allComplete ? (float?)1f : (runningStep >= 0 ? (float?)((float)completed / steps.Count) : null),
+                CurrentStage = planStatus == PlanStatus.Running ? "step " + (runningStep + 1) + " of " + steps.Count : null,
+                Steps = steps,
+                StartedAt = planStatus == PlanStatus.Pending ? (DateTimeOffset?)null : DateTimeOffset.Now.AddMinutes(-3),
+                CompletedAt = allComplete ? DateTimeOffset.Now : (DateTimeOffset?)null,
+                FooterMessage = planStatus == PlanStatus.Running ? "117 searches" :
+                                planStatus == PlanStatus.Failed  ? "Aborted after error" :
+                                planStatus == PlanStatus.Canceled ? "Canceled by user" : null,
+            };
         }
 
         public HTMLElement Render()

--- a/Tesserae/h5.json
+++ b/Tesserae/h5.json
@@ -166,6 +166,7 @@
         "h5/assets/css/tss.kbd.css",
         "h5/assets/css/tss.notificationcenter.css",
         "h5/assets/css/tss.markdown.css",
+        "h5/assets/css/tss.plan.css",
         "h5/assets/css/diff2html.min.css"
       ],
       "output": "assets/css"

--- a/Tesserae/h5/assets/css/tss.plan.css
+++ b/Tesserae/h5/assets/css/tss.plan.css
@@ -1,0 +1,209 @@
+/* Plan component
+ *
+ * The Plan component is a card that shows a multi-step plan with per-step
+ * status (pending / running / completed / failed / canceled), optional
+ * per-step progress, optional substeps, and a plan-level status badge.
+ *
+ * The CSS below covers the unified `tss-plan-*` family and reuses the
+ * existing theme variables (--tss-success-background-color,
+ * --tss-warning-background-color, --tss-danger-background-color,
+ * --tss-primary-background-color and --tss-default-border-color) for the
+ * status accent colors so the look matches the rest of Tesserae.
+ */
+
+.tss-plan {
+    position: relative;
+    border: 1px solid var(--tss-default-border-color);
+    border-radius: 6px;
+    transition: border-color 120ms ease-in-out;
+}
+
+/* Status accent on the card. The accent is applied as a left border so it
+ * doesn't disturb the rest of the card's styling. */
+.tss-plan-pending     { border-left: 3px solid var(--tss-default-border-color); }
+.tss-plan-running     { border-left: 3px solid var(--tss-primary-background-color); }
+.tss-plan-completed   { border-left: 3px solid var(--tss-success-background-color); }
+.tss-plan-failed      { border-left: 3px solid var(--tss-danger-background-color); }
+.tss-plan-canceled    { border-left: 3px solid var(--tss-warning-background-color); }
+
+/* The status badge in the plan header */
+.tss-plan-status-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 2px 8px;
+    border-radius: 10px;
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    line-height: 16px;
+    background: var(--tss-default-background-color);
+    border: 1px solid var(--tss-default-border-color);
+    color: inherit;
+}
+
+.tss-plan-status-badge.tss-plan-pending {
+    background: transparent;
+    border-color: var(--tss-default-border-color);
+}
+.tss-plan-status-badge.tss-plan-running {
+    background: var(--tss-primary-background-color);
+    color: var(--tss-primary-foreground-color, #fff);
+    border-color: var(--tss-primary-background-color);
+}
+.tss-plan-status-badge.tss-plan-completed {
+    background: var(--tss-success-background-color);
+    color: var(--tss-success-foreground-color, #fff);
+    border-color: var(--tss-success-background-color);
+}
+.tss-plan-status-badge.tss-plan-failed {
+    background: var(--tss-danger-background-color);
+    color: var(--tss-danger-foreground-color, #fff);
+    border-color: var(--tss-danger-background-color);
+}
+.tss-plan-status-badge.tss-plan-canceled {
+    background: var(--tss-warning-background-color);
+    color: var(--tss-warning-foreground-color, #fff);
+    border-color: var(--tss-warning-background-color);
+}
+
+/* A row in the steps list */
+.tss-plan-step {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.tss-plan-step-row {
+    display: flex;
+    flex-direction: row;
+    align-items: flex-start;
+    gap: 12px;
+}
+
+.tss-plan-step-icon {
+    flex: 0 0 auto;
+    margin-top: 2px;
+}
+
+.tss-plan-step-body {
+    flex: 1 1 auto;
+    min-width: 0;
+}
+
+.tss-plan-step-title {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.tss-plan-step-stage {
+    font-size: 12px;
+    opacity: 0.8;
+    margin-top: 2px;
+}
+
+/* Per-step status colors on the icon */
+.tss-plan-step-icon.tss-plan-pending    { color: var(--tss-default-border-color); }
+.tss-plan-step-icon.tss-plan-running    { color: var(--tss-primary-background-color); }
+.tss-plan-step-icon.tss-plan-completed  { color: var(--tss-success-background-color); }
+.tss-plan-step-icon.tss-plan-failed     { color: var(--tss-danger-background-color); }
+.tss-plan-step-icon.tss-plan-canceled   { color: var(--tss-warning-background-color); }
+
+/* Per-step progress bar (slim) */
+.tss-plan-step-progress {
+    height: 4px;
+    border-radius: 2px;
+    background: var(--tss-default-border-color);
+    overflow: hidden;
+    margin-top: 6px;
+    position: relative;
+}
+
+.tss-plan-step-progress-bar {
+    height: 100%;
+    width: 0%;
+    background: var(--tss-primary-background-color);
+    transition: width 200ms ease-out;
+}
+
+.tss-plan-step-progress.tss-plan-indeterminate .tss-plan-step-progress-bar {
+    width: 40%;
+    background: linear-gradient(90deg,
+        var(--tss-default-border-color) 0%,
+        var(--tss-primary-background-color) 50%,
+        var(--tss-default-border-color) 100%);
+    animation: tss-plan-indeterminate 1.4s linear infinite;
+}
+
+@keyframes tss-plan-indeterminate {
+    0%   { transform: translateX(-100%); }
+    100% { transform: translateX(350%); }
+}
+
+/* Expand/collapse caret next to a step that has substeps */
+.tss-plan-step-toggle {
+    cursor: pointer;
+    user-select: none;
+    font-size: 11px;
+    opacity: 0.7;
+    padding: 0 4px;
+}
+.tss-plan-step-toggle:hover { opacity: 1; }
+
+/* Substep list */
+.tss-plan-substeps {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    margin-top: 6px;
+    padding-left: 28px;
+    border-left: 1px dashed var(--tss-default-border-color);
+    margin-left: 8px;
+}
+
+.tss-plan-substeps.tss-plan-collapsed {
+    display: none;
+}
+
+.tss-plan-substep {
+    display: flex;
+    flex-direction: row;
+    align-items: flex-start;
+    gap: 8px;
+    font-size: 12px;
+}
+
+.tss-plan-substep-icon {
+    flex: 0 0 auto;
+    margin-top: 2px;
+}
+.tss-plan-substep-icon.tss-plan-pending    { color: var(--tss-default-border-color); }
+.tss-plan-substep-icon.tss-plan-running    { color: var(--tss-primary-background-color); }
+.tss-plan-substep-icon.tss-plan-completed  { color: var(--tss-success-background-color); }
+.tss-plan-substep-icon.tss-plan-failed     { color: var(--tss-danger-background-color); }
+.tss-plan-substep-icon.tss-plan-canceled   { color: var(--tss-warning-background-color); }
+
+.tss-plan-substep-body {
+    flex: 1 1 auto;
+    min-width: 0;
+}
+
+.tss-plan-substep-message {
+    opacity: 0.75;
+    font-size: 11px;
+    margin-top: 1px;
+}
+
+/* Plan-level summary line (rendered alongside FooterMessage) */
+.tss-plan-summary {
+    font-size: 12px;
+    opacity: 0.75;
+}
+
+.tss-plan-timestamps {
+    font-size: 11px;
+    opacity: 0.6;
+    margin-top: 2px;
+}

--- a/Tesserae/src/Components/Plan.cs
+++ b/Tesserae/src/Components/Plan.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using H5;
 using static H5.Core.dom;
 using static Tesserae.UI;
@@ -7,7 +8,158 @@ using static Tesserae.UI;
 namespace Tesserae
 {
     /// <summary>
-    /// A timeline-style display for showing a multi-step plan or schedule with start/end times for each step.
+    /// Status of a <see cref="Plan"/> (or one of its steps / substeps).
+    /// </summary>
+    public enum PlanStatus
+    {
+        Pending,
+        Running,
+        Completed,
+        Failed,
+        Canceled,
+    }
+
+    /// <summary>
+    /// Plain data-model used by <see cref="Plan.SetModel"/> to drive the
+    /// component from a streaming/server-side source. All fields are
+    /// optional except <see cref="Steps"/> (which must not be null).
+    /// </summary>
+    public sealed class PlanModel
+    {
+        public string Id;
+        public string Title;
+        public PlanStatus Status;
+        public float? Progress;
+        public string CurrentStage;
+        public IList<PlanStepModel> Steps = new List<PlanStepModel>();
+        public DateTimeOffset? StartedAt;
+        public DateTimeOffset? CompletedAt;
+        public string FooterMessage;
+    }
+
+    /// <summary>
+    /// Plain data-model for a single step inside a <see cref="PlanModel"/>.
+    /// </summary>
+    public sealed class PlanStepModel
+    {
+        public string Id;
+        public int Index;
+        public string Title;
+        public PlanStatus Status;
+        public float? Progress;
+        public string CurrentStage;
+        public IList<PlanSubstepModel> Substeps;
+        public bool? IsExpanded;
+    }
+
+    /// <summary>
+    /// Plain data-model for a substep inside a <see cref="PlanStepModel"/>.
+    /// </summary>
+    public sealed class PlanSubstepModel
+    {
+        public string Id;
+        public string Title;
+        public PlanStatus Status;
+        public string Message;
+    }
+
+    /// <summary>
+    /// Internal helpers shared across the Plan component: status →
+    /// css class / icon / display text, progress clamping, summary
+    /// derivation and step-key derivation.
+    /// </summary>
+    internal static class PlanVisuals
+    {
+        public static string StatusClass(PlanStatus status)
+        {
+            switch (status)
+            {
+                case PlanStatus.Running:   return "tss-plan-running";
+                case PlanStatus.Completed: return "tss-plan-completed";
+                case PlanStatus.Failed:    return "tss-plan-failed";
+                case PlanStatus.Canceled:  return "tss-plan-canceled";
+                default:                   return "tss-plan-pending";
+            }
+        }
+
+        public static UIcons StatusIcon(PlanStatus status)
+        {
+            switch (status)
+            {
+                case PlanStatus.Running:   return UIcons.Loading;
+                case PlanStatus.Completed: return UIcons.CheckCircle;
+                case PlanStatus.Failed:    return UIcons.CrossCircle;
+                case PlanStatus.Canceled:  return UIcons.Ban;
+                default:                   return UIcons.Circle;
+            }
+        }
+
+        public static string StatusText(PlanStatus status)
+        {
+            switch (status)
+            {
+                case PlanStatus.Running:   return "Running";
+                case PlanStatus.Completed: return "Completed";
+                case PlanStatus.Failed:    return "Failed";
+                case PlanStatus.Canceled:  return "Canceled";
+                default:                   return "Pending";
+            }
+        }
+
+        public static float ClampProgress(float value)
+        {
+            if (float.IsNaN(value)) return 0f;
+            if (value < 0f) return 0f;
+            if (value > 1f) return 1f;
+            return value;
+        }
+
+        public static bool DefaultExpanded(PlanStepModel step)
+        {
+            if (step.IsExpanded.HasValue) return step.IsExpanded.Value;
+            // Auto-expand when running / failed; auto-collapse otherwise.
+            return step.Status == PlanStatus.Running || step.Status == PlanStatus.Failed;
+        }
+
+        public static string StepKey(PlanStepModel step, int positionalIndex)
+        {
+            if (!string.IsNullOrEmpty(step.Id)) return step.Id;
+            return "tss-plan-step-" + positionalIndex;
+        }
+
+        public static string SubstepKey(PlanSubstepModel substep, int positionalIndex)
+        {
+            if (!string.IsNullOrEmpty(substep.Id)) return substep.Id;
+            return "tss-plan-substep-" + positionalIndex;
+        }
+
+        public static string Summary(PlanModel model)
+        {
+            int total = model.Steps == null ? 0 : model.Steps.Count;
+            int completed = 0, running = 0, failed = 0;
+            if (model.Steps != null)
+            {
+                foreach (var s in model.Steps)
+                {
+                    if (s.Status == PlanStatus.Completed) completed++;
+                    else if (s.Status == PlanStatus.Running) running++;
+                    else if (s.Status == PlanStatus.Failed) failed++;
+                }
+            }
+            var parts = new List<string>();
+            parts.Add(completed + " of " + total + " steps complete");
+            if (running > 0) parts.Add(running + " running");
+            if (failed > 0)  parts.Add(failed + " failed");
+            return string.Join(" | ", parts);
+        }
+    }
+
+    /// <summary>
+    /// A timeline-style display for showing a multi-step plan, with optional
+    /// per-step status / progress / substeps. Can be driven imperatively via
+    /// the fluent <see cref="AddTask(string,bool)"/> API or declaratively via
+    /// <see cref="SetModel"/>; <see cref="SetModel"/> performs an in-place
+    /// reconcile keyed by step/substep <c>Id</c> so DOM nodes are reused.
     /// </summary>
     [H5.Name("tss.Plan")]
     public sealed class Plan : IComponent, IHasMarginPadding
@@ -19,15 +171,19 @@ namespace Tesserae
         // Header
         private readonly Stack _headerStack;
         private readonly TextBlock _title;
+        private readonly HTMLElement _statusBadge;
         private readonly Stack _headerCommandsStack;
 
         // Task List
         private readonly Stack _tasksStack;
         private readonly List<Task> _tasks = new List<Task>();
+        private readonly Dictionary<string, Task> _tasksByKey = new Dictionary<string, Task>();
 
         // Footer Message
         private readonly Stack _footerMessageStack;
         private readonly TextBlock _footerMessage;
+        private readonly HTMLElement _summaryLine;
+        private readonly HTMLElement _timestampsLine;
         private readonly Stack _footerCommandsStack;
 
         // Progress
@@ -35,26 +191,55 @@ namespace Tesserae
         private readonly ProgressIndicator _progressIndicator;
         private readonly Button _startStopButton;
 
+        // Model
+        private PlanModel _model;
+
+        /// <summary>
+        /// Gets the last <see cref="PlanModel"/> passed to <see cref="SetModel"/>,
+        /// or <c>null</c> if the component has only been driven by the fluent API.
+        /// </summary>
+        public PlanModel Model => _model;
+
         /// <summary>
         /// Initializes a new instance of this class.
         /// </summary>
         public Plan(string title)
         {
             _title = TextBlock(title).SemiBold().MediumPlus();
+
+            _statusBadge = Span(_("tss-plan-status-badge tss-plan-pending"));
+            _statusBadge.style.display = "none";
+
             _headerCommandsStack = Stack().Horizontal().AlignItems(ItemAlign.Center);
 
-            _headerStack = Stack().Horizontal().JustifyContent(ItemJustify.Between).AlignItems(ItemAlign.Center).Width(100.percent()).Children(
+            var titleRow = Stack().Horizontal().AlignItems(ItemAlign.Center).Gap(8.px()).Children(
                 _title,
+                Raw(_statusBadge)
+            );
+
+            _headerStack = Stack().Horizontal().JustifyContent(ItemJustify.Between).AlignItems(ItemAlign.Center).Width(100.percent()).Children(
+                titleRow,
                 _headerCommandsStack
             );
 
             _tasksStack = Stack().Vertical().Gap(16.px()).Width(100.percent()).PaddingBottom(16.px()).PaddingTop(16.px());
 
             _footerMessage = TextBlock("").Small();
+            _summaryLine = Div(_("tss-plan-summary"));
+            _summaryLine.style.display = "none";
+            _timestampsLine = Div(_("tss-plan-timestamps"));
+            _timestampsLine.style.display = "none";
+
+            var footerLeft = Stack().Vertical().AlignItems(ItemAlign.Start).Gap(2.px()).Children(
+                _footerMessage,
+                Raw(_summaryLine),
+                Raw(_timestampsLine)
+            );
+
             _footerCommandsStack = Stack().Horizontal().AlignItems(ItemAlign.Center);
 
             _footerMessageStack = Stack().Horizontal().JustifyContent(ItemJustify.Between).AlignItems(ItemAlign.Center).Width(100.percent()).Children(
-                _footerMessage,
+                footerLeft,
                 _footerCommandsStack
             );
 
@@ -84,6 +269,8 @@ namespace Tesserae
 
             _card = Card(_mainStack).NoPadding();
             _innerElement = _card.Render();
+            _innerElement.classList.add("tss-plan");
+            _innerElement.classList.add("tss-plan-pending");
         }
 
         /// <summary>
@@ -146,11 +333,27 @@ namespace Tesserae
 
         /// <summary>
         /// Adds the given task to the component.
+        ///
+        /// Note: completed tasks now render with the unified "success" status
+        /// color (green check) instead of the previous primary-tone treatment;
+        /// this matches the generalized status styling shared with SetModel.
         /// </summary>
         public Plan AddTask(string title, bool completed)
         {
-            var task = new Task(title, completed);
+            return AddTask(title, completed ? PlanStatus.Completed : PlanStatus.Pending);
+        }
+
+        /// <summary>
+        /// Adds a task with an explicit <see cref="PlanStatus"/>.
+        /// Auto-generates a positional key so a later <see cref="SetModel"/>
+        /// call still reconciles correctly.
+        /// </summary>
+        public Plan AddTask(string title, PlanStatus status)
+        {
+            var key = "tss-plan-step-" + _tasks.Count;
+            var task = new Task(key, title, status);
             _tasks.Add(task);
+            _tasksByKey[key] = task;
             _tasksStack.Add(task);
             return this;
         }
@@ -227,11 +430,163 @@ namespace Tesserae
             return this;
         }
 
+        /// <summary>
+        /// Applies the supplied <see cref="PlanModel"/> to the component, updating
+        /// the DOM in place. Steps and substeps are matched by their <c>Id</c>
+        /// (or a derived positional key when no id is provided) so existing DOM
+        /// nodes are reused across calls — animations, focus and scroll position
+        /// are preserved as long as the keys are stable.
+        /// </summary>
+        public Plan SetModel(PlanModel model)
+        {
+            if (model == null) throw new ArgumentNullException(nameof(model));
+
+            _model = model;
+
+            // Title
+            if (model.Title != null) _title.Text = model.Title;
+
+            // Plan-level status (card border + badge)
+            ApplyCardStatusClass(model.Status);
+            ApplyBadge(model.Status);
+
+            // Plan-level progress
+            if (model.Progress.HasValue)
+            {
+                var p = PlanVisuals.ClampProgress(model.Progress.Value);
+                _progressIndicator.Progress(p * 100f);
+            }
+            else if (model.Status == PlanStatus.Running)
+            {
+                _progressIndicator.Indeterminated();
+            }
+            else if (model.Status == PlanStatus.Completed)
+            {
+                _progressIndicator.Progress(100f);
+            }
+
+            // Footer message + summary + timestamps
+            if (model.FooterMessage != null) _footerMessage.Text = model.FooterMessage;
+
+            var summary = PlanVisuals.Summary(model);
+            _summaryLine.innerText = summary;
+            _summaryLine.style.display = string.IsNullOrEmpty(summary) ? "none" : "";
+
+            var timestampParts = new List<string>();
+            if (model.StartedAt.HasValue) timestampParts.Add("started " + model.StartedAt.Value.LocalDateTime.ToString());
+            if (model.CompletedAt.HasValue) timestampParts.Add("completed " + model.CompletedAt.Value.LocalDateTime.ToString());
+            if (timestampParts.Count > 0)
+            {
+                _timestampsLine.innerText = string.Join(" | ", timestampParts);
+                _timestampsLine.style.display = "";
+            }
+            else
+            {
+                _timestampsLine.style.display = "none";
+            }
+
+            // Steps reconcile-by-key
+            ReconcileSteps(model.Steps ?? new List<PlanStepModel>());
+
+            return this;
+        }
+
+        private void ApplyCardStatusClass(PlanStatus status)
+        {
+            _innerElement.classList.remove("tss-plan-pending");
+            _innerElement.classList.remove("tss-plan-running");
+            _innerElement.classList.remove("tss-plan-completed");
+            _innerElement.classList.remove("tss-plan-failed");
+            _innerElement.classList.remove("tss-plan-canceled");
+            _innerElement.classList.add(PlanVisuals.StatusClass(status));
+        }
+
+        private void ApplyBadge(PlanStatus status)
+        {
+            _statusBadge.classList.remove("tss-plan-pending");
+            _statusBadge.classList.remove("tss-plan-running");
+            _statusBadge.classList.remove("tss-plan-completed");
+            _statusBadge.classList.remove("tss-plan-failed");
+            _statusBadge.classList.remove("tss-plan-canceled");
+            _statusBadge.classList.add(PlanVisuals.StatusClass(status));
+            _statusBadge.innerText = PlanVisuals.StatusText(status);
+            _statusBadge.style.display = "";
+        }
+
+        private void ReconcileSteps(IList<PlanStepModel> steps)
+        {
+            var newKeys = new List<string>(steps.Count);
+            var seen = new HashSet<string>();
+
+            // Pass 1: update existing or create new, in the requested order.
+            for (int i = 0; i < steps.Count; i++)
+            {
+                var stepModel = steps[i];
+                var key = PlanVisuals.StepKey(stepModel, i);
+                newKeys.Add(key);
+                seen.Add(key);
+
+                Task task;
+                if (_tasksByKey.TryGetValue(key, out task))
+                {
+                    task.UpdateFromModel(stepModel);
+                }
+                else
+                {
+                    task = new Task(key, stepModel.Title ?? string.Empty, stepModel.Status);
+                    task.UpdateFromModel(stepModel);
+                    _tasksByKey[key] = task;
+                }
+            }
+
+            // Pass 2: drop tasks whose key is no longer present.
+            var stale = _tasks.Where(t => !seen.Contains(t.Key)).ToList();
+            foreach (var t in stale)
+            {
+                _tasks.Remove(t);
+                _tasksByKey.Remove(t.Key);
+                var el = t.Render();
+                if (el != null && el.parentNode != null)
+                {
+                    el.parentNode.removeChild(el);
+                }
+            }
+
+            // Pass 3: re-order DOM to match the new ordering, reusing nodes.
+            // We append in the new order; appendChild moves the node if it
+            // already has a parent, which is exactly what we want.
+            var stackEl = _tasksStack.Render();
+            _tasks.Clear();
+            foreach (var key in newKeys)
+            {
+                var t = _tasksByKey[key];
+                _tasks.Add(t);
+                stackEl.appendChild(t.Render());
+            }
+        }
+
+        /// <summary>
+        /// A single row in a <see cref="Plan"/>'s task list. Backed by a
+        /// stable key so the parent <see cref="Plan.SetModel"/> reconciler
+        /// can reuse the DOM across updates.
+        /// </summary>
         public class Task : IComponent
         {
-            private readonly Stack _taskStack;
+            private readonly HTMLElement _root;
+            private readonly HTMLElement _stepRow;
             private readonly Icon _icon;
             private readonly TextBlock _text;
+            private readonly HTMLElement _stageEl;
+            private readonly HTMLElement _toggleEl;
+            private readonly HTMLElement _progressEl;
+            private readonly HTMLElement _progressBar;
+            private readonly HTMLElement _substepsContainer;
+            private readonly Dictionary<string, HTMLElement> _substepsByKey = new Dictionary<string, HTMLElement>();
+            private readonly List<string> _substepOrder = new List<string>();
+            private PlanStatus _status;
+            private bool _expanded;
+
+            internal string Key { get; private set; }
 
             /// <summary>
             /// Gets or sets the title of the component.
@@ -243,49 +598,240 @@ namespace Tesserae
             }
 
             /// <summary>
-            /// Gets or sets the completed.
+            /// Gets or sets the current status of the task.
             /// </summary>
-            public bool Completed
+            public PlanStatus Status
             {
-                get => _icon.Render().dataset["icon"].As<string>().Contains(Icon(UIcons.CheckCircle).Render().dataset["icon"].As<string>());
-                set
-                {
-                    if (value)
-                    {
-                        _icon.SetIcon(UIcons.CheckCircle);
-                        _icon.Render().classList.add("tss-fontcolor-primary");
-                    }
-                    else
-                    {
-                        _icon.SetIcon(UIcons.Circle);
-                        _icon.Render().classList.remove("tss-fontcolor-primary");
-                    }
-                }
+                get => _status;
+                set => ApplyStatus(value);
             }
 
             /// <summary>
-            /// Initializes a new instance of this class.
+            /// Backwards-compatible flag. <c>true</c> when the status is
+            /// <see cref="PlanStatus.Completed"/>; setting <c>true</c> moves
+            /// the task to Completed and setting <c>false</c> moves it to
+            /// Pending.
             /// </summary>
-            public Task(string title, bool completed)
+            public bool Completed
             {
-                _icon = Icon(completed ? UIcons.CheckCircle : UIcons.Circle);
-                if (completed)
-                {
-                    _icon.Render().classList.add("tss-fontcolor-primary");
-                }
+                get => _status == PlanStatus.Completed;
+                set => Status = value ? PlanStatus.Completed : PlanStatus.Pending;
+            }
+
+            internal Task(string key, string title, PlanStatus status)
+            {
+                Key = key;
+                _status = status;
+
+                _icon = Icon(PlanVisuals.StatusIcon(status));
+                _icon.Render().classList.add("tss-plan-step-icon");
+                _icon.Render().classList.add(PlanVisuals.StatusClass(status));
 
                 _text = TextBlock(title).Regular();
 
-                _taskStack = Stack().Horizontal().Gap(16.px()).AlignItems(ItemAlign.Center).Children(
-                    _icon,
-                    _text
-                );
+                _stageEl = Div(_("tss-plan-step-stage"));
+                _stageEl.style.display = "none";
+
+                _toggleEl = Span(_("tss-plan-step-toggle"));
+                _toggleEl.innerText = "▸";
+                _toggleEl.style.display = "none";
+                _toggleEl.onclick = e => { ToggleExpanded(); };
+
+                var titleRow = Div(_("tss-plan-step-title"));
+                titleRow.appendChild(_text.Render());
+                titleRow.appendChild(_toggleEl);
+
+                _progressBar = Div(_("tss-plan-step-progress-bar"));
+                _progressEl = Div(_("tss-plan-step-progress"), _progressBar);
+                _progressEl.style.display = "none";
+
+                var stepBody = Div(_("tss-plan-step-body"));
+                stepBody.appendChild(titleRow);
+                stepBody.appendChild(_stageEl);
+                stepBody.appendChild(_progressEl);
+
+                _stepRow = Div(_("tss-plan-step-row"));
+                _stepRow.appendChild(_icon.Render());
+                _stepRow.appendChild(stepBody);
+
+                _substepsContainer = Div(_("tss-plan-substeps tss-plan-collapsed"));
+
+                _root = Div(_("tss-plan-step"));
+                _root.appendChild(_stepRow);
+                _root.appendChild(_substepsContainer);
+            }
+
+            /// <summary>
+            /// Backwards-compatible ctor used when callers built tasks via the
+            /// old `.AddTask(string, bool)` shape directly.
+            /// </summary>
+            public Task(string title, bool completed)
+                : this("tss-plan-step-task-" + Guid.NewGuid().ToString("N"), title, completed ? PlanStatus.Completed : PlanStatus.Pending)
+            {
             }
 
             /// <summary>
             /// Renders the component's root HTML element.
             /// </summary>
-            public HTMLElement Render() => _taskStack.Render();
+            public HTMLElement Render() => _root;
+
+            internal void UpdateFromModel(PlanStepModel model)
+            {
+                if (model.Title != null) _text.Text = model.Title;
+
+                ApplyStatus(model.Status);
+
+                if (!string.IsNullOrEmpty(model.CurrentStage))
+                {
+                    _stageEl.innerText = model.CurrentStage;
+                    _stageEl.style.display = "";
+                }
+                else
+                {
+                    _stageEl.style.display = "none";
+                }
+
+                // Progress: explicit value wins, otherwise indeterminate when running.
+                if (model.Progress.HasValue)
+                {
+                    var p = PlanVisuals.ClampProgress(model.Progress.Value);
+                    _progressEl.classList.remove("tss-plan-indeterminate");
+                    _progressBar.style.width = (p * 100f).ToString() + "%";
+                    _progressEl.style.display = "";
+                }
+                else if (model.Status == PlanStatus.Running)
+                {
+                    _progressEl.classList.add("tss-plan-indeterminate");
+                    _progressEl.style.display = "";
+                }
+                else
+                {
+                    _progressEl.style.display = "none";
+                }
+
+                // Substeps reconcile by key
+                ReconcileSubsteps(model.Substeps ?? new List<PlanSubstepModel>());
+
+                // Expansion (auto unless overridden)
+                var hasSubsteps = model.Substeps != null && model.Substeps.Count > 0;
+                _toggleEl.style.display = hasSubsteps ? "" : "none";
+                SetExpanded(hasSubsteps && PlanVisuals.DefaultExpanded(model));
+            }
+
+            private void ApplyStatus(PlanStatus status)
+            {
+                _status = status;
+                _icon.SetIcon(PlanVisuals.StatusIcon(status));
+                _icon.Render().classList.add("tss-plan-step-icon");
+                _icon.Render().classList.remove("tss-plan-pending");
+                _icon.Render().classList.remove("tss-plan-running");
+                _icon.Render().classList.remove("tss-plan-completed");
+                _icon.Render().classList.remove("tss-plan-failed");
+                _icon.Render().classList.remove("tss-plan-canceled");
+                _icon.Render().classList.add(PlanVisuals.StatusClass(status));
+            }
+
+            private void ToggleExpanded()
+            {
+                SetExpanded(!_expanded);
+            }
+
+            private void SetExpanded(bool expanded)
+            {
+                _expanded = expanded;
+                if (expanded)
+                {
+                    _substepsContainer.classList.remove("tss-plan-collapsed");
+                    _toggleEl.innerText = "▾";
+                }
+                else
+                {
+                    _substepsContainer.classList.add("tss-plan-collapsed");
+                    _toggleEl.innerText = "▸";
+                }
+            }
+
+            private void ReconcileSubsteps(IList<PlanSubstepModel> substeps)
+            {
+                var newKeys = new List<string>(substeps.Count);
+                var seen = new HashSet<string>();
+
+                for (int i = 0; i < substeps.Count; i++)
+                {
+                    var sub = substeps[i];
+                    var key = PlanVisuals.SubstepKey(sub, i);
+                    newKeys.Add(key);
+                    seen.Add(key);
+
+                    HTMLElement el;
+                    if (_substepsByKey.TryGetValue(key, out el))
+                    {
+                        UpdateSubstepEl(el, sub);
+                    }
+                    else
+                    {
+                        el = BuildSubstepEl(sub);
+                        _substepsByKey[key] = el;
+                    }
+                }
+
+                // Drop stale
+                var stale = _substepOrder.Where(k => !seen.Contains(k)).ToList();
+                foreach (var k in stale)
+                {
+                    var el = _substepsByKey[k];
+                    _substepsByKey.Remove(k);
+                    if (el.parentNode != null) el.parentNode.removeChild(el);
+                }
+
+                // Re-order
+                _substepOrder.Clear();
+                foreach (var k in newKeys)
+                {
+                    _substepOrder.Add(k);
+                    _substepsContainer.appendChild(_substepsByKey[k]);
+                }
+            }
+
+            private static HTMLElement BuildSubstepEl(PlanSubstepModel sub)
+            {
+                var iconEl = I(_("tss-icon tss-plan-substep-icon"));
+                var titleEl = Div(_("tss-plan-substep-title"));
+                titleEl.innerText = sub.Title ?? string.Empty;
+                var msgEl = Div(_("tss-plan-substep-message"));
+                var body = Div(_("tss-plan-substep-body"), titleEl, msgEl);
+                var root = Div(_("tss-plan-substep"), iconEl, body);
+                UpdateSubstepEl(root, sub);
+                return root;
+            }
+
+            private static void UpdateSubstepEl(HTMLElement root, PlanSubstepModel sub)
+            {
+                // Children: [iconEl, body[titleEl, msgEl]]
+                var iconEl = (HTMLElement)root.childNodes[0];
+                var body = (HTMLElement)root.childNodes[1];
+                var titleEl = (HTMLElement)body.childNodes[0];
+                var msgEl = (HTMLElement)body.childNodes[1];
+
+                // Title
+                titleEl.innerText = sub.Title ?? string.Empty;
+
+                // Icon (UIcons font class) — clear previous icon classes
+                // and re-apply just our marker + the new icon class.
+                var newIconClass = Tesserae.Icon.Transform(PlanVisuals.StatusIcon(sub.Status), UIconsWeight.Regular);
+                iconEl.className = "tss-icon tss-plan-substep-icon " + PlanVisuals.StatusClass(sub.Status) + " " + newIconClass + " " + TextSize.Small.ToString();
+
+                // Message
+                if (!string.IsNullOrEmpty(sub.Message))
+                {
+                    msgEl.innerText = sub.Message;
+                    msgEl.style.display = "";
+                }
+                else
+                {
+                    msgEl.style.display = "none";
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
Generalizes the existing `Plan` component so a single instance can be driven either via the existing fluent builder *or* via a new declarative `SetModel(PlanModel)` path that reconciles the DOM in place using stable keys. Lets downstream consumers (e.g. Mosaik's deep-research chat renderer) drop parallel "plan-like" component implementations and use `Plan` directly.

Supersedes #117, which shipped a parallel `DeepResearchPlan` component family instead of extending `Plan`.

## What's new on `Plan`
- New `PlanStatus` enum (`Pending`, `Running`, `Completed`, `Failed`, `Canceled`).
- New plain-data model types: `PlanModel`, `PlanStepModel`, `PlanSubstepModel`.
- New `Plan.SetModel(PlanModel)` — reconciles header, steps, and substeps in place using stable `Id` keys (falls back to positional `tss-plan-step-{index}` keys when no id is provided).
- New `Plan.Model` getter exposing the last model passed to `SetModel`.
- New `AddTask(string title, PlanStatus status)` overload alongside the existing `AddTask(string, bool)`.
- Per-step optional progress (`float?`, auto-indeterminate when `Status==Running` and no value is supplied) and `CurrentStage` text.
- Expandable substeps per task; default expansion derived from status (collapsed when Completed, expanded when Running/Failed; overrideable via `IsExpanded`).
- Plan-level status badge, status-colored card border, and an auto-generated summary line ("X of Y steps complete | Z running | …"), plus optional started/completed timestamps.

## Backward compatibility
- Existing fluent API (`Title`, `HeaderCommands`, `Progress`, `Indeterminate`, `StartStopButton`, `FooterMessage`, `FooterCommands`, `Start`, `Stop`, `AddTask(string, bool)`) is unchanged at the signature level.
- `Plan.Task.Completed` (`bool`) retained as a shim over the new `Status` property.
- `Plan.Task(string, bool)` constructor retained.
- **One intentional visual change:** completed tasks now use the success (green) status color instead of the previous primary tone, to be consistent with the new status palette shared with `SetModel`.

## Files
- `Tesserae/src/Components/Plan.cs` (rewritten)
- `Tesserae/h5/assets/css/tss.plan.css` (new — status modifiers, badge, substeps, expand/collapse, indeterminate progress)
- `Tesserae/h5.json` (registers the new CSS bundle)
- `Tesserae.Tests/src/Samples/Components/PlanSample.cs` (adds "Data-driven / streaming updates" section)

## Verify
- `dotnet build Tesserae.sln` → **0 warnings, 0 errors** under the h5 transpiler.

## Test plan
- [ ] Open `PlanSample` and exercise both the fluent example and the new data-driven section.
- [ ] Cycle the streaming sample through Pending → Running (with substeps) → Completed / Failed / Canceled; confirm DOM nodes are reused (no flicker, no scroll/focus reset).
- [ ] Confirm completed-task color change is acceptable in any existing apps depending on the old primary tint.

https://claude.ai/code/session_01AKDZm62bhLbF5AaSpehtk3

---
_Generated by [Claude Code](https://claude.ai/code/session_01AKDZm62bhLbF5AaSpehtk3)_