### PR TITLE
Cache event handler delegates to fix removeEventListener calls

### DIFF
--- a/Tesserae/src/Components/ContextMenu.cs
+++ b/Tesserae/src/Components/ContextMenu.cs
@@ -35,6 +35,9 @@ namespace Tesserae
         private Item        _activeMenuItem;
         private ContextMenu _activeSubMenu;
 
+        private readonly Action<Event> _onWindowMouseMoveAction;
+        private readonly Action<Event> _onPopupKeyDownAction;
+
         private event Action _onHide;
 
         private event ComponentEventHandler<Item, MouseEvent> ItemClick;
@@ -48,6 +51,9 @@ namespace Tesserae
         {
             InnerElement    = Div(_("tss-contextmenu"));
             _childContainer = Div(_());
+
+            _onWindowMouseMoveAction = (ev) => OnWindowMouseMove(ev);
+            _onPopupKeyDownAction    = (ev) => OnPopupKeyDown(ev);
         }
 
         /// <summary>
@@ -234,7 +240,7 @@ namespace Tesserae
 
             window.setTimeout((e) =>
             {
-                document.addEventListener("keydown", OnPopupKeyDown);
+                document.addEventListener("keydown", _onPopupKeyDownAction);
             }, 100);
 
             _extremeCoordsTopLeft.x     = x;
@@ -335,7 +341,7 @@ namespace Tesserae
 
             window.setTimeout((e) =>
             {
-                document.addEventListener("keydown", OnPopupKeyDown);
+                document.addEventListener("keydown", _onPopupKeyDownAction);
             }, 100);
 
             _extremeCoordsTopLeft.x     = x;
@@ -458,7 +464,7 @@ namespace Tesserae
         {
             if (_items.Any(i => i.HasSubMenu))
             {
-                window.addEventListener("mousemove", OnWindowMouseMove);
+                window.addEventListener("mousemove", _onWindowMouseMoveAction);
                 _menuElementCoordsTopLeft = CalculateTopLeftCoords(_popup);
 
                 foreach (var item in _items)
@@ -473,8 +479,8 @@ namespace Tesserae
         /// </summary>
         public override void Hide(Action onHidden = null)
         {
-            window.removeEventListener("mousemove", OnWindowMouseMove);
-            document.removeEventListener("keydown", OnPopupKeyDown);
+            window.removeEventListener("mousemove", _onWindowMouseMoveAction);
+            document.removeEventListener("keydown", _onPopupKeyDownAction);
          
             base.Hide(() => { _onHide?.Invoke(); onHidden?.Invoke(); });
 

--- a/Tesserae/src/Components/Dropdown.cs
+++ b/Tesserae/src/Components/Dropdown.cs
@@ -458,11 +458,10 @@ namespace Tesserae
             ClearSearch();
             ResetSearchItems();
             InnerElement.setAttribute("aria-expanded", "false");
-            document.removeEventListener("click",       _onWindowClickAction);
-            document.removeEventListener("dblclick",    _onWindowClickAction);
-            document.removeEventListener("contextmenu", _onWindowClickAction);
-            document.removeEventListener("wheel",       _onWindowClickAction);
-            document.removeEventListener("keydown",     _onPopupKeyDownAction);
+            // The click/dblclick/contextmenu/wheel listeners are attached once to
+            // _contentHtml when it's first created (see Show) and intentionally live
+            // for the dropdown's lifetime, so they're not removed here.
+            document.removeEventListener("keydown", _onPopupKeyDownAction);
             base.Hide(onHidden);
 
             if (_isChanged)

--- a/Tesserae/src/Components/Dropdown.cs
+++ b/Tesserae/src/Components/Dropdown.cs
@@ -39,6 +39,9 @@ namespace Tesserae
         private int                      _latestRequestID;
         private Func<Item[], IComponent> _customRenderer;
 
+        private readonly Action<Event> _onWindowClickAction;
+        private readonly Action<Event> _onPopupKeyDownAction;
+
         /// <summary>
         /// Static configuration of the icon shown on the dropdown chevron, applied globally to every <see cref="Dropdown"/> instance.
         /// </summary>
@@ -49,6 +52,9 @@ namespace Tesserae
         /// </summary>
         public Dropdown(HTMLSpanElement noItemsSpan = null)
         {
+            _onWindowClickAction  = (ev) => OnWindowClick(ev);
+            _onPopupKeyDownAction = (ev) => OnPopupKeyDown(ev);
+
             _noItemsSpan = noItemsSpan ?? Span(_(text: "There are no options available"));
             _searchSpan  = Span(_("tss-dropdown-search-term"));
 
@@ -325,12 +331,12 @@ namespace Tesserae
                 }
                 _contentHtml = Div(_("tss-dropdown-layer"), _popupDiv);
 
-                _contentHtml.addEventListener("click",       OnWindowClick);
-                _contentHtml.addEventListener("dblclick",    OnWindowClick);
-                _contentHtml.addEventListener("contextmenu", OnWindowClick);
+                _contentHtml.addEventListener("click",       _onWindowClickAction);
+                _contentHtml.addEventListener("dblclick",    _onWindowClickAction);
+                _contentHtml.addEventListener("contextmenu", _onWindowClickAction);
                 // OnWindowClick doesn't preventDefault, so mark the wheel listener
                 // passive to avoid blocking scroll and silence the browser warning.
-                _contentHtml.addEventListener("wheel",       (Action<Event>)OnWindowClick, new AddEventListenerOptions { passive = true });
+                _contentHtml.addEventListener("wheel",       _onWindowClickAction, new AddEventListenerOptions { passive = true });
 
                 if (_itemsSource is object)
                 {
@@ -354,7 +360,7 @@ namespace Tesserae
 
             DomObserver.WhenMounted(_popupDiv, () =>
             {
-                document.addEventListener("keydown", OnPopupKeyDown);
+                document.addEventListener("keydown", _onPopupKeyDownAction);
 
                 if (_searchBox != null)
                 {
@@ -452,11 +458,11 @@ namespace Tesserae
             ClearSearch();
             ResetSearchItems();
             InnerElement.setAttribute("aria-expanded", "false");
-            document.removeEventListener("click",       OnWindowClick);
-            document.removeEventListener("dblclick",    OnWindowClick);
-            document.removeEventListener("contextmenu", OnWindowClick);
-            document.removeEventListener("wheel",       OnWindowClick);
-            document.removeEventListener("keydown",     OnPopupKeyDown);
+            document.removeEventListener("click",       _onWindowClickAction);
+            document.removeEventListener("dblclick",    _onWindowClickAction);
+            document.removeEventListener("contextmenu", _onWindowClickAction);
+            document.removeEventListener("wheel",       _onWindowClickAction);
+            document.removeEventListener("keydown",     _onPopupKeyDownAction);
             base.Hide(onHidden);
 
             if (_isChanged)

--- a/Tesserae/src/Components/Modal.cs
+++ b/Tesserae/src/Components/Modal.cs
@@ -36,6 +36,11 @@ namespace Tesserae
         private bool             _isDragged;
         private TranslationPoint _startPoint;
 
+        private readonly Action<Event> _onCloseClickAction;
+        private readonly Action<Event> _onDragMouseDownAction;
+        private readonly Action<Event> _onDragMouseMoveAction;
+        private readonly Action<Event> _onDragMouseUpAction;
+
         /// <summary>
         /// Gets or sets the animate on show.
         /// </summary>
@@ -65,6 +70,11 @@ namespace Tesserae
         /// </summary>
         public Modal(IComponent header = null)
         {
+            _onCloseClickAction    = (ev) => OnCloseClick(ev);
+            _onDragMouseDownAction = (ev) => OnDragMouseDown(ev);
+            _onDragMouseMoveAction = (ev) => OnDragMouseMove(ev);
+            _onDragMouseUpAction   = (ev) => OnDragMouseUp(ev);
+
             _modalHeaderContents = Div(_("tss-modal-header-content"));
             _modalFooterContents = Div(_("tss-modal-footer-content"));
 
@@ -287,16 +297,16 @@ namespace Tesserae
                 if (value)
                 {
                     _modalOverlay.classList.add("tss-modal-lightDismiss");
-                    _modalOverlay.addEventListener("click",       OnCloseClick);
-                    _modalOverlay.addEventListener("dblclick",    OnCloseClick);
-                    _modalOverlay.addEventListener("contextmenu", OnCloseClick);
+                    _modalOverlay.addEventListener("click",       _onCloseClickAction);
+                    _modalOverlay.addEventListener("dblclick",    _onCloseClickAction);
+                    _modalOverlay.addEventListener("contextmenu", _onCloseClickAction);
                 }
                 else
                 {
                     _modalOverlay.classList.remove("tss-modal-lightDismiss");
-                    _modalOverlay.removeEventListener("click",       OnCloseClick);
-                    _modalOverlay.removeEventListener("dblclick",    OnCloseClick);
-                    _modalOverlay.removeEventListener("contextmenu", OnCloseClick);
+                    _modalOverlay.removeEventListener("click",       _onCloseClickAction);
+                    _modalOverlay.removeEventListener("dblclick",    _onCloseClickAction);
+                    _modalOverlay.removeEventListener("contextmenu", _onCloseClickAction);
                 }
             }
         }
@@ -331,13 +341,13 @@ namespace Tesserae
                 if (value)
                 {
                     _modalHeaderContents.classList.add("tss-modal-draggable");
-                    _modalHeaderContents.addEventListener("mousedown", OnDragMouseDown);
+                    _modalHeaderContents.addEventListener("mousedown", _onDragMouseDownAction);
 
                 }
                 else
                 {
                     _modalHeaderContents.classList.remove("tss-modal-draggable");
-                    _modalHeaderContents.removeEventListener("mousedown", OnDragMouseDown);
+                    _modalHeaderContents.removeEventListener("mousedown", _onDragMouseDownAction);
                 }
             }
         }
@@ -616,9 +626,9 @@ namespace Tesserae
 
             if (_isDragged && e.button == 0)
             {
-                document.body.removeEventListener("mouseup",    OnDragMouseUp);
-                document.body.removeEventListener("mousemove",  OnDragMouseMove);
-                document.body.removeEventListener("mouseleave", OnDragMouseUp);
+                document.body.removeEventListener("mouseup",    _onDragMouseUpAction);
+                document.body.removeEventListener("mousemove",  _onDragMouseMoveAction);
+                document.body.removeEventListener("mouseleave", _onDragMouseUpAction);
                 document.body.classList.remove("tss-modal-dragging");
                 document.body.style.userSelect = "";
                 _isDragged                     = false;
@@ -631,9 +641,9 @@ namespace Tesserae
 
             if (e.button == 0)
             {
-                document.body.addEventListener("mouseup",    OnDragMouseUp);
-                document.body.addEventListener("mousemove",  OnDragMouseMove);
-                document.body.addEventListener("mouseleave", OnDragMouseUp);
+                document.body.addEventListener("mouseup",    _onDragMouseUpAction);
+                document.body.addEventListener("mousemove",  _onDragMouseMoveAction);
+                document.body.addEventListener("mouseleave", _onDragMouseUpAction);
                 document.body.classList.add("tss-modal-dragging");
                 _modal.style.userSelect = "none";
                 _startPoint             = TranslationPoint.From(_modal.style.transform);

--- a/Tesserae/src/Components/Panel.cs
+++ b/Tesserae/src/Components/Panel.cs
@@ -23,6 +23,8 @@ namespace Tesserae
         private readonly HTMLElement _closeButton;
         private readonly HTMLElement _panelTitle;
 
+        private readonly Action<Event> _onCloseClickAction;
+
         /// <summary>
         /// Initializes a new instance of this class.
         /// </summary>
@@ -33,6 +35,8 @@ namespace Tesserae
         /// </summary>
         public Panel(IComponent title)
         {
+            _onCloseClickAction = (ev) => OnCloseClick(ev);
+
             _panelTitle = Div(_("tss-panel-title"));
 
             _closeButton  = Button(_($"tss-panel-command-button", el: el => el.onclick = (e) => Hide()), I(_("tss-fontsize-small " + UIcons.Cross.ToString())));
@@ -136,12 +140,12 @@ namespace Tesserae
                 if (value)
                 {
                     _panelOverlay.classList.add("tss-panel-lightDismiss");
-                    _panelOverlay.addEventListener("click", OnCloseClick);
+                    _panelOverlay.addEventListener("click", _onCloseClickAction);
                 }
                 else
                 {
                     _panelOverlay.classList.remove("tss-panel-lightDismiss");
-                    _panelOverlay.removeEventListener("click", OnCloseClick);
+                    _panelOverlay.removeEventListener("click", _onCloseClickAction);
                 }
             }
         }


### PR DESCRIPTION
## Summary

This PR fixes a critical bug where event listeners could not be properly removed from DOM elements because new delegate instances were being created each time `addEventListener` and `removeEventListener` were called. In JavaScript/h5, event listener removal requires the exact same function reference that was used during registration.

## Changes

- **Modal.cs**: Cache four event handler delegates (`_onCloseClickAction`, `_onDragMouseDownAction`, `_onDragMouseMoveAction`, `_onDragMouseUpAction`) as instance fields, initialized in the constructor. Update all `addEventListener` and `removeEventListener` calls to use these cached delegates instead of passing method references directly.

- **Dropdown.cs**: Cache two event handler delegates (`_onWindowClickAction`, `_onPopupKeyDownAction`) as instance fields, initialized in the constructor. Update all `addEventListener` and `removeEventListener` calls to use the cached delegates. Clarify in a comment that the click/dblclick/contextmenu/wheel listeners attached to `_contentHtml` are intentionally kept for the dropdown's lifetime.

- **ContextMenu.cs**: Cache two event handler delegates (`_onWindowMouseMoveAction`, `_onPopupKeyDownAction`) as instance fields, initialized in the constructor. Update all `addEventListener` and `removeEventListener` calls to use the cached delegates.

- **Panel.cs**: Cache one event handler delegate (`_onCloseClickAction`) as an instance field, initialized in the constructor. Update all `addEventListener` and `removeEventListener` calls to use the cached delegate.

## Implementation Details

Each component now stores delegate instances that wrap the event handler methods. These delegates are created once during construction and reused for all subsequent event listener operations. This ensures that `removeEventListener` receives the same function reference that was passed to `addEventListener`, allowing proper cleanup when components are hidden or destroyed.

https://claude.ai/code/session_01SYctRUoCc4ZVRUSrAd3Xff