### PR TITLE
Add Pivot-style overflow mechanics to SegmentedPivot

### DIFF
--- a/Tesserae.Tests/src/Samples/Surfaces/SegmentedPivotSample.cs
+++ b/Tesserae.Tests/src/Samples/Surfaces/SegmentedPivotSample.cs
@@ -23,7 +23,18 @@ namespace Tesserae.Tests.Samples
                         .SegmentedPivot("tab1", SegmentTitle("Overview"),  () => CenteredWithBackground(Message("Overview Content")))
                         .SegmentedPivot("tab2", SegmentTitle("Logs"),      () => CenteredWithBackground(Message("Logs Content")))
                         .SegmentedPivot("tab3", SegmentTitle("Analytics"), () => CenteredWithBackground(Message("Analytics Content")))
-                        .SegmentedPivot("tab4", SegmentTitle("Firewall"),  () => CenteredWithBackground(Message("Firewall Content")))
+                        .SegmentedPivot("tab4", SegmentTitle("Firewall"),  () => CenteredWithBackground(Message("Firewall Content"))),
+                    SampleSubTitle("Tab Overflow"),
+                    SplitView().Resizable().WS().H(400).LeftIsSmaller(320.px()).Left(
+                        SegmentedPivot().S()
+                            .SegmentedPivot("s1", SegmentTitle("Overview"),   () => CenteredWithBackground(Message("Overview Content")))
+                            .SegmentedPivot("s2", SegmentTitle("Logs"),       () => CenteredWithBackground(Message("Logs Content")))
+                            .SegmentedPivot("s3", SegmentTitle("Analytics"),  () => CenteredWithBackground(Message("Analytics Content")))
+                            .SegmentedPivot("s4", SegmentTitle("Firewall"),   () => CenteredWithBackground(Message("Firewall Content")))
+                            .SegmentedPivot("s5", SegmentTitle("Alerts"),     () => CenteredWithBackground(Message("Alerts Content")))
+                            .SegmentedPivot("s6", SegmentTitle("Reports"),    () => CenteredWithBackground(Message("Reports Content")))
+                            .SegmentedPivot("s7", SegmentTitle("Settings"),   () => CenteredWithBackground(Message("Settings Content"))))
+                    .Right(TextBlock("👈 resize this area to squeeze the segmented control — use the chevrons or the mouse wheel to scroll the tab strip, and click the ⋯ button for an All Tabs menu").WS().BreakSpaces())
                )).SetTitle("Usage")));
         }
 

--- a/Tesserae/skills/references/segmented-pivot.md
+++ b/Tesserae/skills/references/segmented-pivot.md
@@ -1,12 +1,17 @@
 ---
 name: segmented-pivot
-description: A pivot styled as a connected segmented (pill) control for switching between a few closely related views. Use when toggling related views or filters in limited space in a Tesserae (C#/h5) app.
+description: A pivot styled as a connected segmented (pill) control for switching between a few closely related views, with horizontal scrolling and an overflow menu when the segments don't fit. Use when toggling related views or filters in limited space in a Tesserae (C#/h5) app.
 ---
 
 # SegmentedPivot
 
 A tabbed surface whose tabs render as a single connected segmented control.
 Best for a small number of closely related views or filters.
+
+When the segments are wider than the available space, the strip scrolls
+horizontally (mouse wheel or the chevron buttons that appear on each side) and
+an overflow (⋯) button lists every segment in a menu — the same overflow
+mechanics as `Pivot`.
 
 ## Create
 
@@ -20,6 +25,8 @@ Best for a small number of closely related views or filters.
 - `SegmentTitle("Text")` / `SegmentTitle("Text", UIcons.Rocket)` — convenient title `Func<IComponent>`.
 - `.Select(id, refresh = false)` — switch segment.
 - `.OnNavigate(...)` / `.OnBeforeNavigate(...)` — callbacks; `e.Cancel()` blocks navigation.
+- `.RefreshPivotSizes()` — re-evaluate the scroll/overflow controls after the container is resized in a way a `ResizeObserver` can't observe.
+- `.SelectedTab` — id of the current segment.
 
 ## Example
 

--- a/Tesserae/src/Base/Color.cs
+++ b/Tesserae/src/Base/Color.cs
@@ -227,7 +227,10 @@ namespace Tesserae
             if (hex.Length != 6) throw new ArgumentException();
 
 
-            Script.Write("var bigint = parseInt(hex, 16); var r = (bigint >> 16) & 255; var g = (bigint >> 8) & 255; var b = bigint & 255;");
+            // r, g and b are already declared as C# locals above; assign into them
+            // rather than redeclaring with `var` (a redeclaration that only happened
+            // to work while the transpiler emitted `var` for the locals).
+            Script.Write("var bigint = parseInt(hex, 16); r = (bigint >> 16) & 255; g = (bigint >> 8) & 255; b = bigint & 255;");
 
             return FromArgb(255, r, g, b);
 

--- a/Tesserae/src/Components/SegmentedPivot.cs
+++ b/Tesserae/src/Components/SegmentedPivot.cs
@@ -24,9 +24,20 @@ namespace Tesserae
 
         private readonly HTMLElement _renderedTabs;
         private readonly HTMLElement _renderedContent;
+        private readonly HTMLElement _scroller;
+        private readonly HTMLElement _titlebarWrapper;
 
-        private string _initiallySelectedID;
-        private string _currentSelectedID;
+        private readonly Button _moreBtn;
+        private readonly Button _scrollLeftBtn;
+        private readonly Button _scrollRightBtn;
+
+        private string         _initiallySelectedID;
+        private string         _currentSelectedID;
+        private bool           _isRendered = false;
+        private ResizeObserver _ro;
+
+        // Fraction of the scroller's visible width to move per scroll-button click.
+        private const double ScrollButtonStep = 0.7;
 
         /// <summary>
         /// Gets or sets the selected tab.
@@ -51,11 +62,24 @@ namespace Tesserae
         /// </summary>
         public SegmentedPivot()
         {
+            _scrollLeftBtn  = Button().SetIcon(UIcons.AngleLeft).NoMinSize().HS().NoPadding().NoMargin().Class("tss-segmentedpivot-titlebar-scroll-left").OnClick(() => ScrollByAmount(-_scroller.clientWidth * ScrollButtonStep));
+            _scrollRightBtn = Button().SetIcon(UIcons.AngleRight).NoMinSize().HS().NoPadding().NoMargin().Class("tss-segmentedpivot-titlebar-scroll-right").OnClick(() => ScrollByAmount(_scroller.clientWidth * ScrollButtonStep));
+            _moreBtn        = Button().SetIcon(UIcons.MenuDots).NoMinSize().HS().NoPadding().NoMargin().Class("tss-segmentedpivot-titlebar-more").OnClick(() => ShowAllTabs());
+
             _renderedTabs = Div(Att("tss-segmentedpivot-titlebar", role: "tablist"));
-            var wrapper = Div(Att("tss-segmentedpivot-wrapper"), _renderedTabs);
+            _scroller     = Div(Att("tss-segmentedpivot-titlebar-scroller"), _renderedTabs);
+
+            _titlebarWrapper = Div(Att("tss-segmentedpivot-titlebar-wrapper"),
+                _scrollLeftBtn.Render(),
+                _scroller,
+                _scrollRightBtn.Render(),
+                _moreBtn.Render());
+
             _renderedContent = Div(Att("tss-segmentedpivot-content", role: "tabpanel"));
 
-            StylingContainer = Div(Att("tss-segmentedpivot"), wrapper, _renderedContent);
+            StylingContainer = Div(Att("tss-segmentedpivot"), _titlebarWrapper, _renderedContent);
+
+            AttachScrollerEvents();
         }
 
         /// <summary>
@@ -76,6 +100,16 @@ namespace Tesserae
             return this;
         }
 
+        /// <summary>
+        /// Refreshes the pivot sizes, re-evaluating whether the scroll and overflow
+        /// controls should be visible. Useful after the pivot's container changes size
+        /// in a way a <see cref="ResizeObserver"/> can't observe.
+        /// </summary>
+        public void RefreshPivotSizes()
+        {
+            UpdateScrollState();
+        }
+
         internal SegmentedPivot Add(Tab tab)
         {
             if (_initiallySelectedID is null) _initiallySelectedID = tab.Id;
@@ -83,6 +117,7 @@ namespace Tesserae
 
             var titleContainer = Div(Att("tss-segmentedpivot-tab"));
             titleContainer.tabIndex = 0;
+            titleContainer.setAttribute("role", "tab");
 
             titleContainer.onkeydown = (e) =>
             {
@@ -122,6 +157,8 @@ namespace Tesserae
                 Select(_currentSelectedID, refresh: true);
             }
 
+            UpdateScrollState();
+
             return this;
         }
 
@@ -142,15 +179,20 @@ namespace Tesserae
 
                     _currentSelectedID = id;
 
+                    HTMLElement selectedTitle = null;
+
                     foreach (var kvp in _renderedTitles)
                     {
                         if (kvp.Key.Id == id)
                         {
                             kvp.Value.classList.add("tss-segmentedpivot-selected");
+                            kvp.Value.setAttribute("aria-selected", "true");
+                            selectedTitle = kvp.Value;
                         }
                         else
                         {
                             kvp.Value.classList.remove("tss-segmentedpivot-selected");
+                            kvp.Value.setAttribute("aria-selected", "false");
                         }
                     }
 
@@ -173,6 +215,8 @@ namespace Tesserae
 
                     _renderedContent.appendChild(content);
 
+                    if (selectedTitle is object) ScrollIntoView(selectedTitle);
+
                     _observable.Value = _currentSelectedID;
 
                     var pne = new PivotNavigateEvent(_currentSelectedID, id);
@@ -194,6 +238,84 @@ namespace Tesserae
         {
             if (string.IsNullOrEmpty(value)) return;
             Select(value);
+        }
+
+        private void AttachScrollerEvents()
+        {
+            // Convert vertical wheel motion (typical mouse) into horizontal scrolling.
+            // This listener calls preventDefault() so it must be non-passive; mark it
+            // explicitly so the browser doesn't have to guess.
+            _scroller.addEventListener("wheel", (Action<Event>)(e =>
+            {
+                var we = e.As<WheelEvent>();
+
+                if (Math.Abs(we.deltaY) > Math.Abs(we.deltaX))
+                {
+                    _scroller.scrollLeft += we.deltaY;
+                    e.preventDefault();
+                }
+            }), new AddEventListenerOptions { passive = false });
+
+            _scroller.addEventListener("scroll", e => UpdateScrollButtons());
+        }
+
+        private void ScrollByAmount(double dx)
+        {
+            _scroller.scrollLeft += dx;
+        }
+
+        private void UpdateScrollState()
+        {
+            if (!StylingContainer.IsMounted()) return;
+            UpdateScrollButtons();
+            UpdateMoreVisibility();
+        }
+
+        private void UpdateScrollButtons()
+        {
+            var canScrollLeft  = _scroller.scrollLeft > 0;
+            var canScrollRight = _scroller.scrollLeft + _scroller.clientWidth < _scroller.scrollWidth - 1; // -1 for sub-pixel rounding
+            _scrollLeftBtn.Render().style.display  = canScrollLeft ? "" : "none";
+            _scrollRightBtn.Render().style.display = canScrollRight ? "" : "none";
+        }
+
+        private void UpdateMoreVisibility()
+        {
+            _moreBtn.Render().style.display = _orderedTabs.Count > 0 ? "" : "none";
+        }
+
+        private void ShowAllTabs()
+        {
+            var items = new ContextMenu.Item[_orderedTabs.Count];
+
+            for (int i = 0; i < _orderedTabs.Count; i++)
+            {
+                var tab   = _orderedTabs[i];
+                var title = _renderedTitles[tab];
+                var clone = title.cloneNode(true).As<HTMLElement>();
+                clone.classList.remove("tss-segmentedpivot-selected");
+                var id = tab.Id;
+                items[i] = ContextMenuItem(Raw(clone)).OnClick(() => Select(id));
+            }
+            ContextMenu().Items(items).ShowFor(_moreBtn);
+        }
+
+        private void ScrollIntoView(HTMLElement target)
+        {
+            if (!_scroller.IsMounted()) return;
+            var tabLeft   = (double)target.offsetLeft;
+            var tabRight  = tabLeft + target.offsetWidth;
+            var viewLeft  = _scroller.scrollLeft;
+            var viewRight = viewLeft + _scroller.clientWidth;
+
+            if (tabLeft < viewLeft)
+            {
+                _scroller.scrollLeft = tabLeft;
+            }
+            else if (tabRight > viewRight)
+            {
+                _scroller.scrollLeft = tabRight - _scroller.clientWidth;
+            }
         }
 
         private void ClearChildrenExceptCached()
@@ -220,6 +342,25 @@ namespace Tesserae
             {
                 Select(_initiallySelectedID);
             }
+
+            if (!_isRendered)
+            {
+                _isRendered = true;
+
+                _ro = new ResizeObserver((entries, obs) => UpdateScrollState());
+                _ro.observe(StylingContainer);
+
+                DomObserver.WhenMounted(StylingContainer, () =>
+                {
+                    UpdateScrollState();
+
+                    // Also do on a timeout to account for animations on modals.
+                    window.setTimeout((_) => UpdateScrollState(), 1000);
+                });
+
+                DomObserver.WhenRemoved(StylingContainer, () => _ro.unobserve(StylingContainer));
+            }
+
             return StylingContainer;
         }
 

--- a/Tesserae/tps/assets/css/tss.segmentedpivot.css
+++ b/Tesserae/tps/assets/css/tss.segmentedpivot.css
@@ -13,6 +13,50 @@
     flex-shrink: 0;
 }
 
+/* Titlebar overflow controls — mirrors the mechanics of the normal Pivot: a
+   horizontally-scrollable strip flanked by chevron scroll buttons and an
+   overflow (⋯) menu that lists every tab. */
+.tss-segmentedpivot-titlebar-wrapper {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: nowrap;
+    flex-shrink: 0;
+    flex-grow: 0;
+    align-items: stretch;
+    margin-bottom: 16px;
+}
+
+.tss-segmentedpivot-titlebar-scroller {
+    position: relative;
+    /* Size to the pill's natural width and shrink when it overflows, but never
+       grow past its content so the segmented control stays left-aligned. */
+    flex: 0 1 auto;
+    min-width: 0; /* allow the scroller to shrink below its content size */
+    overflow-x: auto;
+    overflow-y: hidden;
+    scrollbar-width: none; /* Firefox: hide native scrollbar (scroll buttons handle it) */
+    -ms-overflow-style: none;
+    border-radius: var(--tss-border-radius-lg);
+}
+
+.tss-segmentedpivot-titlebar-scroller::-webkit-scrollbar {
+    display: none;
+}
+
+.tss-segmentedpivot-titlebar-more,
+.tss-segmentedpivot-titlebar-scroll-left,
+.tss-segmentedpivot-titlebar-scroll-right {
+    flex-shrink: 0;
+    flex-grow: 0;
+    align-self: center;
+    background: transparent;
+}
+
+.tss-segmentedpivot-titlebar-scroll-left i,
+.tss-segmentedpivot-titlebar-scroll-right i {
+    font-size: 10px;
+}
+
 .tss-segmentedpivot-titlebar {
     display: inline-flex;
     flex-direction: row;

--- a/Tesserae/tps/assets/css/tss.segmentedpivot.css
+++ b/Tesserae/tps/assets/css/tss.segmentedpivot.css
@@ -15,20 +15,40 @@
 
 /* Titlebar overflow controls — mirrors the mechanics of the normal Pivot: a
    horizontally-scrollable strip flanked by chevron scroll buttons and an
-   overflow (⋯) menu that lists every tab. */
+   overflow (⋯) menu that lists every tab. The segmented-control pill background
+   lives on this wrapper (not on the inner titlebar) so the chevrons and the ⋯
+   button sit inside the pill. */
 .tss-segmentedpivot-titlebar-wrapper {
-    display: flex;
+    display: inline-flex;
     flex-direction: row;
     flex-wrap: nowrap;
-    flex-shrink: 0;
-    flex-grow: 0;
     align-items: stretch;
+    /* Keep the control compact (sized to its content) instead of stretching to
+       the full column width, but never exceed the available width so the strip
+       can shrink and scroll when the segments overflow. */
+    align-self: flex-start;
+    max-width: 100%;
+    box-sizing: border-box;
     margin-bottom: 16px;
+    border-radius: var(--tss-border-radius-lg);
+    background: var(--tss-secondary-background-color);
+    padding: 4px;
+    box-shadow: inset 0px 2px 8px var(--tss-colors-dark-neutral-1000);
+}
+
+/* Inside the overflow wrapper the pill styling is on the wrapper, so the inner
+   titlebar is a plain transparent flex row. SidebarPivot uses the titlebar
+   directly (outside this wrapper) and keeps its own background. */
+.tss-segmentedpivot-titlebar-wrapper .tss-segmentedpivot-titlebar {
+    background: transparent;
+    box-shadow: none;
+    border-radius: 0;
+    padding: 0;
 }
 
 .tss-segmentedpivot-titlebar-scroller {
     position: relative;
-    /* Size to the pill's natural width and shrink when it overflows, but never
+    /* Size to the strip's natural width and shrink when it overflows, but never
        grow past its content so the segmented control stays left-aligned. */
     flex: 0 1 auto;
     min-width: 0; /* allow the scroller to shrink below its content size */
@@ -36,7 +56,6 @@
     overflow-y: hidden;
     scrollbar-width: none; /* Firefox: hide native scrollbar (scroll buttons handle it) */
     -ms-overflow-style: none;
-    border-radius: var(--tss-border-radius-lg);
 }
 
 .tss-segmentedpivot-titlebar-scroller::-webkit-scrollbar {


### PR DESCRIPTION
The segmented pivot previously let its tab strip overflow with only a bare
horizontal scrollbar. This brings it to parity with the normal Pivot:

- Wrap the pill titlebar in a scroller flanked by chevron scroll buttons and
  an overflow (⋯) button that lists every segment in a context menu.
- Convert vertical mouse-wheel motion into horizontal scrolling.
- Scroll the selected segment into view on Select, and re-evaluate the
  scroll/overflow controls via a ResizeObserver plus a public
  RefreshPivotSizes() escape hatch.

The chevron/more controls and scroller use new CSS classes
(tss-segmentedpivot-titlebar-wrapper / -scroller / -scroll-left / -scroll-right
/ -more); the shared .tss-segmentedpivot-wrapper and .tss-segmentedpivot-titlebar
rules are left untouched so SidebarPivot is unaffected.

Also extends the SegmentedPivot sample with a resizable Tab Overflow demo and
updates the tesserae skill reference.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XGyv7VSgjK3GCj4g86ABtm