### PR TITLE
Add Diagram component for rendering flow charts

### DIFF
--- a/Tesserae.Tests/src/Samples/Components/DiagramSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/DiagramSample.cs
@@ -1,0 +1,74 @@
+using static H5.Core.dom;
+using static Tesserae.UI;
+using static Tesserae.Tests.Samples.SamplesHelper;
+
+namespace Tesserae.Tests.Samples
+{
+    [SampleDetails(Group = "Components", Order = 207, Icon = UIcons.Workflow)]
+    public class DiagramSample : IComponent, ISample
+    {
+        private readonly IComponent _content;
+
+        public DiagramSample()
+        {
+            // Basic example - mirrors a "connected bindings" style view
+            var basicSource  = DiagramNode("llm-prices").SetIcon(UIcons.Database);
+            var basicBinding = DiagramNode("Binding").SetIcon(UIcons.Plus).Primary();
+
+            var basicDiagram = Diagram().Connect(basicSource, basicBinding).WS().H(300.px());
+
+            // Pipeline example - auto-layout from connectivity, mixed styles, icon-only circle nodes
+            var source    = DiagramNode("Source").SetIcon(UIcons.CloudDownloadAlt);
+            var parse     = DiagramNode("Parse").SetIcon(UIcons.FileCode).Secondary();
+            var enrich    = DiagramNode("Enrich").SetIcon(UIcons.Sparkles).Primary();
+            var index     = DiagramNode("Search Index").SetIcon(UIcons.Search).Success();
+            var graph     = DiagramNode("Graph").SetIcon(UIcons.ChartNetwork).Danger();
+            var iconOnly  = DiagramNode().SetIcon(UIcons.Bolt, color: "white").Color("linear-gradient(135deg, #6a11cb, #2575fc)", "white", "transparent");
+            var custom    = DiagramNode("Custom Colors").SetIcon(UIcons.Palette, color: "#7c4700").Color("#ffd9a1", "#7c4700", "#e0a96d");
+
+            var pipeline = Diagram()
+               .Connect(source, parse)
+               .Connect(parse, enrich)
+               .Connect(enrich, index)
+               .Connect(enrich, graph)
+               .Connect(iconOnly, parse)
+               .Connect(graph, custom)
+               .WS().H(420.px());
+
+            // Events example
+            var clickable = DiagramNode("Click Me").SetIcon(UIcons.CursorFinger).Primary()
+               .OnClick(() => Toast().Success("Node clicked!"))
+               .OnContextMenu(() => Toast().Information("Node context menu!"));
+
+            var pinned = DiagramNode("Pinned at (260, 40)").SetIcon(UIcons.Thumbtack).At(260, 40);
+
+            var eventsDiagram = Diagram().Connect(clickable, pinned).WS().H(280.px());
+
+            _content = SectionStack().Secondary()
+               .SampleTitle(typeof(DiagramSample), UIcons.Workflow, "A flow-chart surface with draggable nodes and auto-computed arrows")
+               .FlatSection(Stack().Children(
+                    Card(VStack().WS().Children(
+                        TextBlock("Diagram renders a flow chart on top of a pannable, dotted-grid background. Nodes are pill-shaped components with an optional icon (or image) and text, supporting the usual button tones (default, primary, secondary, success, danger) as well as arbitrary foreground and background colors. Arrows between connected nodes are computed automatically and drawn on a background canvas that follows panning, node dragging and container resizing (via a resize observer)."),
+                        TextBlock("Node positions are computed automatically from the node sizes and connectivity (nodes are arranged in layers following the arrows). Dragging a node, or positioning it explicitly with At(x, y), pins it so the automatic layout no longer moves it. Call AutoArrange() to reset all nodes back to the computed layout."))).SetTitle("Overview")))
+               .FlatSection(Stack().Children(
+                    Card(VStack().WS().Children(
+                        SampleDo("Use Connect(from, to) to declare the flow - nodes are added automatically and arrows follow the connection direction."),
+                        SampleDo("Use icon-only nodes (no text) for compact junction points - they render as circles."),
+                        SampleDont("Don't use a Diagram for static two-axis layouts - use Grid instead."))).SetTitle("Best Practices")))
+               .FlatSection(Stack().Children(
+                    Card(VStack().WS().Children(
+                        SampleSubTitle("Basic"),
+                        TextBlock("Two connected nodes. Drag the background to pan, drag the nodes to reposition them."),
+                        basicDiagram,
+                        SampleSubTitle("Auto-layout, styles and colors"),
+                        TextBlock("Nodes are positioned automatically based on their sizes and connectivity. Icon-only nodes render as circles."),
+                        pipeline,
+                        SampleSubTitle("Events and pinned positions"),
+                        TextBlock("Click the left node, or right-click it for the context menu event. The right node was pinned with At(x, y). Clicks are not raised after dragging a node."),
+                        eventsDiagram
+                    )).SetTitle("Usage")));
+        }
+
+        public HTMLElement Render() => _content.Render();
+    }
+}

--- a/Tesserae/h5.json
+++ b/Tesserae/h5.json
@@ -156,6 +156,7 @@
                 "h5/assets/css/tss.message.css",
                 "h5/assets/css/tss.tree.css",
                 "h5/assets/css/tss.taskboard.css",
+                "h5/assets/css/tss.diagram.css",
                 "h5/assets/css/tss.uptime.css",
                 "h5/assets/css/baklava.css",
                 "h5/assets/css/tss.chat.css",

--- a/Tesserae/h5/assets/css/tss.diagram.css
+++ b/Tesserae/h5/assets/css/tss.diagram.css
@@ -1,0 +1,124 @@
+/* Diagram */
+
+.tss-diagram {
+    --tss-diagram-dot-color: var(--tss-default-border-color);
+    --tss-diagram-line-color: var(--tss-default-border-color);
+    position: relative;
+    overflow: hidden;
+    width: 100%;
+    height: 100%;
+    min-height: 200px;
+    border: 1px solid var(--tss-default-border-color);
+    border-radius: var(--tss-border-radius-md);
+    background-color: var(--tss-default-background-color);
+    background-image: radial-gradient(circle, var(--tss-diagram-dot-color) 1px, transparent 1.5px);
+    background-size: 24px 24px;
+    cursor: grab;
+    -webkit-user-select: none;
+    user-select: none;
+}
+
+    .tss-diagram.tss-diagram-no-dots {
+        background-image: none;
+    }
+
+    .tss-diagram.tss-diagram-no-pan {
+        cursor: default;
+    }
+
+    .tss-diagram.tss-diagram-panning {
+        cursor: grabbing;
+    }
+
+.tss-diagram-canvas {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+}
+
+.tss-diagram-nodes {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 0;
+    height: 0;
+    overflow: visible;
+}
+
+.tss-diagram-node {
+    position: absolute;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    white-space: nowrap;
+    min-height: 36px;
+    padding: 0px 16px;
+    border: 1px solid var(--tss-default-border-color);
+    border-radius: 9999px;
+    font-weight: 500;
+    box-shadow: var(--tss-shadow-sm);
+    cursor: grab;
+    -webkit-user-select: none;
+    user-select: none;
+}
+
+    .tss-diagram-node.tss-diagram-node-dragging {
+        cursor: grabbing;
+        box-shadow: var(--tss-shadow-hover);
+        z-index: 1;
+    }
+
+    .tss-diagram-node:hover {
+        box-shadow: var(--tss-shadow-hover);
+    }
+
+    .tss-diagram-node.tss-diagram-node-icon-only {
+        aspect-ratio: 1;
+        border-radius: 50%;
+        padding: 0px 10px;
+    }
+
+    .tss-diagram-node .tss-diagram-node-icon + .tss-diagram-node-text:not(:empty),
+    .tss-diagram-node .tss-diagram-node-image + .tss-diagram-node-text:not(:empty) {
+        margin-left: 8px;
+    }
+
+    .tss-diagram-node .tss-diagram-node-image {
+        width: 20px;
+        height: 20px;
+        border-radius: 50%;
+        object-fit: cover;
+    }
+
+.tss-diagram-node-default {
+    color: var(--tss-default-foreground-color);
+    background-color: var(--tss-default-background-color);
+    border-color: var(--tss-default-border-color);
+}
+
+.tss-diagram-node-primary {
+    color: var(--tss-primary-foreground-color);
+    background-color: var(--tss-primary-background-color);
+    border-color: var(--tss-primary-border-color);
+}
+
+.tss-diagram-node-secondary {
+    color: var(--tss-secondary-foreground-color);
+    background-color: var(--tss-secondary-background-color);
+    border-color: var(--tss-default-border-color);
+}
+
+.tss-diagram-node-success {
+    color: var(--tss-success-foreground-color);
+    background-color: var(--tss-success-background-color);
+    border-color: var(--tss-success-border-color);
+}
+
+.tss-diagram-node-danger {
+    color: var(--tss-danger-foreground-color);
+    background-color: var(--tss-danger-background-color);
+    border-color: var(--tss-danger-border-color);
+}

--- a/Tesserae/src/Base/UI.Components.cs
+++ b/Tesserae/src/Base/UI.Components.cs
@@ -1079,6 +1079,16 @@ namespace Tesserae
         /// Creates a <see cref="Tesserae.NodeView"/> component.
         /// </summary>
         public static NodeView NodeView(Action<NodeView.IViewSettings> settings = null)                            => new NodeView(settings);
+
+        /// <summary>
+        /// Creates a <see cref="Tesserae.Diagram"/> component (a flow-chart surface with draggable nodes and auto-computed arrows).
+        /// </summary>
+        public static Diagram Diagram() => new Diagram();
+
+        /// <summary>
+        /// Creates a <see cref="Tesserae.Diagram.Node"/> component to be added to a <see cref="Tesserae.Diagram"/>.
+        /// </summary>
+        public static Diagram.Node DiagramNode(string text = "") => new Diagram.Node(text);
         /// <summary>
         /// Creates a <see cref="Tesserae.Dropdown"/> component.
         /// </summary>

--- a/Tesserae/src/Components/Diagram.Node.cs
+++ b/Tesserae/src/Components/Diagram.Node.cs
@@ -1,0 +1,353 @@
+using System;
+using static H5.Core.dom;
+using static Tesserae.UI;
+
+namespace Tesserae
+{
+    public partial class Diagram
+    {
+        /// <summary>
+        /// A single node within a <see cref="Diagram"/>, rendered as a pill with an optional icon (or image) and text.
+        /// Supports the button-like tonal styles (default, primary, secondary, success, danger), arbitrary
+        /// foreground/background colors, dragging, and click / context-menu events. Icon-only nodes render as circles.
+        /// </summary>
+        [H5.Name("tss.DiagramNode")]
+        public class Node : IComponent, IHasBackgroundColor, IHasForegroundColor
+        {
+            private static readonly string[] _styleClasses = new[] { "tss-diagram-node-default", "tss-diagram-node-primary", "tss-diagram-node-secondary", "tss-diagram-node-success", "tss-diagram-node-danger" };
+
+            private readonly HTMLElement     _element;
+            private readonly HTMLSpanElement _textSpan;
+            private          HTMLElement     _iconElement;
+            private          Diagram         _owner;
+            private          bool            _suppressClick;
+
+            private event ComponentEventHandler<Node, MouseEvent> Clicked;
+            private event ComponentEventHandler<Node, MouseEvent> ContextMenu;
+
+            internal double X;
+            internal double Y;
+            internal double MeasuredWidth;
+            internal double MeasuredHeight;
+
+            /// <summary>
+            /// True after the node is positioned explicitly (via <see cref="At"/>) or dragged by the user - pinned
+            /// nodes keep their position when the automatic layout runs.
+            /// </summary>
+            internal bool IsPinned;
+
+            /// <summary>
+            /// Initializes a new instance of this class.
+            /// </summary>
+            public Node(string text = "")
+            {
+                _textSpan = Span(_("tss-diagram-node-text", text: text));
+                _element  = Div(_("tss-diagram-node tss-diagram-node-default"), _textSpan);
+
+                MoveTo(0, 0);
+                HookDragEvents();
+
+                _element.addEventListener("click", e =>
+                {
+                    if (_suppressClick)
+                    {
+                        _suppressClick = false;
+                        return;
+                    }
+                    Clicked?.Invoke(this, e.As<MouseEvent>());
+                });
+
+                _element.addEventListener("contextmenu", e => ContextMenu?.Invoke(this, e.As<MouseEvent>()));
+            }
+
+            /// <summary>
+            /// Gets or sets the CSS background of the node.
+            /// </summary>
+            public string Background
+            {
+                get => _element.style.background;
+                set => _element.style.background = value;
+            }
+
+            /// <summary>
+            /// Gets or sets the CSS color (foreground) of the node.
+            /// </summary>
+            public string Foreground
+            {
+                get => _element.style.color;
+                set => _element.style.color = value;
+            }
+
+            /// <summary>
+            /// Gets or sets the node text.
+            /// </summary>
+            public string Text
+            {
+                get => _textSpan.innerText;
+                set
+                {
+                    _textSpan.innerText = value;
+                    UpdateIconOnlyState();
+                    _owner?.RequestAutoArrange();
+                }
+            }
+
+            /// <summary>
+            /// Renders the component's root HTML element.
+            /// </summary>
+            public HTMLElement Render() => _element;
+
+            /// <summary>
+            /// Sets the text of the node.
+            /// </summary>
+            public Node SetText(string text)
+            {
+                Text = text;
+                return this;
+            }
+
+            /// <summary>
+            /// Sets the icon of the node.
+            /// </summary>
+            public Node SetIcon(UIcons icon, string color = "", TextSize size = TextSize.Small, UIconsWeight weight = UIconsWeight.Regular)
+            {
+                var i = I(_($"tss-diagram-node-icon {Tesserae.Icon.Transform(icon, weight)} {size}"));
+
+                if (!string.IsNullOrEmpty(color))
+                {
+                    i.style.color = color;
+                }
+
+                ReplaceIcon(i);
+                return this;
+            }
+
+            /// <summary>
+            /// Sets the icon of the node from an emoji glyph.
+            /// </summary>
+            public Node SetIcon(Emoji icon, TextSize size = TextSize.Small)
+            {
+                ReplaceIcon(I(_($"tss-diagram-node-icon ec {icon} {size}")));
+                return this;
+            }
+
+            /// <summary>
+            /// Sets an image (rendered as a small rounded icon) on the node.
+            /// </summary>
+            public Node SetImage(string source)
+            {
+                ReplaceIcon(Image(_("tss-diagram-node-image", src: source)));
+                return this;
+            }
+
+            /// <summary>
+            /// Removes the node's icon or image.
+            /// </summary>
+            public Node ClearIcon()
+            {
+                if (_iconElement is object)
+                {
+                    _iconElement.remove();
+                    _iconElement = null;
+                    UpdateIconOnlyState();
+                }
+                return this;
+            }
+
+            /// <summary>
+            /// Styles the node using the default tone.
+            /// </summary>
+            public Node Default() => SetStyle("tss-diagram-node-default");
+
+            /// <summary>
+            /// Styles the node using the primary tone.
+            /// </summary>
+            public Node Primary() => SetStyle("tss-diagram-node-primary");
+
+            /// <summary>
+            /// Styles the node using the secondary tone.
+            /// </summary>
+            public Node Secondary() => SetStyle("tss-diagram-node-secondary");
+
+            /// <summary>
+            /// Styles the node using the success tone.
+            /// </summary>
+            public Node Success() => SetStyle("tss-diagram-node-success");
+
+            /// <summary>
+            /// Styles the node using the danger tone.
+            /// </summary>
+            public Node Danger() => SetStyle("tss-diagram-node-danger");
+
+            /// <summary>
+            /// Configures the node with arbitrary background, foreground and border colors.
+            /// </summary>
+            public Node Color(string background, string foreground = "", string borderColor = "")
+            {
+                _element.style.background = background;
+
+                if (!string.IsNullOrEmpty(foreground))
+                {
+                    _element.style.color = foreground;
+                }
+
+                if (!string.IsNullOrEmpty(borderColor))
+                {
+                    _element.style.borderColor = borderColor;
+                }
+                return this;
+            }
+
+            /// <summary>
+            /// Pins the node to an explicit position (in diagram coordinates), excluding it from the automatic layout.
+            /// </summary>
+            public Node At(double x, double y)
+            {
+                MoveTo(x, y);
+                IsPinned = true;
+                _owner?.RequestAutoArrange();
+                return this;
+            }
+
+            /// <summary>
+            /// Registers a callback invoked when the node is clicked (not fired after dragging).
+            /// </summary>
+            public Node OnClick(ComponentEventHandler<Node, MouseEvent> onClick)
+            {
+                Clicked += onClick;
+                return this;
+            }
+
+            /// <summary>
+            /// Registers a callback invoked when the node is clicked (not fired after dragging).
+            /// </summary>
+            public Node OnClick(Action action) => OnClick((_, e) =>
+            {
+                StopEvent(e);
+                action.Invoke();
+            });
+
+            /// <summary>
+            /// Registers a callback invoked when the context menu event fires on the node.
+            /// </summary>
+            public Node OnContextMenu(ComponentEventHandler<Node, MouseEvent> onContextMenu)
+            {
+                ContextMenu += onContextMenu;
+                return this;
+            }
+
+            /// <summary>
+            /// Registers a callback invoked when the context menu event fires on the node (suppresses the browser menu).
+            /// </summary>
+            public Node OnContextMenu(Action action) => OnContextMenu((_, e) =>
+            {
+                StopEvent(e);
+                action.Invoke();
+            });
+
+            internal void AttachTo(Diagram owner)
+            {
+                _owner = owner;
+            }
+
+            internal void MoveTo(double x, double y)
+            {
+                X = x;
+                Y = y;
+                _element.style.left = $"{x}px";
+                _element.style.top  = $"{y}px";
+            }
+
+            internal void Measure()
+            {
+                MeasuredWidth  = _element.offsetWidth;
+                MeasuredHeight = _element.offsetHeight;
+            }
+
+            private Node SetStyle(string styleClass)
+            {
+                foreach (var cls in _styleClasses)
+                {
+                    _element.classList.remove(cls);
+                }
+
+                _element.classList.add(styleClass);
+                return this;
+            }
+
+            private void ReplaceIcon(HTMLElement newIcon)
+            {
+                if (_iconElement is object)
+                {
+                    _iconElement.remove();
+                }
+
+                _iconElement = newIcon;
+                _element.insertBefore(_iconElement, _textSpan);
+                UpdateIconOnlyState();
+                _owner?.RequestAutoArrange();
+            }
+
+            private void UpdateIconOnlyState()
+            {
+                _element.UpdateClassIf(string.IsNullOrEmpty(_textSpan.innerText) && _iconElement is object, "tss-diagram-node-icon-only");
+            }
+
+            private void HookDragEvents()
+            {
+                double startX = 0, startY = 0, origX = 0, origY = 0;
+                bool   moved  = false;
+
+                _element.onmousedown += (me) =>
+                {
+                    if (me.button != 0) return;
+
+                    startX = me.clientX;
+                    startY = me.clientY;
+                    origX  = X;
+                    origY  = Y;
+                    moved  = false;
+
+                    window.onmousemove += Drag;
+                    window.onmouseup   += StopDrag;
+                    StopEvent(me);
+                };
+
+                void Drag(MouseEvent me)
+                {
+                    var dx = me.clientX - startX;
+                    var dy = me.clientY - startY;
+
+                    if (!moved && (Math.Abs(dx) + Math.Abs(dy)) > 3)
+                    {
+                        moved    = true;
+                        IsPinned = true;
+                        _element.classList.add("tss-diagram-node-dragging");
+                    }
+
+                    if (moved)
+                    {
+                        MoveTo(origX + dx, origY + dy);
+                        _owner?.OnNodeDragged();
+                    }
+                    StopEvent(me);
+                }
+
+                void StopDrag(MouseEvent me)
+                {
+                    window.onmousemove -= Drag;
+                    window.onmouseup   -= StopDrag;
+                    _element.classList.remove("tss-diagram-node-dragging");
+
+                    if (moved)
+                    {
+                        //The click event fires right after mouseup - swallow it so dragging doesn't trigger OnClick
+                        _suppressClick = true;
+                        window.setTimeout((_) => _suppressClick = false, 100);
+                    }
+                    StopEvent(me);
+                }
+            }
+        }
+    }
+}

--- a/Tesserae/src/Components/Diagram.cs
+++ b/Tesserae/src/Components/Diagram.cs
@@ -1,0 +1,487 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using static H5.Core.dom;
+using static Tesserae.UI;
+
+namespace Tesserae
+{
+    /// <summary>
+    /// A flow-chart style diagram surface with draggable nodes, auto-computed arrows drawn on a background canvas,
+    /// a pannable dotted background and automatic node positioning based on node sizes and connectivity.
+    /// </summary>
+    [H5.Name("tss.Diagram")]
+    public partial class Diagram : IComponent, ISpecialCaseStyling
+    {
+        private readonly HTMLElement       _container;
+        private readonly HTMLCanvasElement _canvas;
+        private readonly HTMLElement       _nodesHost;
+        private readonly List<Node>        _nodes = new List<Node>();
+        private readonly List<Edge>        _edges = new List<Edge>();
+
+        private ResizeObserver _resizeObserver;
+        private double         _offsetX;
+        private double         _offsetY;
+        private int            _dotSpacing = 24;
+        private bool           _userPanned;
+        private bool           _panEnabled = true;
+        private double         _layoutTimeout;
+
+        /// <summary>
+        /// Gets the HTMLElement that should receive styling.
+        /// </summary>
+        public HTMLElement StylingContainer => _container;
+
+        /// <summary>
+        /// Gets whether styling should propagate to the stack item parent.
+        /// </summary>
+        public bool PropagateToStackItemParent => false;
+
+        /// <summary>
+        /// Initializes a new instance of this class.
+        /// </summary>
+        public Diagram()
+        {
+            _canvas    = Canvas(_("tss-diagram-canvas"));
+            _nodesHost = Div(_("tss-diagram-nodes"));
+            _container = Div(_("tss-diagram"), _canvas, _nodesHost);
+
+            ApplyDotSpacing();
+            HookPanEvents();
+
+            DomObserver.WhenMounted(_container, () =>
+            {
+                _resizeObserver = new ResizeObserver((entries, obs) => ResizeCanvas());
+                _resizeObserver.observe(_container);
+                ResizeCanvas();
+                RequestAutoArrange();
+
+                DomObserver.WhenRemoved(_container, () =>
+                {
+                    _resizeObserver.unobserve(_container);
+                    _resizeObserver = null;
+                });
+            });
+        }
+
+        /// <summary>
+        /// Adds the given nodes to the diagram.
+        /// </summary>
+        public Diagram Nodes(params Node[] nodes)
+        {
+            foreach (var node in nodes)
+            {
+                Add(node);
+            }
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a single node to the diagram.
+        /// </summary>
+        public Diagram Add(Node node)
+        {
+            if (_nodes.Contains(node)) return this;
+            _nodes.Add(node);
+            node.AttachTo(this);
+            _nodesHost.appendChild(node.Render());
+            RequestAutoArrange();
+            return this;
+        }
+
+        /// <summary>
+        /// Removes a node (and any arrows connected to it) from the diagram.
+        /// </summary>
+        public Diagram Remove(Node node)
+        {
+            if (_nodes.Remove(node))
+            {
+                _edges.RemoveAll(e => e.From == node || e.To == node);
+                node.Render().remove();
+                RequestAutoArrange();
+            }
+            return this;
+        }
+
+        /// <summary>
+        /// Removes all nodes and arrows from the diagram.
+        /// </summary>
+        public Diagram Clear()
+        {
+            _nodes.Clear();
+            _edges.Clear();
+            ClearChildren(_nodesHost);
+            Redraw();
+            return this;
+        }
+
+        /// <summary>
+        /// Connects two nodes with an auto-computed arrow, adding them to the diagram if needed.
+        /// </summary>
+        public Diagram Connect(Node from, Node to)
+        {
+            Add(from);
+            Add(to);
+            _edges.Add(new Edge() { From = from, To = to });
+            RequestAutoArrange();
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the spacing of the dotted background grid (in pixels).
+        /// </summary>
+        public Diagram DotSpacing(int pixels)
+        {
+            _dotSpacing = Math.Max(4, pixels);
+            ApplyDotSpacing();
+            return this;
+        }
+
+        /// <summary>
+        /// Hides the dotted background grid.
+        /// </summary>
+        public Diagram NoDots()
+        {
+            _container.classList.add("tss-diagram-no-dots");
+            return this;
+        }
+
+        /// <summary>
+        /// Disables panning of the diagram background.
+        /// </summary>
+        public Diagram NotDraggable()
+        {
+            _panEnabled = false;
+            _container.classList.add("tss-diagram-no-pan");
+            return this;
+        }
+
+        /// <summary>
+        /// Re-runs the automatic layout for all nodes (including ones previously dragged or explicitly positioned)
+        /// and re-centers the view.
+        /// </summary>
+        public Diagram AutoArrange()
+        {
+            foreach (var node in _nodes)
+            {
+                node.IsPinned = false;
+            }
+            _userPanned = false;
+            RequestAutoArrange();
+            return this;
+        }
+
+        /// <summary>
+        /// Renders the component's root HTML element.
+        /// </summary>
+        public HTMLElement Render() => _container;
+
+        internal void RequestAutoArrange()
+        {
+            window.clearTimeout(_layoutTimeout);
+
+            _layoutTimeout = window.setTimeout((_) =>
+            {
+                if (_container.IsMounted())
+                {
+                    RunAutoArrange();
+                    Redraw();
+                }
+            }, 16);
+        }
+
+        internal void Redraw()
+        {
+            var ctx = _canvas.getContext("2d").As<CanvasRenderingContext2D>();
+            if (ctx is null) return;
+
+            var dpr = GetDevicePixelRatio();
+
+            ctx.setTransform(1, 0, 0, 1, 0, 0);
+            ctx.clearRect(0, 0, _canvas.width, _canvas.height);
+            ctx.setTransform(dpr, 0, 0, dpr, _offsetX * dpr, _offsetY * dpr);
+
+            var lineColor = GetThemeColor("--tss-diagram-line-color", "#b8bcc2");
+
+            foreach (var edge in _edges)
+            {
+                DrawEdge(ctx, edge, lineColor);
+            }
+        }
+
+        internal void OnNodeDragged()
+        {
+            Redraw();
+        }
+
+        private void HookPanEvents()
+        {
+            double startX = 0, startY = 0, origX = 0, origY = 0;
+
+            _container.onmousedown += (me) =>
+            {
+                if (!_panEnabled || me.button != 0) return;
+                if (me.target != _container && me.target != _canvas) return;
+
+                startX = me.clientX;
+                startY = me.clientY;
+                origX  = _offsetX;
+                origY  = _offsetY;
+
+                _container.classList.add("tss-diagram-panning");
+                window.onmousemove += Pan;
+                window.onmouseup   += StopPan;
+                StopEvent(me);
+            };
+
+            void Pan(MouseEvent me)
+            {
+                _offsetX    = origX + (me.clientX - startX);
+                _offsetY    = origY + (me.clientY - startY);
+                _userPanned = true;
+                ApplyOffset();
+                StopEvent(me);
+            }
+
+            void StopPan(MouseEvent me)
+            {
+                window.onmousemove -= Pan;
+                window.onmouseup   -= StopPan;
+                _container.classList.remove("tss-diagram-panning");
+                StopEvent(me);
+            }
+        }
+
+        private void ApplyOffset()
+        {
+            _nodesHost.style.transform           = $"translate({_offsetX}px, {_offsetY}px)";
+            _container.style.backgroundPosition = $"{_offsetX}px {_offsetY}px";
+            Redraw();
+        }
+
+        private void ApplyDotSpacing()
+        {
+            _container.style.backgroundSize = $"{_dotSpacing}px {_dotSpacing}px";
+        }
+
+        private void ResizeCanvas()
+        {
+            var dpr = GetDevicePixelRatio();
+            _canvas.width  = (uint)Math.Max(1, _container.clientWidth  * dpr);
+            _canvas.height = (uint)Math.Max(1, _container.clientHeight * dpr);
+            Redraw();
+        }
+
+        private static double GetDevicePixelRatio()
+        {
+            var dpr = window.devicePixelRatio;
+            return dpr > 0 ? dpr : 1;
+        }
+
+        private string GetThemeColor(string variable, string fallback)
+        {
+            var value = window.getComputedStyle(_container).getPropertyValue(variable);
+            return string.IsNullOrWhiteSpace(value) ? fallback : value.Trim();
+        }
+
+        /// <summary>
+        /// Assigns layers to nodes based on connectivity (longest path from the roots), orders nodes within each
+        /// layer by the position of their parents, and spaces everything using the measured node sizes.
+        /// </summary>
+        private void RunAutoArrange()
+        {
+            if (_nodes.Count == 0) return;
+
+            foreach (var node in _nodes)
+            {
+                node.Measure();
+            }
+
+            var layerOf  = new Dictionary<Node, int>();
+            var incoming = new Dictionary<Node, List<Node>>();
+
+            foreach (var node in _nodes)
+            {
+                incoming[node] = new List<Node>();
+            }
+
+            foreach (var edge in _edges)
+            {
+                incoming[edge.To].Add(edge.From);
+            }
+
+            int LayerFor(Node node, HashSet<Node> visiting)
+            {
+                if (layerOf.TryGetValue(node, out var known)) return known;
+                if (!visiting.Add(node)) return 0; //Cycle - break it by treating this node as a root
+
+                var layer = 0;
+
+                foreach (var parent in incoming[node])
+                {
+                    layer = Math.Max(layer, LayerFor(parent, visiting) + 1);
+                }
+
+                visiting.Remove(node);
+                layerOf[node] = layer;
+                return layer;
+            }
+
+            var visitingSet = new HashSet<Node>();
+
+            foreach (var node in _nodes)
+            {
+                LayerFor(node, visitingSet);
+            }
+
+            var layers = _nodes.GroupBy(n => layerOf[n]).OrderBy(g => g.Key).Select(g => g.ToList()).ToList();
+
+            //Order nodes within each layer by the average vertical order of their parents to reduce arrow crossings
+            var orderIndex = new Dictionary<Node, double>();
+
+            for (int l = 0; l < layers.Count; l++)
+            {
+                var layer = layers[l];
+
+                if (l > 0)
+                {
+                    layer.Sort((a, b) => Barycenter(a).CompareTo(Barycenter(b)));
+                }
+
+                for (int i = 0; i < layer.Count; i++)
+                {
+                    orderIndex[layer[i]] = i;
+                }
+            }
+
+            double Barycenter(Node node)
+            {
+                var parents = incoming[node];
+                if (parents.Count == 0) return orderIndex.TryGetValue(node, out var self) ? self : 0;
+                return parents.Average(p => orderIndex.TryGetValue(p, out var i) ? i : 0);
+            }
+
+            const double gapX = 80;
+            const double gapY = 32;
+
+            double x = 0;
+
+            foreach (var layer in layers)
+            {
+                var maxWidth    = layer.Max(n => n.MeasuredWidth);
+                var totalHeight = layer.Sum(n => n.MeasuredHeight) + gapY * (layer.Count - 1);
+
+                double y = -totalHeight / 2;
+
+                foreach (var node in layer)
+                {
+                    if (!node.IsPinned)
+                    {
+                        node.MoveTo(x + (maxWidth - node.MeasuredWidth) / 2, y);
+                    }
+
+                    y += node.MeasuredHeight + gapY;
+                }
+
+                x += maxWidth + gapX;
+            }
+
+            if (!_userPanned)
+            {
+                CenterContent();
+            }
+        }
+
+        private void CenterContent()
+        {
+            if (_nodes.Count == 0) return;
+
+            var minX = _nodes.Min(n => n.X);
+            var minY = _nodes.Min(n => n.Y);
+            var maxX = _nodes.Max(n => n.X + n.MeasuredWidth);
+            var maxY = _nodes.Max(n => n.Y + n.MeasuredHeight);
+
+            _offsetX = (_container.clientWidth  - (maxX - minX)) / 2 - minX;
+            _offsetY = (_container.clientHeight - (maxY - minY)) / 2 - minY;
+            ApplyOffset();
+        }
+
+        private static void DrawEdge(CanvasRenderingContext2D ctx, Edge edge, string lineColor)
+        {
+            const double arrowLength = 7;
+            const double anchorGap   = 4;
+
+            var from = edge.From;
+            var to   = edge.To;
+
+            var fromCenterX = from.X + from.MeasuredWidth  / 2;
+            var fromCenterY = from.Y + from.MeasuredHeight / 2;
+            var toCenterX   = to.X   + to.MeasuredWidth    / 2;
+            var toCenterY   = to.Y   + to.MeasuredHeight   / 2;
+
+            var dx = toCenterX - fromCenterX;
+            var dy = toCenterY - fromCenterY;
+
+            double sx, sy, ex, ey, c1x, c1y, c2x, c2y;
+
+            if (Math.Abs(dx) >= Math.Abs(dy))
+            {
+                //Mostly horizontal - anchor on the left/right sides facing each other
+                var dir  = dx >= 0 ? 1 : -1;
+                sx = dir > 0 ? from.X + from.MeasuredWidth + anchorGap : from.X - anchorGap;
+                sy = fromCenterY;
+                ex = dir > 0 ? to.X - anchorGap - arrowLength : to.X + to.MeasuredWidth + anchorGap + arrowLength;
+                ey = toCenterY;
+
+                var bend = Math.Min(60, Math.Max(20, Math.Abs(ex - sx) / 2)) * dir;
+                c1x = sx + bend;
+                c1y = sy;
+                c2x = ex - bend;
+                c2y = ey;
+            }
+            else
+            {
+                //Mostly vertical - anchor on the top/bottom sides facing each other
+                var dir  = dy >= 0 ? 1 : -1;
+                sx = fromCenterX;
+                sy = dir > 0 ? from.Y + from.MeasuredHeight + anchorGap : from.Y - anchorGap;
+                ex = toCenterX;
+                ey = dir > 0 ? to.Y - anchorGap - arrowLength : to.Y + to.MeasuredHeight + anchorGap + arrowLength;
+
+                var bend = Math.Min(60, Math.Max(20, Math.Abs(ey - sy) / 2)) * dir;
+                c1x = sx;
+                c1y = sy + bend;
+                c2x = ex;
+                c2y = ey - bend;
+            }
+
+            ctx.strokeStyle = lineColor;
+            ctx.fillStyle   = lineColor;
+            ctx.lineWidth   = 1.5;
+
+            ctx.beginPath();
+            ctx.moveTo(sx, sy);
+            ctx.bezierCurveTo(c1x, c1y, c2x, c2y, ex, ey);
+            ctx.stroke();
+
+            //Arrowhead pointing along the end tangent of the curve
+            var angle = Math.Atan2(ey - c2y, ex - c2x);
+
+            var tipX = ex + Math.Cos(angle) * arrowLength;
+            var tipY = ey + Math.Sin(angle) * arrowLength;
+
+            ctx.beginPath();
+            ctx.moveTo(tipX, tipY);
+            ctx.lineTo(tipX - Math.Cos(angle - Math.PI / 6) * arrowLength, tipY - Math.Sin(angle - Math.PI / 6) * arrowLength);
+            ctx.lineTo(tipX - Math.Cos(angle + Math.PI / 6) * arrowLength, tipY - Math.Sin(angle + Math.PI / 6) * arrowLength);
+            ctx.closePath();
+            ctx.fill();
+        }
+
+        private sealed class Edge
+        {
+            public Node From;
+            public Node To;
+        }
+    }
+}


### PR DESCRIPTION
Adds a new Diagram component with:
- Diagram.Node inner class with icon/image + text, button-like tonal
  styles (default, primary, secondary, success, danger) and arbitrary
  foreground/background/border colors
- Auto-computed arrows between connected nodes drawn on a background
  canvas (bezier curves with arrowheads, anchored on the facing sides)
- Draggable (pannable) background with a dotted grid that follows the
  pan offset
- Automatic layered node positioning based on node sizes and
  connectivity, with barycenter ordering to reduce arrow crossings
- Draggable nodes (pinned after dragging or explicit At(x, y))
- Container resize handling via ResizeObserver
- OnClick and OnContextMenu events on nodes (clicks are suppressed
  after a drag)
- Icon-only nodes render as circles with aspect-ratio 1

Includes UI.Diagram()/UI.DiagramNode() factories, tss.diagram.css and
a sample page.

https://claude.ai/code/session_018eP1GihPzTJHPtexHnjAmq