### PR TITLE
Restrict CSS animations to transform/opacity and add interaction feedback

### DIFF
--- a/Tesserae/h5/assets/css/tss.annotatedtexteditor.css
+++ b/Tesserae/h5/assets/css/tss.annotatedtexteditor.css
@@ -8,7 +8,7 @@
     border-radius: var(--tss-border-radius-md);
     background: var(--tss-default-background-color);
     color: var(--tss-default-foreground-color);
-    transition: all 0.15s ease-in-out;
+    transition: opacity 0.15s ease-in-out, transform 0.15s ease-in-out;
     overflow: hidden;
 }
 

--- a/Tesserae/h5/assets/css/tss.button.css
+++ b/Tesserae/h5/assets/css/tss.button.css
@@ -35,7 +35,13 @@ a {
     justify-content: center;
     box-shadow: var(--tss-shadow-sm);
     font-weight: 500;
+    transition: transform 0.08s ease, opacity 0.15s ease-in-out;
 }
+
+    /* Click feedback: subtle press using transform only */
+    .tss-btn:not(.tss-disabled):active {
+        transform: scale(0.97);
+    }
 
     .tss-btn.tss-text-ellipsis,
     .tss-btn.tss-text-nowrap,
@@ -88,6 +94,8 @@ a {
     color: var(--tss-disabled-foreground-color);
     background-color: var(--tss-disabled-background-color);
     border-color: var(--tss-disabled-background-color);
+    /* Enabled -> disabled feedback animates through opacity (see .tss-btn transition) */
+    opacity: 0.7;
     pointer-events: none;
 }
 
@@ -482,7 +490,7 @@ a {
         }
 
 .tss-btn.tss-btn-filter-effects {
-    transition: filter 0.15s ease-in-out;
+    transition: transform 0.12s ease, opacity 0.15s ease-in-out;
 }
 
     .tss-btn.tss-btn-filter-effects:hover,
@@ -495,14 +503,14 @@ a {
     }
 
     .tss-btn.tss-btn-filter-effects:hover {
-        filter: brightness(1.1);
+        transform: scale(1.1);
     }
 
     .tss-btn.tss-btn-filter-effects:active {
-        filter: brightness(0.9);
+        transform: scale(0.92);
     }
 
     .tss-btn.tss-btn-filter-effects.tss-disabled {
-        filter: grayscale(1) opacity(0.5);
+        opacity: 0.5;
         pointer-events: none;
     }

--- a/Tesserae/h5/assets/css/tss.cardpivot.css
+++ b/Tesserae/h5/assets/css/tss.cardpivot.css
@@ -22,7 +22,6 @@
     border-right: 1px solid var(--tss-border-color);
     cursor: pointer;
     background: var(--tss-default-background-color);
-    transition: background-color 0.2s;
     border-bottom: 3px solid transparent;
     padding: 4px 12px;    
 }

--- a/Tesserae/h5/assets/css/tss.checkbox.css
+++ b/Tesserae/h5/assets/css/tss.checkbox.css
@@ -27,7 +27,12 @@
         border-radius: var(--tss-border-radius-sm);
         background-color: var(--tss-default-background-color);
         border: 1px solid var(--tss-default-foreground-color);
-        transition: all 0.15s ease-in-out;
+        transition: transform 0.15s ease-in-out;
+    }
+
+    /* Click feedback: press the checkbox mark in */
+    .tss-checkbox-container:not(.tss-disabled):active .tss-checkbox-mark {
+        transform: scale(0.9);
     }
 
     .tss-checkbox-container:hover input ~ .tss-checkbox-mark:after {

--- a/Tesserae/h5/assets/css/tss.choice.css
+++ b/Tesserae/h5/assets/css/tss.choice.css
@@ -36,6 +36,12 @@
         width: 18px;
         border-radius: 50%;
         border: 1px solid var(--tss-default-foreground-color);
+        transition: transform 0.12s ease;
+    }
+
+    /* Click feedback: press the option mark in */
+    .tss-option-container:not(.tss-disabled):active .tss-option-mark {
+        transform: scale(0.9);
     }
 
     .tss-option-container:hover input ~ .tss-option-mark:after {

--- a/Tesserae/h5/assets/css/tss.colorpalette.css
+++ b/Tesserae/h5/assets/css/tss.colorpalette.css
@@ -14,13 +14,18 @@
     cursor: pointer;
     border: 2px solid transparent;
     box-shadow: 0 0 0 1px rgba(0,0,0,0.15);
-    transition: transform 0.12s ease, box-shadow 0.12s ease;
+    transition: transform 0.12s ease;
     flex-shrink: 0;
 }
 
     .tss-colorpalette-swatch:hover {
         transform: scale(1.15);
         box-shadow: 0 0 0 2px var(--tss-primary-background-color);
+    }
+
+    /* Click feedback: press the swatch in */
+    .tss-colorpalette-swatch:active {
+        transform: scale(0.95);
     }
 
     .tss-colorpalette-swatch:focus-visible {

--- a/Tesserae/h5/assets/css/tss.common.css
+++ b/Tesserae/h5/assets/css/tss.common.css
@@ -566,13 +566,11 @@ i.tss-fontsize-tiny {
 
 @keyframes skeleton-glow {
     0% {
-        background: rgba(211, 216, 222, .2);
-        border-color: rgba(211, 216, 222, .2)
+        opacity: 1;
     }
 
     to {
-        background: rgba(95, 107, 124, .2);
-        border-color: rgba(95, 107, 124, .2)
+        opacity: 0.4;
     }
 }
 
@@ -617,15 +615,15 @@ i[class^="fi-"]:before, i[class*=" fi-"]:before, span[class^="fi-"]:before, span
 }
 
 .tss-filter-effects {
-    transition: filter 0.15s ease-in-out;
+    transition: transform 0.12s ease, opacity 0.15s ease;
 }
 
     .tss-filter-effects:hover {
-        filter: brightness(1.1);
+        transform: scale(1.1);
     }
 
     .tss-filter-effects:active {
-        filter: brightness(0.9);
+        transform: scale(0.92);
     }
 
     .tss-filter-effects.tss-disabled {

--- a/Tesserae/h5/assets/css/tss.cron.css
+++ b/Tesserae/h5/assets/css/tss.cron.css
@@ -10,7 +10,6 @@
 .tss-cron-desc {
     cursor: pointer;
     border-bottom: 1px dashed var(--tss-default-foreground-color);
-    transition: border-bottom 0.2s;
 }
 
     .tss-cron-desc:hover {

--- a/Tesserae/h5/assets/css/tss.markdown.css
+++ b/Tesserae/h5/assets/css/tss.markdown.css
@@ -49,10 +49,6 @@
         border-bottom: none;
     }
 
-    .tss-markdown table tbody tr {
-        transition: background-color 0.2s ease-in-out, color 0.2s ease-in-out;
-    }
-
         .tss-markdown table tbody tr:hover {
             background-color: var(--tss-default-background-hover-color);
             color: var(--tss-default-foreground-hover-color);

--- a/Tesserae/h5/assets/css/tss.mobile.css
+++ b/Tesserae/h5/assets/css/tss.mobile.css
@@ -45,7 +45,7 @@ body.tss-mobile .tss-navbar .tss-navbar-drawer {
     padding: 0 !important;
     overflow-y: auto !important;
     transform: translateX(-105%);
-    transition: transform 0.28s cubic-bezier(0.4, 0, 0.2, 1), box-shadow 0.28s ease;
+    transition: transform 0.28s cubic-bezier(0.4, 0, 0.2, 1);
     box-shadow: none;
     background: var(--tss-sidebar-background-color);
 }

--- a/Tesserae/h5/assets/css/tss.notificationcenter.css
+++ b/Tesserae/h5/assets/css/tss.notificationcenter.css
@@ -14,11 +14,16 @@
     border-radius: 50%;
     cursor: pointer;
     color: var(--tss-default-foreground-color);
-    transition: background 0.15s ease;
+    transition: transform 0.12s ease;
 }
 
     .tss-notif-bell:hover {
         background: var(--tss-secondary-background-color);
+    }
+
+    /* Click feedback: press the bell in */
+    .tss-notif-bell:active {
+        transform: scale(0.92);
     }
 
     .tss-notif-bell:focus-visible {

--- a/Tesserae/h5/assets/css/tss.omnibox.css
+++ b/Tesserae/h5/assets/css/tss.omnibox.css
@@ -12,7 +12,7 @@
     align-items: stretch;
     width: 100%;
     outline: transparent none medium;
-    transition: all 0.15s ease-in-out;
+    transition: opacity 0.15s ease-in-out, transform 0.15s ease-in-out;
 }
 
     .tss-omnibox-container.tss-omnibox-chat-and-search,
@@ -310,13 +310,6 @@
 .tss-omnibox-container.tss-omnibox-expanded.tss-omnibox-mode-search .tss-omnibox-search-container,
 .tss-omnibox-container.tss-omnibox-expanded.tss-omnibox-mode-chat .tss-omnibox-search-container {
     min-height: 160px;
-    transition: min-height 0.15s ease-in-out;
-}
-
-.tss-omnibox-container:not(.tss-omnibox-expanded) .tss-omnibox-chat-container,
-.tss-omnibox-container:not(.tss-omnibox-expanded).tss-omnibox-mode-search .tss-omnibox-search-container,
-.tss-omnibox-container:not(.tss-omnibox-expanded).tss-omnibox-mode-chat .tss-omnibox-search-container {
-    transition: min-height 0.15s ease-in-out;
 }
 .tss-omnibox-inline-chips {
     display: flex;
@@ -354,7 +347,6 @@
     border-radius: 50%;
     width: 16px;
     height: 16px;
-    transition: background-color 0.2s;
 }
 
 .tss-omnibox-inline-chip-close:hover {
@@ -431,7 +423,6 @@
     background: var(--tss-secondary-background-color);
     color: var(--tss-secondary-foreground-color);
     border-color: transparent;
-    transition: background-color 0.15s ease-in-out, color 0.15s ease-in-out;
 }
 
 .tss-btn.tss-omnibox-chat-btn:not(.tss-disabled):hover {

--- a/Tesserae/h5/assets/css/tss.pivot.css
+++ b/Tesserae/h5/assets/css/tss.pivot.css
@@ -101,15 +101,18 @@
     bottom: 0;
     left: 0;
     height: 4px;
-    width: 0px;
+    /* Base width of 1px is scaled horizontally via transform so the indicator
+       slides and resizes using only GPU-friendly transform animations. */
+    width: 1px;
+    transform: scaleX(0);
+    transform-origin: left center;
     z-index: 1;
     background-color: var(--tss-primary-background-hover-color);
     overflow: hidden;
     pointer-events: none;
     border-radius: 4px;
-    transition: left 0.5s cubic-bezier(0.2, 0, 0, 1),
-                width 0.5s cubic-bezier(0.2, 0, 0, 1);
-    will-change: left, width;
+    transition: transform 0.5s cubic-bezier(0.2, 0, 0, 1);
+    will-change: transform;
 }
 
 .tss-pivot-line.tss-pivot-line-instant {

--- a/Tesserae/h5/assets/css/tss.plan.css
+++ b/Tesserae/h5/assets/css/tss.plan.css
@@ -15,7 +15,6 @@
     position: relative;
     border: 1px solid var(--tss-default-border-color);
     border-radius: 6px;
-    transition: border-color 120ms ease-in-out;
 }
 
 /* Status accent on the card. The accent is applied as a left border so it
@@ -123,9 +122,13 @@
 
 .tss-plan-step-progress-bar {
     height: 100%;
-    width: 0%;
+    /* Full-width bar scaled horizontally to represent progress, so the fill
+       animates via transform instead of width. */
+    width: 100%;
+    transform: scaleX(0);
+    transform-origin: left center;
     background: var(--tss-primary-background-color);
-    transition: width 200ms ease-out;
+    transition: transform 200ms ease-out;
 }
 
 .tss-plan-step-progress.tss-plan-indeterminate .tss-plan-step-progress-bar {

--- a/Tesserae/h5/assets/css/tss.progressindicator.css
+++ b/Tesserae/h5/assets/css/tss.progressindicator.css
@@ -21,7 +21,6 @@
         position: absolute;
         width: 0px;
         min-width: 25%;
-        transition: width 0.3s ease 0s;
         background: linear-gradient(to right, var(--tss-progress-background-color) 0%, var(--tss-primary-background-color) 50%, var(--tss-progress-background-color) 100%);
         animation: 2.5s ease 0s infinite normal none running progressLeftToRight;
     }

--- a/Tesserae/h5/assets/css/tss.progressring.css
+++ b/Tesserae/h5/assets/css/tss.progressring.css
@@ -17,7 +17,6 @@
     .tss-progressring-fill {
         stroke: var(--tss-primary-background-color);
         stroke-linecap: round;
-        transition: stroke-dashoffset 0.3s ease;
     }
 
     .tss-progressring-label {

--- a/Tesserae/h5/assets/css/tss.questionnaire.css
+++ b/Tesserae/h5/assets/css/tss.questionnaire.css
@@ -34,7 +34,7 @@
     font-size: 13px;
     color: var(--tss-colors-neutral-800, #1f2937);
     cursor: pointer;
-    transition: background-color 120ms ease, border-color 120ms ease, color 120ms ease;
+    transition: opacity 120ms ease;
     font-family: inherit;
     line-height: 1.2;
 }

--- a/Tesserae/h5/assets/css/tss.rating.css
+++ b/Tesserae/h5/assets/css/tss.rating.css
@@ -10,7 +10,7 @@
     font-size: 24px;
     cursor: pointer;
     color: var(--tss-default-border-color);
-    transition: color 0.15s ease, transform 0.1s ease;
+    transition: transform 0.1s ease;
     user-select: none;
     line-height: 1;
 }
@@ -27,6 +27,11 @@
 
     .tss-rating-star.tss-rating-star-hover {
         transform: scale(1.15);
+    }
+
+    /* Click feedback: press the star in */
+    .tss-rating-star:active {
+        transform: scale(0.9);
     }
 
 .tss-rating-readonly .tss-rating-star {

--- a/Tesserae/h5/assets/css/tss.searchbox.css
+++ b/Tesserae/h5/assets/css/tss.searchbox.css
@@ -48,7 +48,7 @@
     width: 100%;
     outline: transparent none medium;
     padding: 0px 5px;
-    transition: all 0.15s ease-in-out;
+    transition: opacity 0.15s ease-in-out, transform 0.15s ease-in-out;
 }
 
     .tss-searchbox-container.tss-disabled {
@@ -92,7 +92,6 @@
     text-align: center;
     color: var(--tss-secondary-foreground-color);
     cursor: text;
-    transition: width 0.167s ease 0s;
     overflow: hidden;
 }
 
@@ -101,7 +100,6 @@
 }
 
 .tss-searchbox-padding {
-    transition: width 0.167s ease 0s;
     width: 0px;
     height: 16px;
 }

--- a/Tesserae/h5/assets/css/tss.segmentedpivot.css
+++ b/Tesserae/h5/assets/css/tss.segmentedpivot.css
@@ -25,7 +25,6 @@
     cursor: pointer;
     background: transparent;
     border-radius: var(--tss-border-radius-md);
-    transition: background-color 0.2s, box-shadow 0.2s, color 0.2s;
     font-size: var(--tss-font-size-smallplus);
     color: var(--tss-secondary-foreground-color);
     font-weight: 500;

--- a/Tesserae/h5/assets/css/tss.sidebar.css
+++ b/Tesserae/h5/assets/css/tss.sidebar.css
@@ -10,7 +10,6 @@
     -webkit-user-select: none;
     user-select: none;
     background: var(--tss-sidebar-background-color);
-    transition: 0.3s width ease-out;
 }
 
     .tss-sidebar .tss-default-component-margin {

--- a/Tesserae/h5/assets/css/tss.splitview.css
+++ b/Tesserae/h5/assets/css/tss.splitview.css
@@ -97,13 +97,12 @@
     height: 3px;
     background: var(--tss-default-border-color);
     cursor: s-resize;
-    transition: all 0.15s ease-in-out;
+    transform-origin: center;
+    transition: transform 0.15s ease-in-out;
 }
 
 .tss-splitview.tss-splitview-horizontal > .tss-splitter:hover:after {
-    left: calc(50% - 40px);
-    top: calc(50% - 1.5px);
-    width: 80px;
+    transform: scaleX(2);
     background: var(--tss-dark-border-color) !important;
 }
 
@@ -116,13 +115,12 @@
     width: 3px;
     background: var(--tss-default-border-color);
     cursor: e-resize;
-    transition: all 0.15s ease-in-out;
+    transform-origin: center;
+    transition: transform 0.15s ease-in-out;
 }
 
 .tss-splitview.tss-splitview-vertical > .tss-splitter:hover:after {
-    top: calc(50% - 40px);
-    left: calc(50% - 1.5px);
-    height: 80px;
+    transform: scaleY(2);
     background: var(--tss-dark-border-color) !important;
 }
 .tss-splitview-panel-style.tss-split-left > *:first-child {

--- a/Tesserae/h5/assets/css/tss.textbox.css
+++ b/Tesserae/h5/assets/css/tss.textbox.css
@@ -14,7 +14,7 @@
     width: 100%;
     outline: transparent none medium;
     padding: 0px 12px;
-    transition: all 0.15s ease-in-out;
+    transition: opacity 0.15s ease-in-out, transform 0.15s ease-in-out;
 }
 
 
@@ -121,10 +121,6 @@
 
 .tss-textblock table tbody tr:last-child td {
   border-bottom: none;
-}
-
-.tss-textblock table tbody tr {
-  transition: background-color 0.2s ease-in-out, color 0.2s ease-in-out;
 }
 
 .tss-textblock table tbody tr:hover {

--- a/Tesserae/h5/assets/css/tss.timehistogrampicker.css
+++ b/Tesserae/h5/assets/css/tss.timehistogrampicker.css
@@ -27,7 +27,7 @@
     border-radius: 3px 3px 0 0;
     background: var(--tss-slider-color);
     opacity: 0.65;
-    transition: background-color 80ms ease, opacity 80ms ease;
+    transition: opacity 80ms ease;
 }
 
 .tss-time-histogram-picker-bar.tss-selected {

--- a/Tesserae/h5/assets/css/tss.toast.css
+++ b/Tesserae/h5/assets/css/tss.toast.css
@@ -18,7 +18,7 @@
     pointer-events: all;
     opacity: 0.85;
     border-radius: 3px;
-    transition: all 0.3s ease-in-out;
+    transition: opacity 0.3s ease-in-out, transform 0.3s ease-in-out;
 }
 
 .tss-toast-container:hover {

--- a/Tesserae/src/Components/Pivot.cs
+++ b/Tesserae/src/Components/Pivot.cs
@@ -584,13 +584,14 @@ namespace Tesserae
 
             // offsetLeft/offsetWidth are relative to the titlebar, which is the line's
             // offsetParent (it's position: relative). This stays correct regardless of
-            // scroll position. CSS transitions on .tss-pivot-line interpolate width/left.
+            // scroll position. The line has a 1px base width and is positioned/sized via
+            // a single transform (translateX + scaleX) so the CSS transition only ever
+            // animates the GPU-friendly transform property.
             if (_firstRender)
             {
                 // Snap to position on first render so the line doesn't animate in from 0/0.
                 _line.classList.add("tss-pivot-line-instant");
-                _line.style.width = target.offsetWidth + "px";
-                _line.style.left  = target.offsetLeft + "px";
+                _line.style.transform = "translateX(" + target.offsetLeft + "px) scaleX(" + target.offsetWidth + ")";
                 // Read offsetWidth to flush the layout before re-enabling the transition.
                 var _flush = _line.offsetWidth;
                 _line.classList.remove("tss-pivot-line-instant");
@@ -598,8 +599,7 @@ namespace Tesserae
                 return;
             }
 
-            _line.style.width = target.offsetWidth + "px";
-            _line.style.left  = target.offsetLeft + "px";
+            _line.style.transform = "translateX(" + target.offsetLeft + "px) scaleX(" + target.offsetWidth + ")";
         }
 
         internal sealed class Tab

--- a/Tesserae/src/Components/Plan.cs
+++ b/Tesserae/src/Components/Plan.cs
@@ -696,11 +696,13 @@ namespace Tesserae
                 {
                     var p = PlanVisuals.ClampProgress(model.Progress.Value);
                     _progressEl.classList.remove("tss-plan-indeterminate");
-                    _progressBar.style.width = (p * 100f).ToString() + "%";
+                    _progressBar.style.transform = "scaleX(" + p.ToString() + ")";
                     _progressEl.style.display = "";
                 }
                 else if (model.Status == PlanStatus.Running)
                 {
+                    // Hand control of the transform to the indeterminate keyframes.
+                    _progressBar.style.transform = "";
                     _progressEl.classList.add("tss-plan-indeterminate");
                     _progressEl.style.display = "";
                 }


### PR DESCRIPTION
Deep review of every CSS animation in the toolkit so that only the
GPU-friendly transform and opacity properties are ever transitioned or
keyframed (per animations.dev / web.dev performance guidance). All
transitions on layout/paint properties (width, left, min-height,
background-color, border-color, color, box-shadow, filter,
stroke-dashoffset, "all") were replaced or removed.

Notable conversions that preserve the original motion via transform:
- Pivot underline indicator: now positioned/sized with translateX+scaleX
  on a 1px base instead of animating left/width (Pivot.cs + tss.pivot.css).
- Plan step progress bar: fill animates via scaleX instead of width
  (Plan.cs + tss.plan.css).
- SplitView grab handle: grows on hover via scaleX/scaleY instead of
  width/height/position.
- Skeleton glow keyframe: pulses opacity instead of background/border.

Removed (no transform/opacity equivalent): sidebar width, searchbox icon
width, omnibox min-height expand, progress-ring stroke-dashoffset, and
assorted background/color/border hover transitions (the hover end-states
remain, they simply apply instantly).

Added feedback using only transform/opacity for elements that warrant it:
- Click/press: buttons, checkbox, choice (radio), rating stars, color
  swatches, filter-effect buttons and the notification bell now scale
  down slightly on :active.
- Enabled->disabled: buttons and filter-effect buttons fade via opacity;
  questionnaire options animate their disabled/answered opacity.

https://claude.ai/code/session_01UUu7jmNF384LfAYB7YusTd