### PR TITLE
Add dark mode styles for message components

### DIFF
--- a/Tesserae/h5/assets/css/tss.message.css
+++ b/Tesserae/h5/assets/css/tss.message.css
@@ -199,12 +199,6 @@
 
 }
 
-/* Dark theme: the colored scales aren't remapped in dark mode, so the light
-   tinted backgrounds would glare. Flip to deep backgrounds with mid-tone
-   borders and lift the title/text/icon colors so they read on the dark fill. */
-/* The note is a callout chip that can sit on the page or inside a variant
-   message. A -900 fill would melt into the info variant's -900 background, so
-   use a brighter, more saturated shade to keep it distinct in either context. */
 .tss-dark-mode .tss-message-note {
     background-color: var(--tss-colors-blue-800);
     color: var(--tss-colors-blue-100);

--- a/Tesserae/h5/assets/css/tss.message.css
+++ b/Tesserae/h5/assets/css/tss.message.css
@@ -202,11 +202,18 @@
 /* Dark theme: the colored scales aren't remapped in dark mode, so the light
    tinted backgrounds would glare. Flip to deep backgrounds with mid-tone
    borders and lift the title/text/icon colors so they read on the dark fill. */
+/* The note is a callout chip that can sit on the page or inside a variant
+   message. A -900 fill would melt into the info variant's -900 background, so
+   use a brighter, more saturated shade to keep it distinct in either context. */
 .tss-dark-mode .tss-message-note {
-    background-color: var(--tss-colors-blue-900);
-    color: var(--tss-colors-blue-200);
-    border-color: var(--tss-colors-blue-700);
+    background-color: var(--tss-colors-blue-800);
+    color: var(--tss-colors-blue-100);
+    border-color: var(--tss-colors-blue-600);
 }
+
+    .tss-dark-mode .tss-message-note i {
+        color: var(--tss-colors-blue-100);
+    }
 
 .tss-dark-mode .tss-message-info {
     background-color: var(--tss-colors-blue-900);

--- a/Tesserae/h5/assets/css/tss.message.css
+++ b/Tesserae/h5/assets/css/tss.message.css
@@ -196,5 +196,86 @@
 
 
 .tss-message-action {
-    
+
 }
+
+/* Dark theme: the colored scales aren't remapped in dark mode, so the light
+   tinted backgrounds would glare. Flip to deep backgrounds with mid-tone
+   borders and lift the title/text/icon colors so they read on the dark fill. */
+.tss-dark-mode .tss-message-note {
+    background-color: var(--tss-colors-blue-900);
+    color: var(--tss-colors-blue-200);
+    border-color: var(--tss-colors-blue-700);
+}
+
+.tss-dark-mode .tss-message-info {
+    background-color: var(--tss-colors-blue-900);
+    border-color: var(--tss-colors-blue-700);
+}
+
+    .tss-dark-mode .tss-message-info .tss-message-icon {
+        color: var(--tss-colors-blue-300);
+        background: var(--tss-colors-blue-800);
+    }
+
+    .tss-dark-mode .tss-message-info .tss-message-title {
+        color: var(--tss-colors-blue-200);
+    }
+
+    .tss-dark-mode .tss-message-info .tss-message-text {
+        color: var(--tss-colors-blue-300);
+    }
+
+.tss-dark-mode .tss-message-success {
+    background-color: var(--tss-colors-green-900);
+    border-color: var(--tss-colors-green-700);
+}
+
+    .tss-dark-mode .tss-message-success .tss-message-icon {
+        color: var(--tss-colors-green-300);
+        background: var(--tss-colors-green-800);
+    }
+
+    .tss-dark-mode .tss-message-success .tss-message-title {
+        color: var(--tss-colors-green-200);
+    }
+
+    .tss-dark-mode .tss-message-success .tss-message-text {
+        color: var(--tss-colors-green-300);
+    }
+
+.tss-dark-mode .tss-message-warning {
+    background-color: var(--tss-colors-orange-900);
+    border-color: var(--tss-colors-orange-700);
+}
+
+    .tss-dark-mode .tss-message-warning .tss-message-icon {
+        color: var(--tss-colors-orange-300);
+        background: var(--tss-colors-orange-800);
+    }
+
+    .tss-dark-mode .tss-message-warning .tss-message-title {
+        color: var(--tss-colors-orange-200);
+    }
+
+    .tss-dark-mode .tss-message-warning .tss-message-text {
+        color: var(--tss-colors-orange-300);
+    }
+
+.tss-dark-mode .tss-message-error {
+    background-color: var(--tss-colors-red-900);
+    border-color: var(--tss-colors-red-700);
+}
+
+    .tss-dark-mode .tss-message-error .tss-message-icon {
+        color: var(--tss-colors-red-300);
+        background: var(--tss-colors-red-800);
+    }
+
+    .tss-dark-mode .tss-message-error .tss-message-title {
+        color: var(--tss-colors-red-200);
+    }
+
+    .tss-dark-mode .tss-message-error .tss-message-text {
+        color: var(--tss-colors-red-300);
+    }


### PR DESCRIPTION
## Summary

Adds comprehensive dark mode styling for all message component variants (info, success, warning, error) and the note callout chip. Dark mode uses deep backgrounds with mid-tone borders and lifted text/icon colors for proper contrast and readability.

## Changes

- **Dark mode message variants**: Added `.tss-dark-mode` scoped styles for `.tss-message-info`, `.tss-message-success`, `.tss-message-warning`, and `.tss-message-error`
  - Each variant uses a `-900` background color with `-700` borders
  - Icon backgrounds use `-800` shades with `-300` text color
  - Titles use `-200` color for prominence
  - Body text uses `-300` color for secondary readability

- **Dark mode note callout**: Added `.tss-dark-mode .tss-message-note` styling
  - Uses `-800` background (brighter than `-900` to remain distinct from info variant's background)
  - `-600` border and `-100` text color for contrast
  - Icon inherits the `-100` text color

- **Color palette**: Leverages existing CSS custom properties (`--tss-colors-{hue}-{shade}`) for blue, green, orange, and red scales

## Implementation Details

The dark mode styles follow the established pattern of scoping to `.tss-dark-mode` parent class. The note component uses a brighter shade (`-800` vs `-900`) to maintain visual distinction when nested inside the info variant message, which also uses a `-900` background.

https://claude.ai/code/session_01Gp33xab7VE5aH6XSUivqpu