### PR TITLE
Add Action component support to Message

### DIFF
--- a/Tesserae.Tests/src/Samples/Components/MessageSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/MessageSample.cs
@@ -87,7 +87,23 @@ namespace Tesserae.Tests.Samples
                                 TextBlock("Tip: changes are saved automatically every few minutes.").SemiBold()
                             )
                         )
-               )).SetTitle("Horizontal layout")));
+               )).SetTitle("Horizontal layout")))
+               .FlatSection(Stack().Children(
+                    Card(VStack().WS().Children(
+                    TextBlock("Use Action(...) to attach an action component. On the default layout it renders below the content; on a horizontal message it renders on the right side, beside the content."),
+
+                    SampleSubTitle("Action (vertical)"),
+                    Message("No Database Schema Yet", "Start by describing your database requirements in the chat.")
+                        .Icon(UIcons.FileCode)
+                        .Action(Button("Get started").Primary()),
+
+                    SampleSubTitle("Action (horizontal)"),
+                    Message("Update available", "A new version of the app is ready to install.")
+                        .Icon(UIcons.Info)
+                        .Variant(MessageVariant.Info)
+                        .Horizontal()
+                        .Action(Button("Update now").Primary())
+               )).SetTitle("Action")));
         }
 
         public HTMLElement Render() => _content.Render();

--- a/Tesserae/src/Components/Message.cs
+++ b/Tesserae/src/Components/Message.cs
@@ -17,6 +17,9 @@ namespace Tesserae
         private readonly HTMLDivElement _textContainer;
         private readonly HTMLDivElement _noteContainer;
 
+        private IComponent  _action;
+        private HTMLElement _renderedRoot;
+
         /// <summary>
         /// Initializes a new instance of this class.
         /// </summary>
@@ -138,6 +141,18 @@ namespace Tesserae
         {
             if (horizontal) InnerElement.classList.add("tss-message-horizontal");
             else            InnerElement.classList.remove("tss-message-horizontal");
+            _renderedRoot = null;
+            return this;
+        }
+
+        /// <summary>
+        /// Adds an action component to the message. On the default (vertical) layout it is rendered below the
+        /// message content; on a horizontal message it is rendered on the right side, beside the content.
+        /// </summary>
+        public Message Action(IComponent action)
+        {
+            _action       = action;
+            _renderedRoot = null;
             return this;
         }
 
@@ -146,7 +161,25 @@ namespace Tesserae
         /// </summary>
         public override HTMLElement Render()
         {
-            return InnerElement;
+            if (_action is null) return InnerElement;
+
+            if (_renderedRoot is null)
+            {
+                if (InnerElement.classList.contains("tss-message-horizontal"))
+                {
+                    _renderedRoot = HStack().WS().AlignItemsCenter()
+                       .Children(Raw(InnerElement).Grow(), _action)
+                       .Render();
+                }
+                else
+                {
+                    _renderedRoot = VStack().WS()
+                       .Children(Raw(InnerElement), _action)
+                       .Render();
+                }
+            }
+
+            return _renderedRoot;
         }
     }
 


### PR DESCRIPTION
## Summary

Adds support for attaching an action component to `Message` via a new `Action()` method. The action renders below the message content in vertical layout and on the right side in horizontal layout.

## Changes

- **Message.cs**
  - Added `_action` and `_renderedRoot` private fields to track the action component and its rendered state
  - Added `Action(IComponent action)` fluent method to attach an action component
  - Modified `Horizontal()` to reset `_renderedRoot` cache when layout changes
  - Updated `Render()` to compose the message with its action using `HStack` (horizontal) or `VStack` (vertical) layouts when an action is present
  - Action is positioned on the right with `.Grow()` in horizontal layout; below content in vertical layout

- **MessageSample.cs**
  - Added sample section demonstrating `Action()` usage with both vertical and horizontal message layouts
  - Shows practical examples: "Get started" button on a vertical message and "Update now" button on a horizontal message

## Implementation Details

The `Render()` method now implements lazy composition: when an action is present, it wraps the original `InnerElement` in a layout container (`HStack` or `VStack`) alongside the action component. The `_renderedRoot` cache is invalidated whenever the layout orientation changes via `Horizontal()`, ensuring the correct layout is applied.

https://claude.ai/code/session_01SyBQ5RMsfUCyxdqVKtuCQP