### PR TITLE
Fix CodeDiff gutter misalignment in scroll containers (+ repro samples)

### DIFF
--- a/Tesserae.Tests/h5/assets/css/tss-samples.css
+++ b/Tesserae.Tests/h5/assets/css/tss-samples.css
@@ -6,3 +6,17 @@
 .flash-bg {
     animation: highlight 2s ease-out;
 }
+/* CodeDiffSample bug repro: let long diff lines wrap instead of scrolling
+   horizontally (what consumer apps do for prose-like diffs). With wrapping
+   enabled, the absolutely-positioned diff2html line-number cells stay one
+   line tall, so the gutter numbers/backgrounds drift out of alignment with
+   their (now multi-line) content rows. */
+.tss-codediff-wrap .d2h-code-line,
+.tss-codediff-wrap .d2h-code-side-line {
+    white-space: normal;
+}
+
+.tss-codediff-wrap .d2h-code-line-ctn {
+    white-space: pre-wrap;
+    word-break: break-word;
+}

--- a/Tesserae.Tests/src/Samples/Components/CodeDiffSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/CodeDiffSample.cs
@@ -46,41 +46,41 @@ index 1111111..2222222 100644
 ";
 
         // Repro for the misaligned side-by-side gutter bug: a diff whose lines are long
-        // prose sentences (much wider than the 50% pane), like the "guidance questions"
-        // and "similar dossier questions" content in the original report.
+        // prose sentences (much wider than the 50% pane), so they wrap when the
+        // tss-codediff-wrap class is applied.
         private const string LongProseDiff =
-@"diff --git a/guidance-questions.md b/guidance-questions.md
+@"diff --git a/lorem-notes.md b/lorem-notes.md
 index 3333333..4444444 100644
---- a/guidance-questions.md
-+++ b/guidance-questions.md
-@@ -1,10 +1,10 @@
- Is there a significant change (increase) in smell event occurrence rate after the last shop visit compared to before?
--Can you inspect the FWD and AFT cargo compartment areas close to the bleed ducts for any signs of oil residue or contamination?
-+Has an inspection of the FWD and AFT cargo compartment areas close to the bleed ducts been performed for any signs of oil residue?
- What cleaning process and products are applied to the cabin interior surfaces during the routine maintenance checks?
- Is the Aerotracer still being used on the aircraft?
--Was the Aerotracer connected via a piping to the air outlet, or placed freely in the cabin during the measurement flights?
-+Was the Aerotracer connected via piping to the air outlet, or placed freely in the cabin during the measurement flights?
--Could you please provide more information about the reported fume events during the climb phase on the affected aircraft?
-+Following the oil smell event: were any mitigations applied after the reported fume events during the climb phase on the affected aircraft?
- In-flight turn-back due to dirty socks smell in cockpit and cabin after thrust reduction during climb. Investigation revealed a massive APU oil leak caused by a defective O-ring at the Fuel/Oil connector, leading to oil contamination of bleed air ducts and both air conditioning packs.
--When was the last wet or dry crank performed on the engines prior to the oil smell event on the 27th of April?
-+When was the last wet or dry crank performed on the engines prior to the oil smell event reported on the 27th of April?
-diff --git a/extracted-questions.md b/sanitized-questions.md
+--- a/lorem-notes.md
++++ b/lorem-notes.md
+@@ -1,8 +1,8 @@
+ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+-Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat in voluptate velit?
++Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat?
+ Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur excepteur sint occaecat.
+ Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+-Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam eaque ipsa?
++Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam?
+-Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione?
++Nemo enim ipsam voluptatem quia voluptas sit magni dolores aspernatur aut odit aut fugit, sed quia consequuntur eos qui ratione?
+ At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate non provident, similique sunt in culpa qui officia deserunt mollitia animi, id est laborum et dolorum fuga.
+-Temporibus autem quibusdam et aut officiis debitis aut rerum necessitatibus saepe eveniet ut et voluptates repudiandae sint?
++Temporibus autem quibusdam et aut officiis debitis aut rerum necessitatibus saepe eveniet ut et voluptates repudiandae sint et molestiae?
+diff --git a/draft-notes.md b/final-notes.md
 similarity index 55%
-rename from extracted-questions.md
-rename to sanitized-questions.md
+rename from draft-notes.md
+rename to final-notes.md
 index 5555555..6666666 100644
---- a/extracted-questions.md
-+++ b/sanitized-questions.md
+--- a/draft-notes.md
++++ b/final-notes.md
 @@ -1,5 +1,5 @@
- What are the APU P/N, S/N, TSLSV (Time Since Last Shop Visit) and the total operating hours accumulated by the unit since new?
--Can you confirm the root cause of the odour was the replaced Oil seal, and can you please share the findings of the workshop report with us as soon as it becomes available?
-+Can you confirm the root cause of the odour was the replaced Oil seal, and share the findings of the workshop report as soon as it becomes available?
- Following the oil traces found in the ENG1 exhaust after a 5-minute idle run, what additional inspections were carried out on the engine before it was released back into service?
--Was the APU bleed used during take-off and climb for the mid-April rotation, and if so at which altitude was it switched off by the crew?
-+Was the APU bleed used during take-off and climb for the mid-April rotation, and if so at which altitude was it switched off?
- When was the last borescope inspection of the LPT module completed, and were any anomalies documented in the inspection report at that time?
+ Nam libero tempore, cum soluta nobis est eligendi optio cumque nihil impedit quo minus id quod maxime placeat facere possimus.
+-Omnis voluptas assumenda est, omnis dolor repellendus, et harum quidem rerum facilis est et expedita distinctio nam libero?
++Omnis voluptas assumenda est, omnis dolor repellendus, et harum quidem rerum facilis est et expedita distinctio?
+ Itaque earum rerum hic tenetur a sapiente delectus, ut aut reiciendis voluptatibus maiores alias consequatur aut perferendis.
+-Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur vel illum qui dolorem?
++Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur?
+ Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi.
 ";
 
         public CodeDiffSample()

--- a/Tesserae.Tests/src/Samples/Components/CodeDiffSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/CodeDiffSample.cs
@@ -139,11 +139,9 @@ index 5555555..6666666 100644
             var multiC = CodeDiff(LongProseDiff, CodeDiff.Format.LineByLine).WS().MT(8);
             multiC.Id("code-diff-multi-c");
 
-            // Line-by-line diff inside a fixed-height scroll container. The diff2html
-            // line-number cells are position:absolute, so their containing block is the
-            // nearest *positioned* ancestor - here the Card (position:relative), which is
-            // OUTSIDE the scroll container. Scrolling the container moves the in-flow
-            // content but not the absolutely-positioned gutter cells.
+            // Line-by-line diff inside a fixed-height scroll container. diff2html's
+            // line-number cells are position:absolute; .tss-codediff is position:relative
+            // (tss.codediff.css) so they stay attached to their rows while scrolling.
             var scrolledDiff = CodeDiff(LongProseDiff, CodeDiff.Format.LineByLine).WS();
             scrolledDiff.Id("code-diff-scrolled");
 
@@ -197,9 +195,9 @@ index 5555555..6666666 100644
                     )).SetTitle("Bug repro: multiple diff views on the same page")))
                .FlatSection(VStack().Children(
                     Card(VStack().WS().Children(
-                        TextBlock("Repro: line-by-line diff inside a fixed-height scrollable container (320px, overflow-y auto). The absolutely-positioned line-number cells resolve their containing block to the nearest positioned ancestor - the Card, which is outside the scroll container - so scrolling moves the diff content but leaves the gutter numbers behind. Scroll inside the box below and watch the numbers detach from their rows."),
+                        TextBlock("Regression check: line-by-line diff inside a fixed-height scrollable container (320px, overflow-y auto). diff2html's line-number cells are absolutely positioned, so without a positioned ancestor inside the scroller they would stay frozen (and escape the clip) while the content scrolls. Tesserae fixes this by making the CodeDiff root position:relative (tss.codediff.css) - scroll inside the box below and the gutter must move with its rows."),
                         Raw(scrollHost)
-                    )).SetTitle("Bug repro: line-by-line diff inside a scroll container")));
+                    )).SetTitle("Line-by-line diff inside a scroll container")));
         }
 
         public HTMLElement Render() => _content.Render();

--- a/Tesserae.Tests/src/Samples/Components/CodeDiffSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/CodeDiffSample.cs
@@ -45,6 +45,44 @@ index 1111111..2222222 100644
 +Or try it out: `node sample.js Tesserae`
 ";
 
+        // Repro for the misaligned side-by-side gutter bug: a diff whose lines are long
+        // prose sentences (much wider than the 50% pane), like the "guidance questions"
+        // and "similar dossier questions" content in the original report.
+        private const string LongProseDiff =
+@"diff --git a/guidance-questions.md b/guidance-questions.md
+index 3333333..4444444 100644
+--- a/guidance-questions.md
++++ b/guidance-questions.md
+@@ -1,10 +1,10 @@
+ Is there a significant change (increase) in smell event occurrence rate after the last shop visit compared to before?
+-Can you inspect the FWD and AFT cargo compartment areas close to the bleed ducts for any signs of oil residue or contamination?
++Has an inspection of the FWD and AFT cargo compartment areas close to the bleed ducts been performed for any signs of oil residue?
+ What cleaning process and products are applied to the cabin interior surfaces during the routine maintenance checks?
+ Is the Aerotracer still being used on the aircraft?
+-Was the Aerotracer connected via a piping to the air outlet, or placed freely in the cabin during the measurement flights?
++Was the Aerotracer connected via piping to the air outlet, or placed freely in the cabin during the measurement flights?
+-Could you please provide more information about the reported fume events during the climb phase on the affected aircraft?
++Following the oil smell event: were any mitigations applied after the reported fume events during the climb phase on the affected aircraft?
+ In-flight turn-back due to dirty socks smell in cockpit and cabin after thrust reduction during climb. Investigation revealed a massive APU oil leak caused by a defective O-ring at the Fuel/Oil connector, leading to oil contamination of bleed air ducts and both air conditioning packs.
+-When was the last wet or dry crank performed on the engines prior to the oil smell event on the 27th of April?
++When was the last wet or dry crank performed on the engines prior to the oil smell event reported on the 27th of April?
+diff --git a/extracted-questions.md b/sanitized-questions.md
+similarity index 55%
+rename from extracted-questions.md
+rename to sanitized-questions.md
+index 5555555..6666666 100644
+--- a/extracted-questions.md
++++ b/sanitized-questions.md
+@@ -1,5 +1,5 @@
+ What are the APU P/N, S/N, TSLSV (Time Since Last Shop Visit) and the total operating hours accumulated by the unit since new?
+-Can you confirm the root cause of the odour was the replaced Oil seal, and can you please share the findings of the workshop report with us as soon as it becomes available?
++Can you confirm the root cause of the odour was the replaced Oil seal, and share the findings of the workshop report as soon as it becomes available?
+ Following the oil traces found in the ENG1 exhaust after a 5-minute idle run, what additional inspections were carried out on the engine before it was released back into service?
+-Was the APU bleed used during take-off and climb for the mid-April rotation, and if so at which altitude was it switched off by the crew?
++Was the APU bleed used during take-off and climb for the mid-April rotation, and if so at which altitude was it switched off?
+ When was the last borescope inspection of the LPT module completed, and were any anomalies documented in the inspection report at that time?
+";
+
         public CodeDiffSample()
         {
             var diff = CodeDiff(SampleDiff).WS();
@@ -81,6 +119,40 @@ index 1111111..2222222 100644
             var fileListToggle = Toggle("Show file list").Checked(false)
                 .OnChange((s, _) => diff.DrawFileList = s.IsChecked);
 
+            var longProseDiff = CodeDiff(LongProseDiff, CodeDiff.Format.SideBySide).WS().MT(8);
+            longProseDiff.Id("code-diff-long-prose").Class("tss-codediff-wrap");
+
+            var wrapToggle = Toggle("Wrap long lines (triggers the bug)").Checked(true)
+                .OnChange((s, _) =>
+                {
+                    if (s.IsChecked) longProseDiff.Class("tss-codediff-wrap");
+                    else longProseDiff.RemoveClass("tss-codediff-wrap");
+                });
+
+            // Several CodeDiff instances on one page, including two rendering the *same*
+            // diff text: diff2html derives element ids from the file names, so multiple
+            // views of the same files produce duplicate DOM ids on the page.
+            var multiA = CodeDiff(LongProseDiff, CodeDiff.Format.SideBySide).WS().MT(8);
+            multiA.Id("code-diff-multi-a");
+            var multiB = CodeDiff(LongProseDiff, CodeDiff.Format.SideBySide).WS().MT(8);
+            multiB.Id("code-diff-multi-b");
+            var multiC = CodeDiff(LongProseDiff, CodeDiff.Format.LineByLine).WS().MT(8);
+            multiC.Id("code-diff-multi-c");
+
+            // Line-by-line diff inside a fixed-height scroll container. The diff2html
+            // line-number cells are position:absolute, so their containing block is the
+            // nearest *positioned* ancestor - here the Card (position:relative), which is
+            // OUTSIDE the scroll container. Scrolling the container moves the in-flow
+            // content but not the absolutely-positioned gutter cells.
+            var scrolledDiff = CodeDiff(LongProseDiff, CodeDiff.Format.LineByLine).WS();
+            scrolledDiff.Id("code-diff-scrolled");
+
+            var scrollHost = Div(_("code-diff-scroll-host"));
+            scrollHost.style.height    = "320px";
+            scrollHost.style.overflowY = "auto";
+            scrollHost.style.marginTop = "8px";
+            scrollHost.appendChild(scrolledDiff.Render());
+
             _content = SectionStack().Secondary()
                .SampleTitle(typeof(CodeDiffSample), UIcons.CodeCompare, "Render unified diffs with diff2html")
                .FlatSection(VStack().Children(
@@ -106,7 +178,28 @@ index 1111111..2222222 100644
                             VStack().Grow().PL(8).Children(
                                 SampleSubTitle("Rendered output"),
                                 diff))
-                    )).SetTitle("Usage")));
+                    )).SetTitle("Usage")))
+               .FlatSection(VStack().Children(
+                    Card(VStack().WS().Children(
+                        TextBlock("Repro: side-by-side diff of long prose lines, with line wrapping enabled (the tss-codediff-wrap class in tss-samples.css). diff2html positions the line-number cells absolutely and assumes every row is exactly one text line tall, so once lines wrap, the gutter numbers and their red/green backgrounds drift out of alignment with the content rows."),
+                        wrapToggle.MT(8),
+                        longProseDiff
+                    )).SetTitle("Bug repro: wrapped long lines misalign the gutter (side-by-side)")))
+               .FlatSection(VStack().Children(
+                    Card(VStack().WS().Children(
+                        TextBlock("Repro: several CodeDiff instances on the same page, two of them rendering the same diff text (side-by-side) plus one line-by-line view. diff2html derives element ids from the file names, so multiple views of the same files create duplicate DOM ids - check whether the gutters of these instances stay aligned with their content rows (no wrap class applied here)."),
+                        SampleSubTitle("Instance A (side-by-side)"),
+                        multiA,
+                        SampleSubTitle("Instance B (same diff, side-by-side)"),
+                        multiB,
+                        SampleSubTitle("Instance C (same diff, line-by-line)"),
+                        multiC
+                    )).SetTitle("Bug repro: multiple diff views on the same page")))
+               .FlatSection(VStack().Children(
+                    Card(VStack().WS().Children(
+                        TextBlock("Repro: line-by-line diff inside a fixed-height scrollable container (320px, overflow-y auto). The absolutely-positioned line-number cells resolve their containing block to the nearest positioned ancestor - the Card, which is outside the scroll container - so scrolling moves the diff content but leaves the gutter numbers behind. Scroll inside the box below and watch the numbers detach from their rows."),
+                        Raw(scrollHost)
+                    )).SetTitle("Bug repro: line-by-line diff inside a scroll container")));
         }
 
         public HTMLElement Render() => _content.Render();

--- a/Tesserae/h5.json
+++ b/Tesserae/h5.json
@@ -172,7 +172,8 @@
                 "h5/assets/css/tss.notificationcenter.css",
                 "h5/assets/css/tss.markdown.css",
                 "h5/assets/css/tss.plan.css",
-                "h5/assets/css/diff2html.min.css"
+                "h5/assets/css/diff2html.min.css",
+                "h5/assets/css/tss.codediff.css"
             ],
             "output": "assets/css"
         },

--- a/Tesserae/h5/assets/css/tss.codediff.css
+++ b/Tesserae/h5/assets/css/tss.codediff.css
@@ -1,0 +1,12 @@
+/* diff2html gives the line-number cells (.d2h-code-linenumber /
+   .d2h-code-side-linenumber) position:absolute, so they position and clip
+   against the nearest positioned ancestor. Without this rule that ancestor can
+   be outside a scroll container wrapping the diff (e.g. a Card), in which case
+   scrolling moves the diff content but leaves the gutter numbers frozen, and
+   the scroller's overflow clip doesn't apply to them. Making the component
+   root the containing block keeps the gutter attached to the content anywhere
+   the diff is placed. The cells use their static position (no top/left), so
+   this changes nothing when the diff isn't inside a scroller. */
+.tss-codediff {
+    position: relative;
+}


### PR DESCRIPTION
## What

1. **Fix**: CodeDiff's line-number gutter detached from the diff content when the component sat inside a scroll container — scrolling moved the content but left the numbers frozen, painting them over the wrong rows and other UI (the reported bug screenshot).
2. **Repro/regression sections** in the CodeDiff sample that were used to isolate the cause.

## The fix

diff2html gives the line-number cells (`.d2h-code-linenumber` / `.d2h-code-side-linenumber`) `position: absolute`, so they position **and clip** against the nearest positioned ancestor. If nothing inside the scroll container is positioned (e.g. the diff sits directly in a Card, which is `position: relative`), that ancestor is *outside* the scroller — the gutter neither scrolls nor clips with the content.

New `Tesserae/h5/assets/css/tss.codediff.css` (bundled after `diff2html.min.css`):

```css
.tss-codediff { position: relative; }
```

The cells use their static position (no top/left), so this changes nothing outside scrollers.

**Verified** in the sample's scroll-container section: scrolling the 320px host previously moved content 120px and the gutter 0px; now both move 120px, 0 misaligned rows while scrolled, gutter clipped correctly at the box edges. Other sample sections unchanged.

## Sample sections (CodeDiffSample)

| Section | Result |
|---|---|
| **Line-by-line diff inside a scroll container** | Was the reported bug; now a regression check — gutter must move with its rows. |
| **Wrapped long lines (side-by-side)** | Still reproduces (26/30 rows misalign with the `tss-codediff-wrap` sample class): the absolute gutter cells stay one text line tall while wrapped rows grow. **Separate issue, not fixed here.** |
| **Multiple diff views on one page** | No misalignment; documents that two views of the same diff produce duplicate DOM ids (diff2html derives ids from file names). |

🤖 Generated with [Claude Code](https://claude.com/claude-code)