### PR TITLE
Add subtle press/drag transform animations to diagram nodes

### DIFF
--- a/Tesserae/h5/assets/css/tss.diagram.css
+++ b/Tesserae/h5/assets/css/tss.diagram.css
@@ -61,13 +61,19 @@
     font-weight: 500;
     box-shadow: var(--tss-shadow-sm);
     cursor: grab;
+    transition: transform 0.1s ease-in-out, box-shadow 0.15s ease-in-out;
     -webkit-user-select: none;
     user-select: none;
 }
 
+    .tss-diagram-node:active {
+        transform: scale(0.95);
+    }
+
     .tss-diagram-node.tss-diagram-node-dragging {
         cursor: grabbing;
         box-shadow: var(--tss-shadow-hover);
+        transform: scale(1.03);
         z-index: 1;
     }
 


### PR DESCRIPTION
Pressing a node scales it down slightly (0.95), dragging scales it up (1.03) with a stronger shadow, and both transition smoothly back on release.

https://claude.ai/code/session_018eP1GihPzTJHPtexHnjAmq