### PR TITLE
Add TSS0001 Roslyn analyzer for Router.Navigate route validation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,13 @@ Tesserae is a C# UI toolkit for building web applications, compiled to JavaScrip
 - Fluent extensions: `Tesserae/src/Extensions`
 - Samples and demos: `Tesserae.Tests/`
 - Project and build config: `Tesserae/Tesserae.csproj`, `Tesserae/h5.json`
+- Roslyn analyzers: `Tesserae.Analyzers/` (rule `TSS0001` checks `Router.Navigate`
+  routes against `Router.Register`; unit-tested in `Tesserae.Analyzers.Tests/`,
+  shipped inside the NuGet package under `analyzers/dotnet/cs`). Note the h5
+  compiler re-parses csproj files and cannot resolve a `ProjectReference` to a
+  non-h5 project, so the h5 projects hook the analyzer in via an MSBuild-task
+  target (`_BuildTesseraeAnalyzers` in `Tesserae.csproj`) and a plain `Analyzer`
+  item (`Tesserae.Tests.csproj`) instead.
 
 ## Skills
 

--- a/Tesserae.Analyzers.Runner/Program.cs
+++ b/Tesserae.Analyzers.Runner/Program.cs
@@ -1,0 +1,262 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Tesserae.Analyzers.Runner
+{
+    /// <summary>
+    /// Runs the Tesserae Roslyn analyzers over a project's sources purely to surface diagnostics.
+    ///
+    /// The h5 build replaces the normal C# CoreCompile with a transpiler CLI call, so Roslyn (and
+    /// therefore the analyzers) never runs during <c>dotnet build</c>. This tool rebuilds a Roslyn
+    /// <see cref="CSharpCompilation"/> from the source files and resolved references that MSBuild
+    /// already computed, runs the analyzer, and reports only its diagnostics (any leftover CS errors
+    /// from the shadow compilation are ignored on purpose - h5 owns the real compile).
+    /// </summary>
+    internal static class Program
+    {
+        private static async Task<int> Main(string[] args)
+        {
+            try
+            {
+                var options = Options.Parse(args);
+
+                if (options is null) return 0; // usage already printed; do not break the build
+
+                return await RunAsync(options).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                // Fail open: a bug in the runner must not break an otherwise-valid build. Surface it
+                // loudly as a warning so it is visible in the build log, but do not fail.
+                Console.Error.WriteLine($"TesseraeAnalyzers: warning : analyzer runner failed and was skipped: {ex}");
+                return 0;
+            }
+        }
+
+        private static async Task<int> RunAsync(Options options)
+        {
+            var analyzers = LoadAnalyzers(options.AnalyzerPaths);
+
+            if (analyzers.IsEmpty)
+            {
+                Console.Error.WriteLine("TesseraeAnalyzers: warning : no analyzers found; skipping");
+                return 0;
+            }
+
+            var parseOptions = new CSharpParseOptions(options.LanguageVersion, preprocessorSymbols: options.Defines);
+
+            var trees = options.SourceFiles
+               .Where(File.Exists)
+               .Select(path => CSharpSyntaxTree.ParseText(SourceText.From(File.ReadAllText(path), Encoding.UTF8), parseOptions, path))
+               .ToImmutableArray();
+
+            var references = options.ReferencePaths
+               .Where(File.Exists)
+               .Select(path => (MetadataReference)MetadataReference.CreateFromFile(path))
+               .ToImmutableArray();
+
+            var compilation = CSharpCompilation.Create(
+                "TesseraeAnalysis",
+                trees,
+                references,
+                new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true));
+
+            var additionalFiles = options.AdditionalFiles
+               .Where(File.Exists)
+               .Select(path => (AdditionalText)new PhysicalAdditionalText(path))
+               .ToImmutableArray();
+
+            var analyzerOptions = new AnalyzerOptions(additionalFiles, new GlobalConfigOptionsProvider(options.ConfigOptions));
+
+            var withAnalyzers = compilation.WithAnalyzers(
+                analyzers,
+                new CompilationWithAnalyzersOptions(
+                    analyzerOptions,
+                    onAnalyzerException: (ex, analyzer, diagnostic) =>
+                        Console.Error.WriteLine($"TesseraeAnalyzers: warning : analyzer '{analyzer}' threw: {ex.Message}"),
+                    concurrentAnalysis: true,
+                    logAnalyzerExecutionTime: false));
+
+            var diagnostics = await withAnalyzers.GetAnalyzerDiagnosticsAsync(CancellationToken.None).ConfigureAwait(false);
+
+            var errorCount = 0;
+
+            foreach (var diagnostic in diagnostics.Where(d => d.Id.StartsWith("TSS", StringComparison.Ordinal))
+                                                  .OrderBy(d => d.Location.SourceTree?.FilePath, StringComparer.Ordinal))
+            {
+                var escalate = options.WarningsAsErrors && diagnostic.Severity == DiagnosticSeverity.Warning;
+                var isError  = diagnostic.Severity == DiagnosticSeverity.Error || escalate;
+
+                if (isError) errorCount++;
+
+                Console.WriteLine(Format(diagnostic, isError));
+            }
+
+            return errorCount > 0 ? 1 : 0;
+        }
+
+        private static ImmutableArray<DiagnosticAnalyzer> LoadAnalyzers(IReadOnlyList<string> paths)
+        {
+            var builder = ImmutableArray.CreateBuilder<DiagnosticAnalyzer>();
+
+            foreach (var path in paths)
+            {
+                if (!File.Exists(path)) continue;
+
+                var reference = new AnalyzerFileReference(path, AssemblyLoader.Instance);
+                builder.AddRange(reference.GetAnalyzers(LanguageNames.CSharp));
+            }
+
+            return builder.ToImmutable();
+        }
+
+        /// <summary>Canonical MSBuild diagnostic line so the build log / CI parses it correctly.</summary>
+        private static string Format(Diagnostic diagnostic, bool asError)
+        {
+            var span     = diagnostic.Location.GetLineSpan();
+            var file     = span.IsValid ? span.Path : "Tesserae.Analyzers";
+            var line     = span.StartLinePosition.Line + 1;
+            var column   = span.StartLinePosition.Character + 1;
+            var severity = asError ? "error" : "warning";
+            var message  = diagnostic.GetMessage();
+
+            return span.IsValid
+                ? $"{file}({line},{column}): {severity} {diagnostic.Id}: {message}"
+                : $"{file}: {severity} {diagnostic.Id}: {message}";
+        }
+
+        private sealed class AssemblyLoader : IAnalyzerAssemblyLoader
+        {
+            public static readonly AssemblyLoader Instance = new AssemblyLoader();
+
+            public void AddDependencyLocation(string fullPath) { }
+
+            public Assembly LoadFromPath(string fullPath) => Assembly.LoadFrom(fullPath);
+        }
+
+        private sealed class PhysicalAdditionalText : AdditionalText
+        {
+            private readonly string _path;
+
+            public PhysicalAdditionalText(string path) => _path = path;
+
+            public override string Path => _path;
+
+            public override SourceText? GetText(CancellationToken cancellationToken = default) =>
+                File.Exists(_path) ? SourceText.From(File.ReadAllText(_path)) : null;
+        }
+
+        private sealed class GlobalConfigOptionsProvider : AnalyzerConfigOptionsProvider
+        {
+            private readonly AnalyzerConfigOptions _global;
+            private readonly AnalyzerConfigOptions _empty = new DictionaryOptions(new Dictionary<string, string>());
+
+            public GlobalConfigOptionsProvider(IReadOnlyDictionary<string, string> options) =>
+                _global = new DictionaryOptions(options);
+
+            public override AnalyzerConfigOptions GlobalOptions => _global;
+
+            public override AnalyzerConfigOptions GetOptions(SyntaxTree tree) => _empty;
+
+            public override AnalyzerConfigOptions GetOptions(AdditionalText textFile) => _empty;
+
+            private sealed class DictionaryOptions : AnalyzerConfigOptions
+            {
+                private readonly IReadOnlyDictionary<string, string> _options;
+
+                public DictionaryOptions(IReadOnlyDictionary<string, string> options) =>
+                    _options = new Dictionary<string, string>(options.Count, StringComparer.OrdinalIgnoreCase)
+                        .Also(d => { foreach (var kv in options) d[kv.Key] = kv.Value; });
+
+                public override bool TryGetValue(string key, out string value) => _options.TryGetValue(key, out value!);
+            }
+        }
+
+        private sealed class Options
+        {
+            public List<string>                     AnalyzerPaths   { get; } = new List<string>();
+            public List<string>                     SourceFiles     { get; } = new List<string>();
+            public List<string>                     ReferencePaths  { get; } = new List<string>();
+            public List<string>                     AdditionalFiles { get; } = new List<string>();
+            public Dictionary<string, string>       ConfigOptions   { get; } = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            public ImmutableArray<string>           Defines         { get; private set; } = ImmutableArray<string>.Empty;
+            public LanguageVersion                  LanguageVersion { get; private set; } = LanguageVersion.CSharp7_2;
+            public bool                             WarningsAsErrors { get; private set; }
+
+            public static Options? Parse(string[] args)
+            {
+                var options = new Options();
+
+                for (var i = 0; i < args.Length; i++)
+                {
+                    var arg = args[i];
+
+                    string Next() => ++i < args.Length ? args[i] : throw new ArgumentException($"missing value after {arg}");
+
+                    switch (arg)
+                    {
+                        case "--analyzer":        options.AnalyzerPaths.Add(Next()); break;
+                        case "--sources":         options.SourceFiles.AddRange(ReadListFile(Next())); break;
+                        case "--refs":            options.ReferencePaths.AddRange(ReadListFile(Next())); break;
+                        case "--additionalfile":  options.AdditionalFiles.Add(Next()); break;
+                        case "--define":          options.Defines = SplitDefines(Next()); break;
+                        case "--langversion":     options.LanguageVersion = ParseLangVersion(Next()); break;
+                        case "--warnaserror":     options.WarningsAsErrors = true; break;
+                        case "--config":
+                        {
+                            var pair  = Next();
+                            var split = pair.IndexOf('=');
+                            if (split > 0) options.ConfigOptions[pair.Substring(0, split)] = pair.Substring(split + 1);
+                            break;
+                        }
+                        default:
+                            Console.Error.WriteLine($"TesseraeAnalyzers: warning : unknown argument '{arg}'");
+                            break;
+                    }
+                }
+
+                if (options.AnalyzerPaths.Count == 0 || options.SourceFiles.Count == 0)
+                {
+                    Console.Error.WriteLine("usage: Tesserae.Analyzers.Runner --analyzer <dll> --sources <listfile> --refs <listfile> [--define A;B] [--langversion 7.2] [--additionalfile <path>] [--config key=value] [--warnaserror]");
+                    return null;
+                }
+
+                return options;
+            }
+
+            private static IEnumerable<string> ReadListFile(string path) =>
+                File.Exists(path)
+                    ? File.ReadAllLines(path).Select(l => l.Trim()).Where(l => l.Length > 0)
+                    : Enumerable.Empty<string>();
+
+            private static ImmutableArray<string> SplitDefines(string value) =>
+                value.Split(new[] { ';', ',' }, StringSplitOptions.RemoveEmptyEntries)
+                     .Select(s => s.Trim())
+                     .Where(s => s.Length > 0)
+                     .ToImmutableArray();
+
+            private static LanguageVersion ParseLangVersion(string value) =>
+                LanguageVersionFacts.TryParse(value, out var parsed) ? parsed : LanguageVersion.CSharp7_2;
+        }
+    }
+
+    internal static class FunctionalExtensions
+    {
+        public static T Also<T>(this T value, Action<T> action)
+        {
+            action(value);
+            return value;
+        }
+    }
+}

--- a/Tesserae.Analyzers.Runner/Tesserae.Analyzers.Runner.csproj
+++ b/Tesserae.Analyzers.Runner/Tesserae.Analyzers.Runner.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <RollForward>LatestMajor</RollForward>
+    <AssemblyName>Tesserae.Analyzers.Runner</AssemblyName>
+    <Description>Runs the Tesserae Roslyn analyzers over a project's sources at build time (h5 builds skip Roslyn, so the analyzers never run otherwise)</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Host Roslyn version. Analyzers built against an older API load fine into a newer host. -->
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
+  </ItemGroup>
+</Project>

--- a/Tesserae.Analyzers.Tests/RouterNavigateAnalyzerTests.cs
+++ b/Tesserae.Analyzers.Tests/RouterNavigateAnalyzerTests.cs
@@ -24,12 +24,27 @@ namespace Tesserae
 }
 ";
 
-        private static Task VerifyAsync(string source, params DiagnosticResult[] expected)
+        private static Task VerifyAsync(string source, params DiagnosticResult[] expected) =>
+            VerifyAsync(source, manifest: null, authoritative: false, expected);
+
+        private static Task VerifyAsync(string source, string manifest, bool authoritative, params DiagnosticResult[] expected)
         {
             var test = new CSharpAnalyzerTest<RouterNavigateAnalyzer, DefaultVerifier>
             {
                 TestCode = source + RouterStub,
             };
+
+            if (manifest is object)
+            {
+                test.TestState.AdditionalFiles.Add(("TesseraeRoutes.txt", manifest));
+            }
+
+            if (authoritative)
+            {
+                test.TestState.AnalyzerConfigFiles.Add(("/.globalconfig",
+                    "is_global = true\ndotnet_diagnostic.TSS0001.route_table_is_authoritative = true\n"));
+            }
+
             test.ExpectedDiagnostics.AddRange(expected);
             return test.RunAsync();
         }
@@ -158,17 +173,100 @@ static class App
 }
 ");
 
+        // Limitation A fix: a dynamic Register with a knowable constant prefix no longer silences the
+        // whole compilation - a Navigate that falls outside that prefix (and matches no constant route)
+        // is still reported.
         [Fact]
-        public Task DynamicRegistration_SuppressesAllDiagnostics() => VerifyAsync(@"
+        public Task DynamicRegisterWithPrefix_NavigateOutsidePrefix_Warns() => VerifyAsync(@"
 static class App
 {
     static void Main(string[] args)
     {
-        Tesserae.Router.Register(""view/"" + args[0], _ => { });
+        Tesserae.Router.Register(""home"", _ => { });
+        Tesserae.Router.Register(""#/admin/"" + args[0], _ => { });
+        Tesserae.Router.Navigate({|#0:""#/settings""|});
+    }
+}
+",
+            new DiagnosticResult(RouterNavigateAnalyzer.DiagnosticId, Microsoft.CodeAnalysis.DiagnosticSeverity.Warning).WithLocation(0).WithArguments("#/settings"));
+
+        // A Navigate under a dynamic registration's constant prefix could be handled at runtime, so it is
+        // not reported.
+        [Fact]
+        public Task DynamicRegisterWithPrefix_NavigateUnderPrefix_NoDiagnostic() => VerifyAsync(@"
+static class App
+{
+    static void Main(string[] args)
+    {
+        Tesserae.Router.Register(""home"", _ => { });
+        Tesserae.Router.Register(""#/admin/"" + args[0], _ => { });
+        Tesserae.Router.Navigate(""#/admin/users"");
+    }
+}
+");
+
+        // A fully-opaque dynamic registration (no knowable prefix) could match anything, so the check
+        // falls back to conservative silence for otherwise-unmatched navigations.
+        [Fact]
+        public Task OpaqueDynamicRegistration_SuppressesUnmatchedNavigations() => VerifyAsync(@"
+static class App
+{
+    static void Main(string[] args)
+    {
+        Tesserae.Router.Register(""home"", _ => { });
+        Tesserae.Router.Register(args[0], _ => { });
         Tesserae.Router.Navigate(""#/definitely-not-registered"");
     }
 }
 ");
+
+        // ...unless the route table is declared authoritative, in which case dynamic registrations no
+        // longer buy leniency and the mismatch is reported.
+        [Fact]
+        public Task OpaqueDynamicRegistration_Authoritative_Warns() => VerifyAsync(@"
+static class App
+{
+    static void Main(string[] args)
+    {
+        Tesserae.Router.Register(""home"", _ => { });
+        Tesserae.Router.Register(args[0], _ => { });
+        Tesserae.Router.Navigate({|#0:""#/definitely-not-registered""|});
+    }
+}
+",
+            manifest: null,
+            authoritative: true,
+            new DiagnosticResult(RouterNavigateAnalyzer.DiagnosticId, Microsoft.CodeAnalysis.DiagnosticSeverity.Warning).WithLocation(0).WithArguments("#/definitely-not-registered"));
+
+        // Limitation B fix: routes declared in a manifest (routes registered in another assembly) are
+        // validated even though this compilation has no Router.Register call of its own.
+        [Fact]
+        public Task ManifestRoutes_UnregisteredNavigate_Warns() => VerifyAsync(@"
+static class App
+{
+    static void Main()
+    {
+        Tesserae.Router.Navigate({|#0:""#/typo""|});
+    }
+}
+",
+            manifest: "#/home\n#/space/:uid\n; a comment\n\n// another comment\n",
+            authoritative: false,
+            new DiagnosticResult(RouterNavigateAnalyzer.DiagnosticId, Microsoft.CodeAnalysis.DiagnosticSeverity.Warning).WithLocation(0).WithArguments("#/typo"));
+
+        [Fact]
+        public Task ManifestRoutes_ValidNavigate_NoDiagnostic() => VerifyAsync(@"
+static class App
+{
+    static void Main()
+    {
+        Tesserae.Router.Navigate(""#/home"");
+        Tesserae.Router.Navigate(""#/space/abc"");
+    }
+}
+",
+            manifest: "#/home\n#/space/:uid\n",
+            authoritative: false);
 
         [Fact]
         public Task NoRegistrationsInCompilation_StaysSilent() => VerifyAsync(@"

--- a/Tesserae.Analyzers.Tests/RouterNavigateAnalyzerTests.cs
+++ b/Tesserae.Analyzers.Tests/RouterNavigateAnalyzerTests.cs
@@ -1,0 +1,199 @@
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using Tesserae.Analyzers;
+using Xunit;
+
+namespace Tesserae.Analyzers.Tests
+{
+    public class RouterNavigateAnalyzerTests
+    {
+        // Minimal stand-in for the real Tesserae.Router surface, so the tests don't need the h5-compiled assembly
+        private const string RouterStub = @"
+namespace Tesserae
+{
+    public class Parameters { }
+
+    public static class Router
+    {
+        public static void Register(string uniquePath, System.Action<Parameters> action) { }
+        public static void Register(string uniquePath, System.Func<Parameters, bool> action) { }
+        public static void Register(string uniqueIdentifier, string path, System.Action<Parameters> action, bool replace = false) { }
+        public static void Navigate(string path, bool reload = false) { }
+    }
+}
+";
+
+        private static Task VerifyAsync(string source, params DiagnosticResult[] expected)
+        {
+            var test = new CSharpAnalyzerTest<RouterNavigateAnalyzer, DefaultVerifier>
+            {
+                TestCode = source + RouterStub,
+            };
+            test.ExpectedDiagnostics.AddRange(expected);
+            return test.RunAsync();
+        }
+
+        [Fact]
+        public Task NavigateToRegisteredRoute_NoDiagnostic() => VerifyAsync(@"
+static class App
+{
+    static void Main()
+    {
+        Tesserae.Router.Register(""home"", _ => { });
+        Tesserae.Router.Navigate(""#/home"");
+    }
+}
+");
+
+        [Fact]
+        public Task NavigateToUnregisteredRoute_Warns() => VerifyAsync(@"
+static class App
+{
+    static void Main()
+    {
+        Tesserae.Router.Register(""home"", _ => { });
+        Tesserae.Router.Navigate({|#0:""#/settings""|});
+    }
+}
+",
+            new DiagnosticResult(RouterNavigateAnalyzer.DiagnosticId, Microsoft.CodeAnalysis.DiagnosticSeverity.Warning).WithLocation(0).WithArguments("#/settings"));
+
+        [Fact]
+        public Task NavigateToParameterizedRoute_NoDiagnostic() => VerifyAsync(@"
+static class App
+{
+    static void Main()
+    {
+        Tesserae.Router.Register(""view/:id"", _ => { });
+        Tesserae.Router.Navigate(""#/view/42"");
+    }
+}
+");
+
+        [Fact]
+        public Task NavigateWithWrongSegmentCount_Warns() => VerifyAsync(@"
+static class App
+{
+    static void Main()
+    {
+        Tesserae.Router.Register(""view/:id"", _ => { });
+        Tesserae.Router.Navigate({|#0:""#/view""|});
+    }
+}
+",
+            new DiagnosticResult(RouterNavigateAnalyzer.DiagnosticId, Microsoft.CodeAnalysis.DiagnosticSeverity.Warning).WithLocation(0).WithArguments("#/view"));
+
+        [Fact]
+        public Task MatchingIsCaseInsensitiveAndIgnoresHashAndSlashes_NoDiagnostic() => VerifyAsync(@"
+static class App
+{
+    static void Main()
+    {
+        Tesserae.Router.Register(""#/Documents/List"", _ => { });
+        Tesserae.Router.Navigate(""documents/list"");
+    }
+}
+");
+
+        [Fact]
+        public Task TwoArgumentRegister_MatchesOnPathNotIdentifier() => VerifyAsync(@"
+static class App
+{
+    static void Main()
+    {
+        Tesserae.Router.Register(""docs"", ""documents/:id"", _ => { });
+        Tesserae.Router.Navigate(""#/documents/5"");
+        Tesserae.Router.Navigate({|#0:""#/docs""|});
+    }
+}
+",
+            new DiagnosticResult(RouterNavigateAnalyzer.DiagnosticId, Microsoft.CodeAnalysis.DiagnosticSeverity.Warning).WithLocation(0).WithArguments("#/docs"));
+
+        [Fact]
+        public Task QueryStringIsIgnoredWhenMatching_NoDiagnostic() => VerifyAsync(@"
+static class App
+{
+    static void Main()
+    {
+        Tesserae.Router.Register(""search"", _ => { });
+        Tesserae.Router.Navigate(""#/search?term=computer&page=2"");
+    }
+}
+");
+
+        [Fact]
+        public Task RootRouteMatchesEmptyHash_NoDiagnostic() => VerifyAsync(@"
+static class App
+{
+    static void Main()
+    {
+        Tesserae.Router.Register(""home"", ""/"", _ => { });
+        Tesserae.Router.Navigate(""#/"");
+    }
+}
+");
+
+        [Fact]
+        public Task ExternalUrl_IsIgnored() => VerifyAsync(@"
+static class App
+{
+    static void Main()
+    {
+        Tesserae.Router.Register(""home"", _ => { });
+        Tesserae.Router.Navigate(""https://example.com/other"");
+    }
+}
+");
+
+        [Fact]
+        public Task NonConstantNavigatePath_IsIgnored() => VerifyAsync(@"
+static class App
+{
+    static void Main(string[] args)
+    {
+        Tesserae.Router.Register(""home"", _ => { });
+        Tesserae.Router.Navigate(""#/view/"" + args[0]);
+    }
+}
+");
+
+        [Fact]
+        public Task DynamicRegistration_SuppressesAllDiagnostics() => VerifyAsync(@"
+static class App
+{
+    static void Main(string[] args)
+    {
+        Tesserae.Router.Register(""view/"" + args[0], _ => { });
+        Tesserae.Router.Navigate(""#/definitely-not-registered"");
+    }
+}
+");
+
+        [Fact]
+        public Task NoRegistrationsInCompilation_StaysSilent() => VerifyAsync(@"
+static class App
+{
+    static void Main()
+    {
+        Tesserae.Router.Navigate(""#/registered-by-a-library"");
+    }
+}
+");
+
+        [Fact]
+        public Task ConstantsPropagateIntoNavigate() => VerifyAsync(@"
+static class App
+{
+    const string Route = ""#/set"" + ""tings"";
+
+    static void Main()
+    {
+        Tesserae.Router.Register(""home"", _ => { });
+        Tesserae.Router.Navigate({|#0:Route|});
+    }
+}
+",
+            new DiagnosticResult(RouterNavigateAnalyzer.DiagnosticId, Microsoft.CodeAnalysis.DiagnosticSeverity.Warning).WithLocation(0).WithArguments("#/settings"));
+    }
+}

--- a/Tesserae.Analyzers.Tests/Tesserae.Analyzers.Tests.csproj
+++ b/Tesserae.Analyzers.Tests/Tesserae.Analyzers.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.2" />
+    <!-- The analyzer-testing package floors Roslyn at 1.0 and expects the test project to pin the version to test against -->
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Tesserae.Analyzers\Tesserae.Analyzers.csproj" />
+  </ItemGroup>
+</Project>

--- a/Tesserae.Analyzers/AnalyzerReleases.Shipped.md
+++ b/Tesserae.Analyzers/AnalyzerReleases.Shipped.md
@@ -1,0 +1,2 @@
+; Shipped analyzer releases
+; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md

--- a/Tesserae.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/Tesserae.Analyzers/AnalyzerReleases.Unshipped.md
@@ -1,0 +1,8 @@
+; Unshipped analyzer release
+; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+TSS0001 | Tesserae.Routing | Warning | Route passed to Router.Navigate is not registered with Router.Register

--- a/Tesserae.Analyzers/RouteMatcher.cs
+++ b/Tesserae.Analyzers/RouteMatcher.cs
@@ -1,0 +1,70 @@
+using System;
+
+namespace Tesserae.Analyzers
+{
+    /// <summary>
+    /// Compile-time mirror of the runtime route matching in Tesserae's Router
+    /// (Router.Register normalization + Route/RoutePart.IsMatch): leading '#' and '/'
+    /// are irrelevant, matching is per-segment and case-insensitive, and a pattern
+    /// segment starting with ':' captures any value.
+    /// </summary>
+    internal static class RouteMatcher
+    {
+        /// <summary>Turns a path passed to Router.Register into its matchable segments.</summary>
+        public static string[] ParsePattern(string registeredPath)
+        {
+            var path = registeredPath.Trim();
+
+            if (path.StartsWith("#", StringComparison.Ordinal)) path = path.TrimStart('#');
+
+            return SplitSegments(path);
+        }
+
+        /// <summary>
+        /// Turns a path passed to Router.Navigate into its matchable segments. Returns false
+        /// for absolute/external URLs, which never go through the route table.
+        /// </summary>
+        public static bool TryGetNavigationParts(string navigatePath, out string[] parts)
+        {
+            parts = null;
+
+            var path = navigatePath.Trim();
+
+            if (path.Contains("://") || path.StartsWith("//", StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            // Routes are matched against window.location.hash, so only the fragment matters when one is present
+            var hashIndex = path.IndexOf('#');
+
+            if (hashIndex >= 0) path = path.Substring(hashIndex + 1);
+
+            // Query-string parameters are parsed separately by the Router and play no part in route matching
+            var queryIndex = path.IndexOf('?');
+
+            if (queryIndex >= 0) path = path.Substring(0, queryIndex);
+
+            parts = SplitSegments(path);
+            return true;
+        }
+
+        public static bool IsMatch(string[] patternParts, string[] navigationParts)
+        {
+            if (patternParts.Length != navigationParts.Length) return false;
+
+            for (var i = 0; i < patternParts.Length; i++)
+            {
+                var patternPart = patternParts[i];
+
+                if (patternPart.StartsWith(":", StringComparison.Ordinal)) continue; // ':name' segments capture any value
+
+                if (!string.Equals(patternPart, navigationParts[i], StringComparison.InvariantCultureIgnoreCase)) return false;
+            }
+
+            return true;
+        }
+
+        private static string[] SplitSegments(string path) => path.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+    }
+}

--- a/Tesserae.Analyzers/RouteMatcher.cs
+++ b/Tesserae.Analyzers/RouteMatcher.cs
@@ -49,6 +49,13 @@ namespace Tesserae.Analyzers
             return true;
         }
 
+        /// <summary>
+        /// Joins already-split segments into a normalized, lower-cased path used for prefix
+        /// comparisons (see <see cref="RouterNavigateAnalyzer"/> dynamic-prefix handling).
+        /// </summary>
+        public static string NormalizeForPrefix(string[] parts) =>
+            string.Join("/", parts).ToLowerInvariant();
+
         public static bool IsMatch(string[] patternParts, string[] navigationParts)
         {
             if (patternParts.Length != navigationParts.Length) return false;

--- a/Tesserae.Analyzers/RouterNavigateAnalyzer.cs
+++ b/Tesserae.Analyzers/RouterNavigateAnalyzer.cs
@@ -1,7 +1,11 @@
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Immutable;
+using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
@@ -9,24 +13,42 @@ using Microsoft.CodeAnalysis.Operations;
 namespace Tesserae.Analyzers
 {
     /// <summary>
-    /// Reports Router.Navigate calls whose (compile-time constant) path does not match any
-    /// route registered with Router.Register in the same compilation.
+    /// Reports Router.Navigate calls whose (compile-time constant) path does not match any known
+    /// route. Known routes come from two sources so the check keeps working in real multi-project
+    /// apps:
     ///
-    /// To avoid false positives the check stays silent when the route table cannot be fully
-    /// known at compile time: when any Router.Register call uses a non-constant path, or when
-    /// the compilation contains no Router.Register call at all (routes registered elsewhere,
-    /// e.g. by a referenced library). Navigate calls with non-constant paths and navigations
-    /// to absolute/external URLs are likewise skipped.
+    /// <list type="bullet">
+    /// <item>constant paths passed to <c>Router.Register</c> in this compilation;</item>
+    /// <item>a route manifest (an <c>AdditionalFiles</c> entry named <c>TesseraeRoutes.txt</c>), which
+    /// lets a project validate against routes registered in a different assembly.</item>
+    /// </list>
+    ///
+    /// A single dynamic <c>Router.Register</c> no longer silences the whole compilation. Instead:
+    /// <list type="bullet">
+    /// <item>a dynamic registration with a knowable constant prefix (e.g. <c>Register(Base + suffix, …)</c>)
+    /// only suppresses Navigate paths that fall under that prefix;</item>
+    /// <item>a fully-opaque dynamic registration (no knowable prefix) falls back to the old conservative
+    /// behavior and suppresses otherwise-unmatched Navigate paths;</item>
+    /// <item>setting <c>dotnet_diagnostic.TSS0001.route_table_is_authoritative = true</c> declares the
+    /// known route set complete and reports mismatches even in the presence of dynamic registrations.</item>
+    /// </list>
+    ///
+    /// To avoid false positives the check still stays silent when no route is known at all (no constant
+    /// registration and no manifest). Navigate calls with non-constant paths and navigations to
+    /// absolute/external URLs are likewise skipped.
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public sealed class RouterNavigateAnalyzer : DiagnosticAnalyzer
     {
         public const string DiagnosticId = "TSS0001";
 
+        internal const string ManifestFileName             = "TesseraeRoutes.txt";
+        internal const string AuthoritativeConfigKey       = "dotnet_diagnostic.TSS0001.route_table_is_authoritative";
+
         private static readonly DiagnosticDescriptor _rule = new DiagnosticDescriptor(
             DiagnosticId,
             title: "Route passed to Router.Navigate is not registered",
-            messageFormat: "The route '{0}' passed to Router.Navigate does not match any route registered with Router.Register in this project",
+            messageFormat: "The route '{0}' passed to Router.Navigate does not match any route registered with Router.Register (or declared in a TesseraeRoutes.txt manifest)",
             category: "Tesserae.Routing",
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true,
@@ -46,9 +68,13 @@ namespace Tesserae.Analyzers
 
                 if (routerType is null) return;
 
-                var registeredPaths          = new ConcurrentBag<string>();
-                var navigations              = new ConcurrentBag<(string Path, Location Location)>();
-                var hasDynamicRegistration   = new StrongBox<bool>(false);
+                var manifestRoutes = ReadManifestRoutes(compilationStart.Options, compilationStart.CancellationToken);
+                var authoritative  = IsRouteTableAuthoritative(compilationStart.Options);
+
+                var registeredPaths              = new ConcurrentBag<string>();
+                var dynamicPrefixes              = new ConcurrentBag<string>();
+                var navigations                  = new ConcurrentBag<(string Path, Location Location)>();
+                var hasOpaqueDynamicRegistration = new StrongBox<bool>(false);
 
                 compilationStart.RegisterOperationAction(operationContext =>
                 {
@@ -63,14 +89,27 @@ namespace Tesserae.Analyzers
                         // matches on uniquePath itself, Register(uniqueIdentifier, path, handler[, replace]) on path
                         if (TryGetArgumentForParameter(invocation, method.Parameters.LastOrDefault(p => p.Type.SpecialType == SpecialType.System_String), out var registerArgument))
                         {
-                            if (registerArgument.Value.ConstantValue is { HasValue: true, Value: string registeredPath })
+                            var (prefix, complete) = GetLeadingConstant(registerArgument.Value);
+
+                            if (complete)
                             {
-                                registeredPaths.Add(registeredPath);
+                                registeredPaths.Add(prefix);
                             }
                             else
                             {
-                                // A route built at runtime means the route table cannot be known at compile time
-                                hasDynamicRegistration.Value = true;
+                                // A route built at runtime: record the constant prefix we can see so we only
+                                // suppress navigations that could actually be covered by it. With no knowable
+                                // prefix the route could be anything, so fall back to conservative suppression.
+                                var normalizedPrefix = RouteMatcher.NormalizeForPrefix(RouteMatcher.ParsePattern(prefix));
+
+                                if (normalizedPrefix.Length > 0)
+                                {
+                                    dynamicPrefixes.Add(normalizedPrefix);
+                                }
+                                else
+                                {
+                                    hasOpaqueDynamicRegistration.Value = true;
+                                }
                             }
                         }
                     }
@@ -87,17 +126,30 @@ namespace Tesserae.Analyzers
 
                 compilationStart.RegisterCompilationEndAction(compilationEnd =>
                 {
-                    if (hasDynamicRegistration.Value) return;
+                    var knownRoutes = registeredPaths.Concat(manifestRoutes).ToArray();
 
-                    if (registeredPaths.IsEmpty) return;
+                    // Nothing is known about the route table (no constant Register in this compilation and no
+                    // manifest): stay silent rather than emit false positives.
+                    if (knownRoutes.Length == 0) return;
 
-                    var patterns = registeredPaths.Select(RouteMatcher.ParsePattern).ToArray();
+                    var patterns = knownRoutes.Select(RouteMatcher.ParsePattern).ToArray();
+
+                    // In authoritative mode the known route set is declared complete, so dynamic registrations
+                    // no longer buy any leniency.
+                    var prefixes    = authoritative ? Array.Empty<string>() : dynamicPrefixes.Distinct().ToArray();
+                    var suppressAll = !authoritative && hasOpaqueDynamicRegistration.Value;
 
                     foreach (var (path, location) in navigations)
                     {
                         if (!RouteMatcher.TryGetNavigationParts(path, out var parts)) continue;
 
                         if (patterns.Any(pattern => RouteMatcher.IsMatch(pattern, parts))) continue;
+
+                        if (suppressAll) continue;
+
+                        var navigationPrefix = RouteMatcher.NormalizeForPrefix(parts);
+
+                        if (prefixes.Any(prefix => navigationPrefix.StartsWith(prefix, StringComparison.Ordinal))) continue;
 
                         compilationEnd.ReportDiagnostic(Diagnostic.Create(_rule, location, path));
                     }
@@ -113,5 +165,101 @@ namespace Tesserae.Analyzers
 
             return argument is object;
         }
+
+        /// <summary>
+        /// Returns the leading compile-time-constant text of a (possibly runtime-built) string expression
+        /// together with whether the whole expression is constant. For <c>"a" + var</c> this yields
+        /// (<c>"a"</c>, false); for a fully constant expression it yields (value, true); for a fully opaque
+        /// expression such as a bare variable it yields (<c>""</c>, false).
+        /// </summary>
+        private static (string prefix, bool complete) GetLeadingConstant(IOperation operation)
+        {
+            if (operation is null) return (string.Empty, false);
+
+            if (operation.ConstantValue is { HasValue: true, Value: string constant }) return (constant, true);
+
+            switch (operation)
+            {
+                case IConversionOperation conversion:
+                    return GetLeadingConstant(conversion.Operand);
+
+                case IParenthesizedOperation parenthesized:
+                    return GetLeadingConstant(parenthesized.Operand);
+
+                case IBinaryOperation binary when binary.OperatorKind == BinaryOperatorKind.Add:
+                {
+                    var (leftPrefix, leftComplete) = GetLeadingConstant(binary.LeftOperand);
+
+                    if (!leftComplete) return (leftPrefix, false);
+
+                    var (rightPrefix, rightComplete) = GetLeadingConstant(binary.RightOperand);
+
+                    return (leftPrefix + rightPrefix, rightComplete);
+                }
+
+                case IInterpolatedStringOperation interpolated:
+                {
+                    var builder = new StringBuilder();
+
+                    foreach (var part in interpolated.Parts)
+                    {
+                        switch (part)
+                        {
+                            case IInterpolatedStringTextOperation text when text.Text.ConstantValue is { HasValue: true, Value: string literal }:
+                                builder.Append(literal);
+                                break;
+
+                            case IInterpolationOperation interpolation when interpolation.Expression.ConstantValue is { HasValue: true, Value: string value }:
+                                builder.Append(value);
+                                break;
+
+                            default:
+                                return (builder.ToString(), false);
+                        }
+                    }
+
+                    return (builder.ToString(), true);
+                }
+
+                default:
+                    return (string.Empty, false);
+            }
+        }
+
+        private static ImmutableArray<string> ReadManifestRoutes(AnalyzerOptions options, CancellationToken cancellationToken)
+        {
+            var builder = ImmutableArray.CreateBuilder<string>();
+
+            foreach (var file in options.AdditionalFiles)
+            {
+                if (!IsManifestFile(Path.GetFileName(file.Path))) continue;
+
+                var text = file.GetText(cancellationToken);
+
+                if (text is null) continue;
+
+                foreach (var line in text.Lines)
+                {
+                    var route = line.ToString().Trim();
+
+                    // Blank lines and comments (';' or '//') are skipped; '#' can start a real hash route.
+                    if (route.Length == 0) continue;
+                    if (route.StartsWith(";", StringComparison.Ordinal)) continue;
+                    if (route.StartsWith("//", StringComparison.Ordinal)) continue;
+
+                    builder.Add(route);
+                }
+            }
+
+            return builder.ToImmutable();
+        }
+
+        private static bool IsManifestFile(string fileName) =>
+            string.Equals(fileName, ManifestFileName, StringComparison.OrdinalIgnoreCase)
+            || fileName.EndsWith("." + ManifestFileName, StringComparison.OrdinalIgnoreCase);
+
+        private static bool IsRouteTableAuthoritative(AnalyzerOptions options) =>
+            options.AnalyzerConfigOptionsProvider.GlobalOptions.TryGetValue(AuthoritativeConfigKey, out var value)
+            && string.Equals(value, "true", StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/Tesserae.Analyzers/RouterNavigateAnalyzer.cs
+++ b/Tesserae.Analyzers/RouterNavigateAnalyzer.cs
@@ -1,0 +1,117 @@
+using System.Collections.Concurrent;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Tesserae.Analyzers
+{
+    /// <summary>
+    /// Reports Router.Navigate calls whose (compile-time constant) path does not match any
+    /// route registered with Router.Register in the same compilation.
+    ///
+    /// To avoid false positives the check stays silent when the route table cannot be fully
+    /// known at compile time: when any Router.Register call uses a non-constant path, or when
+    /// the compilation contains no Router.Register call at all (routes registered elsewhere,
+    /// e.g. by a referenced library). Navigate calls with non-constant paths and navigations
+    /// to absolute/external URLs are likewise skipped.
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class RouterNavigateAnalyzer : DiagnosticAnalyzer
+    {
+        public const string DiagnosticId = "TSS0001";
+
+        private static readonly DiagnosticDescriptor _rule = new DiagnosticDescriptor(
+            DiagnosticId,
+            title: "Route passed to Router.Navigate is not registered",
+            messageFormat: "The route '{0}' passed to Router.Navigate does not match any route registered with Router.Register in this project",
+            category: "Tesserae.Routing",
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            description: "Router.Navigate only activates a view when the target path matches a route previously registered with Router.Register; navigating to an unregistered route ends up in OnNotMatched instead of showing a view.",
+            helpLinkUri: "https://github.com/curiosity-ai/tesserae/blob/master/docs/ROUTING.md");
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(_rule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+
+            context.RegisterCompilationStartAction(compilationStart =>
+            {
+                var routerType = compilationStart.Compilation.GetTypeByMetadataName("Tesserae.Router");
+
+                if (routerType is null) return;
+
+                var registeredPaths          = new ConcurrentBag<string>();
+                var navigations              = new ConcurrentBag<(string Path, Location Location)>();
+                var hasDynamicRegistration   = new StrongBox<bool>(false);
+
+                compilationStart.RegisterOperationAction(operationContext =>
+                {
+                    var invocation = (IInvocationOperation)operationContext.Operation;
+                    var method     = invocation.TargetMethod;
+
+                    if (!SymbolEqualityComparer.Default.Equals(method.ContainingType, routerType)) return;
+
+                    if (method.Name == "Register")
+                    {
+                        // The route pattern is the last string parameter: Register(uniquePath, handler)
+                        // matches on uniquePath itself, Register(uniqueIdentifier, path, handler[, replace]) on path
+                        if (TryGetArgumentForParameter(invocation, method.Parameters.LastOrDefault(p => p.Type.SpecialType == SpecialType.System_String), out var registerArgument))
+                        {
+                            if (registerArgument.Value.ConstantValue is { HasValue: true, Value: string registeredPath })
+                            {
+                                registeredPaths.Add(registeredPath);
+                            }
+                            else
+                            {
+                                // A route built at runtime means the route table cannot be known at compile time
+                                hasDynamicRegistration.Value = true;
+                            }
+                        }
+                    }
+                    else if (method.Name == "Navigate")
+                    {
+                        if (TryGetArgumentForParameter(invocation, method.Parameters.FirstOrDefault(p => p.Type.SpecialType == SpecialType.System_String), out var navigateArgument)
+                            && navigateArgument.Value.ConstantValue is { HasValue: true, Value: string navigatePath })
+                        {
+                            navigations.Add((navigatePath, navigateArgument.Value.Syntax.GetLocation()));
+                        }
+                        // Non-constant Navigate paths cannot be checked - skip them
+                    }
+                }, OperationKind.Invocation);
+
+                compilationStart.RegisterCompilationEndAction(compilationEnd =>
+                {
+                    if (hasDynamicRegistration.Value) return;
+
+                    if (registeredPaths.IsEmpty) return;
+
+                    var patterns = registeredPaths.Select(RouteMatcher.ParsePattern).ToArray();
+
+                    foreach (var (path, location) in navigations)
+                    {
+                        if (!RouteMatcher.TryGetNavigationParts(path, out var parts)) continue;
+
+                        if (patterns.Any(pattern => RouteMatcher.IsMatch(pattern, parts))) continue;
+
+                        compilationEnd.ReportDiagnostic(Diagnostic.Create(_rule, location, path));
+                    }
+                });
+            });
+        }
+
+        private static bool TryGetArgumentForParameter(IInvocationOperation invocation, IParameterSymbol parameter, out IArgumentOperation argument)
+        {
+            argument = parameter is null
+                ? null
+                : invocation.Arguments.FirstOrDefault(a => SymbolEqualityComparer.Default.Equals(a.Parameter, parameter));
+
+            return argument is object;
+        }
+    }
+}

--- a/Tesserae.Analyzers/Tesserae.Analyzers.csproj
+++ b/Tesserae.Analyzers/Tesserae.Analyzers.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <!-- Not packed on its own - the DLL ships inside the Tesserae package under analyzers/dotnet/cs (see Tesserae.csproj) -->
+    <IsPackable>false</IsPackable>
+    <Description>Roslyn analyzers for the Tesserae UI toolkit</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Kept at an old Roslyn API version on purpose: analyzers load in the consumer's compiler/IDE process,
+         so the referenced API version must not exceed the oldest Roslyn we want to support. -->
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AdditionalFiles Include="AnalyzerReleases.Shipped.md" />
+    <AdditionalFiles Include="AnalyzerReleases.Unshipped.md" />
+  </ItemGroup>
+</Project>

--- a/Tesserae.Tests/Tesserae.Tests.csproj
+++ b/Tesserae.Tests/Tesserae.Tests.csproj
@@ -13,4 +13,11 @@
   <ItemGroup>
     <ProjectReference Include="..\Tesserae\Tesserae.csproj" />
   </ItemGroup>
+
+  <!-- Load the Tesserae Roslyn analyzers (built by the Tesserae project) in IDE/design-time builds.
+       An Analyzer item is used instead of a ProjectReference because the h5 compiler re-parses this
+       csproj and cannot resolve references to non-h5 projects. -->
+  <ItemGroup>
+    <Analyzer Include="..\Tesserae.Analyzers\bin\$(Configuration)\netstandard2.0\Tesserae.Analyzers.dll" Condition="Exists('..\Tesserae.Analyzers\bin\$(Configuration)\netstandard2.0\Tesserae.Analyzers.dll')" />
+  </ItemGroup>
 </Project>

--- a/Tesserae.sln
+++ b/Tesserae.sln
@@ -21,6 +21,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Build.UpdateInterfaceIcons", "Build.UpdateInterfaceIcons\Build.UpdateInterfaceIcons.csproj", "{084992F7-74EB-4123-989C-86CDFE8BDBC4}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tesserae.Analyzers", "Tesserae.Analyzers\Tesserae.Analyzers.csproj", "{0C0AF01A-6889-4122-AC13-2D700BBF8218}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tesserae.Analyzers.Tests", "Tesserae.Analyzers.Tests\Tesserae.Analyzers.Tests.csproj", "{446B7927-C9DD-4C6B-A4F2-211A0650F1EE}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -43,6 +47,14 @@ Global
 		{084992F7-74EB-4123-989C-86CDFE8BDBC4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{084992F7-74EB-4123-989C-86CDFE8BDBC4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{084992F7-74EB-4123-989C-86CDFE8BDBC4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0C0AF01A-6889-4122-AC13-2D700BBF8218}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0C0AF01A-6889-4122-AC13-2D700BBF8218}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0C0AF01A-6889-4122-AC13-2D700BBF8218}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0C0AF01A-6889-4122-AC13-2D700BBF8218}.Release|Any CPU.Build.0 = Release|Any CPU
+		{446B7927-C9DD-4C6B-A4F2-211A0650F1EE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{446B7927-C9DD-4C6B-A4F2-211A0650F1EE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{446B7927-C9DD-4C6B-A4F2-211A0650F1EE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{446B7927-C9DD-4C6B-A4F2-211A0650F1EE}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Tesserae.sln
+++ b/Tesserae.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 18
-VisualStudioVersion = 18.3.11415.281 d18.3
+VisualStudioVersion = 18.3.11415.281
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tesserae", "Tesserae\Tesserae.csproj", "{35F1070A-7B2A-4FAF-B433-19BEFD8BA11E}"
 EndProject
@@ -25,36 +25,102 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tesserae.Analyzers", "Tesse
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tesserae.Analyzers.Tests", "Tesserae.Analyzers.Tests\Tesserae.Analyzers.Tests.csproj", "{446B7927-C9DD-4C6B-A4F2-211A0650F1EE}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tesserae.Analyzers.Runner", "Tesserae.Analyzers.Runner\Tesserae.Analyzers.Runner.csproj", "{E14BCCE4-DC9C-4E5C-870A-F26397419E76}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{35F1070A-7B2A-4FAF-B433-19BEFD8BA11E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{35F1070A-7B2A-4FAF-B433-19BEFD8BA11E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{35F1070A-7B2A-4FAF-B433-19BEFD8BA11E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{35F1070A-7B2A-4FAF-B433-19BEFD8BA11E}.Debug|x64.Build.0 = Debug|Any CPU
+		{35F1070A-7B2A-4FAF-B433-19BEFD8BA11E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{35F1070A-7B2A-4FAF-B433-19BEFD8BA11E}.Debug|x86.Build.0 = Debug|Any CPU
 		{35F1070A-7B2A-4FAF-B433-19BEFD8BA11E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{35F1070A-7B2A-4FAF-B433-19BEFD8BA11E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{35F1070A-7B2A-4FAF-B433-19BEFD8BA11E}.Release|x64.ActiveCfg = Release|Any CPU
+		{35F1070A-7B2A-4FAF-B433-19BEFD8BA11E}.Release|x64.Build.0 = Release|Any CPU
+		{35F1070A-7B2A-4FAF-B433-19BEFD8BA11E}.Release|x86.ActiveCfg = Release|Any CPU
+		{35F1070A-7B2A-4FAF-B433-19BEFD8BA11E}.Release|x86.Build.0 = Release|Any CPU
 		{35F1071A-7B2A-4FAF-B433-19BEFD8BA11E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{35F1071A-7B2A-4FAF-B433-19BEFD8BA11E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{35F1071A-7B2A-4FAF-B433-19BEFD8BA11E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{35F1071A-7B2A-4FAF-B433-19BEFD8BA11E}.Debug|x64.Build.0 = Debug|Any CPU
+		{35F1071A-7B2A-4FAF-B433-19BEFD8BA11E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{35F1071A-7B2A-4FAF-B433-19BEFD8BA11E}.Debug|x86.Build.0 = Debug|Any CPU
 		{35F1071A-7B2A-4FAF-B433-19BEFD8BA11E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{35F1071A-7B2A-4FAF-B433-19BEFD8BA11E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{35F1071A-7B2A-4FAF-B433-19BEFD8BA11E}.Release|x64.ActiveCfg = Release|Any CPU
+		{35F1071A-7B2A-4FAF-B433-19BEFD8BA11E}.Release|x64.Build.0 = Release|Any CPU
+		{35F1071A-7B2A-4FAF-B433-19BEFD8BA11E}.Release|x86.ActiveCfg = Release|Any CPU
+		{35F1071A-7B2A-4FAF-B433-19BEFD8BA11E}.Release|x86.Build.0 = Release|Any CPU
 		{BA7E4838-8FF6-470D-8E2E-A9917F57D8EC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{BA7E4838-8FF6-470D-8E2E-A9917F57D8EC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BA7E4838-8FF6-470D-8E2E-A9917F57D8EC}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{BA7E4838-8FF6-470D-8E2E-A9917F57D8EC}.Debug|x64.Build.0 = Debug|Any CPU
+		{BA7E4838-8FF6-470D-8E2E-A9917F57D8EC}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{BA7E4838-8FF6-470D-8E2E-A9917F57D8EC}.Debug|x86.Build.0 = Debug|Any CPU
 		{BA7E4838-8FF6-470D-8E2E-A9917F57D8EC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BA7E4838-8FF6-470D-8E2E-A9917F57D8EC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BA7E4838-8FF6-470D-8E2E-A9917F57D8EC}.Release|x64.ActiveCfg = Release|Any CPU
+		{BA7E4838-8FF6-470D-8E2E-A9917F57D8EC}.Release|x64.Build.0 = Release|Any CPU
+		{BA7E4838-8FF6-470D-8E2E-A9917F57D8EC}.Release|x86.ActiveCfg = Release|Any CPU
+		{BA7E4838-8FF6-470D-8E2E-A9917F57D8EC}.Release|x86.Build.0 = Release|Any CPU
 		{084992F7-74EB-4123-989C-86CDFE8BDBC4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{084992F7-74EB-4123-989C-86CDFE8BDBC4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{084992F7-74EB-4123-989C-86CDFE8BDBC4}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{084992F7-74EB-4123-989C-86CDFE8BDBC4}.Debug|x64.Build.0 = Debug|Any CPU
+		{084992F7-74EB-4123-989C-86CDFE8BDBC4}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{084992F7-74EB-4123-989C-86CDFE8BDBC4}.Debug|x86.Build.0 = Debug|Any CPU
 		{084992F7-74EB-4123-989C-86CDFE8BDBC4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{084992F7-74EB-4123-989C-86CDFE8BDBC4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{084992F7-74EB-4123-989C-86CDFE8BDBC4}.Release|x64.ActiveCfg = Release|Any CPU
+		{084992F7-74EB-4123-989C-86CDFE8BDBC4}.Release|x64.Build.0 = Release|Any CPU
+		{084992F7-74EB-4123-989C-86CDFE8BDBC4}.Release|x86.ActiveCfg = Release|Any CPU
+		{084992F7-74EB-4123-989C-86CDFE8BDBC4}.Release|x86.Build.0 = Release|Any CPU
 		{0C0AF01A-6889-4122-AC13-2D700BBF8218}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{0C0AF01A-6889-4122-AC13-2D700BBF8218}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0C0AF01A-6889-4122-AC13-2D700BBF8218}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{0C0AF01A-6889-4122-AC13-2D700BBF8218}.Debug|x64.Build.0 = Debug|Any CPU
+		{0C0AF01A-6889-4122-AC13-2D700BBF8218}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{0C0AF01A-6889-4122-AC13-2D700BBF8218}.Debug|x86.Build.0 = Debug|Any CPU
 		{0C0AF01A-6889-4122-AC13-2D700BBF8218}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0C0AF01A-6889-4122-AC13-2D700BBF8218}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0C0AF01A-6889-4122-AC13-2D700BBF8218}.Release|x64.ActiveCfg = Release|Any CPU
+		{0C0AF01A-6889-4122-AC13-2D700BBF8218}.Release|x64.Build.0 = Release|Any CPU
+		{0C0AF01A-6889-4122-AC13-2D700BBF8218}.Release|x86.ActiveCfg = Release|Any CPU
+		{0C0AF01A-6889-4122-AC13-2D700BBF8218}.Release|x86.Build.0 = Release|Any CPU
 		{446B7927-C9DD-4C6B-A4F2-211A0650F1EE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{446B7927-C9DD-4C6B-A4F2-211A0650F1EE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{446B7927-C9DD-4C6B-A4F2-211A0650F1EE}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{446B7927-C9DD-4C6B-A4F2-211A0650F1EE}.Debug|x64.Build.0 = Debug|Any CPU
+		{446B7927-C9DD-4C6B-A4F2-211A0650F1EE}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{446B7927-C9DD-4C6B-A4F2-211A0650F1EE}.Debug|x86.Build.0 = Debug|Any CPU
 		{446B7927-C9DD-4C6B-A4F2-211A0650F1EE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{446B7927-C9DD-4C6B-A4F2-211A0650F1EE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{446B7927-C9DD-4C6B-A4F2-211A0650F1EE}.Release|x64.ActiveCfg = Release|Any CPU
+		{446B7927-C9DD-4C6B-A4F2-211A0650F1EE}.Release|x64.Build.0 = Release|Any CPU
+		{446B7927-C9DD-4C6B-A4F2-211A0650F1EE}.Release|x86.ActiveCfg = Release|Any CPU
+		{446B7927-C9DD-4C6B-A4F2-211A0650F1EE}.Release|x86.Build.0 = Release|Any CPU
+		{E14BCCE4-DC9C-4E5C-870A-F26397419E76}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E14BCCE4-DC9C-4E5C-870A-F26397419E76}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E14BCCE4-DC9C-4E5C-870A-F26397419E76}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E14BCCE4-DC9C-4E5C-870A-F26397419E76}.Debug|x64.Build.0 = Debug|Any CPU
+		{E14BCCE4-DC9C-4E5C-870A-F26397419E76}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E14BCCE4-DC9C-4E5C-870A-F26397419E76}.Debug|x86.Build.0 = Debug|Any CPU
+		{E14BCCE4-DC9C-4E5C-870A-F26397419E76}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E14BCCE4-DC9C-4E5C-870A-F26397419E76}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E14BCCE4-DC9C-4E5C-870A-F26397419E76}.Release|x64.ActiveCfg = Release|Any CPU
+		{E14BCCE4-DC9C-4E5C-870A-F26397419E76}.Release|x64.Build.0 = Release|Any CPU
+		{E14BCCE4-DC9C-4E5C-870A-F26397419E76}.Release|x86.ActiveCfg = Release|Any CPU
+		{E14BCCE4-DC9C-4E5C-870A-F26397419E76}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Tesserae/Tesserae.csproj
+++ b/Tesserae/Tesserae.csproj
@@ -39,6 +39,22 @@
 </ItemGroup>
 
   <!--
+    Ship the Tesserae Roslyn analyzers (e.g. TSS0001: Router.Navigate route must have a matching
+    Router.Register) inside the NuGet package so consumer compilations/IDEs load them automatically.
+    The h5 compiler re-parses this csproj and cannot resolve a ProjectReference to a non-h5 project,
+    so build ordering is done with an explicit MSBuild call in _BuildTesseraeAnalyzers below instead.
+  -->
+  <ItemGroup>
+    <None Include="..\Tesserae.Analyzers\bin\$(Configuration)\netstandard2.0\Tesserae.Analyzers.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+  </ItemGroup>
+
+  <Target Name="_BuildTesseraeAnalyzers" BeforeTargets="Build;_GetPackageFiles">
+    <MSBuild Projects="..\Tesserae.Analyzers\Tesserae.Analyzers.csproj" Targets="Restore" Properties="Configuration=$(Configuration)" />
+    <!-- The extra property forces a re-evaluation so Build does not reuse the pre-Restore project state -->
+    <MSBuild Projects="..\Tesserae.Analyzers\Tesserae.Analyzers.csproj" Targets="Build" Properties="Configuration=$(Configuration);_TesseraeAnalyzersBuild=true" />
+  </Target>
+
+  <!--
     Ship the Claude skills (one per component, plus cross-cutting guides) inside the
     NuGet package so consumers of the Tesserae package get them auto-extracted into
     their solution's `.claude/skills/tesserae/` folder (a single skill: root SKILL.md

--- a/Tesserae/Tesserae.csproj
+++ b/Tesserae/Tesserae.csproj
@@ -55,6 +55,35 @@
   </Target>
 
   <!--
+    Ship the analyzer runner (tools/analyzer-runner/) inside the package. h5 builds replace Roslyn's
+    CoreCompile with the transpiler CLI, so the analyzers above never run during `dotnet build`. The
+    buildTransitive target invokes this runner to rebuild a Roslyn compilation from the consumer's
+    resolved sources/references and report TSS#### diagnostics. Same explicit-MSBuild-call ordering
+    as _BuildTesseraeAnalyzers: the h5 compiler cannot resolve a ProjectReference to a non-h5 project.
+    The pack items are added inside the target (after the runner exists) so the glob expands correctly.
+  -->
+  <Target Name="_BuildTesseraeAnalyzersRunner" BeforeTargets="Build;_GetPackageFiles">
+    <MSBuild Projects="..\Tesserae.Analyzers.Runner\Tesserae.Analyzers.Runner.csproj" Targets="Restore" Properties="Configuration=$(Configuration)" />
+    <MSBuild Projects="..\Tesserae.Analyzers.Runner\Tesserae.Analyzers.Runner.csproj" Targets="Build" Properties="Configuration=$(Configuration);_TesseraeAnalyzersRunnerBuild=true" />
+  </Target>
+
+  <!--
+    Pack only the files the runner needs to run under `dotnet <dll>`: its own assembly + the two
+    Roslyn DLLs it loads, plus deps/runtimeconfig. The satellite localization folders, apphost and
+    .pdb are intentionally excluded (they only bloat the package). Explicit files (no **/RecursiveDir)
+    on purpose - a recursive glob's %(RecursiveDir) batches across the skills\** items and explodes
+    the layout. PackagePath ends with '\' so NuGet keeps each file's own name in that folder.
+    _BuildTesseraeAnalyzersRunner (BeforeTargets _GetPackageFiles) ensures these exist by pack time.
+  -->
+  <ItemGroup>
+    <None Include="..\Tesserae.Analyzers.Runner\bin\$(Configuration)\net10.0\Tesserae.Analyzers.Runner.dll"                Pack="true" PackagePath="tools\analyzer-runner\Tesserae.Analyzers.Runner.dll"                Visible="false" />
+    <None Include="..\Tesserae.Analyzers.Runner\bin\$(Configuration)\net10.0\Tesserae.Analyzers.Runner.deps.json"          Pack="true" PackagePath="tools\analyzer-runner\Tesserae.Analyzers.Runner.deps.json"          Visible="false" />
+    <None Include="..\Tesserae.Analyzers.Runner\bin\$(Configuration)\net10.0\Tesserae.Analyzers.Runner.runtimeconfig.json" Pack="true" PackagePath="tools\analyzer-runner\Tesserae.Analyzers.Runner.runtimeconfig.json" Visible="false" />
+    <None Include="..\Tesserae.Analyzers.Runner\bin\$(Configuration)\net10.0\Microsoft.CodeAnalysis.dll"                   Pack="true" PackagePath="tools\analyzer-runner\Microsoft.CodeAnalysis.dll"                   Visible="false" />
+    <None Include="..\Tesserae.Analyzers.Runner\bin\$(Configuration)\net10.0\Microsoft.CodeAnalysis.CSharp.dll"            Pack="true" PackagePath="tools\analyzer-runner\Microsoft.CodeAnalysis.CSharp.dll"            Visible="false" />
+  </ItemGroup>
+
+  <!--
     Ship the Claude skills (one per component, plus cross-cutting guides) inside the
     NuGet package so consumers of the Tesserae package get them auto-extracted into
     their solution's `.claude/skills/tesserae/` folder (a single skill: root SKILL.md

--- a/Tesserae/buildTransitive/Tesserae.targets
+++ b/Tesserae/buildTransitive/Tesserae.targets
@@ -83,4 +83,63 @@
     <Message Condition="'$(_NeedsInstall)' == 'true'" Importance="high"
              Text="Skills $(_SkillsPackageId) updated $(_InstalledVersion) → $(_ShippedVersion) in $(_SkillsTargetDir)" />
   </Target>
+
+  <!--
+    Run the Tesserae Roslyn analyzers (e.g. TSS0001: Router.Navigate route must have a matching
+    Router.Register) at build time.
+
+    h5 builds replace the normal C# CoreCompile with the transpiler CLI, so Roslyn - and therefore
+    the analyzers packaged under analyzers/dotnet/cs - never run during `dotnet build` (they only run
+    in the IDE at design time). This target invokes the packaged runner tool, which rebuilds a Roslyn
+    compilation from the sources + references MSBuild already resolved and reports only TSS#### findings.
+
+      - Opt out entirely:           <TesseraeRunAnalyzers>false</TesseraeRunAnalyzers>
+      - Fail the build on findings:  <TesseraeAnalyzersTreatWarningsAsErrors>true</TesseraeAnalyzersTreatWarningsAsErrors>
+        (otherwise findings are reported as build warnings, matching the analyzer's default severity)
+  -->
+  <PropertyGroup>
+    <TesseraeRunAnalyzers Condition="'$(TesseraeRunAnalyzers)' == ''">true</TesseraeRunAnalyzers>
+    <TesseraeAnalyzersTreatWarningsAsErrors Condition="'$(TesseraeAnalyzersTreatWarningsAsErrors)' == ''">false</TesseraeAnalyzersTreatWarningsAsErrors>
+    <_TesseraeAnalyzerDll>$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)..', 'analyzers', 'dotnet', 'cs', 'Tesserae.Analyzers.dll'))</_TesseraeAnalyzerDll>
+    <_TesseraeRunnerDll>$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)..', 'tools', 'analyzer-runner', 'Tesserae.Analyzers.Runner.dll'))</_TesseraeRunnerDll>
+  </PropertyGroup>
+
+  <Target Name="_RunTesseraeAnalyzers"
+          AfterTargets="ResolveReferences"
+          Condition="'$(TesseraeRunAnalyzers)' == 'true'
+                     and '$(DesignTimeBuild)' != 'true'
+                     and Exists('$(_TesseraeRunnerDll)')
+                     and Exists('$(_TesseraeAnalyzerDll)')"
+          Inputs="@(Compile);@(ReferencePath);$(_TesseraeAnalyzerDll);$(_TesseraeRunnerDll)"
+          Outputs="$(IntermediateOutputPath)tesserae-analyzers.$(TesseraeAnalyzersTreatWarningsAsErrors).stamp">
+
+    <!-- Resolved here (not in the file-level PropertyGroup): $(IntermediateOutputPath) is not yet set
+         when this imported .targets is first evaluated, so capturing it early would drop the stamp in
+         the project root. Target attributes / this inner PropertyGroup are evaluated at execution time,
+         when the SDK has set it. Mode is part of the stamp name so toggling TreatWarningsAsErrors re-runs. -->
+    <PropertyGroup>
+      <_TesseraeSourcesFile>$(IntermediateOutputPath)tesserae-analyzer-sources.txt</_TesseraeSourcesFile>
+      <_TesseraeRefsFile>$(IntermediateOutputPath)tesserae-analyzer-refs.txt</_TesseraeRefsFile>
+      <_TesseraeAnalyzerStamp>$(IntermediateOutputPath)tesserae-analyzers.$(TesseraeAnalyzersTreatWarningsAsErrors).stamp</_TesseraeAnalyzerStamp>
+      <_TesseraeWarnAsError Condition="'$(TesseraeAnalyzersTreatWarningsAsErrors)' == 'true'">--warnaserror</_TesseraeWarnAsError>
+    </PropertyGroup>
+
+    <WriteLinesToFile File="$(_TesseraeSourcesFile)" Lines="@(Compile->'%(FullPath)')" Overwrite="true" WriteOnlyWhenDifferent="true" />
+    <WriteLinesToFile File="$(_TesseraeRefsFile)"    Lines="@(ReferencePath)"        Overwrite="true" WriteOnlyWhenDifferent="true" />
+
+    <ItemGroup>
+      <_TesseraeManifestArg Include="@(AdditionalFiles->'--additionalfile &quot;%(FullPath)&quot;')"
+                            Condition="'%(Filename)%(Extension)' == 'TesseraeRoutes.txt'" />
+    </ItemGroup>
+
+    <!-- IgnoreExitCode: the runner prints diagnostics in MSBuild canonical format, so Exec's output
+         parsing already raises `error TSS0001` lines as real build errors (failing the build). Honoring
+         the exit code too would add a redundant, noisy MSB3073 "exited with code 1" on top. -->
+    <Exec Command="dotnet &quot;$(_TesseraeRunnerDll)&quot; --analyzer &quot;$(_TesseraeAnalyzerDll)&quot; --sources &quot;$(_TesseraeSourcesFile)&quot; --refs &quot;$(_TesseraeRefsFile)&quot; --define &quot;$(DefineConstants)&quot; --langversion &quot;$(LangVersion)&quot; @(_TesseraeManifestArg, ' ') $(_TesseraeWarnAsError)"
+          ConsoleToMSBuild="true"
+          IgnoreExitCode="true"
+          WorkingDirectory="$(MSBuildProjectDirectory)" />
+
+    <Touch Files="$(_TesseraeAnalyzerStamp)" AlwaysCreate="true" />
+  </Target>
 </Project>

--- a/Tesserae/skills/references/routing.md
+++ b/Tesserae/skills/references/routing.md
@@ -71,9 +71,15 @@ private static void Show(IComponent page) { Content.Clear(); Content.Add(page); 
   pages use `Router.Push`/`Replace` directly.
 - `h5.json` reflection must stay enabled for the router to work.
 - The Tesserae package ships a Roslyn analyzer (`TSS0001`) that warns when a
-  constant path passed to `Router.Navigate` matches no `Router.Register` route
-  in the project (skipped when any registration path is non-constant, or when
-  the project registers no routes itself).
+  constant path passed to `Router.Navigate` matches no known route. Known routes
+  come from constant `Router.Register` paths in the project **and** from an
+  optional `TesseraeRoutes.txt` manifest listed as `AdditionalFiles` (one route
+  per line; use it to validate navigations against routes registered in another
+  assembly). A dynamic `Register` no longer mutes the whole project — one with a
+  constant prefix only suppresses navigations under that prefix. Set
+  `dotnet_diagnostic.TSS0001.route_table_is_authoritative = true` to check even
+  when dynamic registrations are present. The analyzer stays silent only when it
+  knows no routes at all (no constant `Register` and no manifest).
 
 ## Related
 

--- a/Tesserae/skills/references/routing.md
+++ b/Tesserae/skills/references/routing.md
@@ -70,6 +70,10 @@ private static void Show(IComponent page) { Content.Clear(); Content.Add(page); 
 - The History API is unavailable inside the sandboxed docs preview iframe — real
   pages use `Router.Push`/`Replace` directly.
 - `h5.json` reflection must stay enabled for the router to work.
+- The Tesserae package ships a Roslyn analyzer (`TSS0001`) that warns when a
+  constant path passed to `Router.Navigate` matches no `Router.Register` route
+  in the project (skipped when any registration path is non-constant, or when
+  the project registers no routes itself).
 
 ## Related
 

--- a/docs/ROUTING.md
+++ b/docs/ROUTING.md
@@ -70,11 +70,59 @@ Navigate with a query string:
 
 The Tesserae NuGet package ships a Roslyn analyzer (`Tesserae.Analyzers`, rule `TSS0001`) that warns when a compile-time constant path passed to `Router.Navigate` does not match any route registered with `Router.Register` in the same project. Matching mirrors the runtime rules: leading `#`/`/` are ignored, comparison is per-segment and case-insensitive, `:name` segments match any value, and query strings are ignored.
 
-To avoid false positives the analyzer stays silent when it cannot know the full route table:
+### Where the analyzer gets the route table
 
-- Any `Router.Register` call with a non-constant path (e.g. built with string interpolation) disables the check for the whole project.
-- Projects with no `Router.Register` calls at all are skipped (routes may be registered by a referenced library).
-- `Router.Navigate` calls with non-constant paths, and navigations to absolute/external URLs, are not checked.
+A Roslyn analyzer only sees the *current* compilation, so it collects known routes from two places:
+
+1. **Constant `Router.Register` paths in this project.** As before.
+2. **A route manifest** — an `AdditionalFiles` entry named `TesseraeRoutes.txt`. This lets a project
+   validate `Router.Navigate` calls against routes that are registered in a *different* assembly
+   (the common case where one project owns `Router.Register` and others only navigate). The file is
+   one route pattern per line; blank lines and lines starting with `;` or `//` are ignored (a leading
+   `#` is a real hash route, so it is *not* a comment):
+
+   ```
+   ; app routes (generated from DefaultRoutes)
+   #/home
+   #/space/:uid
+   #/manage/users
+   ```
+
+   Wire it up in the projects that navigate:
+
+   ```xml
+   <ItemGroup>
+     <AdditionalFiles Include="TesseraeRoutes.txt" />
+   </ItemGroup>
+   ```
+
+### Dynamic registrations no longer mute the whole project
+
+A single `Router.Register` call built at runtime used to disable `TSS0001` for the entire project.
+Now the analyzer is prefix-aware:
+
+- A dynamic registration with a knowable constant prefix (e.g. `Register("#/admin/" + suffix, …)`)
+  only suppresses `Router.Navigate` paths that fall *under* that prefix. Navigations elsewhere are
+  still checked.
+- A fully-opaque dynamic registration (no knowable prefix, e.g. `Register(pathVariable, …)`) falls
+  back to the old conservative behavior and suppresses otherwise-unmatched navigations — declare
+  those routes in the manifest (above) so they become known, or opt in below.
+
+### Opting in to strict checking
+
+If you know your constant/manifest route table is complete, set this in `.editorconfig` (or a
+`.globalconfig`) to report mismatches even in the presence of dynamic registrations:
+
+```ini
+dotnet_diagnostic.TSS0001.route_table_is_authoritative = true
+```
+
+### When the analyzer still stays silent
+
+To avoid false positives (a false "unregistered route" warning is worse than silence), the check does
+nothing when it knows *no* routes at all — no constant `Router.Register` in the project **and** no
+manifest. `Router.Navigate` calls with non-constant paths, and navigations to absolute/external URLs,
+are never checked.
 
 ## Recommendations
 

--- a/docs/ROUTING.md
+++ b/docs/ROUTING.md
@@ -66,6 +66,16 @@ Navigate with a query string:
 - `Router.OnNavigated(...)` lets you respond after navigation completes.
 - `Router.OnNotMatched(...)` is invoked when no route matches the new URL.
 
+## Compile-time route checking (TSS0001)
+
+The Tesserae NuGet package ships a Roslyn analyzer (`Tesserae.Analyzers`, rule `TSS0001`) that warns when a compile-time constant path passed to `Router.Navigate` does not match any route registered with `Router.Register` in the same project. Matching mirrors the runtime rules: leading `#`/`/` are ignored, comparison is per-segment and case-insensitive, `:name` segments match any value, and query strings are ignored.
+
+To avoid false positives the analyzer stays silent when it cannot know the full route table:
+
+- Any `Router.Register` call with a non-constant path (e.g. built with string interpolation) disables the check for the whole project.
+- Projects with no `Router.Register` calls at all are skipped (routes may be registered by a referenced library).
+- `Router.Navigate` calls with non-constant paths, and navigations to absolute/external URLs, are not checked.
+
 ## Recommendations
 
 - Keep route strings normalized. Do not  register routes with a leading `/` or `#/`.


### PR DESCRIPTION
## Summary

Adds a Roslyn analyzer (`TSS0001`) that validates at compile time that paths passed to `Router.Navigate` match routes registered with `Router.Register` in the same project. This catches routing bugs early and provides IDE warnings without runtime overhead.

## Key Changes

- **New analyzer project** (`Tesserae.Analyzers/`): Implements `RouterNavigateAnalyzer` which:
  - Collects all routes registered via `Router.Register` calls with compile-time constant paths
  - Checks each `Router.Navigate` call with a compile-time constant path against the route table
  - Reports `TSS0001` warning when a navigate path doesn't match any registered route
  - Stays silent when the route table cannot be fully known (dynamic registrations, no registrations in compilation, or non-constant navigate paths)

- **Route matching logic** (`RouteMatcher.cs`): Mirrors the runtime route matching rules:
  - Leading `#` and `/` are normalized away
  - Matching is per-segment and case-insensitive
  - `:name` segments match any value (parameters)
  - Query strings are ignored
  - External/absolute URLs are skipped

- **Comprehensive test suite** (`Tesserae.Analyzers.Tests/`): 13 test cases covering:
  - Valid routes (registered and parameterized)
  - Invalid routes (unregistered paths, wrong segment counts)
  - Edge cases (case-insensitivity, query strings, root routes, external URLs)
  - Non-constant paths and dynamic registrations (correctly suppressed)
  - Constant propagation through variables

- **Integration**: 
  - Analyzer DLL shipped inside the Tesserae NuGet package under `analyzers/dotnet/cs/`
  - Automatically loaded by consumer projects and IDEs
  - MSBuild target ensures analyzer builds before the main package
  - Test project configured to load the analyzer for design-time validation

- **Documentation**: Updated `docs/ROUTING.md` and skill references to explain the analyzer, its matching rules, and when it stays silent to avoid false positives.

## Implementation Details

The analyzer uses Roslyn's `IInvocationOperation` to intercept `Router.Register` and `Router.Navigate` calls, extracts compile-time constant string arguments, and performs route matching at the end of compilation. The design prioritizes correctness over coverage: it only reports when confident the route is truly unregistered, staying silent rather than guessing when the route table might be incomplete (e.g., routes registered by referenced libraries).

https://claude.ai/code/session_01MMUG9JLcx6yEfKhU5xZf3L