### PR TITLE
Update Transpose.BCL package reference to latest published version

### DIFF
--- a/Tesserae.Tests/Tesserae.Tests.csproj
+++ b/Tesserae.Tests/Tesserae.Tests.csproj
@@ -4,7 +4,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Transpose.BCL" Version="26.7.2919" />
+    <PackageReference Include="Transpose.BCL" Version="26.7.2947" />
     <PackageReference Include="Transpose.Core" Version="26.7.2920" />
   </ItemGroup>
 

--- a/Tesserae/Tesserae.csproj
+++ b/Tesserae/Tesserae.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Transpose.BCL" Version="26.7.2919" />
+    <PackageReference Include="Transpose.BCL" Version="26.7.2947" />
     <PackageReference Include="Transpose.Core" Version="26.7.2920" />
     <PackageReference Include="Transpose.Newtonsoft.Json" Version="26.7.2921" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- Bump `Transpose.BCL` 26.7.2919 → 26.7.2947 in `Tesserae/Tesserae.csproj` and `Tesserae.Tests/Tesserae.Tests.csproj`
- `Transpose.Core` (26.7.2920) and `Transpose.Newtonsoft.Json` (26.7.2921) were already on their latest published versions

## Test plan
- [x] `dotnet restore Tesserae.sln` — bumped package version resolves cleanly
- [x] `dotnet build Tesserae.sln` — fails with a pre-existing `tps: not found` error (the `h5`/`tps` compiler isn't installed globally in this environment); unrelated to this change
- Not run per request: full test suite / playwright

---
_Generated by [Claude Code](https://claude.ai/code/session_01AnPnZexQJzr5LMoZjVZkh4)_