### PR TITLE
Update Transpose packages to latest versions

### DIFF
--- a/Tesserae.Tests/Tesserae.Tests.csproj
+++ b/Tesserae.Tests/Tesserae.Tests.csproj
@@ -4,8 +4,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Transpose.BCL" Version="26.7.2790" />
-    <PackageReference Include="Transpose.Core" Version="26.7.2771" />
+    <PackageReference Include="Transpose.BCL" Version="26.7.2868" />
+    <PackageReference Include="Transpose.Core" Version="26.7.2862" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tesserae/Tesserae.csproj
+++ b/Tesserae/Tesserae.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Transpose.BCL" Version="26.7.2790" />
-    <PackageReference Include="Transpose.Core" Version="26.7.2771" />
-    <PackageReference Include="Transpose.Newtonsoft.Json" Version="26.7.2772" />
+    <PackageReference Include="Transpose.BCL" Version="26.7.2868" />
+    <PackageReference Include="Transpose.Core" Version="26.7.2862" />
+    <PackageReference Include="Transpose.Newtonsoft.Json" Version="26.7.2866" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
## Summary

Updates the `Transpose.*` NuGet package references to their latest published versions.

| Package | Before | After |
| --- | --- | --- |
| Transpose.BCL | 26.7.2790 | 26.7.2868 |
| Transpose.Core | 26.7.2771 | 26.7.2862 |
| Transpose.Newtonsoft.Json | 26.7.2772 | 26.7.2866 |

The `Transpose.Build.Target` SDK (26.7.2692) is already at the latest published version, so it is left unchanged.

## Verification

- `dotnet build` succeeds with the updated packages (Transpose compilation completes and emits `app.js` for `Tesserae.Tests`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015UZiTWmGnrJSootHvNKC95)_