### PR TITLE
Add elapsed time display to OmniBox generating state

### DIFF
--- a/Tesserae/skills/references/omni-box.md
+++ b/Tesserae/skills/references/omni-box.md
@@ -22,10 +22,12 @@ Config (set via object initializer):
 - `PlaceholderSearch` / `PlaceholderChat`, `ExpandOnFocus`, `TokenIgnoreCase`.
 - `SuggestionsFetcher = async input => OmniBoxSuggestionItem[]` — autocomplete source.
 - `IconSearch` / `IconChat` / `IconStop`, `SearchFooter` / `ChatFooter` (`FooterItems`).
+- `GeneratingText` — label shown in the footer while generating (default `"Generating"`); the live elapsed time is appended, e.g. `"Generating, 1m 25s"`.
 
 OmniBox:
 - `.OnSearch((sender, SearchQuery) => ...)` — fires on search; `query.Tokens` hold the parsed tokens.
 - `.OnChat((sender, ChatMessage) => ...)`, `.OnStop(...)`, `.OnModelChanged(...)`.
+- `.IsGenerating` (bool) — toggles the footer spinner + elapsed-time indicator and swaps the send button for a stop button. `.GeneratingText` (string) — read/write the indicator label; setting it updates the footer live.
 - `.SearchText` / `.ChatText` / `.SetSearchText(string)` — read/write input text.
 - `.RegisterSnap(SnapHandler)` / `.RegisterFilterSnap(FilterSnapHandler)` — turn recognized input into inline filter chips (search modes only).
 - `.WithHistory(Func<Task<SearchQuery[]>>)` — enable the history button.

--- a/Tesserae/src/Components/OmniBox.cs
+++ b/Tesserae/src/Components/OmniBox.cs
@@ -406,6 +406,7 @@ namespace Tesserae
                 TooltipModeToggleChat = "Chat";
                 ExpandOnFocus = false;
                 TokenIgnoreCase = false;
+                GeneratingText = "Generating";
             }
 
             /// <summary>
@@ -461,6 +462,11 @@ namespace Tesserae
             /// Gets or sets the token ignore case.
             /// </summary>
             public bool TokenIgnoreCase { get; set; }
+            /// <summary>
+            /// Gets or sets the label shown next to the spinner while generating (defaults to "Generating").
+            /// The elapsed time is appended after it, e.g. "Generating, 1m 25s".
+            /// </summary>
+            public string GeneratingText { get; set; }
 
             /// <summary>
             /// Gets or sets the chat footer.
@@ -601,6 +607,7 @@ namespace Tesserae
         private HTMLElement _generatingText;
         private double _generatingTimer = 0;
         private double _generatingStartMs = 0;
+        private string _generatingLabel;
 
         public delegate void SearchEventHandler(OmniBox sender, SearchQuery query);
         public delegate void ChatEventHandler(OmniBox sender, ChatMessage query);
@@ -648,6 +655,7 @@ namespace Tesserae
             _tokenIgnoreCase = config.TokenIgnoreCase;
             _iconChat = config.IconChat;
             _iconStop = config.IconStop;
+            _generatingLabel = config.GeneratingText ?? "Generating";
             _suggestionsFetcher = config.SuggestionsFetcher;
 
             _activeMode = new SettableObservable<Mode>(config.InitialMode);
@@ -1043,7 +1051,7 @@ namespace Tesserae
                 }
             }
 
-            _generatingText = TextBlock("Generating").Render();
+            _generatingText = TextBlock(_generatingLabel).Render();
 
             var generatingContainer = Div(Att("tss-omnibox-generating-container"), Spinner().CustomColor(Theme.Colors.Purple500).Small().Render(), _generatingText);
 
@@ -2476,6 +2484,28 @@ namespace Tesserae
             }
         }
 
+        /// <summary>
+        /// Gets or sets the label shown next to the spinner while generating (defaults to "Generating").
+        /// The elapsed time is appended after it, e.g. "Generating, 1m 25s". Setting it updates the
+        /// footer immediately when a generation is in progress.
+        /// </summary>
+        public string GeneratingText
+        {
+            get => _generatingLabel;
+            set
+            {
+                _generatingLabel = value ?? string.Empty;
+                if (_isGenerating)
+                {
+                    UpdateGeneratingText();
+                }
+                else if (_generatingText != null)
+                {
+                    _generatingText.innerText = _generatingLabel;
+                }
+            }
+        }
+
         private void StartGeneratingTimer()
         {
             window.clearInterval(_generatingTimer);
@@ -2498,7 +2528,9 @@ namespace Tesserae
 
             var elapsedSeconds = (int)Math.Floor((Transpose.Core.es5.Date.now() - _generatingStartMs) / 1000);
 
-            _generatingText.innerText = "Generating, " + FormatElapsed(elapsedSeconds);
+            _generatingText.innerText = string.IsNullOrEmpty(_generatingLabel)
+                ? FormatElapsed(elapsedSeconds)
+                : _generatingLabel + ", " + FormatElapsed(elapsedSeconds);
         }
 
         private static string FormatElapsed(int totalSeconds)

--- a/Tesserae/src/Components/OmniBox.cs
+++ b/Tesserae/src/Components/OmniBox.cs
@@ -598,6 +598,9 @@ namespace Tesserae
         private bool _isGenerating = false;
         private readonly UIcons _iconChat;
         private readonly UIcons _iconStop;
+        private HTMLElement _generatingText;
+        private double _generatingTimer = 0;
+        private double _generatingStartMs = 0;
 
         public delegate void SearchEventHandler(OmniBox sender, SearchQuery query);
         public delegate void ChatEventHandler(OmniBox sender, ChatMessage query);
@@ -1040,7 +1043,9 @@ namespace Tesserae
                 }
             }
 
-            var generatingContainer = Div(Att("tss-omnibox-generating-container"), Spinner().CustomColor(Theme.Colors.Purple500).Small().Render(), TextBlock("Generating...").Render());
+            _generatingText = TextBlock("Generating").Render();
+
+            var generatingContainer = Div(Att("tss-omnibox-generating-container"), Spinner().CustomColor(Theme.Colors.Purple500).Small().Render(), _generatingText);
 
             _footer.appendChild(generatingContainer);
 
@@ -2459,7 +2464,55 @@ namespace Tesserae
                         _container.classList.remove("tss-omnibox-generating");
                     }
                 }
+
+                if (value)
+                {
+                    StartGeneratingTimer();
+                }
+                else
+                {
+                    StopGeneratingTimer();
+                }
             }
+        }
+
+        private void StartGeneratingTimer()
+        {
+            window.clearInterval(_generatingTimer);
+            _generatingStartMs = Transpose.Core.es5.Date.now();
+
+            UpdateGeneratingText();
+
+            _generatingTimer = window.setInterval(_ => UpdateGeneratingText(), 1000);
+        }
+
+        private void StopGeneratingTimer()
+        {
+            window.clearInterval(_generatingTimer);
+            _generatingTimer = 0;
+        }
+
+        private void UpdateGeneratingText()
+        {
+            if (_generatingText is null) return;
+
+            var elapsedSeconds = (int)Math.Floor((Transpose.Core.es5.Date.now() - _generatingStartMs) / 1000);
+
+            _generatingText.innerText = "Generating, " + FormatElapsed(elapsedSeconds);
+        }
+
+        private static string FormatElapsed(int totalSeconds)
+        {
+            if (totalSeconds < 0) totalSeconds = 0;
+
+            var hours   = totalSeconds / 3600;
+            var minutes = (totalSeconds % 3600) / 60;
+            var seconds = totalSeconds % 60;
+
+            if (hours > 0) return $"{hours}h {minutes}m {seconds}s";
+            if (minutes > 0) return $"{minutes}m {seconds}s";
+
+            return $"{seconds}s";
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
Enhanced the OmniBox generating indicator to display elapsed time while content is being generated, improving user feedback during long-running operations.

## Changes
- Added three private fields to track generating state: `_generatingText` (HTMLElement reference), `_generatingTimer` (interval ID), and `_generatingStartMs` (start timestamp)
- Modified the `IsGenerating` property setter to start/stop a timer when generation begins/ends
- Implemented `StartGeneratingTimer()` to initialize the timer and begin updating the display every second
- Implemented `StopGeneratingTimer()` to clean up the interval when generation completes
- Added `UpdateGeneratingText()` to calculate and display elapsed time in the generating indicator
- Added `FormatElapsed()` helper method to format elapsed seconds as human-readable time (e.g., "1m 23s", "2h 5m 30s")

## Implementation Details
- The elapsed time display updates every 1000ms while generating
- Time format adapts based on duration: shows seconds only for < 1 minute, minutes+seconds for < 1 hour, and hours+minutes+seconds for longer durations
- Uses `Transpose.Core.es5.Date.now()` for cross-platform timestamp compatibility
- Properly cleans up intervals to prevent memory leaks when generation stops

https://claude.ai/code/session_01RJKeiXAyqMaLtm91D67A9s