### PR TITLE
ToolCall: only render the open state when there is content; tighten chat density

### DIFF
--- a/Tesserae.Tests/src/Samples/Components/ToolCallSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/ToolCallSample.cs
@@ -15,7 +15,7 @@ namespace Tesserae.Tests.Samples
                 .SampleTitle(typeof(ToolCallSample), UIcons.Tools, "Inline tool-call indicators and a multi-tool summary popup")
                 .FlatSection(Stack().Children(
                     Card(VStack().WS().Children(
-                        TextBlock("ToolCall renders a single tool invocation inline. It behaves like an accordion: a compact header with an icon and label, expanding to reveal arbitrary content the first time it is clicked (the content component is created lazily)."),
+                        TextBlock("ToolCall renders a single tool invocation inline. It behaves like an accordion: a compact header with an icon and label, expanding to reveal arbitrary content the first time it is clicked (the content component is created lazily). A ToolCall without content automatically renders as a plain, non-expandable chip — no chevron is shown until content is set."),
                         TextBlock("ToolsUsed groups many ToolCalls behind a compact summary. Clicking it opens a popup with the list of tools on the left; selecting one slides to the detail view on the right, with a back button to return to the list.")
                     )).SetTitle("Overview")))
                 .FlatSection(Stack().Children(
@@ -25,7 +25,7 @@ namespace Tesserae.Tests.Samples
                         ToolCall(UIcons.Terminal, "Bash ls -la && git status", () => TextBlock("total 16\ndrwxr-xr-x  3 user user 4096 Jan 1 12:00 .\n\nOn branch main\nnothing to commit, working tree clean").BreakSpaces()),
                         ToolCall(UIcons.Eye, "Read /home/user/project/README.md", () => TextBlock("# My Project\n\nA sample project demonstrating the ToolCall component.\n\n## Usage\n\n...").BreakSpaces()).Expanded(),
                         ToolCall(UIcons.Search, "Grep \"useEffect\" src/", () => TextBlock("src/App.tsx:5: import { useEffect } from 'react';\nsrc/hooks/useData.ts:1: import { useEffect, useState } from 'react';").BreakSpaces()),
-                        ToolCall(UIcons.ListCheck, "Update todos").NotExpandable(),
+                        ToolCall(UIcons.ListCheck, "Update todos"), // no content -> renders non-expandable automatically
 
                         SampleSubTitle("ToolsUsed summary popup"),
                         TextBlock("When an AI uses many tools, surface a compact summary that opens a list/detail popup, similar to a master-detail navigation on mobile."),

--- a/Tesserae/h5/assets/css/tss.chat.css
+++ b/Tesserae/h5/assets/css/tss.chat.css
@@ -3,7 +3,7 @@
     flex-direction: column;
     overflow-y: auto;
     overflow-x: hidden;
-    padding: 24px;
+    padding: 16px;
     box-sizing: border-box;
     background-color: var(--tss-secondary-background-color);
     width:100%;
@@ -12,19 +12,19 @@
 .tss-chatmessage-container {
     display: flex;
     align-items: flex-start;
-    margin-bottom: 24px;
+    margin-bottom: 12px;
     width: 100%;
 }
 
 .tss-chatmessage-avatar {
     flex-shrink: 0;
-    margin-right: 16px;
-    margin-left: 16px;
-    margin-top: 4px;
+    margin-right: 8px;
+    margin-left: 8px;
+    margin-top: 2px;
 }
 
 .tss-chatmessage-bubble {
-    padding: 4px 0;
+    padding: 2px 0;
     border-radius: 0;
     background-color: transparent;
     color: var(--tss-colors-neutral-900);
@@ -32,19 +32,19 @@
     word-break: break-word;
     display: flex;
     flex-direction: column;
-    font-size: 16px;
+    font-size: 14px;
 }
 
 .tss-chatmessage-content {
-    line-height: 1.6;
+    line-height: 1.5;
 }
 
 .tss-chatmessage-references {
     display: flex;
     flex-wrap: wrap;
     gap: 4px;
-    margin-top: 12px;
-    padding-top: 12px;
+    margin-top: 8px;
+    padding-top: 8px;
     border-top: 1px solid var(--tss-colors-neutral-200);
 }
 
@@ -72,8 +72,8 @@
 .tss-chat-right .tss-chatmessage-bubble {
     background-color: var(--tss-colors-neutral-100);
     color: var(--tss-colors-neutral-900);
-    padding: 12px 16px;
-    border-radius: 24px;
+    padding: 8px 14px;
+    border-radius: 18px;
     border-bottom-right-radius: 4px; /* Subtle tail effect */
 }
 

--- a/Tesserae/h5/assets/css/tss.toolcall.css
+++ b/Tesserae/h5/assets/css/tss.toolcall.css
@@ -14,8 +14,8 @@
 .tss-toolcall-header {
     display: flex;
     align-items: center;
-    gap: 10px;
-    padding: 6px 10px;
+    gap: 8px;
+    padding: 4px 8px;
     cursor: pointer;
     user-select: none;
     font-size: 13px;
@@ -38,13 +38,13 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 22px;
-    height: 22px;
-    border-radius: 6px;
+    width: 18px;
+    height: 18px;
+    border-radius: 5px;
     background: var(--tss-colors-neutral-100, #f3f4f6);
     color: var(--tss-colors-neutral-700, #374151);
     flex-shrink: 0;
-    font-size: 13px;
+    font-size: 12px;
 }
 
 .tss-toolcall-text {
@@ -69,7 +69,7 @@
 
 .tss-toolcall-content {
     border-top: 1px solid var(--tss-default-border-color);
-    padding: 10px 12px;
+    padding: 8px 10px;
     background: var(--tss-default-background-color);
 }
 

--- a/Tesserae/src/Components/ToolCall.cs
+++ b/Tesserae/src/Components/ToolCall.cs
@@ -49,8 +49,10 @@ namespace Tesserae
 
             _header.addEventListener("click", _ =>
             {
-                if (_expandable) Toggle();
+                if (CanExpand) Toggle();
             });
+
+            UpdateExpandableUI();
         }
 
         /// <summary>
@@ -78,6 +80,10 @@ namespace Tesserae
         /// </summary>
         public bool    HasContent      => _contentFactory != null;
 
+        // The expand affordance (chevron + clickable header) is only rendered when there is
+        // actually something to show — a tool call without content stays a plain chip.
+        private bool   CanExpand       => _expandable && _contentFactory != null;
+
         /// <summary>
         /// Returns a fresh IComponent built from the content factory, or null
         /// if no factory was provided. Used by <see cref="ToolsUsed"/> to
@@ -96,6 +102,7 @@ namespace Tesserae
             _contentFactory  = contentFactory;
             _renderedContent = null;
             ClearChildren(_content);
+            UpdateExpandableUI();
             if (_isExpanded)
             {
                 EnsureContentRendered();
@@ -138,8 +145,7 @@ namespace Tesserae
         public ToolCall NotExpandable()
         {
             _expandable = false;
-            _chevron.style.display = "none";
-            _header.classList.add("tss-toolcall-not-expandable");
+            UpdateExpandableUI();
             return this;
         }
 
@@ -158,7 +164,7 @@ namespace Tesserae
         /// </summary>
         public ToolCall Expand()
         {
-            if (_isExpanded || !_expandable) return this;
+            if (_isExpanded || !CanExpand) return this;
             _isExpanded = true;
             EnsureContentRendered();
             UpdateExpandedState();
@@ -212,6 +218,14 @@ namespace Tesserae
             InnerElement.UpdateClassIf(_isExpanded, "tss-expanded");
             _content.style.display = _isExpanded ? "block" : "none";
             _header.setAttribute("aria-expanded", _isExpanded ? "true" : "false");
+        }
+
+        private void UpdateExpandableUI()
+        {
+            var canExpand = CanExpand;
+            _chevron.style.display = canExpand ? "" : "none";
+            _header.UpdateClassIf(!canExpand, "tss-toolcall-not-expandable");
+            if (!canExpand && _isExpanded) Collapse();
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

- **`ToolCall` only offers the expandable "open" state when it actually has content.** A `ToolCall` built without a content factory now renders as a plain chip: the chevron is hidden, the header is not clickable, and `Expand()` is a no-op. Setting content later (via `SetContent`) restores the expand affordance. `NotExpandable()` keeps working as an explicit override.
- **Information-density pass on the chat primitives:**
  - `tss.chat.css`: chat-area padding 24→16px, message spacing 24→12px, bubble font 16→14px, line-height 1.6→1.5, tighter avatar gutters and user-bubble padding/radius.
  - `tss.toolcall.css`: tighter header/icon/content paddings.
- Updated the `ToolCall` sample to document the automatic non-expandable behavior for content-less tool calls.

Companion PR in mosaik: the ChatView / Admin Assistant chat consume these primitives and mirror the density changes as scoped CSS overrides until the next package bump.

## Testing

- `dotnet build` (h5 compile) succeeds with 0 warnings / 0 errors.

https://claude.ai/code/session_01GZpSx7FttCCfjCHvigZs5X

---
_Generated by [Claude Code](https://claude.ai/code/session_01GZpSx7FttCCfjCHvigZs5X)_