### PR TITLE
Auto-resize chat input textarea to fit content

### DIFF
--- a/Tesserae/h5/assets/css/tss.omnibox.css
+++ b/Tesserae/h5/assets/css/tss.omnibox.css
@@ -269,6 +269,7 @@
 .tss-omnibox-chat-input {
     width: 100%;
     flex-grow: 1;
+    box-sizing: border-box;
     border: none;
     background: transparent;
     color: var(--tss-default-foreground-color);
@@ -278,8 +279,11 @@
     margin: 0;
     font-size: 14px;
     font-family: inherit;
+    line-height: 20px;
     z-index: 2;
-    white-space: pre;
+    white-space: pre-wrap;
+    overflow-wrap: break-word;
+    overflow-y: hidden;
     resize: none;
 }
 

--- a/Tesserae/src/Components/OmniBox.cs
+++ b/Tesserae/src/Components/OmniBox.cs
@@ -992,6 +992,7 @@ namespace Tesserae
                 _chatInput.addEventListener("input", (e) =>
                 {
                     UpdateChatTriggerActiveState();
+                    ResizeChatInput();
                     Input?.Invoke(this, e);
                 });
                 _chatInput.addEventListener("keyup", (e) => KeyUp?.Invoke(this, e.As<KeyboardEvent>()));
@@ -1000,6 +1001,9 @@ namespace Tesserae
                 _chatInput.addEventListener("blur", (e) => LostFocus?.Invoke(this, e));
 
                 _chatContainer = Div(_("tss-omnibox-chat-container"), _chatInput);
+
+                // Size the input to its content once it's in the DOM (and whenever it's re-shown).
+                DomObserver.WhenMounted(_chatInput, ResizeChatInput);
 
                 _chatTriggerBtn = Button().SetIcon(config.IconChat).Class("tss-omnibox-chat-btn").OnClick(TriggerChat);
 
@@ -2133,6 +2137,7 @@ namespace Tesserae
             Chatted?.Invoke(this, new ChatMessage() { Text = val });
             _chatInput.value = "";
             UpdateChatTriggerActiveState();
+            ResizeChatInput();
         }
 
         private void UpdateChatTriggerActiveState()
@@ -2142,6 +2147,31 @@ namespace Tesserae
             var el = _chatTriggerBtn.Render();
             if (hasText) el.classList.add("tss-omnibox-chat-btn-active");
             else el.classList.remove("tss-omnibox-chat-btn-active");
+        }
+
+        // Maximum height (in px) the chat input grows to before it starts scrolling internally.
+        private const int chatInputMaxHeight = 200;
+
+        // Grows/shrinks the chat textarea to fit its content (so wrapped long text expands onto new
+        // lines instead of scrolling horizontally), capped at chatInputMaxHeight where it scrolls.
+        private void ResizeChatInput()
+        {
+            if (_chatInput == null) return;
+
+            // Reset to auto so scrollHeight reflects the content height, not the current box height.
+            _chatInput.style.height = "auto";
+            var contentHeight = _chatInput.scrollHeight;
+
+            if (contentHeight > chatInputMaxHeight)
+            {
+                _chatInput.style.height = chatInputMaxHeight + "px";
+                _chatInput.style.overflowY = "auto";
+            }
+            else
+            {
+                _chatInput.style.height = contentHeight + "px";
+                _chatInput.style.overflowY = "hidden";
+            }
         }
 
         private void TriggerStop()
@@ -2768,6 +2798,7 @@ namespace Tesserae
             {
                 _chatInput.value = value;
                 UpdateChatTriggerActiveState();
+                ResizeChatInput();
                 Input?.Invoke(this, null);
             }
         }


### PR DESCRIPTION
## Summary
Adds automatic height resizing to the OmniBox chat input textarea so it grows/shrinks to fit its content, with a maximum height cap before scrolling internally.

## Key Changes
- **ResizeChatInput() method**: New private method that dynamically adjusts textarea height based on content, capping at 200px before enabling internal scrolling
- **Input event handling**: Calls `ResizeChatInput()` on every input event to keep height in sync as user types
- **DOM mounting**: Uses `DomObserver.WhenMounted()` to size the input once it's added to the DOM and whenever it's re-shown
- **Chat submission**: Resizes input after clearing it post-send
- **ChatText property**: Resizes input when text is set programmatically
- **CSS updates**: 
  - Added `box-sizing: border-box` for proper width calculations
  - Changed `white-space: pre` to `pre-wrap` to enable text wrapping
  - Added `overflow-wrap: break-word` for long unbroken text
  - Set `overflow-y: hidden` by default (toggled to `auto` when content exceeds max height)
  - Added explicit `line-height: 20px` for consistent height calculations

## Implementation Details
The resize logic works by temporarily setting height to `auto`, reading `scrollHeight` to get the natural content height, then applying either that height or the 200px cap with appropriate overflow settings. This ensures wrapped text expands onto new lines rather than scrolling horizontally.

https://claude.ai/code/session_011jmNDM4ZeXhTPmfY8Rfyfd