### PR TITLE
Plan: use UIcons for status glyphs (spinning on-center)

### DIFF
--- a/Tesserae/h5/assets/css/tss.plan.css
+++ b/Tesserae/h5/assets/css/tss.plan.css
@@ -192,7 +192,20 @@
     background: var(--tss-default-background-color);
     flex: 0 0 auto;
 }
-.tss-plan-step-icon svg { width: 18px; height: 18px; display: block; }
+/* UIcons status glyph. A fixed, glyph-centered square box is what lets the
+   running spinner rotate around its own center instead of orbiting: the box is
+   sized to the glyph, line-height is collapsed to 1 and the glyph is
+   flex-centered, so transform-origin (50% 50%) lands on the glyph's center. */
+.tss-plan-step-icon .tss-icon {
+    width: 18px;
+    height: 18px;
+    font-size: 18px;
+    line-height: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transform-origin: 50% 50%;
+}
 
 .is-pending   .tss-plan-step-icon { color: var(--tss-colors-neutral-400); }
 .is-running   .tss-plan-step-icon { color: var(--tss-primary-background-color); }
@@ -200,8 +213,9 @@
 .is-failed    .tss-plan-step-icon { color: var(--tss-danger-background-color); }
 .is-canceled  .tss-plan-step-icon { color: var(--tss-warning-background-color); }
 
-/* Spin in place: rotate the SVG around its own center (symmetric viewBox). */
-.is-running .tss-plan-step-icon svg { animation: tss-plan-spin 1.1s linear infinite; transform-origin: center; }
+/* Spin in place: rotate the glyph around its own center (the .tss-icon box
+   above is a glyph-centered square, so the pivot is the glyph center). */
+.is-running .tss-plan-step-icon .tss-icon { animation: tss-plan-spin 1.1s linear infinite; }
 @keyframes tss-plan-spin { to { transform: rotate(360deg); } }
 
 /* Step body. */
@@ -321,13 +335,22 @@
     justify-content: center;
     margin-top: 1px;
 }
-.tss-plan-substep-icon svg { width: 14px; height: 14px; display: block; }
+.tss-plan-substep-icon .tss-icon {
+    width: 14px;
+    height: 14px;
+    font-size: 14px;
+    line-height: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transform-origin: 50% 50%;
+}
 .tss-plan-substep.is-pending   .tss-plan-substep-icon { color: var(--tss-colors-neutral-400); }
 .tss-plan-substep.is-running   .tss-plan-substep-icon { color: var(--tss-primary-background-color); }
 .tss-plan-substep.is-completed .tss-plan-substep-icon { color: var(--tss-success-background-color); }
 .tss-plan-substep.is-failed    .tss-plan-substep-icon { color: var(--tss-danger-background-color); }
 .tss-plan-substep.is-canceled  .tss-plan-substep-icon { color: var(--tss-warning-background-color); }
-.tss-plan-substep.is-running .tss-plan-substep-icon svg { animation: tss-plan-spin 1.1s linear infinite; transform-origin: center; }
+.tss-plan-substep.is-running .tss-plan-substep-icon .tss-icon { animation: tss-plan-spin 1.1s linear infinite; }
 
 .tss-plan-substep-body { min-width: 0; }
 
@@ -446,8 +469,8 @@
 
 /* Respect reduced motion. */
 @media (prefers-reduced-motion: reduce) {
-    .is-running .tss-plan-step-icon svg,
-    .tss-plan-substep.is-running .tss-plan-substep-icon svg,
+    .is-running .tss-plan-step-icon .tss-icon,
+    .tss-plan-substep.is-running .tss-plan-substep-icon .tss-icon,
     .tss-plan-status-badge .tss-plan-badge-dot,
     .tss-plan-step-progress.is-indeterminate .tss-plan-step-progress-bar,
     .tss-plan-progress.is-indeterminate .tss-plan-progress-bar { animation: none !important; }

--- a/Tesserae/src/Components/Plan.cs
+++ b/Tesserae/src/Components/Plan.cs
@@ -109,55 +109,46 @@ namespace Tesserae
 
         // ---- Status glyphs ------------------------------------------------
         //
-        // These five glyphs are from Lucide (https://lucide.dev, ISC license)
-        // and are deliberately kept as inline SVG — instead of the font-based
-        // `UIcons` set used everywhere else in the toolkit — to match the exact
-        // design of the Plan component. Do not swap them for UIcons unless the
-        // design itself changes; they were chosen for two concrete reasons:
-        //   * each glyph is stroked with `currentColor`, so it inherits the
-        //     per-status accent color straight from the `.is-*` CSS rules
-        //     (see tss.plan.css), and
-        //   * the symmetric 24x24 viewBox lets the running glyph spin around
-        //     its own center (a font glyph would orbit off-center instead).
+        // Status glyphs come from the bundled UIcons font set — the same icon
+        // set used across the rest of the toolkit — so they inherit `color`
+        // from the per-status `.is-*` CSS rules like any other icon, and there
+        // is no inline SVG in the component.
         //
-        // The markup lives in the named constants below so the raw SVG no
-        // longer sits inline in the rendering logic; StatusSvg just wraps the
-        // selected glyph in the shared <svg> envelope.
-
-        // Lucide "loader-circle" — Running (spins in place via CSS).
-        private const string GlyphRunning   = "<path d=\"M21 12a9 9 0 1 1-6.219-8.56\"/>";
-        // Lucide "circle-check" — Completed.
-        private const string GlyphCompleted = "<circle cx=\"12\" cy=\"12\" r=\"10\"/><path d=\"m9 12 2 2 4-4\"/>";
-        // Lucide "circle-x" — Failed.
-        private const string GlyphFailed    = "<circle cx=\"12\" cy=\"12\" r=\"10\"/><path d=\"m15 9-6 6\"/><path d=\"m9 9 6 6\"/>";
-        // Lucide "ban" — Canceled.
-        private const string GlyphCanceled  = "<circle cx=\"12\" cy=\"12\" r=\"10\"/><path d=\"m4.9 4.9 14.2 14.2\"/>";
-        // Lucide "circle" — Pending (default).
-        private const string GlyphPending   = "<circle cx=\"12\" cy=\"12\" r=\"10\"/>";
-
-        // Shared <svg> envelope. `fill=none` + `stroke=currentColor` is what
-        // lets the glyphs above pick up the per-status color from CSS.
-        private const string SvgPrefix =
-            "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" " +
-            "stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\">";
-        private const string SvgSuffix = "</svg>";
-
-        /// <summary>
-        /// Returns the inline-SVG status glyph for <paramref name="status"/>.
-        /// See the note above on why these are inline SVG rather than UIcons.
-        /// </summary>
-        public static string StatusSvg(PlanStatus status)
+        // The Running glyph is a spinner rotated by CSS. For a font glyph to
+        // spin *in place* instead of orbiting off-center, the icon element must
+        // be a glyph-centered square with `transform-origin: 50% 50%`; the
+        // `.tss-plan-step-icon .tss-icon` rules in tss.plan.css pin it to a
+        // fixed size, collapse line-height to 1 and flex-center the glyph so the
+        // rotation pivot sits exactly on the glyph's center.
+        public static UIcons StatusIcon(PlanStatus status)
         {
-            string inner;
             switch (status)
             {
-                case PlanStatus.Running:   inner = GlyphRunning;   break;
-                case PlanStatus.Completed: inner = GlyphCompleted; break;
-                case PlanStatus.Failed:    inner = GlyphFailed;    break;
-                case PlanStatus.Canceled:  inner = GlyphCanceled;  break;
-                default:                   inner = GlyphPending;    break;
+                case PlanStatus.Running:   return UIcons.Spinner;     // rotated via CSS
+                case PlanStatus.Completed: return UIcons.CheckCircle;
+                case PlanStatus.Failed:    return UIcons.CrossCircle;
+                case PlanStatus.Canceled:  return UIcons.Ban;
+                default:                   return UIcons.Circle;      // Pending
             }
-            return SvgPrefix + inner + SvgSuffix;
+        }
+
+        /// <summary>
+        /// Creates the status-glyph element (a UIcons <c>&lt;i&gt;</c>) for
+        /// <paramref name="status"/>.
+        /// </summary>
+        public static HTMLElement CreateStatusIcon(PlanStatus status)
+        {
+            return I(_("tss-icon " + StatusIcon(status)));
+        }
+
+        /// <summary>
+        /// Points an existing status-glyph element at the glyph for
+        /// <paramref name="status"/>. Only the icon class changes, so a running
+        /// spinner's CSS animation is not restarted when unrelated fields update.
+        /// </summary>
+        public static void SetStatusIcon(HTMLElement iconEl, PlanStatus status)
+        {
+            iconEl.className = "tss-icon " + StatusIcon(status);
         }
 
         public static string StatusText(PlanStatus status)
@@ -692,6 +683,7 @@ namespace Tesserae
         {
             private readonly HTMLElement _root;
             private readonly HTMLElement _iconSlot;
+            private readonly HTMLElement _statusIcon;
             private readonly HTMLElement _textEl;
             private readonly HTMLElement _stageEl;
             private readonly HTMLElement _toggleEl;
@@ -741,9 +733,10 @@ namespace Tesserae
                 Key = key;
                 _status = status;
 
-                // Rail / status node (Lucide SVG glyph; spins in place when running).
-                _iconSlot = Div(_("tss-plan-step-icon"));
-                _iconSlot.innerHTML = PlanVisuals.StatusSvg(status);
+                // Rail / status node (UIcons glyph; the spinner spins in place
+                // when running — see the centering note in PlanVisuals).
+                _statusIcon = PlanVisuals.CreateStatusIcon(status);
+                _iconSlot = Div(_("tss-plan-step-icon"), _statusIcon);
                 var rail = Div(_("tss-plan-step-rail"), _iconSlot);
 
                 // Title row (text + expand/collapse chevron).
@@ -830,12 +823,12 @@ namespace Tesserae
 
             private void ApplyStatus(PlanStatus status)
             {
-                // Only re-render the SVG when the status actually changes, so the
-                // running glyph's spin animation isn't restarted on every update.
+                // Only swap the glyph when the status actually changes, so the
+                // running spinner's animation isn't restarted on every update.
                 // Color + spin come from the parent `.is-*` class via CSS.
                 if (status != _status)
                 {
-                    _iconSlot.innerHTML = PlanVisuals.StatusSvg(status);
+                    PlanVisuals.SetStatusIcon(_statusIcon, status);
                 }
                 _status = status;
                 PlanVisuals.RemoveStepStatusClasses(_root);
@@ -915,14 +908,15 @@ namespace Tesserae
                 var titleEl = (HTMLElement)body.childNodes[0];
                 var msgEl = (HTMLElement)body.childNodes[1];
 
-                // Status class + SVG glyph (color/size via CSS). Only re-render
-                // when the status changes so a running glyph's spin isn't reset.
+                // Status class + UIcons glyph (color/size via CSS). Only swap
+                // when the status changes so a running spinner isn't reset.
                 var statusName = sub.Status.ToString();
                 if (root.dataset["pstatus"].As<string>() != statusName)
                 {
                     PlanVisuals.RemoveStepStatusClasses(root);
                     root.classList.add(PlanVisuals.StepStatusClass(sub.Status));
-                    iconWrap.innerHTML = PlanVisuals.StatusSvg(sub.Status);
+                    PlanVisuals.ClearChildren(iconWrap);
+                    iconWrap.appendChild(PlanVisuals.CreateStatusIcon(sub.Status));
                     root.dataset["pstatus"] = statusName;
                 }
 


### PR DESCRIPTION
## What

An **alternative** to the inline-SVG status glyphs in the Plan component: this swaps them for the bundled **UIcons** font set, so the component carries no raw SVG and the glyphs inherit `color` from the existing per-status `.is-*` rules like every other icon in the toolkit.

This is meant to be compared against the SVG approach on `claude/peaceful-hopper-6ox93u` — hence the PR is based on that branch, so the diff is just the icon swap (not the whole Plan redesign). Happy to retarget at `master` if preferred.

### Glyph mapping
| Status | UIcons |
|---|---|
| Running | `Spinner` (rotates) |
| Completed | `CheckCircle` |
| Failed | `CrossCircle` |
| Canceled | `Ban` |
| Pending | `Circle` |

## Spinning on-center (the important bit)

Rotating a font `<i>` naively makes it orbit off-center (line-height / inline-box metrics put the rotation pivot off the glyph). The fix: the icon element is pinned to a **glyph-sized square box**, `line-height` collapsed to **1**, the glyph **flex-centered**, and `transform-origin: 50% 50%`.

I verified the one geometric assumption this relies on — that the glyphs are centered in their em — by reading `uicons-regular-rounded.woff2` directly (em = 300 units):

- `check-circle`, `cross-circle`, `ban`, `circle`: ink center exactly **(150, 150)** — dead center.
- `spinner` (the only one that rotates): ink center **(142.8, 150.1)** — vertically perfect, horizontally **2.4% of em (~0.43px at 18px)** left of center, i.e. a sub-pixel orbit that isn't visible.

So the spinner rotates on its own center. `Spinner` is also the same glyph the Tree component already spins.

## Verification
- `dotnet build` clean (0 warnings / 0 errors), including the h5 C#→JS pass.
- Compiled `tss.css` contains the new centered-spin rules; no stale `…-icon svg` selectors remain.
- All five `fi-rr-*` status classes present in the emitted JS.
- Could not run a live browser here (the environment's network policy blocks the Playwright Chromium download), so centering was confirmed from the font geometry above rather than from pixels — worth a quick eyeball in a real browser.


---
_Generated by [Claude Code](https://claude.ai/code/session_0192514TNSEcH5N4nSsc3iHj)_