### PR TITLE
Fix height measurement in Sandbox to use content box instead of scrollHeight

### DIFF
--- a/Tesserae/src/Components/Sandbox.cs
+++ b/Tesserae/src/Components/Sandbox.cs
@@ -36,14 +36,16 @@ namespace Tesserae
         // Height reporting is only armed when the host sends `fit:true` in the init message - i.e. when
         // FitHeightToContent is on AND the host cannot measure the frame itself (no same-origin access).
         // Same-origin frames are measured host-side instead (see SetupHostSideFit). Once armed it forces
-        // html/body to auto height so the measurement tracks content in both directions (grow *and*
-        // shrink), watches for changes with both a ResizeObserver and a MutationObserver, batches updates
-        // through requestAnimationFrame, and de-dupes identical heights to avoid flooding the port.
+        // html/body to auto height and measures the content box (getBoundingClientRect, not scrollHeight,
+        // which the root element clamps to the viewport height and so would never shrink) so the
+        // measurement tracks content in both directions (grow *and* shrink), watches for changes with both
+        // a ResizeObserver and a MutationObserver, batches updates through requestAnimationFrame, and
+        // de-dupes identical heights to avoid flooding the port.
         private const string BootstrapScript =
             "(function(){var port=null,queue=[],fit=false,raf=0,lastH=-1;" +
             "function flush(){if(port){while(queue.length){port.postMessage(queue.shift());}}}" +
             "function send(m){queue.push(m);flush();}" +
-            "function measure(){try{var d=document.documentElement,b=document.body;return Math.max(d?d.scrollHeight:0,b?b.scrollHeight:0);}catch(_){return 0;}}" +
+            "function measure(){try{var d=document.documentElement,b=document.body,h=b?b.scrollHeight:0;if(d){var r=d.getBoundingClientRect();if(r&&r.height>h){h=Math.ceil(r.height);}}return h;}catch(_){return 0;}}" +
             "function report(){raf=0;if(!fit)return;var h=measure();if(h>0&&h!==lastH){lastH=h;send({kind:'height',height:h});}}" +
             "function schedule(){if(!fit||raf)return;raf=(window.requestAnimationFrame||function(cb){return setTimeout(cb,16);})(report);}" +
             "function enableFit(){if(fit)return;fit=true;try{document.documentElement.style.setProperty('height','auto','important');if(document.body){document.body.style.setProperty('height','auto','important');}}catch(_){}" +
@@ -427,7 +429,10 @@ namespace Tesserae
     var de = doc.documentElement, b = doc.body;
     try { if (de) { de.style.setProperty('height', 'auto', 'important'); } if (b) { b.style.setProperty('height', 'auto', 'important'); } } catch (_) {}
     var lastH = -1, raf = 0;
-    function measure(){ try { return Math.max(de ? de.scrollHeight : 0, b ? b.scrollHeight : 0); } catch (_) { return 0; } }
+    // Measure the actual content box (documentElement is forced to height:auto above) rather than
+    // scrollHeight: the root element's scrollHeight is clamped to at least the viewport height, which
+    // equals the frame's current height, so once the frame has grown it could never shrink again.
+    function measure(){ try { var h = b ? b.scrollHeight : 0; if (de) { var r = de.getBoundingClientRect(); if (r && r.height > h) { h = Math.ceil(r.height); } } return h; } catch (_) { return 0; } }
     function apply(){ raf = 0; var h = measure(); if (h > 0 && h !== lastH) { lastH = h; f.style.height = h + 'px'; } }
     function schedule(){ if (raf) return; raf = win.requestAnimationFrame ? win.requestAnimationFrame(apply) : setTimeout(apply, 16); }
     try { if (win.ResizeObserver && de) { new win.ResizeObserver(schedule).observe(de); } } catch (_) {}


### PR DESCRIPTION
## Summary

Fixed a bug in the `Sandbox` component's height-reporting mechanism where `scrollHeight` was being used to measure iframe content. Since `scrollHeight` on the root element is clamped to at least the viewport height, frames could grow but never shrink. The fix measures the actual content box using `getBoundingClientRect()` instead.

## Changes

- **Updated `BootstrapScript` measure function**: Changed from using `Math.max(scrollHeight)` to measuring the documentElement's bounding client rect, falling back to body scrollHeight if the rect height is smaller. This ensures accurate content measurement in both directions (grow and shrink).

- **Updated `SetupHostSideFit` measure function**: Applied the same fix to the host-side measurement logic, with added comments explaining why `scrollHeight` is insufficient.

- **Updated documentation comments**: Clarified in the code comments that the measurement uses the content box (via `getBoundingClientRect`) rather than `scrollHeight`, and explained why this matters for shrinking behavior.

## Implementation Details

The new measurement logic:
1. Gets the body's `scrollHeight` as a baseline
2. If the documentElement exists, gets its `getBoundingClientRect()` 
3. Uses whichever is larger (with `Math.ceil()` for the rect height to handle subpixel values)
4. Falls back to 0 on any exception

This ensures that as content shrinks, the measured height decreases accordingly, allowing the iframe to resize down properly.

https://claude.ai/code/session_01T83Uhv51H9LmKQeyqZ48Vp