### PR TITLE
Add Questionnaire component for inline Q&A interactions

### DIFF
--- a/Tesserae.Tests/src/Samples/Components/QuestionnaireSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/QuestionnaireSample.cs
@@ -1,0 +1,34 @@
+using static H5.Core.dom;
+using static Tesserae.UI;
+using static Tesserae.Tests.Samples.SamplesHelper;
+
+namespace Tesserae.Tests.Samples
+{
+    [SampleDetails(Group = "Components", Order = 103, Icon = UIcons.Comment)]
+    public class QuestionnaireSample : IComponent, ISample
+    {
+        private readonly IComponent _content;
+
+        public QuestionnaireSample()
+        {
+            _content = SectionStack().Secondary()
+                .SampleTitle(typeof(QuestionnaireSample), UIcons.Comment, "Inline question + answer-options widget for AI chats")
+                .FlatSection(Stack().Children(
+                    Card(VStack().WS().Children(
+                        TextBlock("Questionnaire renders a single question and a list of selectable answer options. Once the user picks an option (or one is set programmatically) the component switches to a \"response selected\" mode that disables further input and highlights the chosen answer.")
+                    )).SetTitle("Overview")))
+                .FlatSection(Stack().Children(
+                    Card(VStack().WS().Children(
+                        SampleSubTitle("Unanswered"),
+                        Questionnaire("Do you want to delete this file?", "Yes", "No", "Show me the diff first")
+                            .OnAnswered(q => console.log("Answered: " + q.Answer)),
+
+                        SampleSubTitle("Pre-answered (response-selected mode)"),
+                        Questionnaire("Which framework should we use?", "React", "Vue", "Svelte", "Solid")
+                            .SetAnswer("Svelte")
+                    )).SetTitle("Usage")));
+        }
+
+        public HTMLElement Render() => _content.Render();
+    }
+}

--- a/Tesserae/h5.json
+++ b/Tesserae/h5.json
@@ -160,6 +160,7 @@
         "h5/assets/css/baklava.css",
         "h5/assets/css/tss.chat.css",
         "h5/assets/css/tss.toolcall.css",
+        "h5/assets/css/tss.questionnaire.css",
         "h5/assets/css/tss.rating.css",
         "h5/assets/css/tss.progressring.css",
         "h5/assets/css/tss.colorpalette.css",

--- a/Tesserae/h5/assets/css/tss.questionnaire.css
+++ b/Tesserae/h5/assets/css/tss.questionnaire.css
@@ -1,0 +1,75 @@
+/* Questionnaire — inline question with selectable answer options */
+
+.tss-questionnaire {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    border: 1px solid var(--tss-default-border-color);
+    border-radius: 8px;
+    background: var(--tss-default-background-color);
+    padding: 12px 14px;
+    box-sizing: border-box;
+    max-width: 100%;
+}
+
+.tss-questionnaire-question {
+    font-weight: var(--tss-font-weight-semibold, 600);
+    font-size: 14px;
+    color: var(--tss-colors-neutral-800, #1f2937);
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
+.tss-questionnaire-options {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.tss-questionnaire-option {
+    background: var(--tss-default-background-color);
+    border: 1px solid var(--tss-default-border-color);
+    border-radius: 999px;
+    padding: 6px 12px;
+    font-size: 13px;
+    color: var(--tss-colors-neutral-800, #1f2937);
+    cursor: pointer;
+    transition: background-color 120ms ease, border-color 120ms ease, color 120ms ease;
+    font-family: inherit;
+    line-height: 1.2;
+}
+
+.tss-questionnaire-option:hover:not(:disabled) {
+    background: var(--tss-default-background-hover-color);
+    border-color: var(--tss-colors-primary-400, #60a5fa);
+}
+
+.tss-questionnaire-option:disabled {
+    cursor: default;
+    opacity: 0.7;
+}
+
+.tss-questionnaire-answered .tss-questionnaire-option {
+    opacity: 0.55;
+}
+
+.tss-questionnaire-answered .tss-questionnaire-option.tss-questionnaire-option-selected {
+    background: var(--tss-colors-primary-500, #3b82f6);
+    border-color: var(--tss-colors-primary-500, #3b82f6);
+    color: #ffffff;
+    opacity: 1;
+    font-weight: var(--tss-font-weight-semibold, 600);
+}
+
+.tss-questionnaire-answered-badge {
+    display: inline-block;
+    margin-top: 4px;
+    padding: 4px 10px;
+    border-radius: 6px;
+    background: var(--tss-colors-primary-50, #eff6ff);
+    color: var(--tss-colors-primary-700, #1d4ed8);
+    font-size: 13px;
+    font-weight: var(--tss-font-weight-semibold, 600);
+    white-space: pre-wrap;
+    word-break: break-word;
+}

--- a/Tesserae/src/Base/UI.Components.cs
+++ b/Tesserae/src/Base/UI.Components.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Tesserae;
 using static H5.Core.dom;
@@ -1039,6 +1040,20 @@ namespace Tesserae
         /// list/detail popup when clicked.
         /// </summary>
         public static ToolsUsed ToolsUsed(params ToolCall[] tools) => new ToolsUsed(tools);
+
+        /// <summary>
+        /// Creates a <see cref="Tesserae.Questionnaire"/> component that
+        /// shows the given question and answer options. When the user
+        /// picks an option (or one is set programmatically) the component
+        /// switches to a "response selected" mode.
+        /// </summary>
+        public static Questionnaire Questionnaire(string question, IEnumerable<string> options = null) => new Questionnaire(question, options);
+
+        /// <summary>
+        /// Creates a <see cref="Tesserae.Questionnaire"/> component that
+        /// shows the given question and answer options.
+        /// </summary>
+        public static Questionnaire Questionnaire(string question, params string[] options) => new Questionnaire(question, options);
 
         /// <summary>
         /// Creates a <see cref="Tesserae.Toast"/> component.

--- a/Tesserae/src/Components/Questionnaire.cs
+++ b/Tesserae/src/Components/Questionnaire.cs
@@ -1,0 +1,180 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using static H5.Core.dom;
+using static Tesserae.UI;
+
+namespace Tesserae
+{
+    /// <summary>
+    /// Inline questionnaire that shows a question and a list of choice
+    /// buttons. Once the user picks an answer (or it is set programmatically
+    /// via <see cref="SetAnswer"/>) the component switches to a
+    /// "response selected" mode that shows the question with the chosen
+    /// answer highlighted and disables further input.
+    /// </summary>
+    [H5.Name("tss.Questionnaire")]
+    public sealed class Questionnaire : ComponentBase<Questionnaire, HTMLElement>
+    {
+        private readonly HTMLElement                _questionContainer;
+        private readonly HTMLElement                _optionsContainer;
+        private readonly HTMLElement                _answeredBadge;
+        private readonly List<(string Value, HTMLButtonElement Button)> _optionButtons;
+        private          string                     _question;
+        private          string                     _answer;
+        private          bool                       _isAnswered;
+        private          Action<Questionnaire>      _onAnswered;
+
+        /// <summary>
+        /// Initializes a new instance of this class.
+        /// </summary>
+        public Questionnaire(string question, IEnumerable<string> options)
+        {
+            _question          = question ?? string.Empty;
+            _optionButtons     = new List<(string, HTMLButtonElement)>();
+
+            _questionContainer = Div(_("tss-questionnaire-question", text: _question));
+            _optionsContainer  = Div(_("tss-questionnaire-options"));
+            _answeredBadge     = Div(_("tss-questionnaire-answered-badge"));
+            _answeredBadge.style.display = "none";
+
+            InnerElement = Div(_("tss-questionnaire"),
+                               _questionContainer,
+                               _optionsContainer,
+                               _answeredBadge);
+
+            if (options != null)
+            {
+                foreach (var option in options)
+                {
+                    AddOption(option);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the question shown by the component.
+        /// </summary>
+        public string Question   => _question;
+        /// <summary>
+        /// Gets the answer currently selected, or <c>null</c> when no answer has been set.
+        /// </summary>
+        public string Answer     => _answer;
+        /// <summary>
+        /// Returns a value indicating whether the component is in the "response selected" mode.
+        /// </summary>
+        public bool   IsAnswered => _isAnswered;
+
+        /// <summary>
+        /// Sets the question of the component.
+        /// </summary>
+        public Questionnaire SetQuestion(string question)
+        {
+            _question = question ?? string.Empty;
+            _questionContainer.innerText = _question;
+            return this;
+        }
+
+        /// <summary>
+        /// Adds the given option to the component.
+        /// </summary>
+        public Questionnaire AddOption(string option)
+        {
+            if (option is null) return this;
+
+            var btn = Button(_("tss-questionnaire-option", type: "button"));
+            btn.innerText = option;
+
+            var capturedValue = option;
+            btn.addEventListener("click", _ =>
+            {
+                if (_isAnswered) return;
+                SetAnswer(capturedValue);
+                _onAnswered?.Invoke(this);
+            });
+
+            _optionButtons.Add((capturedValue, btn));
+            _optionsContainer.appendChild(btn);
+            return this;
+        }
+
+        /// <summary>
+        /// Adds the given range of options to the component.
+        /// </summary>
+        public Questionnaire AddOptions(IEnumerable<string> options)
+        {
+            if (options == null) return this;
+            foreach (var o in options) AddOption(o);
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the selected answer and switches the component into the
+        /// "response selected" mode. Calling this does not invoke the
+        /// <see cref="OnAnswered"/> callback — use this to reflect an
+        /// already-known answer (e.g. one fetched from the server).
+        /// </summary>
+        public Questionnaire SetAnswer(string answer)
+        {
+            _answer     = answer;
+            _isAnswered = true;
+            InnerElement.classList.add("tss-questionnaire-answered");
+
+            foreach (var (value, btn) in _optionButtons)
+            {
+                btn.disabled = true;
+                ((HTMLElement)btn).UpdateClassIf(string.Equals(value, answer, StringComparison.Ordinal), "tss-questionnaire-option-selected");
+            }
+
+            if (!string.IsNullOrEmpty(answer) && !_optionButtons.Any(o => string.Equals(o.Value, answer, StringComparison.Ordinal)))
+            {
+                _answeredBadge.innerText      = answer;
+                _answeredBadge.style.display  = "block";
+            }
+            else
+            {
+                _answeredBadge.style.display = "none";
+            }
+
+            return this;
+        }
+
+        /// <summary>
+        /// Clears the selected answer and re-enables the option buttons.
+        /// </summary>
+        public Questionnaire ClearAnswer()
+        {
+            _answer     = null;
+            _isAnswered = false;
+            InnerElement.classList.remove("tss-questionnaire-answered");
+            _answeredBadge.style.display = "none";
+
+            foreach (var (_, btn) in _optionButtons)
+            {
+                btn.disabled = false;
+                btn.classList.remove("tss-questionnaire-option-selected");
+            }
+
+            return this;
+        }
+
+        /// <summary>
+        /// Registers a callback invoked when the user picks an option.
+        /// The callback is not invoked when the answer is set
+        /// programmatically via <see cref="SetAnswer"/>.
+        /// </summary>
+        public Questionnaire OnAnswered(Action<Questionnaire> onAnswered)
+        {
+            _onAnswered += onAnswered;
+            return this;
+        }
+
+        /// <summary>
+        /// Renders the component's root HTML element.
+        /// </summary>
+        public override HTMLElement Render()
+        {
+            return InnerElement;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Introduces a new `Questionnaire` component that displays a question with selectable answer options. Once an answer is selected (either by user interaction or programmatically), the component switches to a "response selected" mode that highlights the chosen answer and disables further input.

## Changes
- **New Component**: `Questionnaire.cs` — A sealed component that manages question display, option buttons, and answer state. Features include:
  - Constructor accepting a question string and enumerable of options
  - Fluent API methods: `SetQuestion()`, `AddOption()`, `AddOptions()`, `SetAnswer()`, `ClearAnswer()`, `OnAnswered()`
  - Properties: `Question`, `Answer`, `IsAnswered`
  - Callback support for user-selected answers (not invoked for programmatic `SetAnswer()` calls)
  - Visual badge display for answers not in the predefined options list

- **Styling**: `tss.questionnaire.css` — Complete styling with:
  - Flexbox layout for question and options
  - Pill-shaped option buttons with hover states
  - "Response selected" mode styling with primary color highlighting
  - Badge styling for custom answers
  - CSS custom properties for theming (borders, backgrounds, colors)

- **Sample**: `QuestionnaireSample.cs` — Demonstrates both unanswered and pre-answered states with event handling

- **Factory Methods**: Added two overloads in `UI.Components.cs`:
  - `Questionnaire(string question, IEnumerable<string> options)`
  - `Questionnaire(string question, params string[] options)`

- **Build Config**: Updated `h5.json` to include the new stylesheet in the build output

## Implementation Details
- Uses `UpdateClassIf()` extension for conditional CSS class application
- Captures option values in closures to preserve state in event listeners
- Disables buttons and applies visual opacity changes when answered
- Supports clearing answers to return to interactive mode

https://claude.ai/code/session_01E9G6xXb3HT2sKxhaoi9chz