### PR TITLE
Add help panel and example values to OmniBox filters and snaps

### DIFF
--- a/Tesserae.Tests/src/Samples/Components/OmniBoxSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/OmniBoxSample.cs
@@ -256,7 +256,7 @@ namespace Tesserae.Tests.Samples
                     OmniBox.ParseQuery("ext:cs lang:csharp"),
                 };
             })
-            .WithHelp(showHistory: true)
+            .WithHelp(showHistory: true, showSyntax: true)
             .OnSearch((s, q) =>
             {
                 var snapInfo = q.Snaps != null && q.Snaps.Length > 0
@@ -286,7 +286,7 @@ namespace Tesserae.Tests.Samples
                     Card(VStack().WS().Children(
                     SampleSubTitle("Snaps and filter snaps"),
                     TextBlock("Type @ to insert a snap (e.g. @docs, @wiki, @code). Type 'ext:', 'filetype:', or 'lang:' to autocomplete filter values. Type 'modified:' (or 'date:' / 'between:') for a time-based filter snap — a date-range picker with shortcuts (last week, last month, last 90 days, last year), or type the range directly as yyyy-MM-dd:yyyy-MM-dd. When committed they become removable chips. All snap and filter selections are passed through with the search query.").MB(8),
-                    TextBlock("Click the ? button on the left of the input to open the help panel — it lists the registered field filters (with their example values) and the registered snaps, and optionally appends a 'Recent' section with previous searches when configured with WithHelp(showHistory: true).").MB(8),
+                    TextBlock("Click the ? button on the left of the input to open the help panel — it lists the registered field filters (with their example values) and the registered snaps. It can also include a 'Query syntax' section describing AND / OR / NOT / parentheses / quotes when configured with WithHelp(showSyntax: true), and a 'Recent' section with previous searches when configured with WithHelp(showHistory: true).").MB(8),
                     Label("Snaps + filter snaps + help").SetContent(snapAndFilterSample.Class("tss-omnibox-snap-and-filter-sample"))
                 )).SetTitle("Snaps & Filter Snaps")));
         }

--- a/Tesserae.Tests/src/Samples/Components/OmniBoxSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/OmniBoxSample.cs
@@ -214,9 +214,9 @@ namespace Tesserae.Tests.Samples
             })
             .WS()
             .RegisterSnaps(
-                new OmniBox.SnapHandler("docs",  "Docs",      new[] { "docs", "documentation" }, Icon(UIcons.Book),   "Search the documentation"),
-                new OmniBox.SnapHandler("wiki",  "Wikipedia", new[] { "wiki", "wikipedia" },     Icon(UIcons.Globe),  "Search Wikipedia"),
-                new OmniBox.SnapHandler("code",  "Code",      new[] { "code", "src", "source" }, Icon(UIcons.FileCode), "Search source code"))
+                new OmniBox.SnapHandler("docs",  "Docs",      new[] { "docs", "documentation" }, Icon(UIcons.Book),   "Search the documentation",   exampleValue: "documentation pages"),
+                new OmniBox.SnapHandler("wiki",  "Wikipedia", new[] { "wiki", "wikipedia" },     Icon(UIcons.Globe),  "Search Wikipedia",            exampleValue: "encyclopedia articles"),
+                new OmniBox.SnapHandler("code",  "Code",      new[] { "code", "src", "source" }, Icon(UIcons.FileCode), "Search source code",        exampleValue: "src/, repo files"))
             .RegisterFilterSnaps(
                 new OmniBox.FilterSnapHandler(
                     "ext",
@@ -224,7 +224,8 @@ namespace Tesserae.Tests.Samples
                     new[] { "ext", "filetype" },
                     new[] { "cs", "ts", "tsx", "js", "jsx", "json", "md", "css", "html", "py", "rb", "go", "rs", "java", "kt", "swift", "yml", "yaml", "xml" },
                     icon: Icon(UIcons.FileCode),
-                    description: "Filter results by file extension"),
+                    description: "Filter results by file extension",
+                    exampleValue: "cs, ts, json…"),
                 new OmniBox.FilterSnapHandler(
                     "lang",
                     "Language",
@@ -237,13 +238,25 @@ namespace Tesserae.Tests.Samples
                         return all.Where(v => v.IndexOf(input, StringComparison.OrdinalIgnoreCase) >= 0).ToArray();
                     },
                     icon: Icon(UIcons.Globe),
-                    description: "Filter results by language (async)"),
+                    description: "Filter results by language (async)",
+                    exampleValue: "csharp, typescript…"),
                 OmniBox.FilterSnapHandler.TimeRange(
                     "modified",
                     "Modified date",
                     new[] { "modified", "date", "between" },
                     icon: Icon(UIcons.Calendar),
-                    description: "Filter results by a date range (yyyy-MM-dd:yyyy-MM-dd)"))
+                    description: "Filter results by a date range (yyyy-MM-dd:yyyy-MM-dd)",
+                    exampleValue: "2025-01-01"))
+            .WithHistory(async () =>
+            {
+                return new[]
+                {
+                    OmniBox.ParseQuery("test AND deploy"),
+                    OmniBox.ParseQuery("\"load testing\" NOT staging"),
+                    OmniBox.ParseQuery("ext:cs lang:csharp"),
+                };
+            })
+            .WithHelp(showHistory: true)
             .OnSearch((s, q) =>
             {
                 var snapInfo = q.Snaps != null && q.Snaps.Length > 0
@@ -273,7 +286,8 @@ namespace Tesserae.Tests.Samples
                     Card(VStack().WS().Children(
                     SampleSubTitle("Snaps and filter snaps"),
                     TextBlock("Type @ to insert a snap (e.g. @docs, @wiki, @code). Type 'ext:', 'filetype:', or 'lang:' to autocomplete filter values. Type 'modified:' (or 'date:' / 'between:') for a time-based filter snap — a date-range picker with shortcuts (last week, last month, last 90 days, last year), or type the range directly as yyyy-MM-dd:yyyy-MM-dd. When committed they become removable chips. All snap and filter selections are passed through with the search query.").MB(8),
-                    Label("Snaps + filter snaps").SetContent(snapAndFilterSample.Class("tss-omnibox-snap-and-filter-sample"))
+                    TextBlock("Click the ? button on the left of the input to open the help panel — it lists the registered field filters (with their example values) and the registered snaps, and optionally appends a 'Recent' section with previous searches when configured with WithHelp(showHistory: true).").MB(8),
+                    Label("Snaps + filter snaps + help").SetContent(snapAndFilterSample.Class("tss-omnibox-snap-and-filter-sample"))
                 )).SetTitle("Snaps & Filter Snaps")));
         }
 

--- a/Tesserae/h5/assets/css/tss.omnibox.css
+++ b/Tesserae/h5/assets/css/tss.omnibox.css
@@ -40,6 +40,15 @@
             border-bottom-right-radius: 0;
         }
 
+        .tss-omnibox-container:not(.tss-omnibox-chat-and-search) .tss-omnibox-search-container .tss-btn.tss-omnibox-search-help-btn {
+            border-right: 1px solid var(--tss-default-border-color);
+            cursor: pointer;
+            background: var(--tss-secondary-background-color);
+            color: var(--tss-secondary-foreground-color);
+            flex-shrink: 0;
+            border-radius: 0;
+        }
+
         .tss-omnibox-container:not(.tss-omnibox-chat-and-search) .tss-omnibox-search-container .tss-btn.tss-omnibox-search-clear-btn,{
             cursor: pointer;
             color: var(--tss-secondary-foreground-color);
@@ -378,6 +387,38 @@
 
 .tss-omnibox-suggestion-highlight {
     background: var(--tss-colors-blue-200) !important;
+}
+
+/* Help panel (WithHelp) */
+.tss-omnibox-help-panel {
+    padding: 4px 0;
+}
+
+.tss-omnibox-help-header {
+    padding: 10px 12px 4px 12px;
+    color: var(--tss-secondary-foreground-color);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    font-size: 11px;
+    opacity: 0.85;
+}
+
+.tippy-box .tss-btn.tss-omnibox-help-entry {
+    height: 36px !important;
+    padding-left: 8px !important;
+    padding-right: 8px !important;
+    margin-bottom: 2px !important;
+}
+
+.tss-omnibox-help-trigger {
+    color: var(--tss-primary-foreground-color);
+    font-family: var(--tss-font-mono, monospace);
+    font-weight: 600;
+}
+
+.tss-omnibox-help-example {
+    color: var(--tss-secondary-foreground-color);
+    opacity: 0.85;
 }
 
 /* Chat trigger (send) button */

--- a/Tesserae/src/Components/OmniBox.cs
+++ b/Tesserae/src/Components/OmniBox.cs
@@ -554,6 +554,7 @@ namespace Tesserae
         private readonly Button      _searchClearBtn;
         private readonly Button      _searchTriggerBtn;
         private bool _helpShowHistory;
+        private bool _helpShowSyntax;
 
         private string[]      _shortcutKeys;
         private Action<Event> _globalShortcutHandler;
@@ -2453,15 +2454,19 @@ namespace Tesserae
         /// filter snaps (and snaps), each with the trigger word and an example value (or the description as
         /// a fallback). When <paramref name="showHistory"/> is <c>true</c> and a history fetcher has been
         /// configured via <see cref="WithHistory(Func{Task{SearchQuery[]}})"/>, the same popup also includes
-        /// a "Recent" section with the latest search queries.
+        /// a "Recent" section with the latest search queries. When <paramref name="showSyntax"/> is
+        /// <c>true</c>, the popup also includes a "Query syntax" section describing the boolean
+        /// operators (<c>AND</c>, <c>OR</c>, <c>NOT</c>), grouping with parentheses, and exact-phrase
+        /// quoting, with a short example next to each.
         /// </summary>
-        public OmniBox WithHelp(bool showHistory = true)
+        public OmniBox WithHelp(bool showHistory = true, bool showSyntax = false)
         {
             if (_mode != Mode.Search && _mode != Mode.SearchAndChat)
             {
                 throw new InvalidOperationException("WithHelp can only be called when OmniBox is in Search or SearchAndChat mode.");
             }
             _helpShowHistory = showHistory;
+            _helpShowSyntax = showSyntax;
             _searchHelpBtn.Show();
             return this;
         }
@@ -2528,6 +2533,16 @@ namespace Tesserae
                 }
             }
 
+            if (_helpShowSyntax)
+            {
+                content.Add(TextBlock("QUERY SYNTAX").Small().SemiBold().Class("tss-omnibox-help-header"));
+                AddSyntaxEntry(content, "AND", "Both terms must match", "alpha AND beta", () => hide);
+                AddSyntaxEntry(content, "OR",  "Either term may match", "alpha OR beta",   () => hide);
+                AddSyntaxEntry(content, "NOT", "Exclude matching term", "alpha NOT beta",  () => hide);
+                AddSyntaxEntry(content, "( )", "Group sub-expressions", "(alpha OR beta) AND gamma", () => hide);
+                AddSyntaxEntry(content, "\" \"", "Exact phrase",        "\"load testing\"",           () => hide);
+            }
+
             if (_helpShowHistory && _historyFetcher != null)
             {
                 SearchQuery[] history = Array.Empty<SearchQuery>();
@@ -2559,7 +2574,7 @@ namespace Tesserae
                 }
             }
 
-            if (!hasFilters && !hasSnaps && !(_helpShowHistory && _historyFetcher != null))
+            if (!hasFilters && !hasSnaps && !_helpShowSyntax && !(_helpShowHistory && _historyFetcher != null))
             {
                 content.Add(Message("Nothing to show", "Register snaps or filter snaps to populate the help panel").Icon(UIcons.EmptySet).H(160));
             }
@@ -2614,6 +2629,41 @@ namespace Tesserae
             OnSearchInputChanged();
             _searchInput.focus();
             TryUpdateSnapSuggestions();
+        }
+
+        private void AddSyntaxEntry(Stack content, string token, string description, string example, Func<Action> hideAccessor)
+        {
+            var btn = Button().Class("tss-omnibox-help-entry").WS().NoPadding().NoMinSize().H(40).MB(4).NoBorder().NoBackground().TextLeft();
+            var row = HStack().WS().AlignItems(ItemAlign.Center).PaddingLeft(12.px()).PaddingRight(12.px());
+            row.Add(TextBlock(token).Class("tss-omnibox-help-trigger"));
+            row.Add(TextBlock(description).Class("tss-omnibox-help-example").ML(6));
+            row.Add(TextBlock(example).Small().Secondary().ML(UnitSize.Auto()));
+            btn.ReplaceContent(row);
+            btn.OnClick(() =>
+            {
+                InsertExampleIntoInput(example);
+                hideAccessor?.Invoke()?.Invoke();
+            });
+            content.Add(btn);
+        }
+
+        private void InsertExampleIntoInput(string example)
+        {
+            if (string.IsNullOrEmpty(example)) return;
+            var val = _searchInput.value ?? string.Empty;
+            string newVal;
+            if (string.IsNullOrEmpty(val) || val.EndsWith(" ") || val.EndsWith(specialWhitespaceString))
+            {
+                newVal = val + example;
+            }
+            else
+            {
+                newVal = val + " " + example;
+            }
+            _searchInput.value = newVal;
+            _searchInput.setSelectionRange((uint)newVal.Length, (uint)newVal.Length);
+            OnSearchInputChanged();
+            _searchInput.focus();
         }
 
         private async Task ShowSearchHistory()

--- a/Tesserae/src/Components/OmniBox.cs
+++ b/Tesserae/src/Components/OmniBox.cs
@@ -130,6 +130,12 @@ namespace Tesserae
             /// Gets or sets the color of the component.
             /// </summary>
             public string Color { get; }
+            /// <summary>
+            /// Gets or sets a short example value (or comma-separated samples) shown next to the filter
+            /// trigger in the help panel. Example: <c>"person"</c>, <c>"Document, Email…"</c>,
+            /// <c>"2025-01-01"</c>.
+            /// </summary>
+            public string ExampleValue { get; set; }
 
             private readonly string[] _values;
             private readonly Func<string, Task<string[]>> _valuesProvider;
@@ -145,8 +151,8 @@ namespace Tesserae
             /// <summary>
             /// Initializes a new instance of this class.
             /// </summary>
-            public FilterSnapHandler(string filterId, string displayName, string[] triggerWords, string[] values, IComponent icon = null, string description = null, string background = null, string color = null)
-                : this(filterId, displayName, triggerWords, icon, description, background, color, false)
+            public FilterSnapHandler(string filterId, string displayName, string[] triggerWords, string[] values, IComponent icon = null, string description = null, string background = null, string color = null, string exampleValue = null)
+                : this(filterId, displayName, triggerWords, icon, description, background, color, false, exampleValue)
             {
                 if (values == null) throw new ArgumentNullException(nameof(values));
                 _values = values;
@@ -155,14 +161,14 @@ namespace Tesserae
             /// <summary>
             /// Initializes a new instance of this class.
             /// </summary>
-            public FilterSnapHandler(string filterId, string displayName, string[] triggerWords, Func<string, Task<string[]>> valuesProvider, IComponent icon = null, string description = null, string background = null, string color = null)
-                : this(filterId, displayName, triggerWords, icon, description, background, color, false)
+            public FilterSnapHandler(string filterId, string displayName, string[] triggerWords, Func<string, Task<string[]>> valuesProvider, IComponent icon = null, string description = null, string background = null, string color = null, string exampleValue = null)
+                : this(filterId, displayName, triggerWords, icon, description, background, color, false, exampleValue)
             {
                 if (valuesProvider == null) throw new ArgumentNullException(nameof(valuesProvider));
                 _valuesProvider = valuesProvider;
             }
 
-            private FilterSnapHandler(string filterId, string displayName, string[] triggerWords, IComponent icon, string description, string background, string color, bool isTimeRange)
+            private FilterSnapHandler(string filterId, string displayName, string[] triggerWords, IComponent icon, string description, string background, string color, bool isTimeRange, string exampleValue = null)
             {
                 if (string.IsNullOrEmpty(filterId)) throw new ArgumentException("filterId is required", nameof(filterId));
                 if (string.IsNullOrEmpty(displayName)) throw new ArgumentException("displayName is required", nameof(displayName));
@@ -175,6 +181,7 @@ namespace Tesserae
                 Background = background;
                 Color = color;
                 _isTimeRange = isTimeRange;
+                ExampleValue = exampleValue;
             }
 
             /// <summary>
@@ -184,9 +191,9 @@ namespace Tesserae
             /// The committed <see cref="FilterSnap.Value"/> is the <c>yyyy-MM-dd:yyyy-MM-dd</c> range string, which can be
             /// parsed back via <see cref="FilterSnap.TryGetDateRange"/>.
             /// </summary>
-            public static FilterSnapHandler TimeRange(string filterId, string displayName, string[] triggerWords, IComponent icon = null, string description = null, string background = null, string color = null)
+            public static FilterSnapHandler TimeRange(string filterId, string displayName, string[] triggerWords, IComponent icon = null, string description = null, string background = null, string color = null, string exampleValue = null)
             {
-                return new FilterSnapHandler(filterId, displayName, triggerWords, icon, description, background, color, true);
+                return new FilterSnapHandler(filterId, displayName, triggerWords, icon, description, background, color, true, exampleValue);
             }
 
             internal async Task<string[]> GetValuesAsync(string input)
@@ -305,11 +312,16 @@ namespace Tesserae
             /// Gets or sets the exclusive.
             /// </summary>
             public bool Exclusive { get; }
+            /// <summary>
+            /// Gets or sets a short example shown next to the snap in the help panel. Example: <c>"docs"</c>,
+            /// <c>"src/repo"</c>. When unset, the help panel falls back to the first trigger word.
+            /// </summary>
+            public string ExampleValue { get; set; }
 
             /// <summary>
             /// Initializes a new instance of this class.
             /// </summary>
-            public SnapHandler(string snapId, string displayName, string[] triggerWords, IComponent icon = null, string description = null, string background = null, string color = null, bool exclusive = false)
+            public SnapHandler(string snapId, string displayName, string[] triggerWords, IComponent icon = null, string description = null, string background = null, string color = null, bool exclusive = false, string exampleValue = null)
             {
                 if (string.IsNullOrEmpty(snapId)) throw new ArgumentException("snapId is required", nameof(snapId));
                 if (string.IsNullOrEmpty(displayName)) throw new ArgumentException("displayName is required", nameof(displayName));
@@ -322,6 +334,7 @@ namespace Tesserae
                 Background = background;
                 Color = color;
                 Exclusive = exclusive;
+                ExampleValue = exampleValue;
             }
         }
 
@@ -537,8 +550,10 @@ namespace Tesserae
         private readonly HTMLDivElement   _searchInputContainer;
         private readonly HTMLDivElement   _searchShortcutContainer;
         private readonly Button      _searchHistoryBtn;
+        private readonly Button      _searchHelpBtn;
         private readonly Button      _searchClearBtn;
         private readonly Button      _searchTriggerBtn;
+        private bool _helpShowHistory;
 
         private string[]      _shortcutKeys;
         private Action<Event> _globalShortcutHandler;
@@ -668,17 +683,21 @@ namespace Tesserae
                 _searchHistoryBtn = Button().SetIcon(UIcons.TimePast).Class("tss-omnibox-search-history-btn");
                 _searchHistoryBtn.Collapse(); // Hidden by default unless WithHistory is called
 
+                _searchHelpBtn = Button().SetIcon(UIcons.Interrogation).Class("tss-omnibox-search-help-btn");
+                _searchHelpBtn.Collapse(); // Hidden by default unless WithHelp is called
+
                 _searchClearBtn = Button().SetIcon(UIcons.CrossCircle).Class("tss-omnibox-search-clear-btn");
                 _searchTriggerBtn = Button().SetIcon(config.IconSearch).Class("tss-omnibox-search-btn");
 
                 if (_mode == Mode.Search)
                 {
-                    _searchContainer = Div(_("tss-omnibox-search-container"), _searchHistoryBtn.Render(), _searchInlineChipsContainer, _searchInputContainer, _searchRightTextContainer, _searchShortcutContainer, _searchClearBtn.Render(), _searchTriggerBtn.Render());
+                    _searchContainer = Div(_("tss-omnibox-search-container"), _searchHistoryBtn.Render(), _searchHelpBtn.Render(), _searchInlineChipsContainer, _searchInputContainer, _searchRightTextContainer, _searchShortcutContainer, _searchClearBtn.Render(), _searchTriggerBtn.Render());
                 }
                 else
                 {
                     _searchContainer = Div(_("tss-omnibox-search-container"), _searchInlineChipsContainer, _searchInputContainer, _searchRightTextContainer, _searchShortcutContainer);
                     _footer.appendChild(_searchHistoryBtn.Render());
+                    _footer.appendChild(_searchHelpBtn.Render());
                     footerEnd.Add(_searchClearBtn);
                     footerEnd.Add(_searchTriggerBtn);
                 }
@@ -935,12 +954,17 @@ namespace Tesserae
 
                 _searchTriggerBtn.OnClick(TriggerSearch);
 
-                _searchHistoryBtn.OnClickSpinWhile(async () => 
+                _searchHistoryBtn.OnClickSpinWhile(async () =>
                 {
                     if (_historyFetcher != null)
                     {
                         await ShowSearchHistory();
                     }
+                });
+
+                _searchHelpBtn.OnClickSpinWhile(async () =>
+                {
+                    await ShowSearchHelp();
                 });
 
                 // Initial parse
@@ -2422,6 +2446,174 @@ namespace Tesserae
             _historyFetcher = historyFetcher;
             _searchHistoryBtn.Show();
             return this;
+        }
+
+        /// <summary>
+        /// Enables a help button next to the search input that opens a popup listing the registered
+        /// filter snaps (and snaps), each with the trigger word and an example value (or the description as
+        /// a fallback). When <paramref name="showHistory"/> is <c>true</c> and a history fetcher has been
+        /// configured via <see cref="WithHistory(Func{Task{SearchQuery[]}})"/>, the same popup also includes
+        /// a "Recent" section with the latest search queries.
+        /// </summary>
+        public OmniBox WithHelp(bool showHistory = true)
+        {
+            if (_mode != Mode.Search && _mode != Mode.SearchAndChat)
+            {
+                throw new InvalidOperationException("WithHelp can only be called when OmniBox is in Search or SearchAndChat mode.");
+            }
+            _helpShowHistory = showHistory;
+            _searchHelpBtn.Show();
+            return this;
+        }
+
+        private async Task ShowSearchHelp()
+        {
+            var content = VStack().NoDefaultMargin().W(520).MaxHeight(500.px()).ScrollY().Class("tss-omnibox-help-panel");
+            Action hide = null;
+
+            var hasFilters = _filterSnapHandlers.Count > 0;
+            var hasSnaps = _snapHandlers.Count > 0;
+
+            if (hasFilters)
+            {
+                content.Add(TextBlock("ADD A FIELD FILTER").Small().SemiBold().Class("tss-omnibox-help-header"));
+                foreach (var f in _filterSnapHandlers)
+                {
+                    var captured = f;
+                    var trigger = (captured.TriggerWords != null && captured.TriggerWords.Length > 0) ? captured.TriggerWords[0] : captured.FilterId;
+                    var example = !string.IsNullOrEmpty(captured.ExampleValue)
+                        ? captured.ExampleValue
+                        : (captured.IsTimeRange ? "yyyy-MM-dd" : (string.IsNullOrEmpty(captured.Description) ? captured.DisplayName : captured.Description));
+
+                    var btn = Button().Class("tss-omnibox-help-entry").WS().NoPadding().NoMinSize().H(40).MB(4).NoBorder().NoBackground().TextLeft();
+                    var row = HStack().WS().AlignItems(ItemAlign.Center).PaddingLeft(12.px()).PaddingRight(12.px());
+                    if (captured.Icon != null) row.Add(captured.Icon.MR(8));
+                    var triggerSpan = TextBlock(trigger + ":").Class("tss-omnibox-help-trigger");
+                    row.Add(triggerSpan);
+                    row.Add(TextBlock(example).Class("tss-omnibox-help-example").ML(6));
+                    btn.ReplaceContent(row);
+                    btn.OnClick(() =>
+                    {
+                        InsertFilterTriggerIntoInput(trigger);
+                        hide?.Invoke();
+                    });
+                    content.Add(btn);
+                }
+            }
+
+            if (hasSnaps)
+            {
+                content.Add(TextBlock("ADD A SNAP").Small().SemiBold().Class("tss-omnibox-help-header"));
+                foreach (var s in _snapHandlers)
+                {
+                    var captured = s;
+                    var trigger = (captured.TriggerWords != null && captured.TriggerWords.Length > 0) ? captured.TriggerWords[0] : captured.SnapId;
+                    var example = !string.IsNullOrEmpty(captured.ExampleValue)
+                        ? captured.ExampleValue
+                        : (string.IsNullOrEmpty(captured.Description) ? captured.DisplayName : captured.Description);
+
+                    var btn = Button().Class("tss-omnibox-help-entry").WS().NoPadding().NoMinSize().H(40).MB(4).NoBorder().NoBackground().TextLeft();
+                    var row = HStack().WS().AlignItems(ItemAlign.Center).PaddingLeft(12.px()).PaddingRight(12.px());
+                    if (captured.Icon != null) row.Add(captured.Icon.MR(8));
+                    var triggerSpan = TextBlock("@" + trigger).Class("tss-omnibox-help-trigger");
+                    row.Add(triggerSpan);
+                    row.Add(TextBlock(example).Class("tss-omnibox-help-example").ML(6));
+                    btn.ReplaceContent(row);
+                    btn.OnClick(() =>
+                    {
+                        InsertSnapTriggerIntoInput(trigger);
+                        hide?.Invoke();
+                    });
+                    content.Add(btn);
+                }
+            }
+
+            if (_helpShowHistory && _historyFetcher != null)
+            {
+                SearchQuery[] history = Array.Empty<SearchQuery>();
+                try
+                {
+                    history = await _historyFetcher() ?? Array.Empty<SearchQuery>();
+                }
+                catch (Exception ex)
+                {
+                    console.error("Failed to fetch history for help: ", ex);
+                }
+
+                if (history.Length > 0)
+                {
+                    content.Add(TextBlock("RECENT").Small().SemiBold().Class("tss-omnibox-help-header"));
+                    foreach (var q in history)
+                    {
+                        var captured = q;
+                        var btn = Button(captured.RawQuery).Class("tss-omnibox-help-entry").SetIcon(UIcons.TimePast).WS().NoPadding().NoMinSize().H(32).MB(4).NoBorder().NoBackground().TextLeft();
+                        btn.OnClick(() =>
+                        {
+                            _searchInput.value = captured.RawQuery;
+                            OnSearchInputChanged();
+                            TriggerSearch();
+                            hide?.Invoke();
+                        });
+                        content.Add(btn);
+                    }
+                }
+            }
+
+            if (!hasFilters && !hasSnaps && !(_helpShowHistory && _historyFetcher != null))
+            {
+                content.Add(Message("Nothing to show", "Register snaps or filter snaps to populate the help panel").Icon(UIcons.EmptySet).H(160));
+            }
+
+            window.setTimeout(_ =>
+            {
+                Tippy.ShowFor(_searchHelpBtn, content, out hide, placement: TooltipPlacement.BottomStart, maxWidth: 560, delayHide: 500);
+            }, 1);
+        }
+
+        private void InsertFilterTriggerIntoInput(string trigger)
+        {
+            var insertion = trigger + ":";
+            var val = _searchInput.value ?? string.Empty;
+            string newVal;
+            int newCursor;
+            if (string.IsNullOrEmpty(val) || val.EndsWith(" ") || val.EndsWith(specialWhitespaceString))
+            {
+                newVal = val + insertion;
+                newCursor = newVal.Length;
+            }
+            else
+            {
+                newVal = val + " " + insertion;
+                newCursor = newVal.Length;
+            }
+            _searchInput.value = newVal;
+            _searchInput.setSelectionRange((uint)newCursor, (uint)newCursor);
+            OnSearchInputChanged();
+            _searchInput.focus();
+            TryUpdateFilterSnapSuggestions();
+        }
+
+        private void InsertSnapTriggerIntoInput(string trigger)
+        {
+            var insertion = "@" + trigger;
+            var val = _searchInput.value ?? string.Empty;
+            string newVal;
+            int newCursor;
+            if (string.IsNullOrEmpty(val) || val.EndsWith(" ") || val.EndsWith(specialWhitespaceString))
+            {
+                newVal = val + insertion;
+                newCursor = newVal.Length;
+            }
+            else
+            {
+                newVal = val + " " + insertion;
+                newCursor = newVal.Length;
+            }
+            _searchInput.value = newVal;
+            _searchInput.setSelectionRange((uint)newCursor, (uint)newCursor);
+            OnSearchInputChanged();
+            _searchInput.focus();
+            TryUpdateSnapSuggestions();
         }
 
         private async Task ShowSearchHistory()


### PR DESCRIPTION
## Summary
Adds a help panel feature to OmniBox that displays registered filter snaps and snaps with their trigger words and example values. The help panel can optionally include a "Recent" section showing previous search queries when history is enabled.

## Key Changes

- **New `ExampleValue` property** on both `FilterSnapHandler` and `SnapHandler` classes to store short example values (e.g., "person", "2025-01-01", "src/repo") displayed in the help panel
- **Updated constructors** for `FilterSnapHandler` and `SnapHandler` to accept optional `exampleValue` parameter
- **New `WithHelp()` method** on OmniBox to enable the help panel with optional history display
- **Help button UI** (`_searchHelpBtn`) added to the search container, positioned next to the history button
- **Help panel implementation** (`ShowSearchHelp()`) that:
  - Lists all registered filter snaps under "ADD A FIELD FILTER" section
  - Lists all registered snaps under "ADD A SNAP" section
  - Optionally includes a "RECENT" section with previous search queries
  - Shows example values or falls back to description/display name
  - Allows clicking entries to insert triggers into the search input
- **Helper methods** `InsertFilterTriggerIntoInput()` and `InsertSnapTriggerIntoInput()` to handle inserting triggers with proper spacing and cursor positioning
- **CSS styling** for the help panel, including styles for headers, entries, trigger words, and example text
- **Sample updates** demonstrating the new feature with example values for filters and snaps, plus history configuration

## Implementation Details

- Example values are optional; when not provided, the help panel falls back to the description or display name
- For time range filters, the default fallback is "yyyy-MM-dd"
- The help panel is displayed in a Tippy tooltip with a maximum width of 560px and scrollable content
- Help button is hidden by default and only shown when `WithHelp()` is called
- The feature respects the OmniBox mode and only works in Search or SearchAndChat modes

https://claude.ai/code/session_01FFWDpCh3R7Ggw4HLbJvhrE