### PR TITLE
Refactor vertical slider to use CSS-driven track and fill

### DIFF
--- a/Tesserae/h5/assets/css/tss.slider.css
+++ b/Tesserae/h5/assets/css/tss.slider.css
@@ -7,7 +7,6 @@
 .tss-slider-div-vertical {
     width: auto;
     padding-bottom: 0;
-    padding-right: 8px;
     display: inline-flex;
     height: 100%;
 }
@@ -20,39 +19,72 @@
     display: block;
 }
 
+    /* Vertical orientation: a 90°-rotated mirror of the horizontal track. The
+       track/fill are an 8px-wide column centred in a 24px-wide container; the
+       fill grows upward from the bottom, and the range input sits on top with
+       only its thumb visible. */
     .tss-slider-container.tss-vertical {
-        writing-mode: vertical-lr;
-        direction: rtl;
-        width: 36px;
+        width: 24px;
         height: 100%;
-        display: inline-flex;
-        align-items: center;
+        display: inline-block;
     }
 
+        /* WebKit/Chromium: keep the native chrome removed (appearance: none) and
+           let writing-mode make the input vertical so the custom thumb still
+           applies. direction: rtl puts the minimum at the bottom. */
         .tss-slider-container.tss-vertical .tss-slider {
             writing-mode: vertical-lr;
             direction: rtl;
+            position: absolute;
+            left: 0;
+            top: 0;
+            width: 24px;
+            height: 100%;
+            margin: 0;
+        }
+
+        /* The fake input only supplies the thumb; the track/fill are drawn by the
+           overlay divs. Keep it transparent even when disabled (the .tss-disabled
+           class otherwise paints the full-height column). */
+        .tss-slider-container.tss-vertical .tss-slider.tss-fake {
+            top: 0;
+            left: 0;
+            background-color: transparent;
+        }
+
+        .tss-slider-container.tss-vertical .tss-slider-fake-background {
+            position: absolute;
+            top: 0;
+            bottom: 0;
+            left: 8px;
             width: 8px;
             height: 100%;
-            -webkit-appearance: slider-vertical;
-            appearance: auto;
+            border-radius: 4px;
         }
 
         .tss-slider-container.tss-vertical .tss-slider-fake-progress {
             top: auto;
-            bottom: 4px;
+            bottom: 0;
+            left: 8px;
             width: 8px;
-            left: 4px;
-            height: 100%;
             border-radius: 0px 0px 4px 4px;
         }
 
-        .tss-slider-container.tss-vertical .tss-slider-fake-background {
-            top: auto;
-            bottom: 4px;
+        /* Thumb sits across the vertical track: swap the horizontal pill so its
+           long axis is horizontal. */
+        .tss-slider-container.tss-vertical .tss-slider::-webkit-slider-thumb {
+            width: 24px;
+            height: 16px;
+        }
+
+        .tss-slider-container.tss-vertical .tss-slider::-moz-range-thumb {
+            width: 24px;
+            height: 16px;
+        }
+
+        /* Firefox native vertical track thickness. */
+        .tss-slider-container.tss-vertical .tss-slider::-moz-range-track {
             width: 8px;
-            left: 4px;
-            height: 100%;
         }
 
 .tss-slider-fake-progress {

--- a/Tesserae/skills/references/slider.md
+++ b/Tesserae/skills/references/slider.md
@@ -33,7 +33,10 @@ var slider = Slider(val: 50, min: 0, max: 100, step: 5)
     .Horizontal()
     .OnInput((s, e) => console.log($"Slider value: {s.Value}"));
 
-var vertical = Slider(val: 25, min: 0, max: 50, step: 5).Vertical();
+// A vertical slider fills the available height, so give it (or its parent) a
+// height — otherwise it collapses. The minimum is at the bottom, maximum at top.
+var vertical = Slider(val: 25, min: 0, max: 50, step: 5).Vertical().HS();
+var column   = VStack().H(150.px()).AlignItems(ItemAlign.Center).Children(vertical);
 ```
 
 ## Related

--- a/Tesserae/src/Components/Slider.cs
+++ b/Tesserae/src/Components/Slider.cs
@@ -45,9 +45,15 @@ namespace Tesserae
             AttachFocus();
             AttachBlur();
 
-            // Subscribe to the underlying events so the observable updates on user input.
-            Changed      += (_, __) => _observable.Value = Value;
-            InputUpdated += (_, __) => _observable.Value = Value;
+            // Subscribe to the underlying events so the observable (and the
+            // exposed aria value) stay in sync on user input, not just when the
+            // value is set programmatically.
+            Changed += (_, __) => _observable.Value = Value;
+            InputUpdated += (_, __) =>
+            {
+                InnerElement.setAttribute("aria-valuenow", Value.ToString());
+                _observable.Value = Value;
+            };
 
             if (navigator.userAgent.IndexOf("AppleWebKit") != -1)
             {
@@ -78,11 +84,16 @@ namespace Tesserae
 
             if (Orientation == SliderOrientation.Vertical)
             {
+                // The fill grows along the vertical axis; let the CSS drive the
+                // track thickness and clear any horizontal value left over from a
+                // previous orientation.
                 _fakeDiv.style.height = $"{percent:0.##}%";
+                _fakeDiv.style.width  = "";
             }
             else
             {
-                _fakeDiv.style.width = $"{percent:0.##}%";
+                _fakeDiv.style.width  = $"{percent:0.##}%";
+                _fakeDiv.style.height = "";
             }
             return percent;
         }
@@ -99,25 +110,29 @@ namespace Tesserae
                 {
                     _outerLabel.classList.add("tss-vertical");
                     _outerDiv.classList.add("tss-slider-div-vertical");
-
-                    if (_fakeDiv is object)
-                    {
-                        _fakeDiv.style.width = "100%";
-                        UpdateFakeProgress();
-                    }
                     InnerElement.setAttribute("aria-orientation", "vertical");
                 }
                 else
                 {
                     _outerLabel.classList.remove("tss-vertical");
                     _outerDiv.classList.remove("tss-slider-div-vertical");
-
-                    if (_fakeDiv is object)
-                    {
-                        _fakeDiv.style.height = "100%";
-                        UpdateFakeProgress();
-                    }
                     InnerElement.setAttribute("aria-orientation", "horizontal");
+                }
+
+                if (_fakeDiv is object)
+                {
+                    // WebKit/Chromium path: the fake fill overlay draws the track.
+                    // Re-project the current value onto the new axis (this also
+                    // clears the inline size on the axis the CSS now controls).
+                    UpdateFakeProgress();
+                }
+                else
+                {
+                    // Firefox native path: the constructor pins an inline height to
+                    // give the horizontal track its thickness. Clear it when going
+                    // vertical so the CSS class can size the native track, and
+                    // restore it when returning to horizontal.
+                    InnerElement.style.height = value == SliderOrientation.Vertical ? "" : "8px";
                 }
             }
         }


### PR DESCRIPTION
## Summary

Redesigned the vertical slider implementation to use CSS-positioned overlay divs for the track and fill, rather than relying on the native browser vertical slider appearance. This improves cross-browser consistency and simplifies the layout model.

## Key Changes

**CSS (`tss.slider.css`)**
- Reduced `.tss-slider-container.tss-vertical` width from 36px to 24px and changed from `inline-flex` to `inline-block`
- Repositioned the input element absolutely within the container with explicit dimensions and zero margins
- Added `.tss-slider.tss-fake` styling to keep the fake input transparent when disabled
- Refactored `.tss-slider-fake-background` and `.tss-slider-fake-progress` to use absolute positioning with explicit left/top/bottom values, removing the `height: 100%` hack
- Added explicit thumb dimensions (24px × 16px) for both WebKit and Firefox to create a horizontal pill shape across the vertical track
- Added `-moz-range-track` styling to control Firefox's native vertical track thickness
- Removed `padding-right: 8px` from `.tss-slider-div-vertical` (no longer needed with the new layout)

**C# (`Slider.cs`)**
- Enhanced `InputUpdated` event handler to sync the `aria-valuenow` attribute on every input change, keeping the exposed ARIA value in sync with the actual slider value
- Updated `UpdateFakeProgress()` to clear the opposite-axis inline style when updating the fill (e.g., clear `width` when setting `height` for vertical)
- Simplified the `Orientation` property setter: removed inline style assignments to the fake div and consolidated the logic to call `UpdateFakeProgress()` once for the WebKit path, which now handles clearing both axes
- Added Firefox-specific handling: clear the inline `height` style when switching to vertical (letting CSS control it), and restore it to "8px" when returning to horizontal

**Documentation (`slider.md`)**
- Added clarification that vertical sliders need an explicit height (or a parent with height) to avoid collapsing
- Updated example to show `.HS()` (height stretch) on the vertical slider and wrapped it in a `VStack` with explicit height for demonstration

## Implementation Details

- The vertical slider now uses a 24px-wide container with an 8px-wide track/fill centered via CSS (`left: 8px`), matching the horizontal design
- The fill grows upward from the bottom (via `bottom: 0` and `border-radius: 0px 0px 4px 4px`)
- The input element sits absolutely on top with only its thumb visible, rotated via `writing-mode: vertical-lr` and `direction: rtl` (WebKit/Chromium) or native vertical rendering (Firefox)
- Thumb dimensions are swapped (24px wide × 16px tall) to create a horizontal pill across the vertical track
- The refactoring eliminates the need for the old `36px` width and simplifies the flex layout model

https://claude.ai/code/session_01EBNJGkqig8h8vLCrBoA3Cc