### PR TITLE
Add Rounded (pill) style to SidebarButton and SidebarSearchBox

### DIFF
--- a/Tesserae.Tests/src/Samples/Components/SidebarSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/SidebarSample.cs
@@ -17,8 +17,19 @@ namespace Tesserae.Tests.Samples
         {
             var sidebar = Sidebar();
 
-            var searchBox = new SidebarSearchBox("search", "Search Sidebar...");
-            searchBox.OnSearch((term) => sidebar.Search(term));
+            // A rounded, primary "pill" button (see .Rounded()), matching the rounded search box below.
+            var newDocument = new SidebarButton("new-doc", UIcons.Plus, "New document")
+                .Primary()
+                .Rounded()
+                .OnClick(() => Toast().Success("New document"));
+
+            sidebar.AddHeader(newDocument);
+
+            // A rounded search box with a keyboard shortcut chip (⌘K / Ctrl+K) that focuses it.
+            var searchBox = new SidebarSearchBox("search", "Search docs, parts, records...")
+                .Rounded()
+                .SetKeyboardShortcut("Ctrl", "K")
+                .OnSearch((term) => sidebar.Search(term));
 
             sidebar.AddHeader(searchBox);
 
@@ -112,7 +123,7 @@ namespace Tesserae.Tests.Samples
                .SampleTitle(typeof(SidebarSample), UIcons.Apps, "A sidebar navigation component")
                .FlatSection(Stack().Children(
                     Card(VStack().WS().Children(
-                    TextBlock("A fully featured Sidebar with Search, Navigation, Buttons, and Separators."))).SetTitle("Overview"),
+                    TextBlock("A fully featured Sidebar with Search, Navigation, Buttons, and Separators. The header shows a rounded (pill) primary button and a rounded search box with a keyboard shortcut (⌘K / Ctrl+K) — enable both with .Rounded()."))).SetTitle("Overview"),
                     Card(VStack().WS().Children(
                         SplitView().WS().H(800).LeftIsSmaller(400.px()).Resizable()
                                    .Left(sidebar.S())

--- a/Tesserae/h5/assets/css/tss.sidebar.css
+++ b/Tesserae/h5/assets/css/tss.sidebar.css
@@ -55,6 +55,27 @@
     margin-bottom: 2px;
 }
 
+/* Rounded (pill) variant for SidebarButton/SidebarSearchBox, enabled via .Rounded().
+   These are rendered 1.5x the normal 28px sidebar button height (= 42px). */
+.tss-sidebar-searchbox.tss-sidebar-searchbox-rounded .tss-searchbox-container {
+    height: 42px;
+    padding-left: 12px;
+    padding-right: 6px;
+}
+
+.tss-sidebar.tss-sidebar-closed .tss-sidebar-btn-closed-icon.tss-sidebar-searchbox-rounded {
+    border-radius: var(--tss-border-radius-full);
+}
+
+.tss-sidebar-btn-open.tss-sidebar-btn-rounded > .tss-btn,
+.tss-sidebar-btn-open.tss-sidebar-btn-rounded > a > .tss-btn {
+    height: 42px !important;
+}
+
+.tss-sidebar.tss-sidebar-closed .tss-sidebar-btn-rounded.tss-sidebar-btn.tss-btn {
+    height: 42px !important;
+}
+
 .tss-sidebar-btn-open .tss-sidebar-btn {
     width: 100%;
     z-index: 1;

--- a/Tesserae/skills/references/sidebar.md
+++ b/Tesserae/skills/references/sidebar.md
@@ -31,8 +31,26 @@ Bring factories into scope with `using static Tesserae.UI;`.
   persist item order.
 
 Common item types: `SidebarButton(id, UIcons icon, text)` (`.Selected()`,
-`.OnClick(...)`, `.Danger()`, `.Tooltip(...)`), `SidebarSeparator(id, text)`,
-`SidebarNav(id, icon, text, initiallyCollapsed)`, `SidebarText(id, text)`.
+`.OnClick(...)`, `.Primary()`, `.Danger()`, `.Rounded()`, `.Tooltip(...)`),
+`SidebarSeparator(id, text)`, `SidebarNav(id, icon, text, initiallyCollapsed)`,
+`SidebarText(id, text)`, `SidebarSearchBox(id, placeholder)`.
+
+## SidebarSearchBox
+
+`new SidebarSearchBox(id, placeholder)` is a search input for the header that
+filters searchable items. Configure it fluently:
+
+- `.OnSearch(term => sidebar.Search(term))` — run on every keystroke.
+- `.SetKeyboardShortcut("Ctrl", "K")` — show a shortcut chip (renders ⌘K on
+  macOS, Ctrl+K elsewhere) and focus the box when the shortcut is pressed.
+- `.Rounded(BorderRadius = Full)` — render as a full bordered, rounded "pill".
+
+## Rounded (pill) style
+
+`SidebarButton.Rounded(BorderRadius = Full)` and
+`SidebarSearchBox.Rounded(BorderRadius = Full)` render the item with rounded
+corners (a full pill by default; pass `BorderRadius.Small`/`Medium`/`Full`).
+Combine `.Primary().Rounded()` on a button for a prominent call-to-action.
 
 ## Example
 
@@ -40,11 +58,17 @@ Common item types: `SidebarButton(id, UIcons icon, text)` (`.Selected()`,
 using static Tesserae.UI;
 
 var sidebar = Sidebar();
-sidebar.AddHeader(new SidebarText("title", "My App"));
+
+sidebar.AddHeader(new SidebarButton("new-doc", UIcons.Plus, "New document")
+    .Primary().Rounded().OnClick(() => Toast().Success("New document")));
+
+sidebar.AddHeader(new SidebarSearchBox("search", "Search docs, parts, records...")
+    .Rounded()
+    .SetKeyboardShortcut("Ctrl", "K")
+    .OnSearch(term => sidebar.Search(term)));
+
 sidebar.AddContent(new SidebarButton("home", UIcons.Home, "Home").Selected());
 sidebar.AddContent(new SidebarSeparator("sep", "Tools"));
-sidebar.AddContent(new SidebarButton("search", UIcons.Search, "Search")
-    .OnClick(() => Toast().Information("Search")));
 sidebar.AddFooter(new SidebarButton("settings", UIcons.Settings, "Settings"));
 
 var app = HStack().WS().Children(sidebar.HS(), VStack().Grow().HS());

--- a/Tesserae/src/Components/Sidebar/SidebarButton.cs
+++ b/Tesserae/src/Components/Sidebar/SidebarButton.cs
@@ -330,6 +330,21 @@ namespace Tesserae
         }
 
         /// <summary>
+        /// Renders the button with rounded corners (defaults to a fully rounded "pill" shape),
+        /// matching the rounded SidebarSearchBox style.
+        /// </summary>
+        /// <param name="radius">The border radius to apply. Defaults to <see cref="BorderRadius.Full"/>.</param>
+        /// <returns>The current instance of the type.</returns>
+        public SidebarButton Rounded(BorderRadius radius = BorderRadius.Full)
+        {
+            _openButton.Rounded(radius);
+            _closedButton.Rounded(radius);
+            _open.Class("tss-sidebar-btn-rounded");
+            _closedButton.Class("tss-sidebar-btn-rounded");
+            return this;
+        }
+
+        /// <summary>
         /// Sets the button to use a danger style.
         /// </summary>
         /// <returns>The current instance of the type.</returns>

--- a/Tesserae/src/Components/Sidebar/SidebarSearchBox.cs
+++ b/Tesserae/src/Components/Sidebar/SidebarSearchBox.cs
@@ -7,9 +7,11 @@ namespace Tesserae
 {
     public class SidebarSearchBox : ISidebarItem
     {
-        private readonly IComponent _closed;
-        private readonly IComponent _open;
-        private readonly SearchBox  _searchBox;
+        private readonly IComponent  _closed;
+        private readonly IComponent  _open;
+        private readonly SearchBox   _searchBox;
+        private readonly HTMLElement _closedElement;
+        private readonly HTMLElement _openElement;
 
         public bool IsSelected { get; set; }
 
@@ -25,17 +27,33 @@ namespace Tesserae
         {
             Identifier = identifier;
 
-            var closedElement = Div(_("tss-sidebar-btn tss-sidebar-btn-closed-icon"), I(UIcons.Search));
-            closedElement.title = placeholder;
+            _closedElement = Div(_("tss-sidebar-btn tss-sidebar-btn-closed-icon"), I(UIcons.Search));
+            _closedElement.title = placeholder;
 
             _searchBox = SearchBox(placeholder).Underlined().SearchAsYouType().NoIcon();
             _searchBox.OnSearch((s, v) => Searched?.Invoke(v));
 
-            var openElement = Div(_("tss-sidebar-btn-open tss-sidebar-searchbox"));
-            openElement.appendChild(_searchBox.Render());
+            _openElement = Div(_("tss-sidebar-btn-open tss-sidebar-searchbox"));
+            _openElement.appendChild(_searchBox.Render());
 
-            _closed = Raw(closedElement);
-            _open   = Raw(openElement);
+            _closed = Raw(_closedElement);
+            _open   = Raw(_openElement);
+        }
+
+        /// <summary>
+        /// Renders the search box with rounded corners (defaults to a fully rounded "pill" shape,
+        /// like the rounded SidebarButton). Removes the underlined style so the box shows a full
+        /// rounded border.
+        /// </summary>
+        /// <param name="radius">The border radius to apply. Defaults to <see cref="BorderRadius.Full"/>.</param>
+        /// <returns>The current instance of the type.</returns>
+        public SidebarSearchBox Rounded(BorderRadius radius = BorderRadius.Full)
+        {
+            _searchBox.IsUnderlined = false;
+            _searchBox.Rounded(radius);
+            _openElement.classList.add("tss-sidebar-searchbox-rounded");
+            _closedElement.classList.add("tss-sidebar-searchbox-rounded");
+            return this;
         }
 
         public SidebarSearchBox OnSearch(Action<string> onSearch)


### PR DESCRIPTION
## Summary

Adds a new `.Rounded()` fluent method to `SidebarButton` and `SidebarSearchBox` to render them with rounded corners in a "pill" shape (42px height, matching 1.5x the normal 28px sidebar button height). This provides a more prominent, modern appearance for key actions and search inputs in the sidebar header.

## Key Changes

- **SidebarButton.cs**: Added `.Rounded(BorderRadius = Full)` method that applies rounded styling to both open and closed button states via the `tss-sidebar-btn-rounded` class.
- **SidebarSearchBox.cs**: 
  - Converted local `closedElement` and `openElement` variables to private fields (`_closedElement`, `_openElement`) to enable styling in the new `.Rounded()` method.
  - Added `.Rounded(BorderRadius = Full)` method that disables the underline style, applies rounded styling to the search box, and adds the `tss-sidebar-searchbox-rounded` class to both elements.
- **tss.sidebar.css**: Added CSS rules for the rounded variant:
  - `.tss-sidebar-searchbox.tss-sidebar-searchbox-rounded` — sets 42px height and adjusted padding for the search input container.
  - `.tss-sidebar-btn-rounded` — enforces 42px height for both open and closed button states.
  - `.tss-sidebar-searchbox-rounded` — applies full border radius to the closed icon.
- **SidebarSample.cs**: Updated the sample to demonstrate the new feature with a rounded primary "New document" button and a rounded search box with keyboard shortcut (⌘K / Ctrl+K).
- **sidebar.md**: Updated the skill reference to document the new `.Rounded()` method, added a dedicated "SidebarSearchBox" section, and added a "Rounded (pill) style" section explaining the feature. Updated the example to show both rounded button and search box usage.

## Implementation Details

- The rounded style is opt-in via the fluent `.Rounded()` method, maintaining backward compatibility.
- Both components use the same 42px height for visual consistency.
- The search box removes its underline when rounded to show a full rounded border instead.
- The implementation stores element references as fields to allow post-construction styling, following the existing pattern in the codebase.

https://claude.ai/code/session_01EB9obUk1e7JRGDtnYYsQcu