### PR TITLE
Add Collapsable method to ContributionBar

### DIFF
--- a/Tesserae.Tests/src/Samples/Components/ContributionBarSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/ContributionBarSample.cs
@@ -41,6 +41,19 @@ namespace Tesserae.Tests.Samples
                            .Add("Location", 0.07, Theme.Colors.Orange500)
                            .Add("Program", 0.06, Theme.Colors.Neutral500))).SetTitle("Explicit colors")))
                .FlatSection(Stack().Children(
+                    Card(VStack().WS().Children(
+                        SampleSubTitle("Collapsable bar"),
+                        TextBlock("Call .Collapsable(color) to add a tiny toggle button next to the bar. When collapsed, every colored segment merges into a single bar painted with the given color (Theme.Primary.Background by default) and the legend is hidden. Click the AngleUp / AngleDown button to expand or collapse."),
+                        ContributionBar()
+                           .Max(1.0)
+                           .Collapsable(Theme.Primary.Background)
+                           .Add("Description", 0.36, Theme.Colors.Blue600)
+                           .Add("ATA chapter", 0.17, Theme.Colors.Blue400)
+                           .Add("Type", 0.15, Theme.Colors.Teal500)
+                           .Add("Damage", 0.13, Theme.Colors.Green500)
+                           .Add("Location", 0.07, Theme.Colors.Orange500)
+                           .Add("Program", 0.06, Theme.Colors.Neutral500))).SetTitle("Collapsable")))
+               .FlatSection(Stack().Children(
                     Card(BuildSimilarityCard()).SetTitle("Example: similarity result card")));
         }
 

--- a/Tesserae/h5/assets/css/tss.contributionbar.css
+++ b/Tesserae/h5/assets/css/tss.contributionbar.css
@@ -5,13 +5,48 @@
     width: 100%;
 }
 
+.tss-contribution-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+}
+
 .tss-contribution-bar {
     display: flex;
+    flex: 1 1 auto;
     width: 100%;
     height: 10px;
     border-radius: 999px;
     overflow: hidden;
     background: var(--tss-colors-neutral-200);
+}
+
+.tss-contribution-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 auto;
+    width: 18px;
+    height: 18px;
+    padding: 0;
+    margin: 0;
+    border: none;
+    border-radius: 50%;
+    cursor: pointer;
+    color: var(--tss-secondary-foreground-color);
+    background: transparent;
+    font-size: var(--tss-font-size-xsmall);
+    line-height: 1;
+}
+
+.tss-contribution-toggle:hover {
+    color: var(--tss-default-foreground-color);
+    background: var(--tss-default-background-hover-color);
+}
+
+.tss-contribution-toggle > i {
+    font-size: var(--tss-font-size-small);
 }
 
 .tss-contribution-segment {

--- a/Tesserae/src/Components/ContributionBar.cs
+++ b/Tesserae/src/Components/ContributionBar.cs
@@ -43,13 +43,18 @@ namespace Tesserae
 
         private readonly List<Segment> _segments = new List<Segment>();
         private readonly HTMLElement   _bar;
+        private readonly HTMLElement   _barRow;
+        private readonly HTMLElement   _toggle;
         private readonly HTMLElement   _legend;
 
-        private double  _max         = double.NaN;
-        private bool    _showLegend  = true;
-        private bool    _showValues  = true;
-        private int     _decimals    = 2;
-        private string  _barHeight   = "10px";
+        private double  _max             = double.NaN;
+        private bool    _showLegend      = true;
+        private bool    _showValues      = true;
+        private int     _decimals        = 2;
+        private string  _barHeight       = "10px";
+        private bool    _collapsable     = false;
+        private bool    _collapsed       = true;
+        private string  _collapsedColor  = Theme.Primary.Background;
 
         /// <summary>
         /// Initializes a new instance of this class.
@@ -57,8 +62,16 @@ namespace Tesserae
         public ContributionBar()
         {
             _bar         = Div(_("tss-contribution-bar"));
+            _toggle      = Button(_("tss-contribution-toggle", role: "button", ariaLabel: "Toggle contribution breakdown"));
+            _barRow      = Div(_("tss-contribution-row"), _bar);
             _legend      = Div(_("tss-contribution-legend"));
-            InnerElement = Div(_("tss-contribution"), _bar, _legend);
+            InnerElement = Div(_("tss-contribution"), _barRow, _legend);
+
+            _toggle.addEventListener("click", _ =>
+            {
+                _collapsed = !_collapsed;
+                Refresh();
+            });
         }
 
         /// <summary>
@@ -79,6 +92,24 @@ namespace Tesserae
         public ContributionBar Max(double max)
         {
             _max = max;
+            Refresh();
+            return this;
+        }
+
+        /// <summary>
+        /// Makes the bar collapsable: a tiny toggle button (showing an
+        /// <see cref="UIcons.AngleUp"/> / <see cref="UIcons.AngleDown"/> icon) is shown next to the bar.
+        /// When collapsed, all of the individually colored segments merge into a single bar painted with
+        /// <paramref name="color"/> (defaulting to <see cref="Theme.Primary.Background"/>) and the legend is
+        /// hidden. Expanding restores the multi-colored segments and the legend.
+        /// </summary>
+        /// <param name="color">The color used for the single, collapsed bar. Defaults to <see cref="Theme.Primary.Background"/>.</param>
+        /// <param name="initiallyCollapsed">Whether the bar starts collapsed. Defaults to <c>true</c>.</param>
+        public ContributionBar Collapsable(string color = Theme.Primary.Background, bool initiallyCollapsed = true)
+        {
+            _collapsable    = true;
+            _collapsedColor = string.IsNullOrEmpty(color) ? Theme.Primary.Background : color;
+            _collapsed      = initiallyCollapsed;
             Refresh();
             return this;
         }
@@ -144,30 +175,62 @@ namespace Tesserae
             return sum;
         }
 
+        private void UpdateToggle()
+        {
+            if (_collapsable)
+            {
+                if (_toggle.parentElement == null) _barRow.appendChild(_toggle);
+
+                var icon = _collapsed ? UIcons.AngleDown : UIcons.AngleUp;
+                _toggle.appendChild(I(icon));
+                _toggle.setAttribute("title", _collapsed ? "Expand contribution breakdown" : "Collapse contribution breakdown");
+            }
+            else if (_toggle.parentElement != null)
+            {
+                _toggle.parentElement.removeChild(_toggle);
+            }
+        }
+
         private void Refresh()
         {
             ClearChildren(_bar);
             ClearChildren(_legend);
+            ClearChildren(_toggle);
 
             _bar.style.height = _barHeight;
 
             var max = double.IsNaN(_max) ? Total() : _max;
             if (max <= 0) max = 1;
 
-            for (int i = 0; i < _segments.Count; i++)
-            {
-                var segment = _segments[i];
-                if (segment.Value <= 0) continue;
+            UpdateToggle();
 
-                var width    = (segment.Value / max) * 100.0;
-                var color    = ColorFor(i);
-                var fragment = Div(_("tss-contribution-segment", title: $"{segment.Label}: {FormatValue(segment.Value)}"));
+            var isCollapsed = _collapsable && _collapsed;
+
+            if (isCollapsed)
+            {
+                var width    = (Total() / max) * 100.0;
+                var fragment = Div(_("tss-contribution-segment", title: FormatValue(Total())));
                 fragment.style.width           = FormatValue(width) + "%";
-                fragment.style.backgroundColor = color;
+                fragment.style.backgroundColor = _collapsedColor;
                 _bar.appendChild(fragment);
             }
+            else
+            {
+                for (int i = 0; i < _segments.Count; i++)
+                {
+                    var segment = _segments[i];
+                    if (segment.Value <= 0) continue;
 
-            if (!_showLegend) return;
+                    var width    = (segment.Value / max) * 100.0;
+                    var color    = ColorFor(i);
+                    var fragment = Div(_("tss-contribution-segment", title: $"{segment.Label}: {FormatValue(segment.Value)}"));
+                    fragment.style.width           = FormatValue(width) + "%";
+                    fragment.style.backgroundColor = color;
+                    _bar.appendChild(fragment);
+                }
+            }
+
+            if (!_showLegend || isCollapsed) return;
 
             for (int i = 0; i < _segments.Count; i++)
             {


### PR DESCRIPTION
## Summary

Adds a `Collapsable` method to the `ContributionBar` component that lets the multi-colored contribution segments collapse into a single-color bar, with a tiny toggle button to expand/collapse.

```csharp
ContributionBar Collapsable(string color = Theme.Primary.Background, bool initiallyCollapsed = true)
```

### Behavior
- When **collapsed**, all individually colored segments merge into a single bar painted with `color` (defaulting to `Theme.Primary.Background`), sized to the total proportion of `Max`, and the legend is hidden.
- A small round toggle button sits next to the bar, showing `AngleDown` when collapsed (click to expand) and `AngleUp` when expanded (click to collapse).
- When `Collapsable` is never called, the bar behaves exactly as before (no toggle button rendered).

### Example
```csharp
var bar = ContributionBar()
   .Max(1.0)
   .Collapsable(Theme.Primary.Background)
   .Add("Description", 0.36, Theme.Colors.Blue600)
   .Add("ATA chapter", 0.17, Theme.Colors.Blue400)
   .Add("Type", 0.15, Theme.Colors.Teal500)
   .Add("Damage", 0.13, Theme.Colors.Green500)
   .Add("Location", 0.07, Theme.Colors.Orange500)
   .Add("Program", 0.06, Theme.Colors.Neutral500);
```

## Changes
- **`ContributionBar.cs`** — new `Collapsable(...)` method, collapsed-state rendering, and toggle button wiring.
- **`tss.contributionbar.css`** — `.tss-contribution-row` flex wrapper and `.tss-contribution-toggle` button styling.
- **`ContributionBarSample.cs`** — new "Collapsable" sample section.

## Testing
- `dotnet build` passes (both C# and h5/JS compilation) with 0 warnings/errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JWTKJuLzQziwx4X58TjypB

---
_Generated by [Claude Code](https://claude.ai/code/session_01JWTKJuLzQziwx4X58TjypB)_