### PR TITLE
Add horizontal mode and tinted variants to Message component

### DIFF
--- a/Tesserae.Tests/src/Samples/Components/MessageSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/MessageSample.cs
@@ -17,7 +17,7 @@ namespace Tesserae.Tests.Samples
                .FlatSection(Stack().Children(
                     Card(VStack().WS().Children(
                     TextBlock("The Message component is used to display static messages, alerts, or empty states. It supports an icon, title, text body, and an optional note area."),
-                    TextBlock("It comes with variants for standard, success, warning, and error states.")
+                    TextBlock("It comes with variants for standard, info, success, warning, and error states, and can be laid out vertically (default) or horizontally.")
                )).SetTitle("Overview")))
                .FlatSection(Stack().Children(
                     Card(VStack().WS().Children(
@@ -40,7 +40,54 @@ namespace Tesserae.Tests.Samples
                     Message("No results found", "We couldn't find any items matching your search criteria.")
                         .Icon(UIcons.Search)
                         .Variant(MessageVariant.Default)
-               )).SetTitle("Usage")));
+               )).SetTitle("Usage")))
+               .FlatSection(Stack().Children(
+                    Card(VStack().WS().Children(
+                    TextBlock("Variants apply a soft tinted background, matching icon, and a rounded border using the TSS color variables."),
+
+                    SampleSubTitle("Info"),
+                    Message("Heads up", "Your trial expires in 7 days. Upgrade now to keep access to all features.")
+                        .Icon(UIcons.Info)
+                        .Variant(MessageVariant.Info),
+
+                    SampleSubTitle("Success"),
+                    Message("All set!", "Your changes have been saved successfully.")
+                        .Icon(UIcons.CheckCircle)
+                        .Variant(MessageVariant.Success),
+
+                    SampleSubTitle("Warning"),
+                    Message("Storage almost full", "You're using 95% of your available storage. Consider removing unused files.")
+                        .Icon(UIcons.TriangleWarning)
+                        .Variant(MessageVariant.Warning)
+               )).SetTitle("Variants")))
+               .FlatSection(Stack().Children(
+                    Card(VStack().WS().Children(
+                    TextBlock("Use Horizontal() to place the icon beside the content. This works great for compact inline alerts."),
+
+                    SampleSubTitle("Horizontal Info"),
+                    Message("Sync complete", "Your workspace is up to date with the latest changes from the server.")
+                        .Icon(UIcons.Info)
+                        .Variant(MessageVariant.Info)
+                        .Horizontal(),
+
+                    SampleSubTitle("Horizontal Success"),
+                    Message("Payment received", "We've received your payment and your subscription is now active.")
+                        .Icon(UIcons.CheckCircle)
+                        .Variant(MessageVariant.Success)
+                        .Horizontal(),
+
+                    SampleSubTitle("Horizontal Warning (with Note)"),
+                    Message("Unsaved changes", "You have unsaved changes that will be lost if you leave this page.")
+                        .Icon(UIcons.TriangleWarning)
+                        .Variant(MessageVariant.Warning)
+                        .Horizontal()
+                        .Note(
+                            HStack().AlignItems(ItemAlign.Center).Children(
+                                Icon(UIcons.Bulb, size: TextSize.Small).PR(8),
+                                TextBlock("Tip: changes are saved automatically every few minutes.").SemiBold()
+                            )
+                        )
+               )).SetTitle("Horizontal layout")));
         }
 
         public HTMLElement Render() => _content.Render();

--- a/Tesserae/h5/assets/css/tss.message.css
+++ b/Tesserae/h5/assets/css/tss.message.css
@@ -21,12 +21,21 @@
     width: 64px;
     border-radius: 64px;
     line-height: 64px;
+    flex-shrink: 0;
 }
 
     .tss-message-icon i {
         line-height: 64px;
         margin-top: 4px;
     }
+
+.tss-message-content {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    min-width: 0;
+}
 
 .tss-message-title {
     font-size: 20px;
@@ -62,15 +71,125 @@
     font-size: 16px;
 }
 
-/* Variants */
-.tss-message-success .tss-message-icon {
-    color: var(--tss-colors-green-500);
+/* Horizontal layout: icon sits beside the content instead of stacked above it */
+.tss-message-horizontal {
+    flex-direction: row;
+    align-items: center;
+    justify-content: flex-start;
+    text-align: left;
+    gap: 16px;
 }
 
-.tss-message-warning .tss-message-icon {
-    color: var(--tss-colors-orange-500);
+    .tss-message-horizontal .tss-message-icon {
+        margin-bottom: 0;
+        font-size: 28px;
+        height: 44px;
+        width: 44px;
+        border-radius: 44px;
+        line-height: 44px;
+    }
+
+        .tss-message-horizontal .tss-message-icon i {
+            line-height: 44px;
+            margin-top: 0;
+        }
+
+    .tss-message-horizontal .tss-message-content {
+        align-items: flex-start;
+        text-align: left;
+        flex: 1;
+    }
+
+    .tss-message-horizontal .tss-message-title {
+        font-size: 16px;
+        margin-bottom: 2px;
+    }
+
+    .tss-message-horizontal .tss-message-text {
+        margin-bottom: 0;
+    }
+
+    .tss-message-horizontal .tss-message-note {
+        margin-top: 12px;
+    }
+
+/* Variants: soft tinted background with a rounded border */
+.tss-message-info,
+.tss-message-success,
+.tss-message-warning,
+.tss-message-error {
+    border-radius: 12px;
+    border: 1px solid transparent;
 }
 
-.tss-message-error .tss-message-icon {
-    color: var(--tss-colors-red-500);
+.tss-message-info {
+    background-color: var(--tss-colors-blue-100);
+    border-color: var(--tss-colors-blue-200);
 }
+
+    .tss-message-info .tss-message-icon {
+        color: var(--tss-colors-blue-600);
+        background: var(--tss-colors-blue-200);
+    }
+
+    .tss-message-info .tss-message-title {
+        color: var(--tss-colors-blue-900);
+    }
+
+    .tss-message-info .tss-message-text {
+        color: var(--tss-colors-blue-800);
+    }
+
+.tss-message-success {
+    background-color: var(--tss-colors-green-100);
+    border-color: var(--tss-colors-green-200);
+}
+
+    .tss-message-success .tss-message-icon {
+        color: var(--tss-colors-green-600);
+        background: var(--tss-colors-green-200);
+    }
+
+    .tss-message-success .tss-message-title {
+        color: var(--tss-colors-green-900);
+    }
+
+    .tss-message-success .tss-message-text {
+        color: var(--tss-colors-green-800);
+    }
+
+.tss-message-warning {
+    background-color: var(--tss-colors-orange-100);
+    border-color: var(--tss-colors-orange-200);
+}
+
+    .tss-message-warning .tss-message-icon {
+        color: var(--tss-colors-orange-600);
+        background: var(--tss-colors-orange-200);
+    }
+
+    .tss-message-warning .tss-message-title {
+        color: var(--tss-colors-orange-900);
+    }
+
+    .tss-message-warning .tss-message-text {
+        color: var(--tss-colors-orange-800);
+    }
+
+.tss-message-error {
+    background-color: var(--tss-colors-red-100);
+    border-color: var(--tss-colors-red-200);
+}
+
+    .tss-message-error .tss-message-icon {
+        color: var(--tss-colors-red-600);
+        background: var(--tss-colors-red-200);
+    }
+
+    .tss-message-error .tss-message-title {
+        color: var(--tss-colors-red-900);
+    }
+
+    .tss-message-error .tss-message-text {
+        color: var(--tss-colors-red-800);
+    }

--- a/Tesserae/src/Components/Message.cs
+++ b/Tesserae/src/Components/Message.cs
@@ -12,6 +12,7 @@ namespace Tesserae
     public class Message : ComponentBase<Message, HTMLDivElement>
     {
         private readonly HTMLDivElement _iconContainer;
+        private readonly HTMLDivElement _contentContainer;
         private readonly HTMLDivElement _titleContainer;
         private readonly HTMLDivElement _textContainer;
         private readonly HTMLDivElement _noteContainer;
@@ -23,17 +24,20 @@ namespace Tesserae
         {
             InnerElement = Div(_("tss-message"));
 
-            _iconContainer = Div(_("tss-message-icon"));
-            _titleContainer = Div(_("tss-message-title"));
-            _textContainer = Div(_("tss-message-text"));
-            _noteContainer = Div(_("tss-message-note"));
+            _iconContainer    = Div(_("tss-message-icon"));
+            _contentContainer = Div(_("tss-message-content"));
+            _titleContainer   = Div(_("tss-message-title"));
+            _textContainer    = Div(_("tss-message-text"));
+            _noteContainer    = Div(_("tss-message-note"));
 
             if (!string.IsNullOrEmpty(title)) Title(title);
             if (!string.IsNullOrEmpty(message)) Text(message);
 
+            _contentContainer.appendChild(_titleContainer);
+            _contentContainer.appendChild(_textContainer);
+
             InnerElement.appendChild(_iconContainer);
-            InnerElement.appendChild(_titleContainer);
-            InnerElement.appendChild(_textContainer);
+            InnerElement.appendChild(_contentContainer);
         }
 
         /// <summary>
@@ -102,7 +106,7 @@ namespace Tesserae
         {
             _noteContainer.innerHTML = "";
             _noteContainer.appendChild(TextBlock(note).Render());
-            if(!InnerElement.contains(_noteContainer)) InnerElement.appendChild(_noteContainer);
+            if(!_contentContainer.contains(_noteContainer)) _contentContainer.appendChild(_noteContainer);
             return this;
         }
 
@@ -113,7 +117,7 @@ namespace Tesserae
         {
             _noteContainer.innerHTML = "";
             _noteContainer.appendChild(note.Render());
-            if(!InnerElement.contains(_noteContainer)) InnerElement.appendChild(_noteContainer);
+            if(!_contentContainer.contains(_noteContainer)) _contentContainer.appendChild(_noteContainer);
             return this;
         }
 
@@ -122,8 +126,18 @@ namespace Tesserae
         /// </summary>
         public Message Variant(MessageVariant variant)
         {
-            InnerElement.classList.remove("tss-message-default", "tss-message-success", "tss-message-warning", "tss-message-error");
+            InnerElement.classList.remove("tss-message-default", "tss-message-info", "tss-message-success", "tss-message-warning", "tss-message-error");
             InnerElement.classList.add($"tss-message-{variant.ToString().ToLower()}");
+            return this;
+        }
+
+        /// <summary>
+        /// Lays the message out horizontally, with the icon beside the text instead of stacked above it.
+        /// </summary>
+        public Message Horizontal(bool horizontal = true)
+        {
+            if (horizontal) InnerElement.classList.add("tss-message-horizontal");
+            else            InnerElement.classList.remove("tss-message-horizontal");
             return this;
         }
 
@@ -140,6 +154,7 @@ namespace Tesserae
     public enum MessageVariant
     {
         Default,
+        Info,
         Success,
         Warning,
         Error


### PR DESCRIPTION
- Add a Horizontal() toggle that lays the icon beside the content
- Add an Info variant alongside Success/Warning/Error
- Style variants with soft tinted backgrounds, matching icons, and a
  rounded border using the TSS color variables
- Wrap title/text/note in a content container so both layouts work
- Showcase the new variants and horizontal layout in the sample page

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018h3xz64NWeTr2e9EczLFSs