### PR TITLE
Add gesture recognition, charts, and property grid components

### DIFF
--- a/Tesserae.Tests/src/Samples/Components/ChartsSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/ChartsSample.cs
@@ -1,0 +1,78 @@
+using System;
+using static H5.Core.dom;
+using static Tesserae.UI;
+using static Tesserae.Tests.Samples.SamplesHelper;
+
+namespace Tesserae.Tests.Samples
+{
+    [SampleDetails(Group = "Components", Order = 208, Icon = UIcons.ChartHistogram)]
+    public class ChartsSample : IComponent, ISample
+    {
+        private readonly IComponent _content;
+
+        public ChartsSample()
+        {
+            var months = new[] { "Jan", "Feb", "Mar", "Apr", "May", "Jun" };
+
+            var revenue = new double[] { 12, 19, 15, 27, 24, 33 };
+            var costs   = new double[] { 8, 11, 13, 14, 18, 20 };
+
+            // An observable series so the chart re-renders when the data changes.
+            var liveData = new SettableObservable<double[]>(new double[] { 5, 8, 6, 12, 9, 15 });
+
+            var lineChart = LineChart()
+               .Series(new ChartSeries("Revenue", revenue), new ChartSeries("Costs", costs))
+               .XAxis(months)
+               .Legend()
+               .Title("Monthly revenue versus costs");
+
+            var barChart = BarChart()
+               .Series(new ChartSeries("Revenue", revenue), new ChartSeries("Costs", costs))
+               .XAxis(months)
+               .Legend()
+               .Rounded(3);
+
+            var areaChart = AreaChart()
+               .Series(liveData, "Sessions")
+               .XAxis(months);
+
+            var pieChart = PieChart()
+               .Data(new double[] { 42, 27, 18, 13 })
+               .Labels("Direct", "Search", "Social", "Referral")
+               .Donut()
+               .Legend();
+
+            _content = SectionStack().Secondary()
+               .SampleTitle(typeof(ChartsSample), UIcons.ChartHistogram, "Lightweight, dependency-free SVG charts")
+               .Section(Stack().Children(
+                    Card(VStack().WS().Children(
+                        TextBlock("LineChart, BarChart, AreaChart and PieChart render as responsive, dependency-free SVG that scales to its container, adapts to the light/dark theme, and exposes hover tooltips plus a role=\"img\" accessibility summary. Data can be supplied as plain values or as an observable that re-renders the chart on change."))).SetTitle("Overview")))
+               .Section(Stack().Children(
+                    Card(VStack().WS().Children(
+                        SampleSubTitle("Line chart"),
+                        lineChart.H(280).WS())).SetTitle("LineChart")))
+               .Section(Stack().Children(
+                    Card(VStack().WS().Children(
+                        SampleSubTitle("Bar chart (grouped series)"),
+                        barChart.H(280).WS())).SetTitle("BarChart")))
+               .Section(Stack().Children(
+                    Card(VStack().WS().Children(
+                        SampleSubTitle("Area chart bound to an observable"),
+                        areaChart.H(280).WS(),
+                        HStack().WS().Children(
+                            Button("Randomize data").SetIcon(UIcons.Dice).OnClick(() =>
+                            {
+                                var rnd = new Random();
+                                var next = new double[6];
+                                for (var i = 0; i < next.Length; i++) next[i] = rnd.Next(2, 30);
+                                liveData.Value = next;
+                            })))).SetTitle("AreaChart + observable")))
+               .Section(Stack().Children(
+                    Card(VStack().WS().Children(
+                        SampleSubTitle("Donut chart"),
+                        pieChart.H(280).WS())).SetTitle("PieChart")));
+        }
+
+        public HTMLElement Render() => _content.Render();
+    }
+}

--- a/Tesserae.Tests/src/Samples/Components/GesturesSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/GesturesSample.cs
@@ -1,0 +1,98 @@
+using System;
+using static H5.Core.dom;
+using static Tesserae.UI;
+using static Tesserae.Tests.Samples.SamplesHelper;
+
+namespace Tesserae.Tests.Samples
+{
+    [SampleDetails(Group = "Components", Order = 210, Icon = UIcons.CursorFingerClick)]
+    public class GesturesSample : IComponent, ISample
+    {
+        private readonly IComponent _content;
+
+        // Live transform state, accumulated from per-event gesture deltas.
+        private double _panX, _panY, _scale = 1, _rotation;
+
+        public GesturesSample()
+        {
+            var status = TextBlock("Drag, pinch or rotate the box (use touch / trackpad for pinch & rotate).").Secondary();
+            var values = TextBlock("pan: 0, 0 · scale: 1.00 · rotation: 0°");
+
+            var box = VStack()
+               .WidthStretch().HeightStretch()
+               .JustifyContent(ItemJustify.Center).AlignItemsCenter()
+               .Children(TextBlock("Tap · Double-tap · Long-press · Drag · Pinch · Rotate").Bold())
+               .Background(Theme.Primary.Background)
+               .Style(s =>
+                {
+                    s.color        = "white";
+                    s.borderRadius = "12px";
+                    s.cursor       = "grab";
+                    s.userSelect   = "none";
+                    s.maxWidth     = "260px";
+                    s.maxHeight    = "160px";
+                    s.textAlign    = "center";
+                    s.padding      = "16px";
+                });
+
+            void ApplyTransform()
+            {
+                box.Render().style.transform = $"translate({_panX.ToString("0.#")}px, {_panY.ToString("0.#")}px) scale({_scale.ToString("0.###")}) rotate({_rotation.ToString("0.#")}deg)";
+                values.Text = $"pan: {_panX.ToString("0")}, {_panY.ToString("0")} · scale: {_scale.ToString("0.00")} · rotation: {_rotation.ToString("0")}°";
+            }
+
+            box
+               .OnTapped(_ => status.Text = "Tapped")
+               .OnDoubleTapped(_ =>
+                {
+                    _panX = 0; _panY = 0; _scale = 1; _rotation = 0;
+                    ApplyTransform();
+                    status.Text = "Double-tapped — reset";
+                })
+               .OnLongPress(_ => status.Text = "Long-pressed")
+               .OnPan(g =>
+                {
+                    _panX += g.DeltaX;
+                    _panY += g.DeltaY;
+                    if (g.Phase == GesturePhase.Start) status.Text = "Panning…";
+                    if (g.Phase == GesturePhase.End)   status.Text = $"Pan ended (offset {g.OffsetX.ToString("0")}, {g.OffsetY.ToString("0")})";
+                    ApplyTransform();
+                })
+               .OnPinch(g =>
+                {
+                    _scale = Math.Max(0.25, Math.Min(4, _scale * g.ScaleDelta));
+                    status.Text = "Pinching…";
+                    ApplyTransform();
+                })
+               .OnRotate(g =>
+                {
+                    _rotation += g.RotationDelta;
+                    ApplyTransform();
+                });
+
+            var stage = Stack().Relative().WS().H(280)
+               .Children(box)
+               .Style(s =>
+                {
+                    s.border          = "1px dashed var(--tss-colors-neutral-500-alpha)";
+                    s.borderRadius     = "8px";
+                    s.overflow         = "hidden";
+                    s.alignItems       = "center";
+                    s.justifyContent   = "center";
+                    s.touchAction      = "none";
+                });
+
+            _content = SectionStack().Secondary()
+               .SampleTitle(typeof(GesturesSample), UIcons.CursorFingerClick, "High-level pointer / touch gesture recognizers")
+               .Section(Stack().Children(
+                    Card(VStack().WS().Children(
+                        TextBlock("The fluent gesture extensions (.OnTapped, .OnDoubleTapped, .OnLongPress, .OnPan, .OnPinch, .OnRotate) layer tap, drag, pinch and rotate recognition on top of the unified Pointer Events API, so a single code path works for mouse, touch and pen. Each handler receives a GestureState snapshot with per-event deltas and cumulative offset/scale/rotation. These same recognizers now drive SplitView resizing on touch screens."))).SetTitle("Overview")))
+               .Section(Stack().Children(
+                    Card(VStack().WS().Children(
+                        stage,
+                        VStack().WS().PT(12).Children(status, values))).SetTitle("Interactive box")));
+        }
+
+        public HTMLElement Render() => _content.Render();
+    }
+}

--- a/Tesserae.Tests/src/Samples/Components/PropertyGridSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/PropertyGridSample.cs
@@ -1,0 +1,99 @@
+using System;
+using static H5.Core.dom;
+using static Tesserae.UI;
+using static Tesserae.Tests.Samples.SamplesHelper;
+
+namespace Tesserae.Tests.Samples
+{
+    [SampleDetails(Group = "Components", Order = 209, Icon = UIcons.ListCheck)]
+    public class PropertyGridSample : IComponent, ISample
+    {
+        public enum AccountTier { Free, Pro, Enterprise }
+
+        public class Address
+        {
+            public string Street  { get; set; }
+            public string City    { get; set; }
+            public string ZipCode { get; set; }
+        }
+
+        public class UserProfile
+        {
+            public string      Name          { get; set; }
+            public string      Email         { get; set; }
+            public string      Bio           { get; set; }
+            public int         Age           { get; set; }
+            public double      CreditBalance { get; set; }
+            public bool        IsActive      { get; set; }
+            public AccountTier Tier          { get; set; }
+            public DateTime    MemberSince   { get; set; }
+            public Color       FavoriteColor { get; set; }
+            public Address     HomeAddress   { get; set; }
+            public string      AccountId     { get; set; }
+        }
+
+        private readonly IComponent _content;
+
+        public PropertyGridSample()
+        {
+            var profile = new UserProfile
+            {
+                Name          = "Ada Lovelace",
+                Email         = "ada@example.com",
+                Bio           = "Mathematician and writer, known for work on Charles Babbage's Analytical Engine.",
+                Age           = 36,
+                CreditBalance = 128.50,
+                IsActive      = true,
+                Tier          = AccountTier.Pro,
+                MemberSince   = new DateTime(2021, 4, 12, 9, 30, 0),
+                FavoriteColor = Color.FromArgb(0x33, 0x99, 0xFF),
+                HomeAddress   = new Address { Street = "12 St James's Square", City = "London", ZipCode = "SW1Y 4LE" },
+                AccountId     = "usr_8f3a91c2"
+            };
+
+            var readout  = TextBlock("").Secondary();
+            var validator = Validator();
+
+            var grid = PropertyGrid(profile)
+               .WithValidator(validator)
+               .Label("Bio", "Biography")
+               .Multiline("Bio")
+               .Description("Email", "Used for sign-in and notifications.")
+               .Description("CreditBalance", "Account balance in USD.")
+               .Order("Name", 1)
+               .Order("Email", 2)
+               .Order("Bio", 3)
+               .ReadOnly("AccountId")
+               .Validate("Name", v => string.IsNullOrWhiteSpace(v as string) ? "Name is required" : null)
+               .Validate("Email", v =>
+               {
+                   var email = v as string ?? "";
+                   return email.Contains("@") && email.Contains(".") ? null : "Enter a valid email address";
+               })
+               .OnChange(p => readout.Text = $"{p.Name} · {p.Email} · age {p.Age} · {p.Tier} · active: {p.IsActive} · balance: {p.CreditBalance}");
+
+            readout.Text = $"{profile.Name} · {profile.Email} · age {profile.Age} · {profile.Tier} · active: {profile.IsActive} · balance: {profile.CreditBalance}";
+
+            _content = SectionStack().Secondary()
+               .SampleTitle(typeof(PropertyGridSample), UIcons.ListCheck, "Metadata-driven, two-way-bound property editor")
+               .Section(Stack().Children(
+                    Card(VStack().WS().Children(
+                        TextBlock("PropertyGrid reflects over a typed object and auto-generates an editing form, mapping each property type to an existing Tesserae input (string→TextBox, multiline→TextArea, numbers→NumberPicker, bool→Toggle, enum→Dropdown, DateTime→DateTimePicker, Color→ColorPicker, and nested objects→a recursive grouped Expander). Edits flow straight back onto the object and are surfaced via an observable. Labels, descriptions, ordering, read-only and validation are configurable."))).SetTitle("Overview")))
+               .Section(Stack().Children(
+                    Card(VStack().WS().Children(
+                        grid.WS(),
+                        HStack().WS().PT(12).Children(
+                            Button("Validate").Primary().SetIcon(UIcons.CheckCircle).OnClick(() =>
+                            {
+                                if (validator.IsValid) Toast().Success("Valid", "All fields are valid");
+                                else Toast().Warning("Invalid", "Please fix the highlighted fields");
+                            })))).SetTitle("Edit profile")))
+               .Section(Stack().Children(
+                    Card(VStack().WS().Children(
+                        SampleSubTitle("Live bound value"),
+                        readout)).SetTitle("Two-way binding")));
+        }
+
+        public HTMLElement Render() => _content.Render();
+    }
+}

--- a/Tesserae.Tests/src/Samples/Components/PropertyGridSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/PropertyGridSample.cs
@@ -91,7 +91,11 @@ namespace Tesserae.Tests.Samples
                .Section(Stack().Children(
                     Card(VStack().WS().Children(
                         SampleSubTitle("Live bound value"),
-                        readout)).SetTitle("Two-way binding")));
+                        readout)).SetTitle("Two-way binding")))
+               .Section(Stack().Children(
+                    Card(VStack().WS().Children(
+                        TextBlock("Calling .ReadOnly() with no arguments renders the whole grid as a non-editable view of the same object — every field shows its value but cannot be changed. Passing property names instead restricts read-only to just those fields."),
+                        PropertyGrid(profile).ReadOnly().Ignore("AccountId").WS())).SetTitle("Read-only view")));
         }
 
         public HTMLElement Render() => _content.Render();

--- a/Tesserae/src/Base/UI.Components.cs
+++ b/Tesserae/src/Base/UI.Components.cs
@@ -1327,6 +1327,52 @@ namespace Tesserae
         public static Sparkline Sparkline(double[] data, double width = 100, double height = 30, string color = "") => new Sparkline(data, width, height, color);
 
         /// <summary>
+        /// Creates a metadata-driven <see cref="Tesserae.PropertyGrid{T}"/> that auto-generates a two-way-bound
+        /// editing form for the supplied object.
+        /// </summary>
+        public static PropertyGrid<T> PropertyGrid<T>(T instance) => new PropertyGrid<T>(instance);
+
+        /// <summary>
+        /// Creates a new responsive SVG <see cref="Tesserae.LineChart"/>. Add data with <c>.Series(...)</c> / <c>.Data(...)</c>.
+        /// </summary>
+        public static LineChart LineChart() => new LineChart();
+
+        /// <summary>
+        /// Creates a new responsive SVG <see cref="Tesserae.LineChart"/> seeded with a single series of values.
+        /// </summary>
+        public static LineChart LineChart(double[] data) => new LineChart().Data(data);
+
+        /// <summary>
+        /// Creates a new responsive SVG <see cref="Tesserae.BarChart"/>. Add data with <c>.Series(...)</c> / <c>.Data(...)</c>.
+        /// </summary>
+        public static BarChart BarChart() => new BarChart();
+
+        /// <summary>
+        /// Creates a new responsive SVG <see cref="Tesserae.BarChart"/> seeded with a single series of values.
+        /// </summary>
+        public static BarChart BarChart(double[] data) => new BarChart().Data(data);
+
+        /// <summary>
+        /// Creates a new responsive SVG <see cref="Tesserae.AreaChart"/>. Add data with <c>.Series(...)</c> / <c>.Data(...)</c>.
+        /// </summary>
+        public static AreaChart AreaChart() => new AreaChart();
+
+        /// <summary>
+        /// Creates a new responsive SVG <see cref="Tesserae.AreaChart"/> seeded with a single series of values.
+        /// </summary>
+        public static AreaChart AreaChart(double[] data) => new AreaChart().Data(data);
+
+        /// <summary>
+        /// Creates a new responsive SVG <see cref="Tesserae.PieChart"/>. Add data with <c>.Data(...)</c> and labels with <c>.Labels(...)</c>.
+        /// </summary>
+        public static PieChart PieChart() => new PieChart();
+
+        /// <summary>
+        /// Creates a new responsive SVG <see cref="Tesserae.PieChart"/> seeded with slice values.
+        /// </summary>
+        public static PieChart PieChart(double[] data) => new PieChart().Data(data);
+
+        /// <summary>
         /// Creates a <see cref="Tesserae.StepsSlider{T}"/> component.
         /// </summary>
         public static StepsSlider<T> StepsSlider<T>(params T[] steps) where T : IEquatable<T> => new StepsSlider<T>(steps);

--- a/Tesserae/src/Components/AreaChart.cs
+++ b/Tesserae/src/Components/AreaChart.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Linq;
+using static H5.Core.dom;
+
+namespace Tesserae
+{
+    /// <summary>
+    /// A lightweight, dependency-free SVG area chart. Renders each series as a gradient-filled region under its
+    /// line (matching <see cref="Sparkline"/>'s fill style), with hoverable points, gridlines and category labels.
+    /// </summary>
+    [H5.Name("tss.AreaChart")]
+    public sealed class AreaChart : CartesianChartBase<AreaChart>
+    {
+        private bool _showPoints = true;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AreaChart"/> class.
+        /// </summary>
+        public AreaChart() : base() { }
+
+        /// <summary>Shows or hides the per-point markers.</summary>
+        public AreaChart Points(bool show = true) { _showPoints = show; QueueRender(); return this; }
+
+        // Areas read most naturally filled down to a zero baseline.
+        protected override bool IncludeZeroBaseline => true;
+
+        protected override void RenderSeries()
+        {
+            var baselineY = PixelY(Math.Max(0, _minValue));
+
+            for (int s = 0; s < _series.Count; s++)
+            {
+                var series = _series[s];
+                var color  = ColorFor(s, series);
+
+                if (series.Values.Length == 0) continue;
+
+                var gradientId = "tss-area-grad-" + Guid.NewGuid().ToString("N").Substring(0, 8);
+
+                var defs           = El("defs");
+                var linearGradient = El("linearGradient");
+                Attr(linearGradient, "id", gradientId);
+                Attr(linearGradient, "x1", "0%");
+                Attr(linearGradient, "y1", "0%");
+                Attr(linearGradient, "x2", "0%");
+                Attr(linearGradient, "y2", "100%");
+
+                var stop1 = El("stop");
+                Attr(stop1, "offset", "0%");
+                Attr(stop1, "stop-color", color);
+                Attr(stop1, "stop-opacity", "0.45");
+                var stop2 = El("stop");
+                Attr(stop2, "offset", "100%");
+                Attr(stop2, "stop-color", color);
+                Attr(stop2, "stop-opacity", "0.02");
+                linearGradient.appendChild(stop1);
+                linearGradient.appendChild(stop2);
+                defs.appendChild(linearGradient);
+                _svg.appendChild(defs);
+
+                var linePoints = string.Join(" ", series.Values.Select((v, i) => $"{PointX(i).ToString("0.###")},{PixelY(v).ToString("0.###")}"));
+
+                var firstX = PointX(0).ToString("0.###");
+                var lastX  = PointX(series.Values.Length - 1).ToString("0.###");
+
+                var polygon = El("polygon");
+                Attr(polygon, "fill", "url(#" + gradientId + ")");
+                Attr(polygon, "points", $"{firstX},{baselineY.ToString("0.###")} {linePoints} {lastX},{baselineY.ToString("0.###")}");
+                _svg.appendChild(polygon);
+
+                var polyline = El("polyline");
+                Attr(polyline, "fill", "none");
+                Attr(polyline, "stroke", color);
+                Attr(polyline, "stroke-width", 2);
+                Attr(polyline, "stroke-linejoin", "round");
+                Attr(polyline, "stroke-linecap", "round");
+                Attr(polyline, "points", linePoints);
+                _svg.appendChild(polyline);
+
+                if (_showPoints)
+                {
+                    for (int i = 0; i < series.Values.Length; i++)
+                    {
+                        var circle = El("circle");
+                        Attr(circle, "cx", PointX(i));
+                        Attr(circle, "cy", PixelY(series.Values[i]));
+                        Attr(circle, "r", 3);
+                        Attr(circle, "fill", color);
+                        AttachPointTooltip(circle, TooltipFor(series, i));
+                        _svg.appendChild(circle);
+                    }
+                }
+            }
+        }
+
+        private string TooltipFor(ChartSeries series, int i)
+        {
+            var label = i < _categories.Length ? _categories[i] : "#" + (i + 1);
+            var name  = string.IsNullOrEmpty(series.Name) ? "" : series.Name + " — ";
+            return $"{name}{label}: {_valueFormatter(series.Values[i])}";
+        }
+    }
+}

--- a/Tesserae/src/Components/BarChart.cs
+++ b/Tesserae/src/Components/BarChart.cs
@@ -1,0 +1,71 @@
+using System;
+using static H5.Core.dom;
+
+namespace Tesserae
+{
+    /// <summary>
+    /// A lightweight, dependency-free SVG bar chart. Renders grouped bars per category (one bar per series),
+    /// with a zero baseline, value gridlines, category labels, hover tooltips and a theme-aware palette.
+    /// </summary>
+    [H5.Name("tss.BarChart")]
+    public sealed class BarChart : CartesianChartBase<BarChart>
+    {
+        private double _cornerRadius = 2;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BarChart"/> class.
+        /// </summary>
+        public BarChart() : base() { }
+
+        /// <summary>Sets the corner radius of the bars.</summary>
+        public BarChart Rounded(double radius = 2) { _cornerRadius = radius; QueueRender(); return this; }
+
+        // Bars are read against a zero baseline.
+        protected override bool IncludeZeroBaseline => true;
+
+        protected override void RenderSeries()
+        {
+            var baselineY  = PixelY(0);
+            var slotWidth  = _plotWidth / _pointCount;
+            var groupInset = slotWidth * 0.15;
+            var groupWidth = slotWidth - groupInset * 2;
+            var barWidth   = _series.Count > 0 ? groupWidth / _series.Count : groupWidth;
+
+            for (int i = 0; i < _pointCount; i++)
+            {
+                var slotLeft = _plotLeft + slotWidth * i + groupInset;
+
+                for (int s = 0; s < _series.Count; s++)
+                {
+                    var series = _series[s];
+                    if (i >= series.Values.Length) continue;
+
+                    var value = series.Values[i];
+                    var color = ColorFor(s, series);
+
+                    var yValue = PixelY(value);
+                    var x      = slotLeft + barWidth * s;
+                    var top    = Math.Min(yValue, baselineY);
+                    var height = Math.Abs(baselineY - yValue);
+
+                    var rect = El("rect");
+                    Attr(rect, "x", x);
+                    Attr(rect, "y", top);
+                    Attr(rect, "width", Math.Max(0, barWidth - 1));
+                    Attr(rect, "height", height);
+                    Attr(rect, "rx", _cornerRadius);
+                    Attr(rect, "fill", color);
+                    AttachPointTooltip(rect, TooltipFor(series, i));
+                    _svg.appendChild(rect);
+                }
+            }
+        }
+
+        private string TooltipFor(ChartSeries series, int i)
+        {
+            var label = i < _categories.Length ? _categories[i] : "#" + (i + 1);
+            var name  = string.IsNullOrEmpty(series.Name) ? "" : series.Name + " — ";
+            return $"{name}{label}: {_valueFormatter(series.Values[i])}";
+        }
+    }
+}

--- a/Tesserae/src/Components/ChartBase.cs
+++ b/Tesserae/src/Components/ChartBase.cs
@@ -1,0 +1,546 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using H5;
+using static H5.Core.dom;
+using static Tesserae.UI;
+
+namespace Tesserae
+{
+    /// <summary>
+    /// A single named data series for a chart, with an optional explicit color (falling back to the chart palette).
+    /// </summary>
+    [H5.Name("tss.ChartSeries")]
+    public sealed class ChartSeries
+    {
+        /// <summary>The series display name, used in the legend, tooltips and accessibility summary.</summary>
+        public string Name { get; set; }
+
+        /// <summary>The series values, one per category/point.</summary>
+        public double[] Values { get; set; }
+
+        /// <summary>An optional explicit CSS color; when null the chart assigns a palette color by index.</summary>
+        public string Color { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ChartSeries"/> class.
+        /// </summary>
+        public ChartSeries(string name, double[] values, string color = null)
+        {
+            Name   = name;
+            Values = values ?? new double[0];
+            Color  = color;
+        }
+    }
+
+    /// <summary>
+    /// Shared base for Tesserae's lightweight, dependency-free SVG charts. Handles the responsive SVG surface
+    /// (sized 1:1 to its container via a <see cref="ResizeObserver"/>), the series/palette model, observable-driven
+    /// re-rendering, theme colors, tooltips (reusing tippy) and the role="img" accessibility summary.
+    /// Mirrors <see cref="Sparkline"/>'s SVG rendering style.
+    /// </summary>
+    [H5.Name("tss.ChartBase")]
+    public abstract class ChartBase<T> : IComponent where T : ChartBase<T>
+    {
+        /// <summary>The SVG namespace used for every chart element.</summary>
+        protected const string SvgNs = "http://www.w3.org/2000/svg";
+
+        /// <summary>The default theme-aware palette (CSS variables that adapt to light/dark mode).</summary>
+        protected static readonly string[] DefaultPalette =
+        {
+            Theme.Colors.Blue600,
+            Theme.Colors.Green600,
+            Theme.Colors.Orange600,
+            Theme.Colors.Purple600,
+            Theme.Colors.Red600,
+            Theme.Colors.Teal600,
+            Theme.Colors.Yellow600,
+            Theme.Colors.Neutral600
+        };
+
+        /// <summary>The root container element.</summary>
+        protected readonly HTMLElement _container;
+
+        /// <summary>The SVG surface that the chart draws into.</summary>
+        protected readonly Element _svg;
+
+        /// <summary>The chart's series.</summary>
+        protected readonly List<ChartSeries> _series = new List<ChartSeries>();
+
+        private readonly ResizeObserver _resizeObserver;
+        private readonly List<IDisposable> _subscriptions = new List<IDisposable>();
+
+        /// <summary>The active color palette.</summary>
+        protected string[] _palette = DefaultPalette;
+
+        /// <summary>Whether to render per-element tippy + native &lt;title&gt; tooltips.</summary>
+        protected bool _showTooltips = true;
+
+        /// <summary>Whether to render the legend.</summary>
+        protected bool _showLegend = false;
+
+        /// <summary>An optional caption used as the accessibility summary; falls back to a generated description.</summary>
+        protected string _title;
+
+        /// <summary>Optional formatter for values shown in tooltips / axis labels.</summary>
+        protected Func<double, string> _valueFormatter = v => v.ToString("0.##");
+
+        private bool _renderQueued;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ChartBase{T}"/> class.
+        /// </summary>
+        protected ChartBase(double minWidth = 120, double minHeight = 80)
+        {
+            _container = Div(_("tss-chart"));
+            _container.style.width     = "100%";
+            _container.style.height    = "100%";
+            _container.style.minWidth  = minWidth + "px";
+            _container.style.minHeight = minHeight + "px";
+            _container.setAttribute("role", "img");
+
+            _svg = document.createElementNS(SvgNs, "svg");
+            _svg.setAttribute("width", "100%");
+            _svg.setAttribute("height", "100%");
+            _svg.As<HTMLElement>().style.display = "block";
+            _container.appendChild(_svg);
+
+            _resizeObserver = new ResizeObserver((entries, obs) => QueueRender());
+            _resizeObserver.observe(_container);
+            DomObserver.WhenMounted(_container, QueueRender);
+            DomObserver.WhenRemoved(_container, () =>
+            {
+                _resizeObserver.unobserve(_container);
+                foreach (var s in _subscriptions) s.Dispose();
+                _subscriptions.Clear();
+            });
+        }
+
+        private T Self => (T)this;
+
+        /// <summary>Replaces the chart's series with a single unnamed series of plain values.</summary>
+        public T Data(double[] values) => Series(new ChartSeries(null, values));
+
+        /// <summary>Replaces the chart's series.</summary>
+        public T Series(params ChartSeries[] series)
+        {
+            _series.Clear();
+            if (series != null) _series.AddRange(series);
+            QueueRender();
+            return Self;
+        }
+
+        /// <summary>Appends a single named series of plain values.</summary>
+        public T Series(string name, double[] values, string color = null)
+        {
+            _series.Add(new ChartSeries(name, values, color));
+            QueueRender();
+            return Self;
+        }
+
+        /// <summary>
+        /// Binds a single series to an observable sequence of values: the chart re-renders whenever the
+        /// observable changes. The subscription is released when the chart leaves the DOM.
+        /// </summary>
+        public T Series(IObservable<double[]> values, string name = null, string color = null)
+        {
+            var series = new ChartSeries(name, values?.Value ?? new double[0], color);
+            _series.Add(series);
+
+            if (values != null)
+            {
+                _subscriptions.Add(values.Subscribe(v =>
+                {
+                    series.Values = v ?? new double[0];
+                    QueueRender();
+                }, fireImmediately: false));
+            }
+
+            QueueRender();
+            return Self;
+        }
+
+        /// <summary>Binds the chart to an observable list of series, re-rendering on every change.</summary>
+        public T Series(IObservable<ChartSeries[]> series)
+        {
+            if (series != null)
+            {
+                _subscriptions.Add(series.Subscribe(s =>
+                {
+                    _series.Clear();
+                    if (s != null) _series.AddRange(s);
+                    QueueRender();
+                }, fireImmediately: true));
+            }
+            return Self;
+        }
+
+        /// <summary>Sets the series color palette (used for series without an explicit color).</summary>
+        public T Colors(params string[] palette)
+        {
+            if (palette != null && palette.Length > 0) _palette = palette;
+            QueueRender();
+            return Self;
+        }
+
+        /// <summary>Enables or disables per-element tooltips.</summary>
+        public T Tooltips(bool show = true) { _showTooltips = show; QueueRender(); return Self; }
+
+        /// <summary>Enables or disables the legend.</summary>
+        public T Legend(bool show = true) { _showLegend = show; QueueRender(); return Self; }
+
+        /// <summary>Sets an accessibility caption / summary for the chart.</summary>
+        public T Title(string title) { _title = title; QueueRender(); return Self; }
+
+        /// <summary>Sets the formatter used for values in tooltips and labels.</summary>
+        public T FormatValues(Func<double, string> formatter) { if (formatter != null) _valueFormatter = formatter; QueueRender(); return Self; }
+
+        /// <summary>Returns the color for the series at the given index (explicit color or palette by index).</summary>
+        protected string ColorFor(int index, ChartSeries series) => series.Color ?? _palette[index % _palette.Length];
+
+        /// <summary>Creates an SVG element in the SVG namespace.</summary>
+        protected Element El(string name) => document.createElementNS(SvgNs, name);
+
+        /// <summary>Sets an attribute on an SVG element (double values are invariant-formatted).</summary>
+        protected static void Attr(Element el, string name, double value) => el.setAttribute(name, value.ToString("0.###"));
+
+        /// <summary>Sets an attribute on an SVG element.</summary>
+        protected static void Attr(Element el, string name, string value) => el.setAttribute(name, value);
+
+        /// <summary>
+        /// Attaches a hover tooltip to an SVG element: a native &lt;title&gt; child (for accessibility / no-JS fallback)
+        /// and, when enabled, a tippy popover reusing the bundled tippy.js.
+        /// </summary>
+        protected void AttachPointTooltip(Element el, string content)
+        {
+            if (string.IsNullOrEmpty(content)) return;
+
+            var title = El("title");
+            title.textContent = content;
+            el.appendChild(title);
+
+            if (_showTooltips)
+            {
+                Script.Write("tippy({0}, { content: {1}, allowHTML: true, delay: [100, 0], appendTo: document.body });", el, content);
+            }
+        }
+
+        /// <summary>Removes every child of the SVG surface.</summary>
+        protected void ClearSvg()
+        {
+            while (_svg.firstChild != null) _svg.removeChild(_svg.firstChild);
+        }
+
+        /// <summary>Schedules a render on the next animation frame, coalescing bursts of changes.</summary>
+        protected void QueueRender()
+        {
+            if (_renderQueued) return;
+            _renderQueued = true;
+            window.requestAnimationFrame(_ =>
+            {
+                _renderQueued = false;
+                Render(force: true);
+            });
+        }
+
+        private void Render(bool force)
+        {
+            var rect = _container.getBoundingClientRect().As<DOMRect>();
+            var w    = rect.width;
+            var h    = rect.height;
+
+            if (w < 1 || h < 1) return; // not laid out yet; a later resize/mount will trigger us
+
+            _svg.setAttribute("viewBox", $"0 0 {w.ToString("0.##")} {h.ToString("0.##")}");
+            _svg.setAttribute("preserveAspectRatio", "none");
+
+            ClearSvg();
+            RenderChart(w, h);
+            _container.setAttribute("aria-label", BuildAriaLabel());
+        }
+
+        /// <summary>Draws the chart into the SVG surface at the given pixel dimensions.</summary>
+        protected abstract void RenderChart(double width, double height);
+
+        /// <summary>Builds the accessibility summary describing the chart's data.</summary>
+        protected virtual string BuildAriaLabel()
+        {
+            if (!string.IsNullOrEmpty(_title)) return _title;
+
+            var kind = GetType().Name.Replace("Chart", " chart");
+
+            if (_series.Count == 0) return kind + " with no data";
+
+            var parts = _series.Select(s =>
+            {
+                var name = string.IsNullOrEmpty(s.Name) ? "series" : s.Name;
+                if (s.Values.Length == 0) return name + " (empty)";
+                return $"{name}: {s.Values.Length} points, from {_valueFormatter(s.Values.Min())} to {_valueFormatter(s.Values.Max())}";
+            });
+
+            return $"{kind}. " + string.Join("; ", parts);
+        }
+
+        /// <summary>Renders the legend swatches into the supplied container element, returning its height.</summary>
+        protected double RenderLegend(double width, double y)
+        {
+            if (!_showLegend || _series.Count == 0) return 0;
+
+            const double swatch = 10;
+            const double gap    = 6;
+            const double itemGap = 16;
+            double x = 8;
+
+            for (int i = 0; i < _series.Count; i++)
+            {
+                var color = ColorFor(i, _series[i]);
+                var name  = string.IsNullOrEmpty(_series[i].Name) ? $"Series {i + 1}" : _series[i].Name;
+
+                var rect = El("rect");
+                Attr(rect, "x", x);
+                Attr(rect, "y", y);
+                Attr(rect, "width", swatch);
+                Attr(rect, "height", swatch);
+                Attr(rect, "rx", 2);
+                Attr(rect, "fill", color);
+                _svg.appendChild(rect);
+
+                var text = El("text");
+                Attr(text, "x", x + swatch + gap);
+                Attr(text, "y", y + swatch);
+                Attr(text, "font-size", "11");
+                Attr(text, "fill", Theme.Default.Foreground);
+                text.textContent = name;
+                _svg.appendChild(text);
+
+                x += swatch + gap + name.Length * 6.5 + itemGap;
+            }
+
+            return 22;
+        }
+
+        /// <summary>
+        /// Renders the component's root HTML element.
+        /// </summary>
+        public HTMLElement Render() => _container;
+    }
+
+    /// <summary>
+    /// Base for cartesian (x/y) charts — line, bar and area. Draws the value (Y) gridlines and labels, the
+    /// category (X) axis labels, the axis lines, and computes the plot rectangle and value-to-pixel scale that
+    /// subclasses use to plot their series.
+    /// </summary>
+    [H5.Name("tss.CartesianChartBase")]
+    public abstract class CartesianChartBase<T> : ChartBase<T> where T : CartesianChartBase<T>
+    {
+        /// <summary>Category labels along the X axis.</summary>
+        protected string[] _categories = new string[0];
+
+        /// <summary>Whether to draw horizontal gridlines.</summary>
+        protected bool _showGrid = true;
+
+        /// <summary>Whether to draw the axes and their labels.</summary>
+        protected bool _showAxes = true;
+
+        /// <summary>Optional X axis title.</summary>
+        protected string _xAxisTitle;
+
+        /// <summary>Optional Y axis title.</summary>
+        protected string _yAxisTitle;
+
+        // Plot rectangle + value scale, populated before RenderSeries is called.
+        /// <summary>Left edge of the plot area, in pixels.</summary>
+        protected double _plotLeft;
+        /// <summary>Top edge of the plot area, in pixels.</summary>
+        protected double _plotTop;
+        /// <summary>Width of the plot area, in pixels.</summary>
+        protected double _plotWidth;
+        /// <summary>Height of the plot area, in pixels.</summary>
+        protected double _plotHeight;
+        /// <summary>The minimum value mapped to the bottom of the plot.</summary>
+        protected double _minValue;
+        /// <summary>The maximum value mapped to the top of the plot.</summary>
+        protected double _maxValue;
+        /// <summary>The number of categories/points along the X axis.</summary>
+        protected int _pointCount;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CartesianChartBase{T}"/> class.
+        /// </summary>
+        protected CartesianChartBase(double minWidth = 200, double minHeight = 120) : base(minWidth, minHeight) { }
+
+        private T Self => (T)this;
+
+        /// <summary>Sets the category labels along the X axis.</summary>
+        public T XAxis(params string[] categories) { _categories = categories ?? new string[0]; QueueRender(); return Self; }
+
+        /// <summary>Sets the X axis title.</summary>
+        public T XAxisTitle(string title) { _xAxisTitle = title; QueueRender(); return Self; }
+
+        /// <summary>Sets the Y axis title.</summary>
+        public T YAxisTitle(string title) { _yAxisTitle = title; QueueRender(); return Self; }
+
+        /// <summary>Shows or hides the horizontal gridlines.</summary>
+        public T Grid(bool show = true) { _showGrid = show; QueueRender(); return Self; }
+
+        /// <summary>Shows or hides the axes and their labels.</summary>
+        public T Axes(bool show = true) { _showAxes = show; QueueRender(); return Self; }
+
+        /// <summary>When true the value axis always includes zero as a baseline (bar/area); when false it fits the data.</summary>
+        protected virtual bool IncludeZeroBaseline => true;
+
+        /// <summary>Maps a value to its pixel Y coordinate within the plot area.</summary>
+        protected double PixelY(double value)
+        {
+            var range = _maxValue - _minValue;
+            if (range <= 0) range = 1;
+            return _plotTop + _plotHeight - ((value - _minValue) / range) * _plotHeight;
+        }
+
+        /// <inheritdoc />
+        protected override void RenderChart(double width, double height)
+        {
+            _pointCount = _series.Count == 0 ? 0 : _series.Max(s => s.Values.Length);
+
+            var legendHeight = RenderLegend(width, 6);
+
+            double marginTop    = 8 + legendHeight;
+            double marginRight  = 12;
+            double marginBottom = _showAxes ? (_categories.Length > 0 || !string.IsNullOrEmpty(_xAxisTitle) ? 34 : 18) : 6;
+            double marginLeft   = _showAxes ? 44 : 6;
+
+            _plotLeft   = marginLeft;
+            _plotTop    = marginTop;
+            _plotWidth  = Math.Max(1, width - marginLeft - marginRight);
+            _plotHeight = Math.Max(1, height - marginTop - marginBottom);
+
+            ComputeValueRange();
+
+            if (_showGrid || _showAxes) DrawGridAndAxes();
+
+            if (_pointCount > 0) RenderSeries();
+        }
+
+        private void ComputeValueRange()
+        {
+            var all = _series.SelectMany(s => s.Values).ToArray();
+
+            if (all.Length == 0)
+            {
+                _minValue = 0;
+                _maxValue = 1;
+                return;
+            }
+
+            var dataMin = all.Min();
+            var dataMax = all.Max();
+
+            if (IncludeZeroBaseline)
+            {
+                dataMin = Math.Min(0, dataMin);
+                dataMax = Math.Max(0, dataMax);
+            }
+
+            if (dataMin == dataMax)
+            {
+                // Avoid a zero range so a flat series still renders sensibly.
+                dataMax = dataMin + 1;
+                if (!IncludeZeroBaseline) dataMin -= 1;
+            }
+            else if (!IncludeZeroBaseline)
+            {
+                var pad = (dataMax - dataMin) * 0.08;
+                dataMin -= pad;
+                dataMax += pad;
+            }
+
+            _minValue = dataMin;
+            _maxValue = dataMax;
+        }
+
+        private void DrawGridAndAxes()
+        {
+            const int ticks = 4;
+            var gridColor = Theme.Colors.Neutral500Alpha;
+            var textColor = Theme.Default.Foreground;
+
+            for (int i = 0; i <= ticks; i++)
+            {
+                var value = _minValue + (_maxValue - _minValue) * i / ticks;
+                var y     = PixelY(value);
+
+                if (_showGrid)
+                {
+                    var line = El("line");
+                    Attr(line, "x1", _plotLeft);
+                    Attr(line, "y1", y);
+                    Attr(line, "x2", _plotLeft + _plotWidth);
+                    Attr(line, "y2", y);
+                    Attr(line, "stroke", gridColor);
+                    Attr(line, "stroke-width", 1);
+                    _svg.appendChild(line);
+                }
+
+                if (_showAxes)
+                {
+                    var label = El("text");
+                    Attr(label, "x", _plotLeft - 6);
+                    Attr(label, "y", y + 3);
+                    Attr(label, "text-anchor", "end");
+                    Attr(label, "font-size", "10");
+                    Attr(label, "fill", textColor);
+                    label.textContent = _valueFormatter(value);
+                    _svg.appendChild(label);
+                }
+            }
+
+            if (!_showAxes) return;
+
+            // X category labels
+            if (_categories.Length > 0 && _pointCount > 0)
+            {
+                for (int i = 0; i < _categories.Length && i < _pointCount; i++)
+                {
+                    var x = CategoryCenterX(i);
+                    var label = El("text");
+                    Attr(label, "x", x);
+                    Attr(label, "y", _plotTop + _plotHeight + 14);
+                    Attr(label, "text-anchor", "middle");
+                    Attr(label, "font-size", "10");
+                    Attr(label, "fill", textColor);
+                    label.textContent = _categories[i];
+                    _svg.appendChild(label);
+                }
+            }
+
+            // Axis lines
+            var axis = El("line");
+            Attr(axis, "x1", _plotLeft);
+            Attr(axis, "y1", _plotTop + _plotHeight);
+            Attr(axis, "x2", _plotLeft + _plotWidth);
+            Attr(axis, "y2", _plotTop + _plotHeight);
+            Attr(axis, "stroke", textColor);
+            Attr(axis, "stroke-width", 1);
+            _svg.appendChild(axis);
+        }
+
+        /// <summary>Returns the pixel X coordinate of the center of category slot <paramref name="index"/>.</summary>
+        protected double CategoryCenterX(int index)
+        {
+            if (_pointCount <= 1) return _plotLeft + _plotWidth / 2;
+            // Bar-style centered slots; line/area override via PointX for edge-to-edge layout.
+            var slot = _plotWidth / _pointCount;
+            return _plotLeft + slot * index + slot / 2;
+        }
+
+        /// <summary>Returns the pixel X coordinate for point <paramref name="index"/> of a line/area series.</summary>
+        protected double PointX(int index)
+        {
+            if (_pointCount <= 1) return _plotLeft + _plotWidth / 2;
+            return _plotLeft + _plotWidth * index / (_pointCount - 1);
+        }
+
+        /// <summary>Plots the series into the computed plot rectangle.</summary>
+        protected abstract void RenderSeries();
+    }
+}

--- a/Tesserae/src/Components/HorizontalSplitView.cs
+++ b/Tesserae/src/Components/HorizontalSplitView.cs
@@ -60,52 +60,36 @@ namespace Tesserae
 
         private void HookDragEvents(IComponent dragArea)
         {
-            var el = dragArea.Render();
+            // Use the unified pointer-based pan gesture so the splitter is draggable with mouse, touch and pen.
+            // (Previously only mouse events were wired, so resizing did not work on touch screens.)
+            double      height       = 0;
+            DOMRect     rect         = null;
+            HTMLElement current      = null;
+            bool        currentIsBottom = false;
 
-            double      height = 0;
-            DOMRect     rect;
-            HTMLElement current;
-
-            el.onmousedown += (me) =>
+            dragArea.OnPan(g =>
             {
-                if (_splitContainer.classList.contains("tss-split-bottom"))
+                if (g.Phase == GesturePhase.Start)
                 {
-                    current = _bottomComponent.Render();
+                    currentIsBottom = _splitContainer.classList.contains("tss-split-bottom");
+                    current         = currentIsBottom ? _bottomComponent.Render() : _topComponent.Render();
+                    rect            = _splitContainer.getBoundingClientRect().As<DOMRect>();
                 }
-                else
-                {
-                    current = _topComponent.Render();
-                }
-                rect               =  _splitContainer.getBoundingClientRect().As<DOMRect>();
-                window.onmousemove += Resize;
-                window.onmouseup   += StopResize;
-                StopEvent(me);
-            };
 
-            void Resize(MouseEvent me)
-            {
-                if (_splitContainer.classList.contains("tss-split-bottom"))
-                {
-                    height = Math.Min(rect.height - 16, Math.Max(16, (rect.bottom - me.clientY)));
-                }
-                else
-                {
-                    height = Math.Min(rect.height - 16, Math.Max(16, (me.clientY - rect.top)));
-                }
+                if (rect == null || current == null) return;
+
+                double raw = currentIsBottom ? (rect.bottom - g.Y) : (g.Y - rect.top);
+                height                   = Math.Min(rect.height - 16, Math.Max(16, raw));
                 current.style.height     = height + "px";
                 current.style.flexGrow   = "0";
                 current.style.flexShrink = "1";
-                StopEvent(me);
-            }
 
-            void StopResize(MouseEvent me)
-            {
-                window.onmousemove -= Resize;
-                window.onmouseup   -= StopResize;
-                _onResizeEnd?.Invoke((int)height);
-                rect = null;
-                StopEvent(me);
-            }
+                if (g.Phase == GesturePhase.End)
+                {
+                    _onResizeEnd?.Invoke((int)height);
+                    rect = null;
+                }
+            });
         }
 
         /// <summary>

--- a/Tesserae/src/Components/LineChart.cs
+++ b/Tesserae/src/Components/LineChart.cs
@@ -1,0 +1,69 @@
+using System.Linq;
+using static H5.Core.dom;
+
+namespace Tesserae
+{
+    /// <summary>
+    /// A lightweight, dependency-free SVG line chart. Plots one or more series as connected polylines with
+    /// hoverable points, value gridlines, category labels and a theme-aware palette. Fluent and responsive.
+    /// </summary>
+    [H5.Name("tss.LineChart")]
+    public sealed class LineChart : CartesianChartBase<LineChart>
+    {
+        private bool _showPoints = true;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LineChart"/> class.
+        /// </summary>
+        public LineChart() : base() { }
+
+        /// <summary>Shows or hides the per-point markers.</summary>
+        public LineChart Points(bool show = true) { _showPoints = show; QueueRender(); return this; }
+
+        // Line charts fit the data range rather than forcing a zero baseline.
+        protected override bool IncludeZeroBaseline => false;
+
+        protected override void RenderSeries()
+        {
+            for (int s = 0; s < _series.Count; s++)
+            {
+                var series = _series[s];
+                var color  = ColorFor(s, series);
+
+                if (series.Values.Length == 0) continue;
+
+                var points = string.Join(" ", series.Values.Select((v, i) => $"{PointX(i).ToString("0.###")},{PixelY(v).ToString("0.###")}"));
+
+                var polyline = El("polyline");
+                Attr(polyline, "fill", "none");
+                Attr(polyline, "stroke", color);
+                Attr(polyline, "stroke-width", 2);
+                Attr(polyline, "stroke-linejoin", "round");
+                Attr(polyline, "stroke-linecap", "round");
+                Attr(polyline, "points", points);
+                _svg.appendChild(polyline);
+
+                if (_showPoints)
+                {
+                    for (int i = 0; i < series.Values.Length; i++)
+                    {
+                        var circle = El("circle");
+                        Attr(circle, "cx", PointX(i));
+                        Attr(circle, "cy", PixelY(series.Values[i]));
+                        Attr(circle, "r", 3);
+                        Attr(circle, "fill", color);
+                        AttachPointTooltip(circle, TooltipFor(series, i));
+                        _svg.appendChild(circle);
+                    }
+                }
+            }
+        }
+
+        private string TooltipFor(ChartSeries series, int i)
+        {
+            var label = i < _categories.Length ? _categories[i] : "#" + (i + 1);
+            var name  = string.IsNullOrEmpty(series.Name) ? "" : series.Name + " — ";
+            return $"{name}{label}: {_valueFormatter(series.Values[i])}";
+        }
+    }
+}

--- a/Tesserae/src/Components/PieChart.cs
+++ b/Tesserae/src/Components/PieChart.cs
@@ -1,0 +1,160 @@
+using System;
+using System.Linq;
+using static H5.Core.dom;
+using static Tesserae.UI;
+
+namespace Tesserae
+{
+    /// <summary>
+    /// A lightweight, dependency-free SVG pie / donut chart. Renders the first series' values as slices, labelled
+    /// by the configured category labels, with hover tooltips, an optional legend and a theme-aware palette.
+    /// </summary>
+    [H5.Name("tss.PieChart")]
+    public sealed class PieChart : ChartBase<PieChart>
+    {
+        private string[] _labels = new string[0];
+        private double   _donutRatio;   // 0 = full pie; (0,1) = donut hole as a fraction of the radius
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PieChart"/> class.
+        /// </summary>
+        public PieChart() : base() { }
+
+        /// <summary>Sets the per-slice labels.</summary>
+        public PieChart Labels(params string[] labels) { _labels = labels ?? new string[0]; QueueRender(); return this; }
+
+        /// <summary>Renders the chart as a donut with a hole sized as a fraction (0..1) of the radius.</summary>
+        public PieChart Donut(double holeRatio = 0.6) { _donutRatio = Math.Max(0, Math.Min(0.95, holeRatio)); QueueRender(); return this; }
+
+        protected override void RenderChart(double width, double height)
+        {
+            var values = _series.Count > 0 ? _series[0].Values : new double[0];
+            var total  = values.Sum();
+
+            var legendWidth = 0.0;
+            if (_showLegend && values.Length > 0)
+            {
+                legendWidth = Math.Min(width * 0.4, 140);
+            }
+
+            var chartWidth = width - legendWidth;
+            var cx         = chartWidth / 2;
+            var cy         = height / 2;
+            var radius     = Math.Max(4, Math.Min(chartWidth, height) / 2 - 8);
+            var innerR     = radius * _donutRatio;
+
+            if (total <= 0 || values.Length == 0)
+            {
+                return;
+            }
+
+            double startAngle = -Math.PI / 2; // start at 12 o'clock
+
+            for (int i = 0; i < values.Length; i++)
+            {
+                if (values[i] <= 0) continue;
+
+                var sweep    = values[i] / total * Math.PI * 2;
+                var endAngle = startAngle + sweep;
+                var color    = _series[0].Color != null && i == 0 ? _series[0].Color : _palette[i % _palette.Length];
+
+                var path = El("path");
+                Attr(path, "d", SlicePath(cx, cy, radius, innerR, startAngle, endAngle, sweep));
+                Attr(path, "fill", color);
+                Attr(path, "stroke", Theme.Default.Background);
+                Attr(path, "stroke-width", 1);
+                AttachPointTooltip(path, TooltipFor(i, values[i], total));
+                _svg.appendChild(path);
+
+                startAngle = endAngle;
+            }
+
+            DrawLegend(values, chartWidth, height);
+        }
+
+        private string SlicePath(double cx, double cy, double ro, double ri, double a0, double a1, double sweep)
+        {
+            var largeArc = sweep > Math.PI ? 1 : 0;
+
+            var ox0 = cx + ro * Math.Cos(a0);
+            var oy0 = cy + ro * Math.Sin(a0);
+            var ox1 = cx + ro * Math.Cos(a1);
+            var oy1 = cy + ro * Math.Sin(a1);
+
+            if (ri <= 0)
+            {
+                // Full wedge from the center.
+                return $"M {F(cx)} {F(cy)} L {F(ox0)} {F(oy0)} A {F(ro)} {F(ro)} 0 {largeArc} 1 {F(ox1)} {F(oy1)} Z";
+            }
+
+            // Donut annulus segment.
+            var ix1 = cx + ri * Math.Cos(a1);
+            var iy1 = cy + ri * Math.Sin(a1);
+            var ix0 = cx + ri * Math.Cos(a0);
+            var iy0 = cy + ri * Math.Sin(a0);
+
+            return $"M {F(ox0)} {F(oy0)} A {F(ro)} {F(ro)} 0 {largeArc} 1 {F(ox1)} {F(oy1)} " +
+                   $"L {F(ix1)} {F(iy1)} A {F(ri)} {F(ri)} 0 {largeArc} 0 {F(ix0)} {F(iy0)} Z";
+        }
+
+        private static string F(double v) => v.ToString("0.###");
+
+        private void DrawLegend(double[] values, double chartWidth, double height)
+        {
+            if (!_showLegend) return;
+
+            double x = chartWidth + 8;
+            double y = Math.Max(12, height / 2 - values.Length * 9);
+
+            for (int i = 0; i < values.Length; i++)
+            {
+                var color = _palette[i % _palette.Length];
+                var label = i < _labels.Length ? _labels[i] : "#" + (i + 1);
+
+                var rect = El("rect");
+                Attr(rect, "x", x);
+                Attr(rect, "y", y);
+                Attr(rect, "width", 10);
+                Attr(rect, "height", 10);
+                Attr(rect, "rx", 2);
+                Attr(rect, "fill", color);
+                _svg.appendChild(rect);
+
+                var text = El("text");
+                Attr(text, "x", x + 16);
+                Attr(text, "y", y + 9);
+                Attr(text, "font-size", "11");
+                Attr(text, "fill", Theme.Default.Foreground);
+                text.textContent = label;
+                _svg.appendChild(text);
+
+                y += 18;
+            }
+        }
+
+        private string TooltipFor(int i, double value, double total)
+        {
+            var label   = i < _labels.Length ? _labels[i] : "#" + (i + 1);
+            var percent = (value / total * 100).ToString("0.#");
+            return $"{label}: {_valueFormatter(value)} ({percent}%)";
+        }
+
+        protected override string BuildAriaLabel()
+        {
+            if (!string.IsNullOrEmpty(_title)) return _title;
+
+            var values = _series.Count > 0 ? _series[0].Values : new double[0];
+            if (values.Length == 0) return (_donutRatio > 0 ? "Donut" : "Pie") + " chart with no data";
+
+            var total = values.Sum();
+            var parts = values.Select((v, i) =>
+            {
+                var label = i < _labels.Length ? _labels[i] : "#" + (i + 1);
+                var pct   = total > 0 ? (v / total * 100).ToString("0.#") : "0";
+                return $"{label} {pct}%";
+            });
+
+            return (_donutRatio > 0 ? "Donut" : "Pie") + " chart. " + string.Join(", ", parts);
+        }
+    }
+}

--- a/Tesserae/src/Components/PropertyGrid.cs
+++ b/Tesserae/src/Components/PropertyGrid.cs
@@ -1,0 +1,497 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using static H5.Core.dom;
+using static Tesserae.UI;
+
+namespace Tesserae
+{
+    /// <summary>
+    /// Marks a property with a friendly label for the <see cref="PropertyGrid{T}"/>. Attribute support is
+    /// best-effort (it depends on reflection metadata being available); the fluent config API is always honored.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property)]
+    [H5.Name("tss.PropertyGridLabelAttribute")]
+    public sealed class PropertyGridLabelAttribute : Attribute
+    {
+        /// <summary>The display label.</summary>
+        public string Label { get; }
+        /// <summary>Initializes a new instance of the <see cref="PropertyGridLabelAttribute"/> class.</summary>
+        public PropertyGridLabelAttribute(string label) { Label = label; }
+    }
+
+    /// <summary>Marks a property with a helper description for the <see cref="PropertyGrid{T}"/>.</summary>
+    [AttributeUsage(AttributeTargets.Property)]
+    [H5.Name("tss.PropertyGridDescriptionAttribute")]
+    public sealed class PropertyGridDescriptionAttribute : Attribute
+    {
+        /// <summary>The description text.</summary>
+        public string Description { get; }
+        /// <summary>Initializes a new instance of the <see cref="PropertyGridDescriptionAttribute"/> class.</summary>
+        public PropertyGridDescriptionAttribute(string description) { Description = description; }
+    }
+
+    /// <summary>Sets the display order of a property in the <see cref="PropertyGrid{T}"/> (lower comes first).</summary>
+    [AttributeUsage(AttributeTargets.Property)]
+    [H5.Name("tss.PropertyGridOrderAttribute")]
+    public sealed class PropertyGridOrderAttribute : Attribute
+    {
+        /// <summary>The sort order.</summary>
+        public int Order { get; }
+        /// <summary>Initializes a new instance of the <see cref="PropertyGridOrderAttribute"/> class.</summary>
+        public PropertyGridOrderAttribute(int order) { Order = order; }
+    }
+
+    /// <summary>Marks a property as read-only in the <see cref="PropertyGrid{T}"/>.</summary>
+    [AttributeUsage(AttributeTargets.Property)]
+    [H5.Name("tss.PropertyGridReadOnlyAttribute")]
+    public sealed class PropertyGridReadOnlyAttribute : Attribute { }
+
+    /// <summary>Hides a property from the <see cref="PropertyGrid{T}"/>.</summary>
+    [AttributeUsage(AttributeTargets.Property)]
+    [H5.Name("tss.PropertyGridIgnoreAttribute")]
+    public sealed class PropertyGridIgnoreAttribute : Attribute { }
+
+    /// <summary>Renders a string property as a multi-line <see cref="TextArea"/> in the <see cref="PropertyGrid{T}"/>.</summary>
+    [AttributeUsage(AttributeTargets.Property)]
+    [H5.Name("tss.PropertyGridMultilineAttribute")]
+    public sealed class PropertyGridMultilineAttribute : Attribute { }
+
+    /// <summary>Per-property display / behaviour options resolved from attributes and the fluent config API.</summary>
+    [H5.Name("tss.PropertyGridFieldOptions")]
+    public sealed class PropertyGridFieldOptions
+    {
+        /// <summary>Overrides the field label.</summary>
+        public string Label;
+        /// <summary>A helper description shown beneath the editor.</summary>
+        public string Description;
+        /// <summary>Explicit display order (lower comes first).</summary>
+        public int? Order;
+        /// <summary>Whether the field is read-only.</summary>
+        public bool ReadOnly;
+        /// <summary>Whether the field is hidden.</summary>
+        public bool Ignore;
+        /// <summary>Whether a string field is rendered multi-line.</summary>
+        public bool Multiline;
+        /// <summary>A validation function returning an error message (or null/empty when valid) for the current value.</summary>
+        public Func<object, string> Validate;
+    }
+
+    /// <summary>
+    /// A metadata-driven property editor. Given a typed object it reflects over its public properties and
+    /// auto-generates a two-way-bound editing form, mapping each property type to an existing Tesserae input
+    /// (string → TextBox/TextArea, numbers → NumberPicker, bool → Toggle, enum → Dropdown, DateTime →
+    /// DateTimePicker, Color → ColorPicker, nested objects → a recursive grouped <see cref="Expander"/> section).
+    /// Edits flow straight back onto the bound object and are surfaced via <see cref="AsObservable"/> /
+    /// <see cref="OnChange"/>. Per-property label/description/order/read-only overrides come from attributes or the
+    /// fluent config API, and validation integrates with the existing <see cref="Validator"/>.
+    /// </summary>
+    [H5.Name("tss.PropertyGrid")]
+    public sealed class PropertyGrid<T> : IComponent
+    {
+        private readonly T                       _instance;
+        private readonly Stack                   _stack;
+        private readonly SettableObservable<T>   _observable;
+        private readonly Dictionary<string, PropertyGridFieldOptions> _config = new Dictionary<string, PropertyGridFieldOptions>();
+        private          Validator               _validator;
+        private          Action<T>               _onChange;
+        private          bool                    _built;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PropertyGrid{T}"/> class bound to <paramref name="instance"/>.
+        /// </summary>
+        public PropertyGrid(T instance)
+        {
+            _instance   = instance;
+            _observable = new SettableObservable<T>(instance);
+            _stack      = VStack().WS().Class("tss-propertygrid");
+        }
+
+        /// <summary>Returns an observable that fires (with the bound instance) whenever any field is edited.</summary>
+        public IObservable<T> AsObservable() => _observable;
+
+        /// <summary>Registers a callback invoked (with the bound instance) whenever any field is edited.</summary>
+        public PropertyGrid<T> OnChange(Action<T> onChange) { _onChange += onChange; return this; }
+
+        /// <summary>Wires the grid's validatable editors to the supplied <see cref="Validator"/>.</summary>
+        public PropertyGrid<T> WithValidator(Validator validator) { _validator = validator; return this; }
+
+        private PropertyGridFieldOptions Options(string propertyName)
+        {
+            if (!_config.TryGetValue(propertyName, out var opts))
+            {
+                opts = new PropertyGridFieldOptions();
+                _config[propertyName] = opts;
+            }
+            return opts;
+        }
+
+        /// <summary>Overrides the label shown for a property.</summary>
+        public PropertyGrid<T> Label(string propertyName, string label) { Options(propertyName).Label = label; return this; }
+
+        /// <summary>Sets a helper description shown beneath a property's editor.</summary>
+        public PropertyGrid<T> Description(string propertyName, string description) { Options(propertyName).Description = description; return this; }
+
+        /// <summary>Sets the display order of a property (lower comes first).</summary>
+        public PropertyGrid<T> Order(string propertyName, int order) { Options(propertyName).Order = order; return this; }
+
+        /// <summary>Marks one or more properties as read-only.</summary>
+        public PropertyGrid<T> ReadOnly(params string[] propertyNames) { foreach (var p in propertyNames) Options(p).ReadOnly = true; return this; }
+
+        /// <summary>Hides one or more properties.</summary>
+        public PropertyGrid<T> Ignore(params string[] propertyNames) { foreach (var p in propertyNames) Options(p).Ignore = true; return this; }
+
+        /// <summary>Renders a string property as a multi-line text area.</summary>
+        public PropertyGrid<T> Multiline(string propertyName) { Options(propertyName).Multiline = true; return this; }
+
+        /// <summary>
+        /// Adds a validation rule for a property. The function receives the property's current value and returns an
+        /// error message (or null/empty when valid). Integrates with the configured <see cref="Validator"/>.
+        /// </summary>
+        public PropertyGrid<T> Validate(string propertyName, Func<object, string> validate) { Options(propertyName).Validate = validate; return this; }
+
+        private void RaiseChanged()
+        {
+            _observable.Update(_ => { });
+            _onChange?.Invoke(_instance);
+        }
+
+        private void EnsureBuilt()
+        {
+            if (_built) return;
+            _built = true;
+            BuildObject(_instance, typeof(T), _stack);
+        }
+
+        private void BuildObject(object instance, Type type, Stack target)
+        {
+            if (instance == null) return;
+
+            var fields = new List<(PropertyInfo prop, PropertyGridFieldOptions opts, int order)>();
+            var props  = type.GetProperties(BindingFlags.Public | BindingFlags.Instance);
+            int index  = 0;
+
+            foreach (var prop in props)
+            {
+                if (!prop.CanRead) continue;
+                if (prop.GetIndexParameters().Length > 0) continue;
+
+                var opts = ResolveOptions(prop);
+                if (opts.Ignore) continue;
+                if (!prop.CanWrite) opts.ReadOnly = true;
+
+                fields.Add((prop, opts, opts.Order ?? (1000 + index)));
+                index++;
+            }
+
+            foreach (var f in fields.OrderBy(f => f.order))
+            {
+                var row = BuildField(instance, f.prop, f.opts);
+                if (row != null) target.Add(row);
+            }
+        }
+
+        private PropertyGridFieldOptions ResolveOptions(PropertyInfo prop)
+        {
+            // Start from any fluent config, then layer best-effort attribute values where the config did not specify them.
+            var opts = _config.TryGetValue(prop.Name, out var cfg) ? cfg : new PropertyGridFieldOptions();
+
+            try
+            {
+                foreach (var attr in prop.GetCustomAttributes(true))
+                {
+                    if (attr is PropertyGridLabelAttribute la && opts.Label == null)             opts.Label = la.Label;
+                    else if (attr is PropertyGridDescriptionAttribute da && opts.Description == null) opts.Description = da.Description;
+                    else if (attr is PropertyGridOrderAttribute oa && !opts.Order.HasValue)       opts.Order = oa.Order;
+                    else if (attr is PropertyGridReadOnlyAttribute)                               opts.ReadOnly = true;
+                    else if (attr is PropertyGridIgnoreAttribute)                                 opts.Ignore = true;
+                    else if (attr is PropertyGridMultilineAttribute)                              opts.Multiline = true;
+                }
+            }
+            catch
+            {
+                // Reflection metadata for custom attributes may be unavailable in some builds — config still applies.
+            }
+
+            return opts;
+        }
+
+        private IComponent BuildField(object instance, PropertyInfo prop, PropertyGridFieldOptions opts)
+        {
+            var labelText    = opts.Label ?? Prettify(prop.Name);
+            var propType     = prop.PropertyType;
+            var underlying   = Nullable.GetUnderlyingType(propType);
+            var effective    = underlying ?? propType;
+            var currentValue = SafeGet(prop, instance);
+
+            // Nested object -> recursive grouped section.
+            if (IsNestedObject(effective))
+            {
+                if (currentValue == null)
+                {
+                    return WithDescription(UI.Label(labelText).SetContent(TextBlock("(not set)").Secondary()), opts.Description);
+                }
+
+                var nested = VStack().WS();
+                BuildObject(currentValue, effective, nested);
+                return Expander(labelText, nested).WS();
+            }
+
+            IComponent editor;
+
+            if (effective == typeof(string))
+            {
+                editor = BuildStringEditor(instance, prop, opts);
+            }
+            else if (effective == typeof(bool))
+            {
+                editor = BuildBoolEditor(instance, prop, opts);
+            }
+            else if (effective.IsEnum)
+            {
+                editor = BuildEnumEditor(instance, prop, effective, opts, currentValue);
+            }
+            else if (effective == typeof(Color))
+            {
+                editor = BuildColorEditor(instance, prop, opts, currentValue);
+            }
+            else if (effective == typeof(DateTime))
+            {
+                editor = BuildDateEditor(instance, prop, opts, currentValue);
+            }
+            else if (IsInteger(effective) || IsFloating(effective))
+            {
+                editor = BuildNumberEditor(instance, prop, effective, opts, currentValue);
+            }
+            else
+            {
+                // Fallback: read-only string projection of the value.
+                editor = TextBox(currentValue?.ToString() ?? "").ReadOnly().WS();
+            }
+
+            return WithDescription(UI.Label(labelText).SetContent(editor), opts.Description);
+        }
+
+        private IComponent WithDescription(IComponent field, string description)
+        {
+            if (string.IsNullOrEmpty(description)) return field;
+            return VStack().WS().Children(field, TextBlock(description).Tiny().Secondary().PB(4));
+        }
+
+        private IComponent BuildStringEditor(object instance, PropertyInfo prop, PropertyGridFieldOptions opts)
+        {
+            var value = SafeGet(prop, instance) as string ?? "";
+
+            if (opts.Multiline)
+            {
+                var ta = TextArea(value).WS();
+                if (opts.ReadOnly) { ta.IsReadOnly = true; }
+                else
+                {
+                    ta.AsObservable().Subscribe(v => { SafeSet(prop, instance, v); RaiseChanged(); }, fireImmediately: false);
+                    ApplyValidation(ta, opts, () => SafeGet(prop, instance));
+                }
+                return ta;
+            }
+
+            var tb = TextBox(value).WS();
+            if (opts.ReadOnly) { tb.IsReadOnly = true; }
+            else
+            {
+                tb.AsObservable().Subscribe(v => { SafeSet(prop, instance, v); RaiseChanged(); }, fireImmediately: false);
+                ApplyValidation(tb, opts, () => SafeGet(prop, instance));
+            }
+            return tb;
+        }
+
+        private IComponent BuildBoolEditor(object instance, PropertyInfo prop, PropertyGridFieldOptions opts)
+        {
+            var value  = SafeGet(prop, instance);
+            var toggle = Toggle().Checked(value is bool b && b);
+
+            if (opts.ReadOnly)
+            {
+                toggle.Disabled();
+            }
+            else
+            {
+                toggle.AsObservable().Subscribe(v => { SafeSet(prop, instance, v); RaiseChanged(); }, fireImmediately: false);
+            }
+            return toggle;
+        }
+
+        private IComponent BuildEnumEditor(object instance, PropertyInfo prop, Type enumType, PropertyGridFieldOptions opts, object currentValue)
+        {
+            var dropdown = Dropdown().Single().WS();
+            var values   = Enum.GetValues(enumType);
+            var items    = new List<Dropdown.Item>();
+
+            for (int i = 0; i < values.Length; i++)
+            {
+                var ev   = values.GetValue(i);
+                var item = DropdownItem(ev.ToString()).SetData(ev).SelectedIf(currentValue != null && currentValue.Equals(ev));
+                items.Add(item);
+            }
+
+            dropdown.Items(items.ToArray());
+
+            if (opts.ReadOnly)
+            {
+                dropdown.Disabled();
+            }
+            else
+            {
+                dropdown.Attach(dd =>
+                {
+                    var sel = dd.SelectedItems.FirstOrDefault();
+                    if (sel != null)
+                    {
+                        SafeSet(prop, instance, sel.GetDataAs<object>());
+                        RaiseChanged();
+                    }
+                });
+                ApplyValidation(dropdown, opts, () => SafeGet(prop, instance));
+            }
+            return dropdown;
+        }
+
+        private IComponent BuildColorEditor(object instance, PropertyInfo prop, PropertyGridFieldOptions opts, object currentValue)
+        {
+            var picker = ColorPicker(currentValue as Color ?? Color.FromArgb(0, 0, 0));
+
+            if (opts.ReadOnly)
+            {
+                picker.Render().setAttribute("disabled", "");
+            }
+            else
+            {
+                picker.OnChange((s, e) => { SafeSet(prop, instance, s.Color); RaiseChanged(); });
+            }
+            return picker;
+        }
+
+        private IComponent BuildDateEditor(object instance, PropertyInfo prop, PropertyGridFieldOptions opts, object currentValue)
+        {
+            DateTime? initial = currentValue is DateTime dt ? dt : (DateTime?)null;
+            var picker        = DateTimePicker(initial).WS();
+
+            if (opts.ReadOnly)
+            {
+                picker.Render().setAttribute("readonly", "");
+            }
+            else
+            {
+                ((IObservableComponent<DateTime?>)picker).AsObservable().Subscribe(v =>
+                {
+                    if (v.HasValue) { SafeSet(prop, instance, v.Value); RaiseChanged(); }
+                }, fireImmediately: false);
+            }
+            return picker;
+        }
+
+        private IComponent BuildNumberEditor(object instance, PropertyInfo prop, Type effective, PropertyGridFieldOptions opts, object currentValue)
+        {
+            if (IsInteger(effective))
+            {
+                var initial = 0;
+                try { initial = Convert.ToInt32(currentValue); } catch { }
+
+                var np = NumberPicker(initial).WS();
+                if (opts.ReadOnly) { np.Render().setAttribute("readonly", ""); }
+                else
+                {
+                    ((IObservableComponent<int>)np).AsObservable().Subscribe(v => { SafeSet(prop, instance, CoerceNumber(effective, v)); RaiseChanged(); }, fireImmediately: false);
+                    ApplyValidation(np, opts, () => SafeGet(prop, instance));
+                }
+                return np;
+            }
+
+            // Floating point -> numeric TextBox (NumberPicker is integer-only).
+            var text = currentValue == null ? "" : Convert.ToDouble(currentValue).ToString();
+            var tb   = TextBox(text).WS();
+            tb.Render().setAttribute("type", "number");
+            tb.Render().setAttribute("step", "any");
+
+            if (opts.ReadOnly) { tb.IsReadOnly = true; }
+            else
+            {
+                tb.AsObservable().Subscribe(v =>
+                {
+                    if (double.TryParse(v, out var d)) { SafeSet(prop, instance, CoerceNumber(effective, d)); RaiseChanged(); }
+                }, fireImmediately: false);
+                ApplyValidation(tb, opts, () => SafeGet(prop, instance));
+            }
+            return tb;
+        }
+
+        private void ApplyValidation<TEditor>(TEditor editor, PropertyGridFieldOptions opts, Func<object> currentValue) where TEditor : ICanValidate<TEditor>
+        {
+            if (opts.Validate == null) return;
+            editor.Validation(_ => opts.Validate(currentValue()), _validator);
+        }
+
+        private static object CoerceNumber(Type effective, double value)
+        {
+            if (effective == typeof(int))     return (int)value;
+            if (effective == typeof(long))    return (long)value;
+            if (effective == typeof(short))   return (short)value;
+            if (effective == typeof(byte))    return (byte)value;
+            if (effective == typeof(float))   return (float)value;
+            if (effective == typeof(decimal)) return (decimal)value;
+            return value; // double and anything else
+        }
+
+        private static object CoerceNumber(Type effective, int value) => CoerceNumber(effective, (double)value);
+
+        private static bool IsInteger(Type t) =>
+            t == typeof(int) || t == typeof(long) || t == typeof(short) || t == typeof(byte) ||
+            t == typeof(uint) || t == typeof(ulong) || t == typeof(ushort) || t == typeof(sbyte);
+
+        private static bool IsFloating(Type t) => t == typeof(double) || t == typeof(float) || t == typeof(decimal);
+
+        private static bool IsNestedObject(Type t)
+        {
+            if (t == typeof(string) || t == typeof(Color) || t == typeof(DateTime)) return false;
+            if (t.IsEnum || t.IsPrimitive || IsFloating(t)) return false;
+            if (typeof(System.Collections.IEnumerable).IsAssignableFrom(t)) return false;
+            return t.IsClass || (t.IsValueType && !t.IsPrimitive);
+        }
+
+        private object SafeGet(PropertyInfo prop, object instance)
+        {
+            try { return prop.GetValue(instance); }
+            catch { return null; }
+        }
+
+        private void SafeSet(PropertyInfo prop, object instance, object value)
+        {
+            try { if (prop.CanWrite) prop.SetValue(instance, value); }
+            catch { }
+        }
+
+        private static string Prettify(string name)
+        {
+            if (string.IsNullOrEmpty(name)) return name;
+
+            var sb = new StringBuilder();
+            for (int i = 0; i < name.Length; i++)
+            {
+                var c = name[i];
+                if (i > 0 && char.IsUpper(c) && !char.IsUpper(name[i - 1])) sb.Append(' ');
+                sb.Append(i == 0 ? char.ToUpper(c) : c);
+            }
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Renders the component's root HTML element.
+        /// </summary>
+        public HTMLElement Render()
+        {
+            EnsureBuilt();
+            return _stack.Render();
+        }
+    }
+}

--- a/Tesserae/src/Components/PropertyGrid.cs
+++ b/Tesserae/src/Components/PropertyGrid.cs
@@ -98,6 +98,7 @@ namespace Tesserae
         private          Validator               _validator;
         private          Action<T>               _onChange;
         private          bool                    _built;
+        private          bool                    _allReadOnly;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PropertyGrid{T}"/> class bound to <paramref name="instance"/>.
@@ -137,8 +138,23 @@ namespace Tesserae
         /// <summary>Sets the display order of a property (lower comes first).</summary>
         public PropertyGrid<T> Order(string propertyName, int order) { Options(propertyName).Order = order; return this; }
 
-        /// <summary>Marks one or more properties as read-only.</summary>
-        public PropertyGrid<T> ReadOnly(params string[] propertyNames) { foreach (var p in propertyNames) Options(p).ReadOnly = true; return this; }
+        /// <summary>
+        /// Marks fields as read-only. When <paramref name="restrictTo"/> is null or empty the whole grid becomes a
+        /// read-only view (every field shows its value but cannot be edited); otherwise only the named properties
+        /// are made read-only. Read-only fields do not flow edits back to the bound object.
+        /// </summary>
+        public PropertyGrid<T> ReadOnly(params string[] restrictTo)
+        {
+            if (restrictTo == null || restrictTo.Length == 0)
+            {
+                _allReadOnly = true;
+            }
+            else
+            {
+                foreach (var p in restrictTo) Options(p).ReadOnly = true;
+            }
+            return this;
+        }
 
         /// <summary>Hides one or more properties.</summary>
         public PropertyGrid<T> Ignore(params string[] propertyNames) { foreach (var p in propertyNames) Options(p).Ignore = true; return this; }
@@ -214,6 +230,9 @@ namespace Tesserae
             {
                 // Reflection metadata for custom attributes may be unavailable in some builds — config still applies.
             }
+
+            // Grid-wide read-only mode forces every field read-only, regardless of per-property config.
+            if (_allReadOnly) opts.ReadOnly = true;
 
             return opts;
         }

--- a/Tesserae/src/Components/SplitView.cs
+++ b/Tesserae/src/Components/SplitView.cs
@@ -69,49 +69,44 @@ namespace Tesserae
 
         private void HookDragEvents(IComponent dragArea)
         {
-            var el = dragArea.Render();
+            // Use the unified pointer-based pan gesture so the splitter is draggable with mouse, touch and pen.
+            // (Previously only mouse events were wired, so resizing did not work on touch screens.)
+            double      width          = 0;
+            DOMRect     rect           = null;
+            HTMLElement current        = null;
+            bool        currentIsRight = false;
 
-            double      width = 0;
-            DOMRect     rect;
-            HTMLElement current;
-            bool        currentIsRight;
-
-            el.onmousedown += (me) =>
+            dragArea.OnPan(g =>
             {
-                if (_splitContainer.classList.contains("tss-split-right"))
+                if (g.Phase == GesturePhase.Start)
                 {
-                    current        = _rightComponent.Render();
-                    currentIsRight = true;
+                    if (_splitContainer.classList.contains("tss-split-right"))
+                    {
+                        current        = _rightComponent.Render();
+                        currentIsRight = true;
+                    }
+                    else
+                    {
+                        current        = _leftComponent.Render();
+                        currentIsRight = false;
+                    }
+                    rect = _splitContainer.getBoundingClientRect().As<DOMRect>();
                 }
-                else
-                {
-                    current        = _leftComponent.Render();
-                    currentIsRight = false;
-                }
-                rect               =  _splitContainer.getBoundingClientRect().As<DOMRect>();
-                window.onmousemove += Resize;
-                window.onmouseup   += StopResize;
-                StopEvent(me);
-            };
 
-            void Resize(MouseEvent me)
-            {
-                double raw = currentIsRight ? (rect.right - me.clientX) : (me.clientX - rect.left);
+                if (rect == null || current == null) return;
+
+                double raw = currentIsRight ? (rect.right - g.X) : (g.X - rect.left);
                 width                    = Math.Min(rect.width - 16, Math.Max(16, raw));
                 current.style.width      = width + "px";
                 current.style.flexGrow   = "0";
                 current.style.flexShrink = "1";
-                StopEvent(me);
-            }
 
-            void StopResize(MouseEvent me)
-            {
-                window.onmousemove -= Resize;
-                window.onmouseup   -= StopResize;
-                _onResizeEnd?.Invoke((int)width);
-                rect = null;
-                StopEvent(me);
-            }
+                if (g.Phase == GesturePhase.End)
+                {
+                    _onResizeEnd?.Invoke((int)width);
+                    rect = null;
+                }
+            });
         }
 
         /// <summary>

--- a/Tesserae/src/Extensions/GestureExtensions.cs
+++ b/Tesserae/src/Extensions/GestureExtensions.cs
@@ -1,0 +1,553 @@
+using System;
+using System.Collections.Generic;
+using H5;
+using static H5.Core.dom;
+using static Tesserae.UI;
+
+namespace Tesserae
+{
+    /// <summary>
+    /// Identifies the phase of a continuous gesture (pan / pinch / rotate).
+    /// </summary>
+    [H5.Name("tss.GesturePhase")]
+    public enum GesturePhase
+    {
+        /// <summary>The gesture has just started (movement crossed the threshold, or a second finger landed).</summary>
+        Start,
+        /// <summary>The gesture is in progress.</summary>
+        Move,
+        /// <summary>The gesture has ended (the last relevant pointer was lifted or cancelled).</summary>
+        End
+    }
+
+    /// <summary>
+    /// Immutable-ish snapshot of a recognised gesture, handed to gesture callbacks. A single instance is reused
+    /// per recogniser and its fields are refreshed before every callback, so do not hold a reference across events.
+    /// </summary>
+    [H5.Name("tss.GestureState")]
+    public sealed class GestureState
+    {
+        /// <summary>The component the gesture was recognised on.</summary>
+        public IComponent Component { get; internal set; }
+
+        /// <summary>The current phase of a continuous gesture (always <see cref="GesturePhase.End"/> for taps / long-press).</summary>
+        public GesturePhase Phase { get; internal set; }
+
+        /// <summary>Current pointer (or two-pointer centroid) X position in client coordinates.</summary>
+        public double X { get; internal set; }
+
+        /// <summary>Current pointer (or two-pointer centroid) Y position in client coordinates.</summary>
+        public double Y { get; internal set; }
+
+        /// <summary>Horizontal movement since the previous event of this gesture.</summary>
+        public double DeltaX { get; internal set; }
+
+        /// <summary>Vertical movement since the previous event of this gesture.</summary>
+        public double DeltaY { get; internal set; }
+
+        /// <summary>Cumulative horizontal movement since the gesture started.</summary>
+        public double OffsetX { get; internal set; }
+
+        /// <summary>Cumulative vertical movement since the gesture started.</summary>
+        public double OffsetY { get; internal set; }
+
+        /// <summary>Cumulative scale factor since the pinch started (1 = no change).</summary>
+        public double Scale { get; internal set; } = 1;
+
+        /// <summary>Scale factor change since the previous pinch event (1 = no change).</summary>
+        public double ScaleDelta { get; internal set; } = 1;
+
+        /// <summary>Cumulative rotation in degrees since the rotate gesture started.</summary>
+        public double Rotation { get; internal set; }
+
+        /// <summary>Rotation change in degrees since the previous rotate event.</summary>
+        public double RotationDelta { get; internal set; }
+
+        /// <summary>Number of pointers currently down on the element.</summary>
+        public int PointerCount { get; internal set; }
+
+        /// <summary>The underlying DOM pointer event that produced this state, if any.</summary>
+        public Event Event { get; internal set; }
+    }
+
+    /// <summary>
+    /// Higher-level pointer/touch gesture recognition layered on top of the unified Pointer Events API
+    /// (<c>pointerdown</c>/<c>pointermove</c>/<c>pointerup</c> + <c>setPointerCapture</c>). A single recogniser is
+    /// attached per element and shared by every gesture handler registered through <see cref="GestureExtensions"/>.
+    /// </summary>
+    [H5.Name("tss.GestureRecognizer")]
+    public sealed class GestureRecognizer
+    {
+        // Movement (px) a single pointer may drift before a press is reclassified as a pan (and disqualified as a tap).
+        private const double TapMoveTolerance = 10;
+        // Max time (ms) between two taps for them to count as a double-tap.
+        private const int DoubleTapMs = 300;
+        // Time (ms) a stationary pointer must be held to fire a long-press.
+        private const int LongPressMs = 500;
+
+        private sealed class PointerInfo
+        {
+            public double StartX, StartY, LastX, LastY, StartTime;
+        }
+
+        private readonly IComponent  _component;
+        private readonly HTMLElement _element;
+        private readonly GestureState _state = new GestureState();
+        private readonly Dictionary<int, PointerInfo> _pointers = new Dictionary<int, PointerInfo>();
+        private readonly List<int> _order = new List<int>();
+
+        private event Action<GestureState> Tapped;
+        private event Action<GestureState> DoubleTapped;
+        private event Action<GestureState> LongPressed;
+        private event Action<GestureState> Panned;
+        private event Action<GestureState> Pinched;
+        private event Action<GestureState> Rotated;
+
+        private bool   _panning;
+        private bool   _multiTouched;
+        private bool   _longPressed;
+        private double _panStartX, _panStartY, _panLastX, _panLastY;
+        private double _startDistance, _startAngle, _lastScale, _lastRotation;
+        private int    _longPressTimer = -1;
+        private int    _pendingTapTimer = -1;
+        private double _lastTapTime;
+
+        private GestureRecognizer(IComponent component)
+        {
+            _component       = component;
+            _element         = component.Render();
+            _state.Component = component;
+
+            _element.addEventListener("pointerdown",   e => OnPointerDown(e));
+            _element.addEventListener("pointermove",   e => OnPointerMove(e));
+            _element.addEventListener("pointerup",     e => OnPointerUp(e));
+            _element.addEventListener("pointercancel", e => OnPointerUp(e));
+        }
+
+        /// <summary>
+        /// Returns the recogniser attached to the component's element, creating and caching one on the element on
+        /// first use so multiple gesture handlers share a single set of DOM listeners.
+        /// </summary>
+        public static GestureRecognizer For(IComponent component)
+        {
+            var el = component.Render();
+
+            if (el.HasOwnProperty("__tssGesture"))
+            {
+                return el["__tssGesture"].As<GestureRecognizer>();
+            }
+
+            var recognizer        = new GestureRecognizer(component);
+            el["__tssGesture"] = recognizer;
+            return recognizer;
+        }
+
+        /// <summary>Registers a tap (quick press-and-release without movement) handler.</summary>
+        public GestureRecognizer OnTapped(Action<GestureState> handler) { Tapped += handler; return this; }
+
+        /// <summary>Registers a double-tap handler. When present, single taps are delayed to disambiguate.</summary>
+        public GestureRecognizer OnDoubleTapped(Action<GestureState> handler) { DoubleTapped += handler; return this; }
+
+        /// <summary>Registers a long-press handler (stationary press held past the long-press threshold).</summary>
+        public GestureRecognizer OnLongPress(Action<GestureState> handler) { LongPressed += handler; return this; }
+
+        /// <summary>Registers a pan handler. Enables <c>touch-action: none</c> so touch panning isn't hijacked by scrolling.</summary>
+        public GestureRecognizer OnPan(Action<GestureState> handler) { Panned += handler; SuppressTouchAction(); return this; }
+
+        /// <summary>Registers a pinch (two-finger scale) handler. Enables <c>touch-action: none</c>.</summary>
+        public GestureRecognizer OnPinch(Action<GestureState> handler) { Pinched += handler; SuppressTouchAction(); return this; }
+
+        /// <summary>Registers a rotate (two-finger angle) handler. Enables <c>touch-action: none</c>.</summary>
+        public GestureRecognizer OnRotate(Action<GestureState> handler) { Rotated += handler; SuppressTouchAction(); return this; }
+
+        private void SuppressTouchAction() => _element.style.touchAction = "none";
+
+        private static double Now() => Script.Write<double>("Date.now()");
+
+        private static int PointerId(Event e) => Script.Write<int>("({0}.pointerId || 0)", e);
+
+        private void CapturePointer(int id)   => Script.Write("try { {0}.setPointerCapture({1}); } catch (e) { }", _element, id);
+        private void ReleasePointer(int id)    => Script.Write("try { {0}.releasePointerCapture({1}); } catch (e) { }", _element, id);
+
+        private void OnPointerDown(Event e)
+        {
+            var me = e.As<MouseEvent>();
+            var id = PointerId(e);
+
+            CapturePointer(id);
+
+            var info = new PointerInfo { StartX = me.clientX, StartY = me.clientY, LastX = me.clientX, LastY = me.clientY, StartTime = Now() };
+
+            if (!_pointers.ContainsKey(id))
+            {
+                _pointers[id] = info;
+                _order.Add(id);
+            }
+            else
+            {
+                _pointers[id] = info;
+            }
+
+            if (_pointers.Count == 1)
+            {
+                _panning      = false;
+                _multiTouched = false;
+                _longPressed  = false;
+                _panStartX    = me.clientX;
+                _panStartY    = me.clientY;
+                _panLastX     = me.clientX;
+                _panLastY     = me.clientY;
+
+                if (LongPressed != null)
+                {
+                    CancelLongPress();
+                    _longPressTimer = (int)window.setTimeout(_ => FireLongPress(), LongPressMs);
+                }
+            }
+            else if (_pointers.Count == 2)
+            {
+                _multiTouched = true;
+                _panning      = false;
+                CancelLongPress();
+                InitTwoPointerBaseline();
+            }
+        }
+
+        private void OnPointerMove(Event e)
+        {
+            var id = PointerId(e);
+
+            if (!_pointers.TryGetValue(id, out var info))
+                return;
+
+            var me = e.As<MouseEvent>();
+            info.LastX = me.clientX;
+            info.LastY = me.clientY;
+
+            if (_pointers.Count >= 2)
+            {
+                HandleTwoPointerMove(e);
+                return;
+            }
+
+            // Single pointer -> potential pan.
+            var offsetX = me.clientX - _panStartX;
+            var offsetY = me.clientY - _panStartY;
+
+            if (!_panning)
+            {
+                if (Math.Sqrt(offsetX * offsetX + offsetY * offsetY) <= TapMoveTolerance)
+                    return;
+
+                _panning = true;
+                CancelLongPress();
+                _panLastX = _panStartX;
+                _panLastY = _panStartY;
+                EmitPan(GesturePhase.Start, me, offsetX, offsetY);
+            }
+            else
+            {
+                EmitPan(GesturePhase.Move, me, offsetX, offsetY);
+            }
+
+            StopEvent(e);
+        }
+
+        private void EmitPan(GesturePhase phase, MouseEvent me, double offsetX, double offsetY)
+        {
+            _state.Phase        = phase;
+            _state.X            = me.clientX;
+            _state.Y            = me.clientY;
+            _state.DeltaX       = me.clientX - _panLastX;
+            _state.DeltaY       = me.clientY - _panLastY;
+            _state.OffsetX      = offsetX;
+            _state.OffsetY      = offsetY;
+            _state.Scale        = 1;
+            _state.ScaleDelta   = 1;
+            _state.Rotation     = 0;
+            _state.RotationDelta = 0;
+            _state.PointerCount = _pointers.Count;
+            _state.Event        = me;
+            _panLastX           = me.clientX;
+            _panLastY           = me.clientY;
+            Panned?.Invoke(_state);
+        }
+
+        private void InitTwoPointerBaseline()
+        {
+            var (ax, ay, bx, by) = FirstTwoPositions();
+            var dx = bx - ax;
+            var dy = by - ay;
+            _startDistance = Math.Max(1, Math.Sqrt(dx * dx + dy * dy));
+            _startAngle    = Math.Atan2(dy, dx) * 180 / Math.PI;
+            _lastScale     = 1;
+            _lastRotation  = 0;
+        }
+
+        private void HandleTwoPointerMove(Event e)
+        {
+            var (ax, ay, bx, by) = FirstTwoPositions();
+            var dx       = bx - ax;
+            var dy       = by - ay;
+            var distance = Math.Max(1, Math.Sqrt(dx * dx + dy * dy));
+            var angle    = Math.Atan2(dy, dx) * 180 / Math.PI;
+
+            var scale         = distance / _startDistance;
+            var scaleDelta    = scale / (_lastScale == 0 ? 1 : _lastScale);
+            var rotation      = NormalizeAngle(angle - _startAngle);
+            var rotationDelta = NormalizeAngle(rotation - _lastRotation);
+
+            _state.Phase         = GesturePhase.Move;
+            _state.X             = (ax + bx) / 2;
+            _state.Y             = (ay + by) / 2;
+            _state.DeltaX        = 0;
+            _state.DeltaY        = 0;
+            _state.OffsetX       = 0;
+            _state.OffsetY       = 0;
+            _state.Scale         = scale;
+            _state.ScaleDelta    = scaleDelta;
+            _state.Rotation      = rotation;
+            _state.RotationDelta = rotationDelta;
+            _state.PointerCount  = _pointers.Count;
+            _state.Event         = e;
+
+            Pinched?.Invoke(_state);
+            Rotated?.Invoke(_state);
+
+            _lastScale    = scale;
+            _lastRotation = rotation;
+
+            StopEvent(e);
+        }
+
+        private (double, double, double, double) FirstTwoPositions()
+        {
+            var a = _pointers[_order[0]];
+            var b = _pointers[_order[1]];
+            return (a.LastX, a.LastY, b.LastX, b.LastY);
+        }
+
+        private static double NormalizeAngle(double angle)
+        {
+            while (angle > 180) angle  -= 360;
+            while (angle < -180) angle += 360;
+            return angle;
+        }
+
+        private void OnPointerUp(Event e)
+        {
+            var id = PointerId(e);
+
+            if (!_pointers.TryGetValue(id, out var info))
+                return;
+
+            ReleasePointer(id);
+            CancelLongPress();
+
+            var me               = e.As<MouseEvent>();
+            var wasSinglePointer = _pointers.Count == 1;
+            var movedX           = me.clientX - info.StartX;
+            var movedY           = me.clientY - info.StartY;
+            var moved            = Math.Sqrt(movedX * movedX + movedY * movedY);
+            var duration         = Now() - info.StartTime;
+
+            _pointers.Remove(id);
+            _order.Remove(id);
+
+            if (_panning && _pointers.Count == 0)
+            {
+                _state.Phase        = GesturePhase.End;
+                _state.X            = me.clientX;
+                _state.Y            = me.clientY;
+                _state.DeltaX       = me.clientX - _panLastX;
+                _state.DeltaY       = me.clientY - _panLastY;
+                _state.OffsetX      = me.clientX - _panStartX;
+                _state.OffsetY      = me.clientY - _panStartY;
+                _state.PointerCount = 0;
+                _state.Event        = me;
+                Panned?.Invoke(_state);
+            }
+
+            // A tap only counts if a single pointer was down, it stayed put, was quick, and no pan / pinch / long-press fired.
+            if (wasSinglePointer && !_panning && !_multiTouched && !_longPressed && moved <= TapMoveTolerance && duration < LongPressMs)
+            {
+                HandleTap(me);
+            }
+
+            if (_pointers.Count < 2)
+            {
+                _multiTouched = _multiTouched && _pointers.Count > 0;
+            }
+
+            if (_pointers.Count == 0)
+            {
+                _panning = false;
+            }
+        }
+
+        private void HandleTap(MouseEvent me)
+        {
+            var now = Now();
+
+            FillTapState(me);
+
+            if (_lastTapTime > 0 && (now - _lastTapTime) < DoubleTapMs && DoubleTapped != null)
+            {
+                CancelPendingTap();
+                _lastTapTime = 0;
+                DoubleTapped?.Invoke(_state);
+                return;
+            }
+
+            _lastTapTime = now;
+
+            if (DoubleTapped != null && Tapped != null)
+            {
+                // Delay the single tap so a follow-up tap can upgrade it to a double-tap.
+                var captured = me;
+                _pendingTapTimer = (int)window.setTimeout(_ =>
+                {
+                    _pendingTapTimer = -1;
+                    FillTapState(captured);
+                    Tapped?.Invoke(_state);
+                }, DoubleTapMs);
+            }
+            else
+            {
+                Tapped?.Invoke(_state);
+            }
+        }
+
+        private void FillTapState(MouseEvent me)
+        {
+            _state.Phase         = GesturePhase.End;
+            _state.X             = me.clientX;
+            _state.Y             = me.clientY;
+            _state.DeltaX        = 0;
+            _state.DeltaY        = 0;
+            _state.OffsetX       = 0;
+            _state.OffsetY       = 0;
+            _state.Scale         = 1;
+            _state.ScaleDelta    = 1;
+            _state.Rotation      = 0;
+            _state.RotationDelta = 0;
+            _state.PointerCount  = 0;
+            _state.Event         = me;
+        }
+
+        private void FireLongPress()
+        {
+            _longPressTimer = -1;
+
+            if (_pointers.Count != 1 || _panning)
+                return;
+
+            _longPressed = true;
+
+            var info = _pointers[_order[0]];
+            _state.Phase         = GesturePhase.End;
+            _state.X             = info.LastX;
+            _state.Y             = info.LastY;
+            _state.DeltaX        = 0;
+            _state.DeltaY        = 0;
+            _state.OffsetX       = info.LastX - info.StartX;
+            _state.OffsetY       = info.LastY - info.StartY;
+            _state.Scale         = 1;
+            _state.ScaleDelta    = 1;
+            _state.Rotation      = 0;
+            _state.RotationDelta = 0;
+            _state.PointerCount  = 1;
+            _state.Event         = null;
+            LongPressed?.Invoke(_state);
+        }
+
+        private void CancelLongPress()
+        {
+            if (_longPressTimer != -1)
+            {
+                window.clearTimeout(_longPressTimer);
+                _longPressTimer = -1;
+            }
+        }
+
+        private void CancelPendingTap()
+        {
+            if (_pendingTapTimer != -1)
+            {
+                window.clearTimeout(_pendingTapTimer);
+                _pendingTapTimer = -1;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Fluent gesture extensions on <see cref="IComponent"/>. These layer tap, double-tap, long-press, pan, pinch
+    /// and rotate recognition on top of the native pointer events already exposed by <see cref="ComponentBase{T, THTML}"/>.
+    /// All handlers receive a <see cref="GestureState"/> snapshot; thresholds (tap tolerance, double-tap timing,
+    /// long-press duration) are sensible defaults shared by the per-element <see cref="GestureRecognizer"/>.
+    /// </summary>
+    [H5.Name("tss.GestureX")]
+    public static class GestureExtensions
+    {
+        /// <summary>Recognises a tap (quick press-and-release without movement).</summary>
+        public static T OnTapped<T>(this T component, Action<GestureState> handler) where T : IComponent
+        {
+            GestureRecognizer.For(component).OnTapped(handler);
+            return component;
+        }
+
+        /// <summary>Recognises a tap, invoking a parameterless handler.</summary>
+        public static T OnTapped<T>(this T component, Action handler) where T : IComponent => component.OnTapped(_ => handler());
+
+        /// <summary>Recognises a double-tap. Registering this delays single taps to disambiguate them.</summary>
+        public static T OnDoubleTapped<T>(this T component, Action<GestureState> handler) where T : IComponent
+        {
+            GestureRecognizer.For(component).OnDoubleTapped(handler);
+            return component;
+        }
+
+        /// <summary>Recognises a double-tap, invoking a parameterless handler.</summary>
+        public static T OnDoubleTapped<T>(this T component, Action handler) where T : IComponent => component.OnDoubleTapped(_ => handler());
+
+        /// <summary>Recognises a long-press (stationary press held past the long-press threshold).</summary>
+        public static T OnLongPress<T>(this T component, Action<GestureState> handler) where T : IComponent
+        {
+            GestureRecognizer.For(component).OnLongPress(handler);
+            return component;
+        }
+
+        /// <summary>Recognises a long-press, invoking a parameterless handler.</summary>
+        public static T OnLongPress<T>(this T component, Action handler) where T : IComponent => component.OnLongPress(_ => handler());
+
+        /// <summary>
+        /// Recognises a pan / drag. The handler receives per-event deltas (<see cref="GestureState.DeltaX"/>/
+        /// <see cref="GestureState.DeltaY"/>) and the cumulative offset since the gesture started
+        /// (<see cref="GestureState.OffsetX"/>/<see cref="GestureState.OffsetY"/>).
+        /// </summary>
+        public static T OnPan<T>(this T component, Action<GestureState> handler) where T : IComponent
+        {
+            GestureRecognizer.For(component).OnPan(handler);
+            return component;
+        }
+
+        /// <summary>
+        /// Recognises a two-finger pinch. The handler receives the cumulative <see cref="GestureState.Scale"/> and the
+        /// per-event <see cref="GestureState.ScaleDelta"/>.
+        /// </summary>
+        public static T OnPinch<T>(this T component, Action<GestureState> handler) where T : IComponent
+        {
+            GestureRecognizer.For(component).OnPinch(handler);
+            return component;
+        }
+
+        /// <summary>
+        /// Recognises a two-finger rotation. The handler receives the cumulative <see cref="GestureState.Rotation"/>
+        /// and the per-event <see cref="GestureState.RotationDelta"/> in degrees.
+        /// </summary>
+        public static T OnRotate<T>(this T component, Action<GestureState> handler) where T : IComponent
+        {
+            GestureRecognizer.For(component).OnRotate(handler);
+            return component;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This PR introduces three major new components to Tesserae:

1. **Gesture Recognition** — A unified pointer-based gesture system for recognizing taps, double-taps, long-presses, pans, pinches, and rotations across mouse, touch, and pen input.
2. **Chart Components** — A family of lightweight, dependency-free SVG charts (line, bar, area, pie) built on a shared `ChartBase` foundation.
3. **Property Grid** — A metadata-driven property editor that auto-generates two-way-bound forms from reflected object properties.

## Key Changes

### Gesture Recognition (`GestureExtensions.cs`)
- New `GestureRecognizer` class that unifies pointer events (`pointerdown`, `pointermove`, `pointerup`, `pointercancel`) into higher-level gesture callbacks
- Recognizes: taps (with double-tap disambiguation), long-press, pan, pinch (two-finger scale), and rotate (two-finger angle)
- Immutable-ish `GestureState` snapshot passed to callbacks with position, delta, offset, scale, rotation, and pointer count
- `GesturePhase` enum (Start/Move/End) for continuous gestures
- Fluent API: `.OnTapped()`, `.OnDoubleTapped()`, `.OnLongPress()`, `.OnPan()`, `.OnPinch()`, `.OnRotate()`
- Automatically suppresses `touch-action` when pan/pinch/rotate handlers are registered
- Single recognizer per element, shared by all gesture handlers (cached on element via `__tssGesture` property)

### Chart Components
- **`ChartBase<T>`** — Shared foundation for all charts
  - Responsive SVG surface (1:1 to container via `ResizeObserver`)
  - Series/palette model with observable-driven re-rendering
  - Theme-aware default palette (8 CSS variable colors)
  - Tooltips (native `<title>` + optional tippy popovers)
  - Legend rendering
  - Accessibility summary via `aria-label`
  - Value formatter customization

- **`CartesianChartBase<T>`** — Base for axis-based charts
  - X-axis category labels
  - Y-axis value gridlines with auto-scaling
  - Optional zero baseline inclusion
  - Shared point/pixel coordinate mapping

- **`LineChart`** — Connected polylines with hoverable points
  - Per-series colors from palette or explicit override
  - Optional point markers
  - Fits data range (no forced zero baseline)

- **`BarChart`** — Grouped bars per category
  - Configurable corner radius
  - Zero baseline
  - Value gridlines

- **`AreaChart`** — Gradient-filled regions under lines
  - Matches `Sparkline` fill style
  - Optional point markers
  - Zero baseline

- **`PieChart`** — Pie/donut chart
  - Per-slice labels
  - Configurable donut hole ratio
  - Legend support

- **`ChartSeries`** — Named data series with optional explicit color

### Property Grid (`PropertyGrid.cs`)
- Metadata-driven property editor for any typed object
- Auto-generates two-way-bound form from reflected public properties
- Type-to-control mapping:
  - `string` → `TextBox` (or `TextArea` if marked multiline)
  - Numbers → `NumberPicker`
  - `bool` → `Toggle`
  - `enum` → `Dropdown`
  - `DateTime` → `DateTimePicker`
  - `Color` → `ColorPicker`
  - Nested objects → Recursive grouped `Expander` sections
- Per-property configuration via attributes or fluent API:
  - `PropertyGridLabelAttribute` / `.Label()`
  - `PropertyGridDescriptionAttribute` / `.Description()`
  - `PropertyGridOrderAttribute` / `.Order()`
  - `PropertyGridReadOnlyAttribute` / `.ReadOnly()`
  - `PropertyGridIgnoreAttribute` / `.Ignore()`
  - `PropertyGridMultilineAttribute` / `.Multiline

https://claude.ai/code/session_01PoN52iQ7uch5jU1eF1Zj5t