### PR TITLE
Add ListItemText component for title/subtitle list items

### DIFF
--- a/Tesserae.Tests/src/Samples/Components/ListItemTextSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/ListItemTextSample.cs
@@ -21,20 +21,20 @@ namespace Tesserae.Tests.Samples
                .FlatSection(Stack().Children(
                     Card(VStack().WS().Children(
                     SampleSubTitle("Title and subtitle"),
-                    ListItemText("SB A320-78-1042", "Thrust reverser — blocker door hinge fitting inspection"),
+                    ListItemText("Project roadmap", "Last edited 3 hours ago by Alex"),
 
                     SampleSubTitle("Title only"),
-                    ListItemText("SB A320-78-1042"),
+                    ListItemText("Project roadmap"),
 
                     SampleSubTitle("With an icon in a rounded square"),
                     VStack().Children(
-                        ListItemText("SB A320-78-1042", "Thrust reverser — blocker door hinge fitting inspection")
-                            .SetIcon(UIcons.WrenchSimple),
-                        ListItemText("Inspection passed", "All hinge fittings within tolerance")
+                        ListItemText("General settings", "Theme, language and notifications")
+                            .SetIcon(UIcons.Settings),
+                        ListItemText("Backup completed", "All files synced successfully")
                             .SetIcon(UIcons.Check)
                             .IconForeground("var(--tss-success-foreground-color)")
                             .IconBackground("var(--tss-success-background-color)"),
-                        ListItemText("Action required", "Re-torque fitting and re-inspect within 48h")
+                        ListItemText("Storage almost full", "Free up space to keep syncing")
                             .SetIcon(UIcons.TriangleWarning)
                             .IconForeground("var(--tss-danger-foreground-color)")
                             .IconBackground("var(--tss-danger-background-color)")

--- a/Tesserae.Tests/src/Samples/Components/ListItemTextSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/ListItemTextSample.cs
@@ -1,0 +1,47 @@
+using System;
+using static H5.Core.dom;
+using static Tesserae.UI;
+using static Tesserae.Tests.Samples.SamplesHelper;
+
+namespace Tesserae.Tests.Samples
+{
+    [SampleDetails(Group = "Components", Order = 0, Icon = UIcons.List)]
+    public class ListItemTextSample : IComponent, ISample
+    {
+        private readonly IComponent _content;
+
+        public ListItemTextSample()
+        {
+            _content = SectionStack().Secondary()
+               .SampleTitle(typeof(ListItemTextSample), UIcons.List, "A simple title + subtitle list item, with an optional icon")
+               .FlatSection(Stack().Children(
+                    Card(VStack().WS().Children(
+                    TextBlock("ListItemText displays a bold title with a lighter subtitle underneath. It is handy for list rows, settings entries and notification items where a short heading needs a secondary line of context."),
+                    TextBlock("An optional leading icon can be shown inside a rounded-square background to add visual identity to each row."))).SetTitle("Overview")))
+               .FlatSection(Stack().Children(
+                    Card(VStack().WS().Children(
+                    SampleSubTitle("Title and subtitle"),
+                    ListItemText("SB A320-78-1042", "Thrust reverser — blocker door hinge fitting inspection"),
+
+                    SampleSubTitle("Title only"),
+                    ListItemText("SB A320-78-1042"),
+
+                    SampleSubTitle("With an icon in a rounded square"),
+                    VStack().Children(
+                        ListItemText("SB A320-78-1042", "Thrust reverser — blocker door hinge fitting inspection")
+                            .SetIcon(UIcons.WrenchSimple),
+                        ListItemText("Inspection passed", "All hinge fittings within tolerance")
+                            .SetIcon(UIcons.Check)
+                            .IconForeground("var(--tss-success-foreground-color)")
+                            .IconBackground("var(--tss-success-background-color)"),
+                        ListItemText("Action required", "Re-torque fitting and re-inspect within 48h")
+                            .SetIcon(UIcons.TriangleWarning)
+                            .IconForeground("var(--tss-danger-foreground-color)")
+                            .IconBackground("var(--tss-danger-background-color)")
+                    )
+                )).SetTitle("Usage")));
+        }
+
+        public HTMLElement Render() => _content.Render();
+    }
+}

--- a/Tesserae/h5.json
+++ b/Tesserae/h5.json
@@ -90,6 +90,7 @@
                 "h5/assets/css/tss.animations.css",
                 "h5/assets/css/tss.label.css",
                 "h5/assets/css/tss.textblock.css",
+                "h5/assets/css/tss.listitemtext.css",
                 "h5/assets/css/tss.textbox.css",
                 "h5/assets/css/tss.textarea.css",
                 "h5/assets/css/tss.card.css",

--- a/Tesserae/h5/assets/css/tss.listitemtext.css
+++ b/Tesserae/h5/assets/css/tss.listitemtext.css
@@ -1,0 +1,45 @@
+/* ListItemText */
+.tss-listitemtext {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 12px;
+    -webkit-user-select: none;
+    user-select: none;
+}
+
+.tss-listitemtext-content {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+}
+
+.tss-listitemtext-title {
+    font-size: var(--tss-font-size-medium);
+    font-weight: var(--tss-font-weight-semibold);
+    color: var(--tss-default-foreground-color);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.tss-listitemtext-subtitle {
+    font-size: var(--tss-font-size-small);
+    font-weight: var(--tss-font-weight-regular);
+    color: var(--tss-secondary-foreground-color);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.tss-listitemtext-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    width: 40px;
+    height: 40px;
+    border-radius: 8px;
+    background: var(--tss-secondary-background-color);
+    color: var(--tss-default-foreground-color);
+}

--- a/Tesserae/src/Base/UI.Components.cs
+++ b/Tesserae/src/Base/UI.Components.cs
@@ -699,6 +699,11 @@ namespace Tesserae
         public static TextBlock TextBlock(string text = string.Empty, bool treatAsHTML = false, bool selectable = false, TextSize textSize = TextSize.Small, TextWeight textWeight = TextWeight.Regular, string afterText = null) => new TextBlock(text, treatAsHTML, selectable, textSize, textWeight, afterText: afterText);
 
         /// <summary>
+        /// Creates a <see cref="Tesserae.ListItemText"/> component showing a title with an optional subtitle.
+        /// </summary>
+        public static ListItemText ListItemText(string title, string subtitle = null) => new ListItemText(title, subtitle);
+
+        /// <summary>
         /// Creates a <see cref="Tesserae.MarkdownBlock"/> component that renders Markdown source as sanitized HTML.
         /// </summary>
         public static MarkdownBlock MarkdownBlock(string text = "") => new MarkdownBlock(text);

--- a/Tesserae/src/Components/ListItemText.cs
+++ b/Tesserae/src/Components/ListItemText.cs
@@ -1,0 +1,136 @@
+using System;
+using static H5.Core.dom;
+using static Tesserae.UI;
+
+namespace Tesserae
+{
+    /// <summary>
+    /// A simple two-line list item that shows a bold title with a lighter subtitle
+    /// underneath, plus an optional leading icon rendered inside a rounded-square background.
+    /// </summary>
+    [H5.Name("tss.ListItemText")]
+    public class ListItemText : ComponentBase<ListItemText, HTMLElement>
+    {
+        private readonly HTMLElement _title;
+        private readonly HTMLElement _subtitle;
+        private readonly HTMLElement _content;
+
+        private HTMLElement _iconContainer;
+        private Icon        _icon;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ListItemText"/> class.
+        /// </summary>
+        /// <param name="title">The (bold) title text.</param>
+        /// <param name="subtitle">The (lighter) subtitle text. When null or empty the subtitle is hidden.</param>
+        public ListItemText(string title, string subtitle = null)
+        {
+            _title             = Div(_("tss-listitemtext-title"));
+            _title.textContent = title ?? string.Empty;
+
+            _subtitle = Div(_("tss-listitemtext-subtitle"));
+
+            if (string.IsNullOrEmpty(subtitle))
+            {
+                _subtitle.style.display = "none";
+            }
+            else
+            {
+                _subtitle.textContent = subtitle;
+            }
+
+            _content = Div(_("tss-listitemtext-content"), _title, _subtitle);
+
+            InnerElement = Div(_("tss-listitemtext"), _content);
+
+            AttachClick();
+            AttachContextMenu();
+        }
+
+        /// <summary>Gets or sets the title text.</summary>
+        public string Title
+        {
+            get => _title.textContent;
+            set => _title.textContent = value ?? string.Empty;
+        }
+
+        /// <summary>Gets or sets the subtitle text. Setting it to null or empty hides the subtitle.</summary>
+        public string Subtitle
+        {
+            get => _subtitle.textContent;
+            set
+            {
+                if (string.IsNullOrEmpty(value))
+                {
+                    _subtitle.textContent   = string.Empty;
+                    _subtitle.style.display = "none";
+                }
+                else
+                {
+                    _subtitle.textContent   = value;
+                    _subtitle.style.display = "";
+                }
+            }
+        }
+
+        /// <summary>Sets the title text.</summary>
+        public ListItemText SetTitle(string title)
+        {
+            Title = title;
+            return this;
+        }
+
+        /// <summary>Sets the subtitle text.</summary>
+        public ListItemText SetSubtitle(string subtitle)
+        {
+            Subtitle = subtitle;
+            return this;
+        }
+
+        /// <summary>
+        /// Shows a leading icon inside a rounded-square background. Calling this again updates the existing icon.
+        /// </summary>
+        public ListItemText SetIcon(UIcons icon, UIconsWeight weight = UIconsWeight.Regular, TextSize size = TextSize.Medium)
+        {
+            if (_icon is null)
+            {
+                _icon          = new Icon(icon, weight, size);
+                _iconContainer = Div(_("tss-listitemtext-icon"), _icon.Render());
+                InnerElement.insertBefore(_iconContainer, _content);
+            }
+            else
+            {
+                _icon.SetIcon(icon, weight, size);
+            }
+
+            return this;
+        }
+
+        /// <summary>Sets the color of the leading icon. Has no effect until an icon is set.</summary>
+        public ListItemText IconForeground(string color)
+        {
+            if (_icon is object)
+            {
+                _icon.Foreground = color;
+            }
+
+            return this;
+        }
+
+        /// <summary>Sets the background color of the rounded square behind the leading icon. Has no effect until an icon is set.</summary>
+        public ListItemText IconBackground(string color)
+        {
+            if (_iconContainer is object)
+            {
+                _iconContainer.style.background = color;
+            }
+
+            return this;
+        }
+
+        /// <summary>
+        /// Renders the component's root HTML element.
+        /// </summary>
+        public override HTMLElement Render() => InnerElement;
+    }
+}


### PR DESCRIPTION
## Summary

Adds a new `ListItemText` component that displays a bold title with an optional lighter subtitle underneath, plus an optional leading icon in a rounded-square background. This is useful for list rows, settings entries, and notification items.

## Changes

- **New component**: `ListItemText` in `Tesserae/src/Components/ListItemText.cs`
  - Displays a two-line list item with bold title and lighter subtitle
  - Optional leading icon with customizable foreground and background colors
  - Fluent API: `SetTitle()`, `SetSubtitle()`, `SetIcon()`, `IconForeground()`, `IconBackground()`
  - Subtitle can be hidden by setting to null or empty string

- **Component styling**: `Tesserae/h5/assets/css/tss.listitemtext.css`
  - Flexbox layout with icon, title, and subtitle
  - Title uses semibold font weight with ellipsis overflow handling
  - Subtitle uses secondary foreground color with ellipsis overflow handling
  - Icon container is a 40×40px rounded square (8px border-radius)

- **Factory method**: Added `ListItemText(string title, string subtitle = null)` to `UI.Components.cs` following the standard component creation pattern

- **Sample**: `ListItemTextSample` in `Tesserae.Tests/src/Samples/Components/` demonstrating:
  - Title and subtitle usage
  - Title-only variant
  - Icon variants with success and danger color schemes

- **Build config**: Added stylesheet reference to `h5.json`

## Implementation Details

- The component extends `ComponentBase<ListItemText, HTMLElement>` and manages internal state for title, subtitle, and optional icon
- Icon is lazily initialized on first `SetIcon()` call and updated on subsequent calls
- Subtitle visibility is controlled via `display: none` CSS property
- Both title and subtitle use `text-overflow: ellipsis` with `white-space: nowrap` to handle overflow gracefully
- Follows the repository's fluent API pattern with method chaining support

https://claude.ai/code/session_014LCQYTZEvuqbMNbsiQ7hqG