### PR TITLE
Enhance ChatArea with smart auto-scroll and turn anchoring

### DIFF
--- a/Tesserae.Tests/src/Samples/Components/ChatSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/ChatSample.cs
@@ -42,8 +42,9 @@ namespace Tesserae.Tests.Samples
                 copyButton.Render().classList.remove("tss-btn-default");
                 copyButton.Render().classList.add("tss-btn-icon-only");
 
-                var msgComponent = ChatMessage(TextBlock(""), Avatar(null, "AI"), copyButton).MaxWidth();
+                var msgComponent = ChatMessage(TextBlock(""), Avatar(null, "AI"), copyButton).Animated().MaxWidth();
                 chatArea.Add(msgComponent);
+                chatArea.Busy(true);
 
                 int index = 0;
                 string currentText = "";
@@ -53,12 +54,14 @@ namespace Tesserae.Tests.Samples
                     if (cancelled)
                     {
                         input.IsGenerating = false;
+                        chatArea.Busy(false);
                         return;
                     }
 
                     if (index >= words.Length)
                     {
                         input.IsGenerating = false;
+                        chatArea.Busy(false);
                         return;
                     }
 
@@ -108,7 +111,8 @@ namespace Tesserae.Tests.Samples
                 var text = msg.Text;
                 if (string.IsNullOrWhiteSpace(text)) return;
 
-                chatArea.Add(ChatMessage(TextBlock(text), Avatar(null, "U")).RightAligned().MaxWidth());
+                // Anchor the user's turn: it settles near the top and the reply grows into the screen below it.
+                chatArea.Add(ChatMessage(TextBlock(text), Avatar(null, "U")).RightAligned().MaxWidth().ScrollAnchor());
 
                 sender.IsGenerating = true;
                 AddAIAnswer();

--- a/Tesserae/h5/assets/css/tss.chat.css
+++ b/Tesserae/h5/assets/css/tss.chat.css
@@ -1,6 +1,17 @@
+.tss-chatarea-wrapper {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    height: 100%;
+    min-height: 0;
+}
+
 .tss-chatarea {
     display: flex;
     flex-direction: column;
+    flex: 1 1 auto;
+    min-height: 0;
     overflow-y: auto;
     overflow-x: hidden;
     padding: 16px;
@@ -9,11 +20,36 @@
     width:100%;
 }
 
+.tss-chatarea-scrollbtn {
+    position: absolute;
+    right: 16px;
+    bottom: 16px;
+    z-index: 2;
+    width: 36px;
+    height: 36px;
+    min-width: 36px;
+    padding: 0;
+    border-radius: 50%;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.18);
+    opacity: 0;
+    transform: translateY(8px);
+    pointer-events: none;
+    transition: opacity 0.15s ease-in-out, transform 0.15s ease-in-out;
+}
+
+.tss-chatarea-scrollbtn.tss-visible {
+    opacity: 1;
+    transform: translateY(0);
+    pointer-events: auto;
+}
+
 .tss-chatmessage-container {
     display: flex;
     align-items: flex-start;
     margin-bottom: 12px;
     width: 100%;
+    content-visibility: auto;
+    contain-intrinsic-size: auto 60px;
 }
 
 .tss-chatmessage-avatar {

--- a/Tesserae/skills/references/chat.md
+++ b/Tesserae/skills/references/chat.md
@@ -5,9 +5,11 @@ description: A chat transcript surface (ChatArea) holding aligned message bubble
 
 # Chat (ChatArea / ChatMessage)
 
-`ChatArea` is a scrolling transcript that auto-scrolls to new messages (unless the user
-scrolled up). `ChatMessage` is one bubble; its content is wrapped in a `DeltaComponent`,
-so you can call `.ReplaceContent(...)` repeatedly to animate streamed/typed text.
+`ChatArea` is a scrolling transcript built for streaming replies. It follows the live edge
+while the reader is at the bottom, stops following the moment they scroll up (new content
+arrives off-screen without yanking them back), and shows a scroll-to-latest button to
+re-engage. `ChatMessage` is one bubble; its content is wrapped in a `DeltaComponent`, so you
+can call `.ReplaceContent(...)` repeatedly to animate streamed/typed text.
 
 ## Create
 
@@ -19,18 +21,36 @@ Bring factories into scope with `using static Tesserae.UI;`.
 
 ChatArea:
 
-- `.Add(ChatMessage)` — append a message (auto-scrolls into view).
-- `.Clear()` — remove all messages.
+- `.Add(ChatMessage)` — append a message. Auto-scrolls into view **only if the reader is at
+  the bottom**; if they scrolled up, the message is appended without moving them. Adding an
+  anchored message (see `.ScrollAnchor()`) always re-engages following.
+- `.PrependRange(IEnumerable<ChatMessage>)` — insert older messages at the top while keeping
+  the reader's scroll position stable (for loading history above the fold).
+- `.Clear()` — remove all messages (also resets follow state and start-position).
 - `.Background(string)` — bubble background color for all messages.
+- `.DefaultScrollPosition(StartPosition)` — where the transcript settles when first populated
+  (or re-populated after `Clear`): `Start`, `End` (default), or `LastAnchor` (the last
+  anchored turn, with a peek of prior content above it).
+- `.PreviousItemPeek(int px)` — pixels of the previous turn kept visible above an anchored
+  message when a new turn begins (default 64).
+- `.Busy(bool)` — toggles `aria-busy` on the transcript; set `true` while a reply streams.
+- `.ScrollToEnd(bool smooth = false)` / `.ScrollToStart(...)` / `.ScrollToMessage(string id,
+  bool smooth = true)` — imperative scrolling. `ScrollToEnd` re-engages following.
+- `.IsAtBottom` / `.IsFollowingOutput` — read current scroll state.
 - `.OnScroll(...)` / `.OnFocus(...)` / `.OnBlur(...)`.
 
 ChatMessage:
 
 - `.LeftAligned()` (default) / `.RightAligned()` — bubble side.
 - `.MaxWidth()` / `.FullWidth()` — bubble width.
-- `.ReplaceContent(IComponent)` — swap content (animated; use for streaming text).
+- `.ScrollAnchor()` — mark this message as a turn boundary. When added it settles near the top
+  (with a peek of the previous turn above it) so the reply that follows grows into the screen
+  below. Typically set on the user's message.
+- `.Animated()` — fade in streamed deltas.
+- `.ReplaceContent(IComponent)` — swap content (use for streaming text).
 - `.WithReferences(IEnumerable<IComponent>)` — attach reference chips.
-- `.KeepVisible()` — re-scroll the area to keep this message in view.
+- `.KeepVisible()` — keep this message at the live edge while it streams (respects the reader's
+  scroll — a no-op if they scrolled away).
 - `.Background(string)` — this bubble's background.
 
 ## Example
@@ -38,13 +58,17 @@ ChatMessage:
 ```csharp
 using static Tesserae.UI;
 
-var chat = ChatArea();
-chat.Add(ChatMessage(TextBlock("Hi!"), Avatar(null, "U")).RightAligned().MaxWidth());
+var chat = ChatArea().DefaultScrollPosition(ChatArea.StartPosition.LastAnchor);
 
-var reply = ChatMessage(TextBlock(""), Avatar(null, "AI")).MaxWidth();
+// Anchor the user's turn so the reply grows into the screen below it.
+chat.Add(ChatMessage(TextBlock("Hi!"), Avatar(null, "U")).RightAligned().MaxWidth().ScrollAnchor());
+
+var reply = ChatMessage(TextBlock(""), Avatar(null, "AI")).Animated().MaxWidth();
 chat.Add(reply);
+chat.Busy(true);
 reply.ReplaceContent(TextBlock("Hello, how can I help?")); // call repeatedly to stream
 reply.KeepVisible();
+chat.Busy(false);
 ```
 
 ## Related

--- a/Tesserae/src/Components/Chat.cs
+++ b/Tesserae/src/Components/Chat.cs
@@ -7,17 +7,44 @@ namespace Tesserae
 {
     /// <summary>
     /// A chat transcript surface that lays out a sequence of messages with sender attribution, avatars and
-    /// timestamps.
+    /// timestamps. It keeps streamed replies in view while the reader is at the live edge, stops following
+    /// the moment the reader scrolls away, and offers a scroll-to-latest button to re-engage.
     /// </summary>
     [H5.Name("tss.ChatArea")]
     public class ChatArea : IComponent
     {
-        private HTMLElement _innerElement;
-        private ObservableList<IComponentWithID> _messages;
-        private KeyedObservableStack _stack;
+        /// <summary>
+        /// Where the transcript settles when it is first populated (or re-populated after <see cref="Clear"/>).
+        /// </summary>
+        public enum StartPosition
+        {
+            /// <summary>Start at the top of the transcript.</summary>
+            Start,
+            /// <summary>Start at the bottom (the most recent message). This is the default.</summary>
+            End,
+            /// <summary>Start at the last anchored turn (e.g. the reader's most recent message), with a peek of the prior content above it.</summary>
+            LastAnchor
+        }
 
-        private bool _stopAutoScroll = false;
+        private const int BOTTOM_THRESHOLD = 5;
+
+        private readonly HTMLElement _outerElement;
+        private readonly HTMLElement _scrollContainer;
+        private readonly HTMLElement _contentElement;
+        private readonly HTMLElement _scrollButton;
+        private readonly ObservableList<IComponentWithID> _messages;
+        private readonly KeyedObservableStack _stack;
+
+        private bool _followOutput = true;
+        private bool _hasPositioned = false;
+        private double _positionTimer = 0;
         private string _bubbleBackground = null;
+
+        private StartPosition _defaultScrollPosition = StartPosition.End;
+        private int _previousItemPeek = 64;
+
+        private ChatMessage _pendingAnchor = null;
+        private ChatMessage _reservedMessage = null;
 
         /// <summary>
         /// Raised when scrolled occurs.
@@ -41,30 +68,44 @@ namespace Tesserae
 
             _stack = new KeyedObservableStack(_messages, Stack.Orientation.Vertical, debounce: false).S();
 
-            _innerElement = Div(_("tss-chatarea"), _stack.Render());
+            _contentElement = _stack.Render();
+            _contentElement.setAttribute("role", "log");
+            _contentElement.setAttribute("aria-relevant", "additions");
 
-            _innerElement.addEventListener("scroll", (e) =>
+            _scrollContainer = Div(_("tss-chatarea"), _contentElement);
+            _scrollContainer.setAttribute("role", "region");
+            _scrollContainer.setAttribute("aria-label", "Messages");
+            _scrollContainer.tabIndex = 0;
+
+            _scrollButton = BuildScrollButton();
+
+            _outerElement = Div(_("tss-chatarea-wrapper"), _scrollContainer, _scrollButton);
+
+            _scrollContainer.addEventListener("scroll", (e) =>
             {
-                // If user scrolls up (meaning not at the bottom), stop auto-scrolling
-                var scrollHeight = _innerElement.scrollHeight;
-                var scrollTop = _innerElement.scrollTop;
-                var clientHeight = _innerElement.clientHeight;
+                // Follow the live edge only while the reader is at (or within a few px of) the bottom.
+                var distanceFromBottom = _scrollContainer.scrollHeight - _scrollContainer.scrollTop - _scrollContainer.clientHeight;
+                _followOutput = distanceFromBottom <= BOTTOM_THRESHOLD;
 
-                // Allow a small threshold (e.g. 5px) for being "at the bottom"
-                if (scrollHeight - scrollTop - clientHeight > 5)
-                {
-                    _stopAutoScroll = true;
-                }
-                else
-                {
-                    _stopAutoScroll = false;
-                }
-
+                UpdateScrollButton();
                 Scrolled?.Invoke(this, e);
             });
 
-            _innerElement.addEventListener("focusin", (e) => ReceivedFocus?.Invoke(this, e));
-            _innerElement.addEventListener("focusout", (e) => LostFocus?.Invoke(this, e));
+            _scrollContainer.addEventListener("focusin", (e) => ReceivedFocus?.Invoke(this, e));
+            _scrollContainer.addEventListener("focusout", (e) => LostFocus?.Invoke(this, e));
+        }
+
+        private HTMLElement BuildScrollButton()
+        {
+            var button = Button(UIcons.ArrowDown).OnClick(() => ScrollToEnd(smooth: true));
+            var el = button.Render();
+
+            el.classList.add("tss-chatarea-scrollbtn");
+            el.setAttribute("aria-label", "Scroll to latest");
+            el.setAttribute("tabindex", "-1");
+            el.setAttribute("inert", "");
+
+            return el;
         }
 
         /// <summary>
@@ -111,6 +152,41 @@ namespace Tesserae
         }
 
         /// <summary>
+        /// Sets where the transcript settles when it is first populated (or re-populated after <see cref="Clear"/>).
+        /// </summary>
+        public ChatArea DefaultScrollPosition(StartPosition position)
+        {
+            _defaultScrollPosition = position;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets how many pixels of the previous turn stay visible above an anchored message when a new turn begins.
+        /// </summary>
+        public ChatArea PreviousItemPeek(int pixels)
+        {
+            _previousItemPeek = pixels < 0 ? 0 : pixels;
+            return this;
+        }
+
+        /// <summary>
+        /// Toggles the <c>aria-busy</c> state on the transcript; set it while a turn is streaming so screen readers
+        /// can defer announcements until the reply completes.
+        /// </summary>
+        public ChatArea Busy(bool isBusy)
+        {
+            if (isBusy)
+            {
+                _contentElement.setAttribute("aria-busy", "true");
+            }
+            else
+            {
+                _contentElement.removeAttribute("aria-busy");
+            }
+            return this;
+        }
+
+        /// <summary>
         /// Adds the given item to the component.
         /// </summary>
         public ChatArea Add(ChatMessage message)
@@ -120,13 +196,75 @@ namespace Tesserae
                 message.Background(_bubbleBackground);
             }
             message.SetParent(this);
+
+            if (message.IsAnchor)
+            {
+                // A new turn boundary: collapse the previous turn's reserved space and re-engage following.
+                ReleaseReservation();
+                _pendingAnchor = message;
+                _followOutput = true;
+            }
+
             _messages.Add(message);
 
-            // Reset stop flag on new message so it auto-scrolls to it
-            _stopAutoScroll = false;
+            // Delay slightly to let the DOM update before measuring / scrolling.
+            _positionTimer = window.setTimeout((_) => OnMessageAdded(message), 10);
 
-            // Delay slighty to let DOM update
-            window.setTimeout((_) => EnsureVisible(message), 10);
+            return this;
+        }
+
+        /// <summary>
+        /// Inserts a batch of older messages at the top of the transcript while preserving the reader's current
+        /// scroll position (so loading history above the fold does not move what they are reading).
+        /// </summary>
+        public ChatArea PrependRange(IEnumerable<ChatMessage> older)
+        {
+            var beforeHeight = _scrollContainer.scrollHeight;
+            var beforeTop = _scrollContainer.scrollTop;
+
+            int index = 0;
+            foreach (var message in older)
+            {
+                if (_bubbleBackground != null && message.BubbleBackground == null)
+                {
+                    message.Background(_bubbleBackground);
+                }
+                message.SetParent(this);
+                _messages.Insert(index, message);
+                index++;
+            }
+
+            window.setTimeout((_) =>
+            {
+                var afterHeight = _scrollContainer.scrollHeight;
+                _scrollContainer.scrollTop = beforeTop + (afterHeight - beforeHeight);
+                UpdateScrollButton();
+            }, 10);
+
+            return this;
+        }
+
+        /// <summary>
+        /// Runs a repopulation (typically <see cref="Clear"/> followed by a batch of <see cref="Add"/> calls) while
+        /// preserving the reader's scroll position: if they were at the live edge it stays pinned to the bottom,
+        /// otherwise their current position is restored so re-rendering the transcript does not yank them around.
+        /// </summary>
+        public ChatArea RebuildPreservingScroll(Action populate)
+        {
+            var wasAtBottom = IsAtBottom;
+            var previousTop = _scrollContainer.scrollTop;
+
+            populate();
+
+            // The batch's own positioning must not fight the restore below.
+            _hasPositioned = true;
+            _followOutput  = wasAtBottom;
+
+            window.setTimeout((_) =>
+            {
+                _scrollContainer.scrollTop = wasAtBottom ? _scrollContainer.scrollHeight : previousTop;
+                UpdateScrollButton();
+            }, 20);
 
             return this;
         }
@@ -137,17 +275,220 @@ namespace Tesserae
         public ChatArea Clear()
         {
             _messages.Clear();
+            _pendingAnchor = null;
+            _reservedMessage = null;
+            _hasPositioned = false;
+            _followOutput = true;
             return this;
+        }
+
+        /// <summary>
+        /// Gets whether the transcript is currently scrolled to (or within a few pixels of) the bottom.
+        /// </summary>
+        public bool IsAtBottom
+        {
+            get
+            {
+                var distanceFromBottom = _scrollContainer.scrollHeight - _scrollContainer.scrollTop - _scrollContainer.clientHeight;
+                return distanceFromBottom <= BOTTOM_THRESHOLD;
+            }
+        }
+
+        /// <summary>
+        /// Gets whether the transcript is currently following streamed output (auto-scrolling to the live edge).
+        /// </summary>
+        public bool IsFollowingOutput => _followOutput;
+
+        /// <summary>
+        /// Scrolls to the bottom of the transcript and re-engages following of streamed output.
+        /// </summary>
+        public ChatArea ScrollToEnd(bool smooth = false)
+        {
+            _followOutput = true;
+
+            if (smooth && _messages.Value.Count > 0)
+            {
+                var last = _messages.Value[_messages.Value.Count - 1].Render();
+                if (last != null)
+                {
+                    last.scrollIntoView(new ScrollIntoViewOptions() { behavior = ScrollBehavior.smooth, block = ScrollLogicalPosition.end });
+                }
+            }
+            else
+            {
+                _scrollContainer.scrollTop = _scrollContainer.scrollHeight;
+            }
+
+            UpdateScrollButton();
+            return this;
+        }
+
+        /// <summary>
+        /// Scrolls to the top of the transcript.
+        /// </summary>
+        public ChatArea ScrollToStart(bool smooth = false)
+        {
+            _followOutput = false;
+
+            if (smooth && _messages.Value.Count > 0)
+            {
+                var first = _messages.Value[0].Render();
+                if (first != null)
+                {
+                    first.scrollIntoView(new ScrollIntoViewOptions() { behavior = ScrollBehavior.smooth, block = ScrollLogicalPosition.start });
+                }
+            }
+            else
+            {
+                _scrollContainer.scrollTop = 0;
+            }
+
+            UpdateScrollButton();
+            return this;
+        }
+
+        /// <summary>
+        /// Scrolls the message with the given identifier into view. Returns false if no such message is mounted.
+        /// </summary>
+        public bool ScrollToMessage(string identifier, bool smooth = true)
+        {
+            foreach (var msg in _messages.Value)
+            {
+                if (msg.Identifier == identifier)
+                {
+                    var el = msg.Render();
+                    if (el == null) return false;
+
+                    _followOutput = false;
+                    var options = new ScrollIntoViewOptions() { block = ScrollLogicalPosition.start };
+                    if (smooth) { options.behavior = ScrollBehavior.smooth; } else { options.behavior = ScrollBehavior.instant; }
+                    el.scrollIntoView(options);
+                    UpdateScrollButton();
+                    return true;
+                }
+            }
+            return false;
         }
 
         internal void EnsureVisible(ChatMessage message)
         {
-            if (_stopAutoScroll) return;
+            if (!_followOutput) return;
 
-            var el = message.Render();
-            if (el != null)
+            _scrollContainer.scrollTop = _scrollContainer.scrollHeight;
+            UpdateScrollButton();
+        }
+
+        private void OnMessageAdded(ChatMessage message)
+        {
+            if (!message.IsAnchor && _pendingAnchor != null)
             {
-                _innerElement.scrollTop = _innerElement.scrollHeight;
+                ReserveFor(_pendingAnchor, message);
+                _pendingAnchor = null;
+            }
+
+            if (!_hasPositioned)
+            {
+                ApplyStartPosition();
+                ArmPositionLock();
+            }
+            else if (_followOutput)
+            {
+                _scrollContainer.scrollTop = _scrollContainer.scrollHeight;
+            }
+
+            UpdateScrollButton();
+        }
+
+        // Reserve enough vertical space on the answer bubble that scrolling to the bottom lands the anchor (the
+        // turn's opening message) near the top with a small peek above it, letting the reply grow into the screen.
+        private void ReserveFor(ChatMessage anchor, ChatMessage answer)
+        {
+            var viewport = _scrollContainer.clientHeight;
+            if (viewport <= 0) return;
+
+            var reserve = viewport - anchor.MeasuredHeight - _previousItemPeek;
+            if (reserve < 0) reserve = 0;
+
+            answer.ReserveMinHeight(reserve);
+            _reservedMessage = answer;
+        }
+
+        private void ReleaseReservation()
+        {
+            if (_reservedMessage != null)
+            {
+                _reservedMessage.ReserveMinHeight(0);
+                _reservedMessage = null;
+            }
+        }
+
+        private void ApplyStartPosition()
+        {
+            switch (_defaultScrollPosition)
+            {
+                case StartPosition.Start:
+                    _scrollContainer.scrollTop = 0;
+                    break;
+                case StartPosition.LastAnchor:
+                    var anchor = FindLastAnchor();
+                    if (anchor != null)
+                    {
+                        var target = OffsetWithin(anchor.Render()) - _previousItemPeek;
+                        _scrollContainer.scrollTop = target < 0 ? 0 : target;
+                    }
+                    else
+                    {
+                        _scrollContainer.scrollTop = _scrollContainer.scrollHeight;
+                    }
+                    break;
+                default:
+                    _scrollContainer.scrollTop = _scrollContainer.scrollHeight;
+                    break;
+            }
+        }
+
+        private ChatMessage FindLastAnchor()
+        {
+            for (int i = _messages.Value.Count - 1; i >= 0; i--)
+            {
+                if (_messages.Value[i] is ChatMessage chatMsg && chatMsg.IsAnchor)
+                {
+                    return chatMsg;
+                }
+            }
+            return null;
+        }
+
+        private double OffsetWithin(HTMLElement el)
+        {
+            return ((DOMRect)el.getBoundingClientRect()).top - ((DOMRect)_scrollContainer.getBoundingClientRect()).top + _scrollContainer.scrollTop;
+        }
+
+        // Keep re-applying the start position for the whole initial batch, then lock it in shortly after the last add.
+        private void ArmPositionLock()
+        {
+            if (_positionTimer != 0)
+            {
+                window.clearTimeout(_positionTimer);
+            }
+            _positionTimer = window.setTimeout((_) =>
+            {
+                _hasPositioned = true;
+                _positionTimer = 0;
+            }, 150);
+        }
+
+        private void UpdateScrollButton()
+        {
+            if (IsAtBottom)
+            {
+                _scrollButton.classList.remove("tss-visible");
+                _scrollButton.setAttribute("inert", "");
+            }
+            else
+            {
+                _scrollButton.classList.add("tss-visible");
+                _scrollButton.removeAttribute("inert");
             }
         }
 
@@ -156,7 +497,7 @@ namespace Tesserae
         /// </summary>
         public HTMLElement Render()
         {
-            return _innerElement;
+            return _outerElement;
         }
     }
 
@@ -185,6 +526,11 @@ namespace Tesserae
         /// Gets or sets the bubble background.
         /// </summary>
         public string BubbleBackground { get; private set; }
+
+        /// <summary>
+        /// Gets whether this message is a turn boundary that the transcript should settle near the top when a new turn begins.
+        /// </summary>
+        public bool IsAnchor { get; private set; }
 
         /// <summary>
         /// Initializes a new instance of this class.
@@ -229,6 +575,25 @@ namespace Tesserae
         internal void SetParent(ChatArea parent)
         {
             _parent = parent;
+        }
+
+        internal double MeasuredHeight => _innerElement.offsetHeight;
+
+        internal void ReserveMinHeight(double pixels)
+        {
+            _innerElement.style.minHeight = pixels > 0 ? pixels + "px" : "";
+        }
+
+        /// <summary>
+        /// Marks this message as a turn boundary. When it is added, the transcript treats it as the start of a new
+        /// turn: it re-engages following and settles the message near the top of the viewport (with a peek of the
+        /// previous turn above), so the reply that follows grows into the screen below it.
+        /// </summary>
+        public ChatMessage ScrollAnchor()
+        {
+            IsAnchor = true;
+            _innerElement.setAttribute("tss-chat-anchor", "true");
+            return this;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

Significantly improves the ChatArea component's handling of streamed replies and user scroll interactions. The transcript now intelligently follows the live edge only while the reader is at the bottom, stops following when they scroll up (so new content arrives off-screen without yanking them back), and offers a scroll-to-latest button to re-engage. Adds turn anchoring so replies can settle near the top of the viewport with a peek of prior context, allowing them to grow into the screen below.

## Key Changes

- **Smart auto-scroll behavior**: Replaced simple `_stopAutoScroll` flag with `_followOutput` state that tracks whether the reader is within a threshold (5px) of the bottom. New messages only auto-scroll into view if following is active; otherwise they append silently.

- **Turn anchoring**: Added `ChatMessage.ScrollAnchor()` to mark turn boundaries (typically user messages). When an anchored message is added, the transcript re-engages following and reserves vertical space on the reply bubble so scrolling to the bottom lands the anchor near the top with a configurable peek of prior content above it.

- **Scroll-to-latest button**: Added a floating button that appears when the reader scrolls away from the bottom, allowing them to jump back to the live edge. Button is hidden and inert when at the bottom.

- **Configurable start position**: New `DefaultScrollPosition` enum (Start, End, LastAnchor) lets the transcript settle at different positions when first populated or after `Clear()`. LastAnchor mode scrolls to the last anchored turn with a peek above it.

- **Batch operations**: Added `PrependRange()` to insert older messages at the top while preserving scroll position (for loading history). Added `RebuildPreservingScroll()` to repopulate the transcript while keeping the reader's position stable or pinned to the bottom if they were following.

- **Imperative scroll methods**: Added `ScrollToEnd()`, `ScrollToStart()`, and `ScrollToMessage(id)` with optional smooth scrolling. `ScrollToEnd()` re-engages following.

- **State queries**: Added `IsAtBottom` and `IsFollowingOutput` properties to read current scroll state.

- **Accessibility**: Added ARIA attributes (`role="log"`, `aria-relevant="additions"`, `aria-busy`) and semantic structure to support screen readers. Scroll button is inert when hidden.

- **DOM structure refactor**: Split the single scroll container into a wrapper (`_outerElement`) containing the scroll container and button, improving layout control and button positioning.

- **CSS enhancements**: Added styles for the scroll button with smooth fade-in/out transitions, content-visibility optimization on message containers, and proper flex layout for the wrapper.

- **Documentation**: Updated `chat.md` reference with new methods, examples showing turn anchoring and streaming patterns, and clarified auto-scroll behavior.

## Implementation Details

- The scroll threshold (5px) is defined as `BOTTOM_THRESHOLD` constant for consistency.
- Position locking uses a 150ms debounce timer to apply the start position across the initial batch of messages, then locks it in so subsequent adds respect the follow state.
- Reservation system measures the anchor's height and reserves space on the reply bubble equal to `viewport - anchor height - peek`, allowing the reply to grow into the reserved space.
- Scroll button visibility is toggled via CSS class (`tss-visible`) rather than display changes, enabling smooth transitions.
- The `_positionTimer` field manages both initial positioning and message-add debouncing.

https://claude.ai/code/session_01DyUPHtcVTspBPnAzYxcAtt