### PR TITLE
Only show segmented pivot ⋯ button on overflow, and add its right margin

### DIFF
--- a/Tesserae/src/Components/SegmentedPivot.cs
+++ b/Tesserae/src/Components/SegmentedPivot.cs
@@ -281,7 +281,11 @@ namespace Tesserae
 
         private void UpdateMoreVisibility()
         {
-            _moreBtn.Render().style.display = _orderedTabs.Count > 0 ? "" : "none";
+            // Only surface the overflow (⋯) menu when segments are actually clipped,
+            // i.e. the strip content is wider than the visible scroller. Driven by the
+            // ResizeObserver so it re-evaluates whenever the available width changes.
+            var overflows = _scroller.scrollWidth > _scroller.clientWidth + 1; // +1 for sub-pixel rounding
+            _moreBtn.Render().style.display = (_orderedTabs.Count > 0 && overflows) ? "" : "none";
         }
 
         private void ShowAllTabs()

--- a/Tesserae/tps/assets/css/tss.segmentedpivot.css
+++ b/Tesserae/tps/assets/css/tss.segmentedpivot.css
@@ -71,6 +71,19 @@
     background: transparent;
 }
 
+/* Give the controls breathing room. The extra selectors (.tss-btn plus the
+   wrapper) raise specificity above .tss-btn.tss-btn-remove-padding /
+   -remove-margin, which the buttons carry from NoPadding()/NoMargin(). */
+.tss-segmentedpivot-titlebar-wrapper .tss-btn.tss-segmentedpivot-titlebar-more,
+.tss-segmentedpivot-titlebar-wrapper .tss-btn.tss-segmentedpivot-titlebar-scroll-left,
+.tss-segmentedpivot-titlebar-wrapper .tss-btn.tss-segmentedpivot-titlebar-scroll-right {
+    padding: 0 4px;
+}
+
+.tss-segmentedpivot-titlebar-wrapper .tss-btn.tss-segmentedpivot-titlebar-more {
+    margin-right: 6px;
+}
+
 .tss-segmentedpivot-titlebar-scroll-left i,
 .tss-segmentedpivot-titlebar-scroll-right i {
     font-size: 10px;


### PR DESCRIPTION
- The overflow (⋯) button now appears only when the tab strip is actually clipped (scrollWidth > clientWidth), evaluated via the existing ResizeObserver, instead of showing whenever any segment exists.
- Give the ⋯ button right margin (and the control buttons a little horizontal padding) so it isn't flush against the pill edge. The selectors are specific enough to override the .tss-btn-remove-margin / -remove-padding classes the buttons carry from NoMargin()/NoPadding().


Claude-Session: https://claude.ai/code/session_01XGyv7VSgjK3GCj4g86ABtm