### PR TITLE
Add ContributionBar component for stacked score breakdowns

### DIFF
--- a/Tesserae.Tests/src/Samples/Components/ContributionBarSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/ContributionBarSample.cs
@@ -1,0 +1,81 @@
+using static Tesserae.UI;
+using static Tesserae.Tests.Samples.SamplesHelper;
+using static H5.Core.dom;
+
+namespace Tesserae.Tests.Samples
+{
+    [SampleDetails(Group = "Components", Order = 31, Icon = UIcons.ChartSimpleHorizontal)]
+    public class ContributionBarSample : IComponent, ISample
+    {
+        private readonly IComponent _content;
+
+        public ContributionBarSample()
+        {
+            _content = SectionStack().Secondary()
+               .SampleTitle(typeof(ContributionBarSample), UIcons.ChartSimpleHorizontal, "A stacked bar showing how weighted parts add up to a total")
+               .FlatSection(Stack().Children(
+                    Card(VStack().WS().Children(
+                        TextBlock("A ContributionBar renders a single stacked bar where each segment is sized proportionally to its value, plus an optional legend listing each part with its value."),
+                        TextBlock("Use it to make the composition of a score always visible at a glance — for example, how each signal contributes to a similarity score, how a budget splits across categories, or how a result's relevance breaks down."))).SetTitle("Overview")))
+               .FlatSection(Stack().Children(
+                    Card(VStack().WS().Children(
+                        SampleSubTitle("Basic usage"),
+                        TextBlock("Segments are added with .Add(label, value) and get a color from the default palette. By default the bar fills entirely (the maximum equals the sum of the segments)."),
+                        ContributionBar()
+                           .Add("Description", 0.36)
+                           .Add("ATA chapter", 0.17)
+                           .Add("Type", 0.15)
+                           .Add("Damage", 0.13)
+                           .Add("Location", 0.07)
+                           .Add("Program", 0.06))).SetTitle("Default palette")))
+               .FlatSection(Stack().Children(
+                    Card(VStack().WS().Children(
+                        SampleSubTitle("Pinned maximum with a remainder track"),
+                        TextBlock("Call .Max(value) to pin the full-width value. When the segments add up to less than the maximum, the remaining space is shown as an empty track."),
+                        ContributionBar()
+                           .Max(1.0)
+                           .Add("Description", 0.36, Theme.Colors.Blue600)
+                           .Add("ATA chapter", 0.17, Theme.Colors.Blue400)
+                           .Add("Type", 0.15, Theme.Colors.Teal500)
+                           .Add("Damage", 0.13, Theme.Colors.Green500)
+                           .Add("Location", 0.07, Theme.Colors.Orange500)
+                           .Add("Program", 0.06, Theme.Colors.Neutral500))).SetTitle("Explicit colors")))
+               .FlatSection(Stack().Children(
+                    Card(BuildSimilarityCard()).SetTitle("Example: similarity result card")));
+        }
+
+        private static IComponent BuildSimilarityCard()
+        {
+            var bar = ContributionBar()
+               .Max(1.0)
+               .Add("Description", 0.36, Theme.Colors.Blue600)
+               .Add("ATA chapter", 0.17, Theme.Colors.Blue400)
+               .Add("Type", 0.15, Theme.Colors.Teal500)
+               .Add("Damage", 0.13, Theme.Colors.Green500)
+               .Add("Location", 0.07, Theme.Colors.Orange500)
+               .Add("Program", 0.06, Theme.Colors.Neutral500);
+
+            var score = VStack().AlignItems(ItemAlign.Center).Children(
+                TextBlock("0.94").XXLarge().Bold().Foreground(Theme.Colors.Green600),
+                Badge("HIGH MATCH").Success().Pill());
+
+            var header = VStack().WS().Children(
+                TextBlock("NC-2023-04412 · 2023-06-18").Tiny().SemiBold().Foreground(Theme.Secondary.Foreground),
+                TextBlock("Composite skin delamination on LH wing trailing-edge panel").MediumPlus().SemiBold(),
+                TextBlock("CONTRIBUTION TO SIMILARITY · SUMS TO 0.94").Tiny().SemiBold().Foreground(Theme.Secondary.Foreground).PT(12).PB(4),
+                bar,
+                HStack().Wrap().PT(12).Children(
+                    Badge("A350-900").Outline().Pill(),
+                    Badge("ATA 57 · Wings").Outline().Pill(),
+                    Badge("Delamination").Outline().Pill(),
+                    Badge("LH wing trailing edge").Outline().Pill(),
+                    Badge("Composite delamination").Outline().Pill()));
+
+            return HStack().WS().Children(
+                score.NoShrink().PR(16),
+                header.Grow());
+        }
+
+        public HTMLElement Render() => _content.Render();
+    }
+}

--- a/Tesserae/h5.json
+++ b/Tesserae/h5.json
@@ -118,6 +118,7 @@
                 "h5/assets/css/tss.cardpivot.css",
                 "h5/assets/css/tss.segmentedpivot.css",
                 "h5/assets/css/tss.metric.css",
+                "h5/assets/css/tss.contributionbar.css",
                 "h5/assets/css/tss.progressindicator.css",
                 "h5/assets/css/tss.modal.css",
                 "h5/assets/css/tss.dialog.css",

--- a/Tesserae/h5/assets/css/tss.contributionbar.css
+++ b/Tesserae/h5/assets/css/tss.contributionbar.css
@@ -1,0 +1,50 @@
+.tss-contribution {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    width: 100%;
+}
+
+.tss-contribution-bar {
+    display: flex;
+    width: 100%;
+    height: 10px;
+    border-radius: 999px;
+    overflow: hidden;
+    background: var(--tss-colors-neutral-200);
+}
+
+.tss-contribution-segment {
+    height: 100%;
+    min-width: 1px;
+}
+
+.tss-contribution-legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px 16px;
+}
+
+.tss-contribution-legend-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: var(--tss-font-size-xsmall);
+    color: var(--tss-default-foreground-color);
+}
+
+.tss-contribution-legend-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    flex: 0 0 auto;
+}
+
+.tss-contribution-legend-label {
+    color: var(--tss-secondary-foreground-color);
+}
+
+.tss-contribution-legend-value {
+    font-weight: var(--tss-font-weight-semibold);
+    font-variant-numeric: tabular-nums;
+}

--- a/Tesserae/src/Base/UI.Components.cs
+++ b/Tesserae/src/Base/UI.Components.cs
@@ -954,6 +954,11 @@ namespace Tesserae
         public static Metric Metric(IComponent title, IComponent value) => new Metric(title, value);
 
         /// <summary>
+        /// Creates a new <see cref="Tesserae.ContributionBar"/>.
+        /// </summary>
+        public static ContributionBar ContributionBar() => new ContributionBar();
+
+        /// <summary>
         /// Creates a <see cref="Tesserae.PivotSelector"/> component.
         /// </summary>
         public static PivotSelector PivotSelector() => new PivotSelector();

--- a/Tesserae/src/Components/ContributionBar.cs
+++ b/Tesserae/src/Components/ContributionBar.cs
@@ -1,0 +1,196 @@
+using System;
+using System.Collections.Generic;
+using static H5.Core.dom;
+using static Tesserae.UI;
+
+namespace Tesserae
+{
+    /// <summary>
+    /// A single stacked horizontal bar that shows how a set of weighted components add up to a total
+    /// (for example, how each signal contributes to a similarity score). Each segment is sized
+    /// proportionally to its value and gets a distinct color, and an optional legend lists every
+    /// segment with its label and numeric value.
+    /// </summary>
+    /// <remarks>
+    /// Add segments with <see cref="Add(string, double, string)"/>. By default the bar fills entirely
+    /// (the largest extent equals the sum of all segments); call <see cref="Max(double)"/> to pin the
+    /// full-width value so a remainder track is shown when the segments do not reach it.
+    /// </remarks>
+    [H5.Name("tss.ContributionBar")]
+    public sealed class ContributionBar : ComponentBase<ContributionBar, HTMLElement>
+    {
+        private sealed class Segment
+        {
+            public string Label;
+            public double Value;
+            public string Color;
+        }
+
+        /// <summary>
+        /// The default color palette used for segments that do not specify an explicit color, cycled in order.
+        /// </summary>
+        public static readonly string[] DefaultPalette =
+        {
+            Theme.Colors.Blue500,
+            Theme.Colors.Teal500,
+            Theme.Colors.Green500,
+            Theme.Colors.Orange500,
+            Theme.Colors.Purple500,
+            Theme.Colors.Magenta500,
+            Theme.Colors.Red500,
+            Theme.Colors.Blue400,
+        };
+
+        private readonly List<Segment> _segments = new List<Segment>();
+        private readonly HTMLElement   _bar;
+        private readonly HTMLElement   _legend;
+
+        private double  _max         = double.NaN;
+        private bool    _showLegend  = true;
+        private bool    _showValues  = true;
+        private int     _decimals    = 2;
+        private string  _barHeight   = "10px";
+
+        /// <summary>
+        /// Initializes a new instance of this class.
+        /// </summary>
+        public ContributionBar()
+        {
+            _bar         = Div(_("tss-contribution-bar"));
+            _legend      = Div(_("tss-contribution-legend"));
+            InnerElement = Div(_("tss-contribution"), _bar, _legend);
+        }
+
+        /// <summary>
+        /// Adds a contribution segment. When <paramref name="color"/> is null a color is picked from
+        /// <see cref="DefaultPalette"/> based on the segment's position.
+        /// </summary>
+        public ContributionBar Add(string label, double value, string color = null)
+        {
+            _segments.Add(new Segment { Label = label, Value = value, Color = color });
+            Refresh();
+            return this;
+        }
+
+        /// <summary>
+        /// Pins the value that corresponds to a full-width bar. When the segments sum to less than this
+        /// value the remaining space is rendered as an empty track. Defaults to the sum of all segments.
+        /// </summary>
+        public ContributionBar Max(double max)
+        {
+            _max = max;
+            Refresh();
+            return this;
+        }
+
+        /// <summary>
+        /// Controls whether the legend below the bar is shown. Defaults to <c>true</c>.
+        /// </summary>
+        public ContributionBar ShowLegend(bool show = true)
+        {
+            _showLegend = show;
+            Refresh();
+            return this;
+        }
+
+        /// <summary>
+        /// Hides the legend below the bar.
+        /// </summary>
+        public ContributionBar HideLegend() => ShowLegend(false);
+
+        /// <summary>
+        /// Controls whether the numeric value of each segment is shown in the legend. Defaults to <c>true</c>.
+        /// </summary>
+        public ContributionBar ShowValues(bool show = true)
+        {
+            _showValues = show;
+            Refresh();
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the number of decimal places used when formatting segment values. Defaults to 2.
+        /// </summary>
+        public ContributionBar Decimals(int decimals)
+        {
+            _decimals = decimals < 0 ? 0 : decimals;
+            Refresh();
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the thickness (height) of the bar. Defaults to <c>10px</c>.
+        /// </summary>
+        public ContributionBar Thickness(UnitSize size)
+        {
+            _barHeight = size.ToString();
+            _bar.style.height = _barHeight;
+            return this;
+        }
+
+        private string ColorFor(int index)
+        {
+            var segment = _segments[index];
+            if (!string.IsNullOrEmpty(segment.Color)) return segment.Color;
+            return DefaultPalette[index % DefaultPalette.Length];
+        }
+
+        private string FormatValue(double value) => H5.Script.Write<string>("{0}.toFixed({1})", value, _decimals);
+
+        private double Total()
+        {
+            double sum = 0;
+            foreach (var s in _segments) sum += s.Value > 0 ? s.Value : 0;
+            return sum;
+        }
+
+        private void Refresh()
+        {
+            ClearChildren(_bar);
+            ClearChildren(_legend);
+
+            _bar.style.height = _barHeight;
+
+            var max = double.IsNaN(_max) ? Total() : _max;
+            if (max <= 0) max = 1;
+
+            for (int i = 0; i < _segments.Count; i++)
+            {
+                var segment = _segments[i];
+                if (segment.Value <= 0) continue;
+
+                var width    = (segment.Value / max) * 100.0;
+                var color    = ColorFor(i);
+                var fragment = Div(_("tss-contribution-segment", title: $"{segment.Label}: {FormatValue(segment.Value)}"));
+                fragment.style.width           = FormatValue(width) + "%";
+                fragment.style.backgroundColor = color;
+                _bar.appendChild(fragment);
+            }
+
+            if (!_showLegend) return;
+
+            for (int i = 0; i < _segments.Count; i++)
+            {
+                var segment = _segments[i];
+                var dot     = Span(_("tss-contribution-legend-dot"));
+                dot.style.backgroundColor = ColorFor(i);
+
+                var item = Div(_("tss-contribution-legend-item"),
+                    dot,
+                    Span(_("tss-contribution-legend-label", text: segment.Label)));
+
+                if (_showValues)
+                {
+                    item.appendChild(Span(_("tss-contribution-legend-value", text: FormatValue(segment.Value))));
+                }
+
+                _legend.appendChild(item);
+            }
+        }
+
+        /// <summary>
+        /// Renders the component's root HTML element.
+        /// </summary>
+        public override HTMLElement Render() => InnerElement;
+    }
+}


### PR DESCRIPTION
## Summary

Adds a new **`ContributionBar`** component: a single stacked horizontal bar that shows how a set of weighted parts add up to a total, with an optional legend listing each part and its value. It makes the composition of a score always visible at a glance — for example, how each signal contributes to a similarity score.

This is the reusable Tesserae primitive behind the upcoming similarity-result renderer in the Curiosity Search Renderer (Mosaik). A follow-up PR there will compose this with node badges to render full similarity results.

## What's included

- **`Tesserae/src/Components/ContributionBar.cs`** — fluent API:
  - `.Add(label, value, color = null)` — adds a segment; color defaults to the built-in palette (cycled by position) and can be overridden per segment.
  - `.Max(value)` — pins the full-width value so a remainder track is shown when segments sum to less than it (defaults to the sum of all segments → bar fills entirely).
  - `.ShowLegend(bool)` / `.HideLegend()`, `.ShowValues(bool)`, `.Decimals(int)`, `.Thickness(UnitSize)`.
  - `DefaultPalette` exposed as a public static, built from `Theme.Colors` tokens (theme/dark-mode aware).
- **`Tesserae/h5/assets/css/tss.contributionbar.css`** — registered in `h5.json`.
- **`UI.ContributionBar()`** factory in `UI.Components.cs`.
- **Samples page** (`ContributionBarSample`) under *Components*, demonstrating the default palette, explicit colors with a remainder track, and a composed similarity-result card matching the target design.

## Notes
- Values are formatted via `toFixed` (H5/JS), tabular-nums in the legend for stable alignment.
- Builds clean (`dotnet build Tesserae.sln`: 0 warnings, 0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ao48y8hxJ5TrM78rjwjmEV

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ao48y8hxJ5TrM78rjwjmEV)_