### PR TITLE
Update Transpose packages to latest versions

### DIFF
--- a/Tesserae.Tests/Tesserae.Tests.csproj
+++ b/Tesserae.Tests/Tesserae.Tests.csproj
@@ -4,8 +4,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Transpose.BCL" Version="26.7.2868" />
-    <PackageReference Include="Transpose.Core" Version="26.7.2862" />
+    <PackageReference Include="Transpose.BCL" Version="26.7.2882" />
+    <PackageReference Include="Transpose.Core" Version="26.7.2871" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tesserae/Tesserae.csproj
+++ b/Tesserae/Tesserae.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Transpose.BCL" Version="26.7.2868" />
-    <PackageReference Include="Transpose.Core" Version="26.7.2862" />
-    <PackageReference Include="Transpose.Newtonsoft.Json" Version="26.7.2866" />
+    <PackageReference Include="Transpose.BCL" Version="26.7.2882" />
+    <PackageReference Include="Transpose.Core" Version="26.7.2871" />
+    <PackageReference Include="Transpose.Newtonsoft.Json" Version="26.7.2881" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
## Summary
- Bump `Transpose.BCL` 26.7.2868 → 26.7.2882
- Bump `Transpose.Core` 26.7.2862 → 26.7.2871
- Bump `Transpose.Newtonsoft.Json` 26.7.2866 → 26.7.2881

Applied to `Tesserae/Tesserae.csproj` and `Tesserae.Tests/Tesserae.Tests.csproj`. No other package references were out of date.

## Test plan
- [ ] Not built/tested per request — versions were verified against the latest available on NuGet.org

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AXWFiiNF7nmU7WjQDLqPpx)_