### PR TITLE
Preserve text when switching between Search and Chat modes

### DIFF
--- a/Tesserae/src/Components/OmniBox.cs
+++ b/Tesserae/src/Components/OmniBox.cs
@@ -1161,6 +1161,7 @@ namespace Tesserae
             {
                 case Mode.Search:
                 {
+                    TransferTextOnModeSwitch(Mode.Search);
                     _activeInput = _searchInput;
                     _container.classList.add("tss-omnibox-mode-search");
                     _container.classList.remove("tss-omnibox-mode-chat");
@@ -1168,6 +1169,7 @@ namespace Tesserae
                 }
                 case Mode.Chat:
                 {
+                    TransferTextOnModeSwitch(Mode.Chat);
                     _activeInput = _chatInput;
                     _container.classList.add("tss-omnibox-mode-chat");
                     _container.classList.remove("tss-omnibox-mode-search");
@@ -1176,6 +1178,30 @@ namespace Tesserae
                 case Mode.SearchAndChat:
                 {
                     throw new InvalidOperationException("Can't set active mode to mixed value");
+                }
+            }
+        }
+
+        // When toggling between search and chat, carry whatever text is sitting in the box being left
+        // over to the box being entered, so switching modes never silently discards what was typed.
+        private void TransferTextOnModeSwitch(Mode enteringMode)
+        {
+            if (_searchInput == null || _chatInput == null) return;
+
+            if (enteringMode == Mode.Chat)
+            {
+                var searchText = _searchInput.value;
+                if (!string.IsNullOrEmpty(searchText))
+                {
+                    ChatText = searchText.Replace(specialWhitespaceString, " ");
+                }
+            }
+            else if (enteringMode == Mode.Search)
+            {
+                var chatText = _chatInput.value;
+                if (!string.IsNullOrEmpty(chatText))
+                {
+                    SearchText = chatText;
                 }
             }
         }


### PR DESCRIPTION
## Summary

When users toggle between Search and Chat modes in the OmniBox component, any text they've typed is now preserved and transferred to the other input field, preventing accidental data loss during mode switches.

## Changes

- Added `TransferTextOnModeSwitch()` method to handle text preservation when switching modes
- Updated `UpdateMode()` to call `TransferTextOnModeSwitch()` before changing the active input for both Search and Chat modes
- When entering Chat mode, any text in the Search input is transferred (with whitespace normalization)
- When entering Search mode, any text in the Chat input is transferred as-is

## Implementation Details

The new `TransferTextOnModeSwitch()` method:
- Checks that both input fields are initialized before attempting transfer
- Only transfers non-empty text to avoid polluting empty inputs
- Applies `specialWhitespaceString` replacement when transferring from Search to Chat (normalizing whitespace)
- Transfers Chat text to Search without modification
- Uses the existing `ChatText` and `SearchText` properties to set values, ensuring any associated logic runs

https://claude.ai/code/session_017VfxZ6XmPDhRaMQaVFaJsf