### PR TITLE
Add ToolAgentSelector component with chat mention support

### DIFF
--- a/Tesserae.Tests/src/Samples/Components/OmniBoxSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/OmniBoxSample.cs
@@ -268,6 +268,70 @@ namespace Tesserae.Tests.Samples
                 Toast().Information($"Searched for: {q.RawQuery}{snapInfo}{filterInfo}");
             });
 
+            var toolAgentSelectorForSearch = ToolAgentSelector()
+                .Agents(
+                    ToolAgentSelectorItem("deep-researcher", "Deep Researcher", "Multi-step web research with citations", UIcons.Search).Selected(),
+                    ToolAgentSelectorItem("code-assistant", "Code Assistant", "Plans, writes and debugs code end to end", UIcons.FileCode),
+                    ToolAgentSelectorItem("data-analyst", "Data Analyst", "Explores data and builds charts", UIcons.ChartHistogram))
+                .Tools(
+                    ToolAgentSelectorItem("web-search", "Web Search", "Search the live web for fresh results", UIcons.Globe).Selected(),
+                    ToolAgentSelectorItem("code-interpreter", "Code Interpreter", "Run Python in a sandbox", UIcons.Terminal),
+                    ToolAgentSelectorItem("image-generation", "Image Generation", "Create images from a prompt", UIcons.Picture),
+                    ToolAgentSelectorItem("file-search", "File Search", "Search files in this workspace", UIcons.FolderOpen),
+                    ToolAgentSelectorItem("calculator", "Calculator", "Evaluate math expressions", UIcons.Calculator))
+                .Compact()
+                .OnChange(s => Toast().Information($"{s.SelectedCount} tool(s)/agent(s) enabled"));
+
+            var toolAgentSearchSample = OmniBox(new OmniBox.Config(OmniBox.Mode.Search)
+            {
+                PlaceholderSearch = "Search anything",
+                SearchFooter = new OmniBox.FooterItems { RightSide = new IComponent[] { toolAgentSelectorForSearch } }
+            })
+            .WS()
+            .OnSearch((s, q) => Toast().Information($"Searched for: {q.RawQuery}"));
+
+            var toolAgentSelectorForChat = ToolAgentSelector()
+                .Agents(
+                    ToolAgentSelectorItem("deep-researcher", "Deep Researcher", "Multi-step web research with citations", UIcons.Search),
+                    ToolAgentSelectorItem("code-assistant", "Code Assistant", "Plans, writes and debugs code end to end", UIcons.FileCode).Selected(),
+                    ToolAgentSelectorItem("data-analyst", "Data Analyst", "Explores data and builds charts", UIcons.ChartHistogram))
+                .Tools(
+                    ToolAgentSelectorItem("web-search", "Web Search", "Search the live web for fresh results", UIcons.Globe),
+                    ToolAgentSelectorItem("code-interpreter", "Code Interpreter", "Run Python in a sandbox", UIcons.Terminal).Selected(),
+                    ToolAgentSelectorItem("image-generation", "Image Generation", "Create images from a prompt", UIcons.Picture),
+                    ToolAgentSelectorItem("file-search", "File Search", "Search files in this workspace", UIcons.FolderOpen),
+                    ToolAgentSelectorItem("calculator", "Calculator", "Evaluate math expressions", UIcons.Calculator))
+                .OnChange(s => Toast().Information($"{s.SelectedCount} tool(s)/agent(s) enabled"));
+
+            var toolAgentChatSample = OmniBox(new OmniBox.Config(OmniBox.Mode.Chat)
+            {
+                PlaceholderChat = "Ask me anything — type @ to mention a tool or agent",
+                ChatFooter = new OmniBox.FooterItems { LeftSide = new IComponent[] { toolAgentSelectorForChat } }
+            })
+            .WS()
+            .OnChat((s, q) =>
+            {
+                s.IsGenerating = true;
+                window.setTimeout((_) =>
+                {
+                    if (s.IsGenerating)
+                    {
+                        s.IsGenerating = false;
+                        Toast().Information(q.Text);
+                    }
+                }, 5000);
+            })
+            .OnStop(s => s.IsGenerating = false)
+            .EnableChatMentions(new OmniBox.ChatMention
+            {
+                OnShow         = (x, y) => toolAgentSelectorForChat.ShowInlineAt(x, y),
+                OnQueryChanged = text    => toolAgentSelectorForChat.Filter(text),
+                OnMove         = dir     => toolAgentSelectorForChat.MoveHighlight(dir),
+                OnCommit       = ()      => toolAgentSelectorForChat.ActivateHighlighted(),
+                OnHide         = ()      => toolAgentSelectorForChat.Hide(),
+                IsOpen         = ()      => toolAgentSelectorForChat.IsVisible
+            });
+
             _content = SectionStack().Secondary()
                .SampleTitle(typeof(OmniBoxSample), UIcons.Search, "An omnibox search component")
                .FlatSection(VStack().Children(
@@ -288,7 +352,15 @@ namespace Tesserae.Tests.Samples
                     TextBlock("Type @ to insert a snap (e.g. @docs, @wiki, @code). Type 'ext:', 'filetype:', or 'lang:' to autocomplete filter values. Type 'modified:' (or 'date:' / 'between:') for a time-based filter snap — a date-range picker with shortcuts (last week, last month, last 90 days, last year), or type the range directly as yyyy-MM-dd:yyyy-MM-dd. When committed they become removable chips. All snap and filter selections are passed through with the search query.").MB(8),
                     TextBlock("Click the ? button on the left of the input to open the help panel — it lists the registered field filters (with their example values) and the registered snaps. It can also include a 'Query syntax' section describing AND / OR / NOT / parentheses / quotes when configured with WithHelp(showSyntax: true). Recent searches are reached via the separate history button enabled with WithHistory(...).").MB(8),
                     Label("Snaps + filter snaps + help").SetContent(snapAndFilterSample.Class("tss-omnibox-snap-and-filter-sample"))
-                )).SetTitle("Snaps & Filter Snaps")));
+                )).SetTitle("Snaps & Filter Snaps")))
+               .FlatSection(VStack().WS().Children(
+                    Card(VStack().WS().Children(
+                    SampleSubTitle("Tool / agent selector"),
+                    TextBlock("ToolAgentSelector is a Dropdown-style trigger button + searchable popup for enabling agents and tools, grouped into \"Agents\" and \"Tools\" sections with a leading icon, a title and an optional description per row. Selecting items shows a count badge on the trigger button, and .Compact() hides the descriptions for a denser list.").MB(8),
+                    Label("Search mode (trigger button, compact)").SetContent(toolAgentSearchSample).MB(6),
+                    TextBlock("In chat mode, the same selector also backs an inline \"@mention\" picker: type @ in the box below to open it anchored at the caret, keep typing to filter, use Arrow Up/Down to navigate, Enter/Tab to select, and Escape to close.").MT(6).MB(8),
+                    Label("Chat mode (trigger button + @ mentions)").SetContent(toolAgentChatSample)
+                )).SetTitle("Tools & Agents")));
         }
 
         private static string DescribeFilterSnap(OmniBox.FilterSnap f)

--- a/Tesserae/skills/SKILL.md
+++ b/Tesserae/skills/SKILL.md
@@ -167,7 +167,7 @@ virtualized-list
 **Surfaces** (overlays, tabs, panels)
 card-pivot · context-menu · dialog · float · horizontal-split-view · layer ·
 modal · panel · pivot · pivot-selector · progress-modal · section-stack ·
-segmented-pivot · split-view · tabbed-modal · tutorial-modal
+segmented-pivot · split-view · tabbed-modal · tool-agent-selector · tutorial-modal
 
 **Utilities** (non-visual helpers, theming, gestures)
 color-palette · command-palette · defer · defer-with-progress · emoji ·

--- a/Tesserae/skills/references/omni-box.md
+++ b/Tesserae/skills/references/omni-box.md
@@ -31,6 +31,13 @@ OmniBox:
 - `.SearchText` / `.ChatText` / `.SetSearchText(string)` — read/write input text.
 - `.RegisterSnap(SnapHandler)` / `.RegisterFilterSnap(FilterSnapHandler)` — turn recognized input into inline filter chips (search modes only).
 - `.WithHistory(Func<Task<SearchQuery[]>>)` — enable the history button.
+- `.EnableChatMentions(ChatMention)` — turns typing `@` at a word boundary in the chat input into an
+  "@mention" style picker (chat/search-and-chat modes only). `ChatMention` is a set of UI-agnostic
+  callbacks (`OnShow(x, y)`, `OnQueryChanged(text)`, `OnMove(direction)`, `OnCommit()`, `OnHide()`,
+  `IsOpen()`) — wire them up to any anchored popup, e.g. a `ToolAgentSelector`'s
+  `ShowInlineAt`/`Filter`/`MoveHighlight`/`ActivateHighlighted`/`Hide`/`IsVisible` (see
+  `tool-agent-selector.md`). Arrow Up/Down, Enter/Tab and Escape are forwarded to the callbacks
+  while the picker is open; a `true` return from `OnCommit` removes the typed `@mention` text.
 - `.Focus()`.
 - `OmniBox.ParseQuery(string, bool tokenIgnoreCase = false)` — static parser returning a `SearchQuery`.
 
@@ -59,4 +66,5 @@ var omni = new OmniBox(config)
 
 - TextBox — `/tesserae/components/text-box`
 - SearchBox — `/tesserae/components/search-box`
+- ToolAgentSelector — the tool/agent picker `EnableChatMentions` is commonly wired to — `tool-agent-selector.md`
 - Full docs & API: `/tesserae/components/omni-box`

--- a/Tesserae/skills/references/tool-agent-selector.md
+++ b/Tesserae/skills/references/tool-agent-selector.md
@@ -1,0 +1,79 @@
+---
+name: tool-agent-selector
+description: A Dropdown-style trigger button + searchable popup for enabling agents and tools, grouped into "Agents" and "Tools" sections with a selection-count badge. Use when adding a tool/agent picker next to an OmniBox (or any other) chat/search input, including an "@mention" inline picker.
+---
+
+# ToolAgentSelector
+
+A trigger button that opens a searchable, checkbox-based popup listing agents and tools under
+"Agents" and "Tools" section headers (icon + title + optional description per row). Selecting
+items shows a count badge on the trigger. It can also be driven inline — anchored at an explicit
+viewport position instead of the trigger — to back an "@mention" style picker inside a chat input
+(see `OmniBox.EnableChatMentions` in `omni-box.md`).
+
+## Create
+
+`UI.ToolAgentSelector(string label = "Tools", UIcons icon = UIcons.Tools)` — the trigger + popup.
+`UI.ToolAgentSelectorItem(string id, string title, string description = null, UIcons? icon = null)`
+— a selectable row. Bring factories into scope with `using static Tesserae.UI;`.
+
+## Key configuration
+
+ToolAgentSelector:
+
+- `.Agents(params Item[])` / `.Tools(params Item[])` — set the items in each section (replaces
+  existing).
+- `.Compact(bool = true)` — hides item descriptions for a denser list.
+- `.SelectedItems` / `.SelectedCount` — current selection, agents first then tools.
+- `.OnChange(Action<ToolAgentSelector>)` — fires whenever any item's selection changes.
+- `.Show()` / `.Hide()` — anchored below the trigger button (also toggled by clicking the
+  trigger, or Enter/Space when it has focus).
+- `.ShowInlineAt(double clientX, double clientY)` — shows the popup anchored at an explicit
+  viewport position instead of the trigger, without moving focus or toggling the trigger's
+  pressed state. Used for an "@mention" picker inside a text input/textarea.
+- `.Filter(string text)` — filters visible items by title/description; also drives the popup from
+  an inline mention as more is typed after `@`.
+- `.MoveHighlight(int direction)` / `.ActivateHighlighted()` — keyboard navigation among currently
+  visible items (`+1`/`-1` to move, toggling the highlighted item's selection).
+
+ToolAgentSelector.Item:
+
+- `.Selected(bool = true)` / `.IsSelected` — selection state.
+- `.Tag` — arbitrary payload.
+
+## Example
+
+```csharp
+using static Tesserae.UI;
+
+var toolAgentSelector = ToolAgentSelector()
+    .Agents(
+        ToolAgentSelectorItem("deep-researcher", "Deep Researcher", "Multi-step web research with citations", UIcons.Search).Selected(),
+        ToolAgentSelectorItem("code-assistant", "Code Assistant", "Plans, writes and debugs code end to end", UIcons.FileCode))
+    .Tools(
+        ToolAgentSelectorItem("web-search", "Web Search", "Search the live web for fresh results", UIcons.Globe).Selected(),
+        ToolAgentSelectorItem("calculator", "Calculator", "Evaluate math expressions", UIcons.Calculator))
+    .OnChange(s => Toast().Information($"{s.SelectedCount} tool(s)/agent(s) enabled"));
+
+var chatSample = OmniBox(new OmniBox.Config(OmniBox.Mode.Chat)
+{
+    PlaceholderChat = "Ask me anything — type @ to mention a tool or agent",
+    ChatFooter = new OmniBox.FooterItems { LeftSide = new IComponent[] { toolAgentSelector } }
+})
+.EnableChatMentions(new OmniBox.ChatMention
+{
+    OnShow         = (x, y) => toolAgentSelector.ShowInlineAt(x, y),
+    OnQueryChanged = text    => toolAgentSelector.Filter(text),
+    OnMove         = dir     => toolAgentSelector.MoveHighlight(dir),
+    OnCommit       = ()      => toolAgentSelector.ActivateHighlighted(),
+    OnHide         = ()      => toolAgentSelector.Hide(),
+    IsOpen         = ()      => toolAgentSelector.IsVisible
+});
+```
+
+## Related
+
+- OmniBox, `OmniBox.EnableChatMentions` — `omni-box.md`
+- Dropdown — a single/multi-select combobox with a similar Layer-based popup — `dropdown.md`
+- NotificationCenter — the count-badge-on-a-trigger pattern this reuses — `notification-center.md`
+- Full docs & API: `/tesserae/components/tool-agent-selector`

--- a/Tesserae/src/Base/UI.Components.cs
+++ b/Tesserae/src/Base/UI.Components.cs
@@ -1424,6 +1424,16 @@ namespace Tesserae
         public static NotificationCenter NotificationCenter() => new NotificationCenter();
 
         /// <summary>
+        /// Creates a <see cref="Tesserae.ToolAgentSelector"/> component.
+        /// </summary>
+        public static ToolAgentSelector ToolAgentSelector(string label = "Tools", UIcons icon = UIcons.Tools) => new ToolAgentSelector(label, icon);
+
+        /// <summary>
+        /// Creates a <see cref="Tesserae.ToolAgentSelector.Item"/> component.
+        /// </summary>
+        public static ToolAgentSelector.Item ToolAgentSelectorItem(string id, string title, string description = null, UIcons? icon = null) => new ToolAgentSelector.Item(id, title, description, icon);
+
+        /// <summary>
         /// Converts a <see cref="Tesserae.Button"/> to a <see cref="Tesserae.ToggleButton"/>.
         /// </summary>
         public static ToggleButton ToToggle(this Button button) => new ToggleButton(button);

--- a/Tesserae/src/Components/OmniBox.cs
+++ b/Tesserae/src/Components/OmniBox.cs
@@ -573,6 +573,10 @@ namespace Tesserae
         private ThinkingEffort            _selectedEffort = ThinkingEffort.Medium;
         private bool                      _isModelLocked;
         private Action                    _hideModelPopover;
+        private ChatMention                _chatMention;
+        private int                        _mentionStart = -1;
+        private int                        _mentionEnd   = -1;
+        private static HTMLDivElement       _mentionCaretMirror;
         private readonly HTMLDivElement _footer;
         private Func<Task<SearchQuery[]>> _historyFetcher;
         private Action _hideSearchHistory;
@@ -993,6 +997,37 @@ namespace Tesserae
                     var ke = e.As<KeyboardEvent>();
                     KeyDown?.Invoke(this, ke);
 
+                    if (_chatMention != null && _mentionStart >= 0 && (_chatMention.IsOpen?.Invoke() ?? false))
+                    {
+                        if (ke.key == "ArrowDown")
+                        {
+                            StopEvent(e);
+                            _chatMention.OnMove?.Invoke(1);
+                            return;
+                        }
+                        if (ke.key == "ArrowUp")
+                        {
+                            StopEvent(e);
+                            _chatMention.OnMove?.Invoke(-1);
+                            return;
+                        }
+                        if (ke.key == "Enter" || ke.key == "Tab")
+                        {
+                            StopEvent(e);
+                            if (_chatMention.OnCommit?.Invoke() ?? false)
+                            {
+                                CommitChatMention();
+                            }
+                            return;
+                        }
+                        if (ke.key == "Escape")
+                        {
+                            StopEvent(e);
+                            HideChatMention();
+                            return;
+                        }
+                    }
+
                     if (ke.key == "Enter" && !ke.shiftKey)
                     {
                         TriggerChat();
@@ -1005,6 +1040,7 @@ namespace Tesserae
                     UpdateChatTriggerActiveState();
                     ResizeChatInput();
                     Input?.Invoke(this, e);
+                    TryUpdateChatMention();
                 });
                 _chatInput.addEventListener("keyup", (e) => KeyUp?.Invoke(this, e.As<KeyboardEvent>()));
                 _chatInput.addEventListener("keypress", (e) => KeyPress?.Invoke(this, e.As<KeyboardEvent>()));
@@ -1676,6 +1712,222 @@ namespace Tesserae
             if (filters == null) return this;
             foreach (var f in filters) RegisterFilterSnap(f);
             return this;
+        }
+
+        /// <summary>
+        /// Enables an "@mention" style inline picker in the chat input: typing <see cref="ChatMention.Trigger"/>
+        /// (default <c>@</c>) at a word boundary shows a picker anchored at the text caret, live-filters as more is
+        /// typed, and forwards Arrow Up/Down, Enter/Tab and Escape to the callbacks below. This is a thin,
+        /// UI-agnostic hook — wire it up to any anchored picker (for example a <see cref="ToolAgentSelector"/> via
+        /// its <see cref="ToolAgentSelector.ShowInlineAt"/>/<see cref="ToolAgentSelector.Filter"/>/
+        /// <see cref="ToolAgentSelector.MoveHighlight"/>/<see cref="ToolAgentSelector.ActivateHighlighted"/> methods).
+        /// </summary>
+        public OmniBox EnableChatMentions(ChatMention mention)
+        {
+            if (_mode != Mode.Chat && _mode != Mode.SearchAndChat)
+            {
+                throw new InvalidOperationException("EnableChatMentions can only be called when OmniBox is in Chat or SearchAndChat mode.");
+            }
+            _chatMention = mention;
+            return this;
+        }
+
+        private void TryUpdateChatMention()
+        {
+            if (_chatMention == null) return;
+
+            var val    = _chatInput.value ?? string.Empty;
+            var cursor = (int)_chatInput.selectionStart;
+
+            int atIdx = -1;
+            for (int i = cursor - 1; i >= 0; i--)
+            {
+                var ch = val[i];
+                if (ch == _chatMention.Trigger)
+                {
+                    if (i == 0 || char.IsWhiteSpace(val[i - 1])) atIdx = i;
+                    break;
+                }
+                if (char.IsWhiteSpace(ch)) break;
+            }
+
+            if (atIdx < 0)
+            {
+                if (_mentionStart >= 0) HideChatMention();
+                return;
+            }
+
+            var typed   = val.Substring(atIdx + 1, cursor - atIdx - 1);
+            var wasOpen = _mentionStart >= 0;
+
+            _mentionStart = atIdx;
+            _mentionEnd   = cursor;
+
+            if (!wasOpen)
+            {
+                var (x, y) = GetCaretClientPosition(_chatInput, atIdx);
+                _chatMention.OnShow?.Invoke(x, y);
+            }
+
+            _chatMention.OnQueryChanged?.Invoke(typed);
+        }
+
+        private void HideChatMention()
+        {
+            _mentionStart = -1;
+            _mentionEnd   = -1;
+            _chatMention?.OnHide?.Invoke();
+        }
+
+        private void CommitChatMention()
+        {
+            if (_mentionStart < 0 || _mentionEnd < 0)
+            {
+                HideChatMention();
+                return;
+            }
+
+            var val   = _chatInput.value ?? string.Empty;
+            var start = _mentionStart;
+            var end   = Math.Min(_mentionEnd, val.Length);
+
+            if (start > end)
+            {
+                HideChatMention();
+                return;
+            }
+
+            var before = val.Substring(0, start);
+            var after  = val.Substring(end);
+
+            if (before.Length > 0 && before[before.Length - 1] == ' ' && after.StartsWith(" "))
+            {
+                after = after.Substring(1);
+            }
+
+            _chatInput.value = before + after;
+            _chatInput.setSelectionRange((uint)before.Length, (uint)before.Length);
+
+            HideChatMention();
+            ResizeChatInput();
+            _chatInput.focus();
+        }
+
+        // Adapted from the well-known "textarea-caret-position" technique: an off-screen mirror <div> is styled to
+        // match every metric that affects text layout, filled with the text up to the caret plus a marker span, and
+        // the marker's offset within the mirror (plus the textarea's own screen position) gives the caret's
+        // viewport-relative coordinates without needing any canvas/measureText trickery.
+        private static (double x, double y) GetCaretClientPosition(HTMLTextAreaElement textarea, int caretIndex)
+        {
+            if (_mentionCaretMirror == null)
+            {
+                _mentionCaretMirror = Div(Att());
+                document.body.appendChild(_mentionCaretMirror);
+            }
+
+            var mirror   = _mentionCaretMirror;
+            var computed = window.getComputedStyle(textarea);
+
+            mirror.style.position   = "absolute";
+            mirror.style.visibility = "hidden";
+            mirror.style.top        = "0px";
+            mirror.style.left       = "-9999px";
+            mirror.style.whiteSpace = "pre-wrap";
+            mirror.style.wordWrap   = "break-word";
+            mirror.style.boxSizing         = computed.boxSizing;
+            mirror.style.width             = computed.width;
+            mirror.style.paddingTop        = computed.paddingTop;
+            mirror.style.paddingRight      = computed.paddingRight;
+            mirror.style.paddingBottom     = computed.paddingBottom;
+            mirror.style.paddingLeft       = computed.paddingLeft;
+            mirror.style.borderTopWidth    = computed.borderTopWidth;
+            mirror.style.borderRightWidth  = computed.borderRightWidth;
+            mirror.style.borderBottomWidth = computed.borderBottomWidth;
+            mirror.style.borderLeftWidth   = computed.borderLeftWidth;
+            mirror.style.borderStyle       = "solid";
+            mirror.style.fontFamily        = computed.fontFamily;
+            mirror.style.fontSize          = computed.fontSize;
+            mirror.style.fontWeight        = computed.fontWeight;
+            mirror.style.fontStyle         = computed.fontStyle;
+            mirror.style.lineHeight        = computed.lineHeight;
+            mirror.style.letterSpacing     = computed.letterSpacing;
+
+            var text   = textarea.value ?? string.Empty;
+            var index  = Math.Max(0, Math.Min(caretIndex, text.Length));
+            var before = text.Substring(0, index);
+            var after  = text.Substring(index);
+
+            ClearChildren(mirror);
+            mirror.appendChild(document.createTextNode(before));
+
+            var marker = Span(Att());
+            marker.textContent = ((char)0x200B).ToString();
+            mirror.appendChild(marker);
+            mirror.appendChild(document.createTextNode(after.Length > 0 ? after : " "));
+
+            var textareaRect = textarea.getBoundingClientRect().As<DOMRect>();
+            var lineHeight    = ParseCssPixels(computed.lineHeight, ParseCssPixels(computed.fontSize, 16) * 1.2);
+            var borderTop     = ParseCssPixels(computed.borderTopWidth, 0);
+            var borderLeft    = ParseCssPixels(computed.borderLeftWidth, 0);
+
+            var left = textareaRect.left - textarea.scrollLeft + marker.offsetLeft + borderLeft;
+            var top  = textareaRect.top  - textarea.scrollTop  + marker.offsetTop  + borderTop + lineHeight;
+
+            return (left, top);
+        }
+
+        private static double ParseCssPixels(string cssValue, double fallback)
+        {
+            if (string.IsNullOrEmpty(cssValue) || !cssValue.EndsWith("px")) return fallback;
+            return double.TryParse(cssValue.Substring(0, cssValue.Length - 2), out var v) ? v : fallback;
+        }
+
+        /// <summary>
+        /// Callbacks that back an "@mention" style inline picker in the chat input (see
+        /// <see cref="EnableChatMentions"/>). None of these are required to reference any specific component type —
+        /// wire them up to whatever anchored popup should back the mention experience.
+        /// </summary>
+        public sealed class ChatMention
+        {
+            /// <summary>
+            /// The character that opens the picker when typed at a word boundary. Defaults to <c>@</c>.
+            /// </summary>
+            public char Trigger { get; set; } = '@';
+
+            /// <summary>
+            /// Invoked to show the picker anchored at the given viewport-relative coordinates (just below the text
+            /// caret), the first time the trigger character is recognized.
+            /// </summary>
+            public Action<double, double> OnShow { get; set; }
+
+            /// <summary>
+            /// Invoked whenever the text typed after the trigger changes (including once, with an empty string,
+            /// right after <see cref="OnShow"/>), so the picker can live-filter its list.
+            /// </summary>
+            public Action<string> OnQueryChanged { get; set; }
+
+            /// <summary>
+            /// Invoked when Arrow Up (<c>-1</c>) or Arrow Down (<c>+1</c>) is pressed while the picker is open.
+            /// </summary>
+            public Action<int> OnMove { get; set; }
+
+            /// <summary>
+            /// Invoked when Enter or Tab is pressed while the picker is open. Return <c>true</c> if an item was
+            /// activated (the mention text typed so far is then removed from the chat input); return <c>false</c> to
+            /// leave the typed text untouched.
+            /// </summary>
+            public Func<bool> OnCommit { get; set; }
+
+            /// <summary>
+            /// Invoked when the picker should close (Escape, or the trigger word no longer matches).
+            /// </summary>
+            public Action OnHide { get; set; }
+
+            /// <summary>
+            /// Returns whether the picker is currently open. Consulted on every keydown so navigation keys are only
+            /// intercepted while the picker is actually visible.
+            /// </summary>
+            public Func<bool> IsOpen { get; set; }
         }
 
         private bool TryUpdateFilterSnapSuggestions()

--- a/Tesserae/src/Components/ToolAgentSelector.cs
+++ b/Tesserae/src/Components/ToolAgentSelector.cs
@@ -1,0 +1,554 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using static Transpose.Core.dom;
+using static Tesserae.UI;
+
+namespace Tesserae
+{
+    /// <summary>
+    /// A trigger button with a searchable popup for enabling agents and tools, shown grouped under "Agents" and
+    /// "Tools" sections. Selecting items updates a count badge on the trigger. Designed to be dropped into one of
+    /// <see cref="OmniBox.FooterItems"/>'s slots, and can also be driven inline (see <see cref="ShowInlineAt"/>) to
+    /// back an "@mention" style picker inside a chat input.
+    /// </summary>
+    [Transpose.Name("tss.ToolAgentSelector")]
+    public sealed class ToolAgentSelector : Layer<ToolAgentSelector>
+    {
+        private readonly HTMLElement _triggerLabel;
+        private readonly HTMLElement _badge;
+
+        private readonly SearchBox _searchBox;
+        private readonly HTMLElement _agentsSection;
+        private readonly HTMLElement _toolsSection;
+        private readonly HTMLElement _agentsList;
+        private readonly HTMLElement _toolsList;
+        private readonly HTMLElement _emptyState;
+        private readonly HTMLDivElement _popup;
+
+        private readonly Action<Event> _onWindowClickAction;
+
+        private readonly List<Item> _agents = new List<Item>();
+        private readonly List<Item> _tools  = new List<Item>();
+        private readonly List<Item> _visible = new List<Item>();
+
+        private int  _highlightIndex = -1;
+        private bool _isInline;
+
+        /// <summary>
+        /// Raised whenever an item's selected state changes.
+        /// </summary>
+        public event Action<ToolAgentSelector> SelectionChanged;
+
+        /// <summary>
+        /// Initializes a new instance of this class.
+        /// </summary>
+        public ToolAgentSelector(string label = "Tools", UIcons icon = UIcons.Tools)
+        {
+            _onWindowClickAction = (ev) => OnWindowClick(ev);
+
+            _badge = Span(Att("tss-toolagent-badge"));
+            _badge.style.display = "none";
+
+            _triggerLabel = Span(Att("tss-toolagent-trigger-label", text: label));
+
+            InnerElement = Div(Att("tss-toolagent-trigger", role: "button", ariaLabel: label),
+                I(icon, cssClass: "tss-toolagent-trigger-icon"),
+                _triggerLabel,
+                I(UIcons.AngleDown, cssClass: "tss-toolagent-trigger-chevron"),
+                _badge);
+            InnerElement.tabIndex = 0;
+
+            InnerElement.addEventListener("click", e =>
+            {
+                StopEvent(e);
+                Toggle();
+            });
+
+            InnerElement.addEventListener("keydown", e =>
+            {
+                var ke = e.As<KeyboardEvent>();
+                if (ke.key == "Enter" || ke.key == " ")
+                {
+                    StopEvent(e);
+                    Toggle();
+                }
+            });
+
+            _searchBox = new SearchBox("Search tools & agents").SearchAsYouType();
+            _searchBox.OnSearch((s, text) => ApplyFilter(text));
+            _searchBox.OnKeyDown((s, e) => HandlePopupKeyDown(e));
+
+            _agentsList = Div(Att("tss-toolagent-list"));
+            _toolsList  = Div(Att("tss-toolagent-list"));
+
+            _agentsSection = Div(Att("tss-toolagent-section"), Div(Att("tss-toolagent-section-title", text: "Agents")), _agentsList);
+            _toolsSection  = Div(Att("tss-toolagent-section"), Div(Att("tss-toolagent-section-title", text: "Tools")), _toolsList);
+
+            _emptyState = Div(Att("tss-toolagent-empty", text: "No matches"));
+            _emptyState.style.display = "none";
+
+            _popup = Div(Att("tss-toolagent-popup"), _searchBox.Render(), _agentsSection, _toolsSection, _emptyState);
+
+            UpdateSectionVisibility();
+        }
+
+        /// <summary>
+        /// Renders the component's root HTML element.
+        /// </summary>
+        public override HTMLElement Render()
+        {
+            DomObserver.WhenMounted(InnerElement, () =>
+            {
+                DomObserver.WhenRemoved(InnerElement, () => Hide());
+            });
+            return InnerElement;
+        }
+
+        /// <summary>
+        /// Sets the items shown under the "Agents" section (replaces any previously set).
+        /// </summary>
+        public ToolAgentSelector Agents(params Item[] items)
+        {
+            SetItems(_agents, _agentsList, items);
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the items shown under the "Tools" section (replaces any previously set).
+        /// </summary>
+        public ToolAgentSelector Tools(params Item[] items)
+        {
+            SetItems(_tools, _toolsList, items);
+            return this;
+        }
+
+        /// <summary>
+        /// Hides item descriptions, rendering a denser list of icon + title rows only.
+        /// </summary>
+        public ToolAgentSelector Compact(bool value = true)
+        {
+            _popup.UpdateClassIf(value, "tss-toolagent-compact");
+            return this;
+        }
+
+        /// <summary>
+        /// Registers a callback invoked whenever the selection changes.
+        /// </summary>
+        public ToolAgentSelector OnChange(Action<ToolAgentSelector> handler)
+        {
+            SelectionChanged += handler;
+            return this;
+        }
+
+        /// <summary>
+        /// Gets every currently selected item, agents first, then tools.
+        /// </summary>
+        public Item[] SelectedItems => _agents.Concat(_tools).Where(i => i.IsSelected).ToArray();
+
+        /// <summary>
+        /// Gets the number of currently selected items.
+        /// </summary>
+        public int SelectedCount => _agents.Count(i => i.IsSelected) + _tools.Count(i => i.IsSelected);
+
+        private void SetItems(List<Item> target, HTMLElement container, Item[] items)
+        {
+            foreach (var existing in target)
+            {
+                existing.SelectionChanged -= OnItemSelectionChanged;
+            }
+
+            target.Clear();
+            ClearChildren(container);
+
+            foreach (var item in items ?? Array.Empty<Item>())
+            {
+                target.Add(item);
+                container.appendChild(item.Render());
+                item.SelectionChanged += OnItemSelectionChanged;
+            }
+
+            UpdateSectionVisibility();
+            UpdateBadge();
+        }
+
+        private void OnItemSelectionChanged(Item item)
+        {
+            UpdateBadge();
+            SelectionChanged?.Invoke(this);
+        }
+
+        private void UpdateBadge()
+        {
+            var count = SelectedCount;
+            if (count > 0)
+            {
+                _badge.innerText = count > 99 ? "99+" : count.ToString();
+                _badge.style.display = "flex";
+            }
+            else
+            {
+                _badge.style.display = "none";
+            }
+        }
+
+        /// <summary>
+        /// Shows the popup anchored below the trigger button.
+        /// </summary>
+        public override ToolAgentSelector Show()
+        {
+            EnsurePopupLayer();
+
+            _isInline = false;
+            _searchBox.Render().style.display = "";
+            InnerElement.classList.add("tss-toolagent-trigger-active");
+
+            base.Show();
+            PositionPopupNearTrigger();
+            ResetFilter();
+
+            // The short delay is required: the click that opens the popup also gives the (focusable, for
+            // keyboard activation) trigger element the browser's default focus, which is only committed a few
+            // milliseconds after the click handler returns - focusing the search box any earlier (even on the
+            // very next macrotask) loses that race and the trigger keeps focus instead.
+            DomObserver.WhenMounted(_popup, () => window.setTimeout(_ => _searchBox.Focus(), 100));
+
+            return this;
+        }
+
+        /// <summary>
+        /// Shows the popup anchored at an explicit viewport position (for example, next to a text caret), without
+        /// moving focus or toggling the trigger button's pressed state. Used to back an "@mention" style picker.
+        /// </summary>
+        public ToolAgentSelector ShowInlineAt(double clientX, double clientY)
+        {
+            EnsurePopupLayer();
+
+            _isInline = true;
+            _searchBox.Render().style.display = "none";
+            InnerElement.classList.remove("tss-toolagent-trigger-active");
+
+            base.Show();
+            PositionPopupAt(clientX, clientY);
+            ApplyFilter(string.Empty);
+
+            return this;
+        }
+
+        /// <summary>
+        /// Hides the popup.
+        /// </summary>
+        public override void Hide(Action onHidden = null)
+        {
+            InnerElement.classList.remove("tss-toolagent-trigger-active");
+            _isInline = false;
+            base.Hide(onHidden);
+        }
+
+        private void Toggle()
+        {
+            if (IsVisible) Hide();
+            else Show();
+        }
+
+        private void EnsurePopupLayer()
+        {
+            if (_contentHtml != null) return;
+
+            _contentHtml = Div(Att("tss-toolagent-layer"), _popup);
+            _contentHtml.addEventListener("click",       _onWindowClickAction);
+            _contentHtml.addEventListener("contextmenu", _onWindowClickAction);
+        }
+
+        private void OnWindowClick(Event e)
+        {
+            if (e.srcElement != _popup && !_popup.contains(e.srcElement))
+            {
+                Hide();
+            }
+        }
+
+        private void PositionPopupNearTrigger()
+        {
+            _popup.style.visibility = "hidden";
+            _popup.style.top  = "-1000px";
+            _popup.style.left = "-1000px";
+
+            var rect      = InnerElement.getBoundingClientRect().As<DOMRect>();
+            var popupRect = _popup.getBoundingClientRect().As<DOMRect>();
+
+            var top = rect.bottom + 4;
+            if (window.innerHeight - rect.bottom - 4 < popupRect.height && rect.top > popupRect.height)
+            {
+                top = rect.top - popupRect.height - 4;
+            }
+
+            var left = rect.left;
+            if (left + popupRect.width + 8 > window.innerWidth)
+            {
+                left = Math.Max(8, window.innerWidth - popupRect.width - 8);
+            }
+
+            _popup.style.top        = top  + "px";
+            _popup.style.left       = left + "px";
+            _popup.style.minWidth   = rect.width + "px";
+            _popup.style.visibility = "visible";
+        }
+
+        private void PositionPopupAt(double clientX, double clientY)
+        {
+            _popup.style.visibility = "hidden";
+            _popup.style.top  = "-1000px";
+            _popup.style.left = "-1000px";
+            _popup.style.minWidth = "";
+
+            var popupRect = _popup.getBoundingClientRect().As<DOMRect>();
+
+            var top = clientY;
+            if (window.innerHeight - clientY < popupRect.height && clientY > popupRect.height)
+            {
+                top = clientY - popupRect.height - 20;
+            }
+
+            var left = clientX;
+            if (left + popupRect.width + 8 > window.innerWidth)
+            {
+                left = Math.Max(8, window.innerWidth - popupRect.width - 8);
+            }
+
+            _popup.style.top        = top  + "px";
+            _popup.style.left       = left + "px";
+            _popup.style.visibility = "visible";
+        }
+
+        /// <summary>
+        /// Filters the visible items by the given free-text query (matches title or description). Used both by the
+        /// built-in search box and externally, to drive the popup from an inline "@" mention as the user types.
+        /// </summary>
+        public ToolAgentSelector Filter(string text)
+        {
+            if (!_isInline)
+            {
+                _searchBox.Text = text ?? string.Empty;
+            }
+            ApplyFilter(text ?? string.Empty);
+            return this;
+        }
+
+        private void ResetFilter()
+        {
+            _searchBox.Text = string.Empty;
+            ApplyFilter(string.Empty);
+        }
+
+        private void ApplyFilter(string text)
+        {
+            var terms = (text ?? string.Empty).Trim().ToLower().Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+
+            foreach (var item in _agents.Concat(_tools))
+            {
+                item.SetVisible(terms.Length == 0 || terms.All(t => item.SearchText.Contains(t)));
+            }
+
+            UpdateSectionVisibility();
+            RebuildVisibleList();
+        }
+
+        private void UpdateSectionVisibility()
+        {
+            var anyAgentsVisible = _agents.Any(i => i.IsVisible);
+            var anyToolsVisible  = _tools.Any(i => i.IsVisible);
+
+            _agentsSection.style.display = _agents.Count > 0 && anyAgentsVisible ? "" : "none";
+            _toolsSection.style.display  = _tools.Count  > 0 && anyToolsVisible  ? "" : "none";
+            _emptyState.style.display    = (_agents.Count + _tools.Count == 0) || (!anyAgentsVisible && !anyToolsVisible) ? "block" : "none";
+        }
+
+        private void RebuildVisibleList()
+        {
+            _visible.Clear();
+            _visible.AddRange(_agents.Concat(_tools).Where(i => i.IsVisible));
+
+            foreach (var item in _visible)
+            {
+                item.SetHighlighted(false);
+            }
+
+            _highlightIndex = -1;
+        }
+
+        private void HandlePopupKeyDown(KeyboardEvent e)
+        {
+            if (e.key == "ArrowDown")
+            {
+                StopEvent(e);
+                MoveHighlight(1);
+            }
+            else if (e.key == "ArrowUp")
+            {
+                StopEvent(e);
+                MoveHighlight(-1);
+            }
+            else if (e.key == "Enter" || e.key == "Tab")
+            {
+                StopEvent(e);
+                ActivateHighlighted();
+            }
+            else if (e.key == "Escape")
+            {
+                StopEvent(e);
+                Hide();
+            }
+        }
+
+        /// <summary>
+        /// Moves the keyboard-navigation highlight forward (positive) or backward (negative) among the currently
+        /// visible items, wrapping around at either end.
+        /// </summary>
+        public void MoveHighlight(int direction)
+        {
+            if (_visible.Count == 0)
+            {
+                _highlightIndex = -1;
+                return;
+            }
+
+            if (_highlightIndex < 0)
+            {
+                _highlightIndex = direction > 0 ? 0 : _visible.Count - 1;
+            }
+            else
+            {
+                _highlightIndex = (_highlightIndex + direction + _visible.Count) % _visible.Count;
+            }
+
+            for (var i = 0; i < _visible.Count; i++)
+            {
+                _visible[i].SetHighlighted(i == _highlightIndex);
+            }
+
+            _visible[_highlightIndex].ScrollIntoView();
+        }
+
+        /// <summary>
+        /// Toggles the selection of the currently highlighted item (defaulting to the first visible item if none is
+        /// highlighted yet). Returns <c>true</c> if an item was toggled.
+        /// </summary>
+        public bool ActivateHighlighted()
+        {
+            if (_visible.Count == 0) return false;
+
+            if (_highlightIndex < 0 || _highlightIndex >= _visible.Count)
+            {
+                _highlightIndex = 0;
+            }
+
+            _visible[_highlightIndex].Toggle();
+            return true;
+        }
+
+        /// <summary>
+        /// A single selectable agent or tool row, with a checkbox, an optional leading icon, a title and an
+        /// optional description.
+        /// </summary>
+        public sealed class Item : IComponent
+        {
+            private readonly HTMLElement _root;
+            private readonly HTMLInputElement _input;
+            private readonly HTMLElement _description;
+            private readonly string _searchText;
+
+            /// <summary>
+            /// Gets the identifier of this item.
+            /// </summary>
+            public string Id { get; }
+
+            /// <summary>
+            /// Gets or sets an arbitrary payload associated with this item.
+            /// </summary>
+            public object Tag { get; set; }
+
+            internal event Action<Item> SelectionChanged;
+
+            /// <summary>
+            /// Initializes a new instance of this class.
+            /// </summary>
+            public Item(string id, string title, string description = null, UIcons? icon = null)
+            {
+                Id = id;
+
+                _input = CheckBox(Att("tss-toolagent-item-input"));
+                var checkmark = Span(Att("tss-toolagent-item-checkmark"));
+
+                var iconContainer = Div(Att("tss-toolagent-item-icon"));
+                if (icon.HasValue)
+                {
+                    iconContainer.appendChild(I(icon.Value));
+                }
+                else
+                {
+                    iconContainer.style.display = "none";
+                }
+
+                var titleEl = Div(Att("tss-toolagent-item-title", text: title ?? string.Empty));
+                _description = Div(Att("tss-toolagent-item-description", text: description ?? string.Empty));
+                if (string.IsNullOrEmpty(description))
+                {
+                    _description.style.display = "none";
+                }
+
+                var content = Div(Att("tss-toolagent-item-content"), titleEl, _description);
+
+                _root = Label(Att("tss-toolagent-item"), _input, checkmark, iconContainer, content);
+
+                _input.addEventListener("change", _ => SelectionChanged?.Invoke(this));
+
+                _searchText = ((title ?? string.Empty) + " " + (description ?? string.Empty)).ToLower();
+            }
+
+            /// <summary>
+            /// Gets or sets whether this item is selected.
+            /// </summary>
+            public bool IsSelected
+            {
+                get => _input.@checked;
+                set
+                {
+                    if (_input.@checked == value) return;
+                    _input.@checked = value;
+                    SelectionChanged?.Invoke(this);
+                }
+            }
+
+            /// <summary>
+            /// Marks the item as selected.
+            /// </summary>
+            public Item Selected(bool value = true)
+            {
+                IsSelected = value;
+                return this;
+            }
+
+            internal bool IsVisible => _root.style.display != "none";
+
+            internal string SearchText => _searchText;
+
+            internal void SetVisible(bool value) => _root.style.display = value ? "" : "none";
+
+            internal void SetHighlighted(bool value) => _root.UpdateClassIf(value, "tss-toolagent-item-highlight");
+
+            internal void ScrollIntoView()
+            {
+                try { _root.scrollIntoViewIfNeeded(); }
+                catch { _root.scrollIntoView(); }
+            }
+
+            internal void Toggle() => IsSelected = !IsSelected;
+
+            /// <summary>
+            /// Renders the component's root HTML element.
+            /// </summary>
+            public HTMLElement Render() => _root;
+        }
+    }
+}

--- a/Tesserae/tps.json
+++ b/Tesserae/tps.json
@@ -65,6 +65,7 @@
                 "tps/assets/css/tss.nav.css",
                 "tps/assets/css/tss.searchbox.css",
                 "tps/assets/css/tss.omnibox.css",
+                "tps/assets/css/tss.toolagentselector.css",
                 "tps/assets/css/tss.annotatedtexteditor.css",
                 "tps/assets/css/tss.sectiontitle.css",
                 "tps/assets/css/tss.sectionstack.css",

--- a/Tesserae/tps/assets/css/tss.toolagentselector.css
+++ b/Tesserae/tps/assets/css/tss.toolagentselector.css
@@ -1,0 +1,216 @@
+/* ToolAgentSelector */
+.tss-toolagent-trigger {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    height: 32px;
+    padding: 0 10px;
+    border-radius: var(--tss-border-radius-sm, 4px);
+    border: 1px solid var(--tss-default-border-color);
+    background: var(--tss-default-background-color);
+    color: var(--tss-default-foreground-color);
+    cursor: pointer;
+    font-size: var(--tss-font-size-small);
+    font-weight: var(--tss-font-weight-regular);
+    -webkit-user-select: none;
+    user-select: none;
+}
+
+    .tss-toolagent-trigger:hover {
+        background: var(--tss-default-background-hover-color);
+    }
+
+    .tss-toolagent-trigger:focus-visible {
+        outline: 2px solid var(--tss-primary-background-color);
+        outline-offset: 2px;
+    }
+
+    .tss-toolagent-trigger.tss-toolagent-trigger-active {
+        border-color: var(--tss-primary-border-color, var(--tss-primary-background-color));
+        background: var(--tss-default-background-hover-color);
+    }
+
+    .tss-toolagent-trigger-icon {
+        font-size: 14px;
+    }
+
+    .tss-toolagent-trigger-chevron {
+        font-size: 10px;
+        color: var(--tss-secondary-foreground-color);
+    }
+
+.tss-toolagent-badge {
+    position: absolute;
+    top: -6px;
+    right: -6px;
+    min-width: 16px;
+    height: 16px;
+    padding: 0 4px;
+    border-radius: 999px;
+    background: var(--tss-primary-background-color);
+    color: var(--tss-primary-foreground-color);
+    font-size: 10px;
+    font-weight: 700;
+    line-height: 16px;
+    text-align: center;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    pointer-events: none;
+    box-shadow: 0 0 0 2px var(--tss-default-background-color);
+}
+
+.tss-toolagent-layer {
+    position: absolute;
+    top: 0px;
+    left: 0px;
+    bottom: 0px;
+    right: 0px;
+    margin: 0;
+    padding: 0;
+    visibility: visible;
+}
+
+.tss-toolagent-popup {
+    position: absolute;
+    display: flex;
+    flex-direction: column;
+    width: 340px;
+    max-height: 420px;
+    background: var(--tss-default-background-color);
+    border: 1px solid var(--tss-default-border-color);
+    border-radius: 10px;
+    box-shadow: 0px 4px 16px var(--tss-shadow-color, rgba(0, 0, 0, 0.4));
+    overflow: hidden;
+}
+
+    .tss-toolagent-popup .tss-searchbox-container {
+        margin: 8px;
+        flex-shrink: 0;
+    }
+
+.tss-toolagent-section {
+    display: flex;
+    flex-direction: column;
+    overflow-y: auto;
+}
+
+.tss-toolagent-section-title {
+    padding: 6px 12px 4px;
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--tss-secondary-foreground-color);
+    flex-shrink: 0;
+}
+
+.tss-toolagent-list {
+    display: flex;
+    flex-direction: column;
+    padding: 0 6px 4px;
+}
+
+.tss-toolagent-item {
+    position: relative;
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+    padding: 8px;
+    border-radius: 8px;
+    cursor: pointer;
+    -webkit-user-select: none;
+    user-select: none;
+}
+
+    .tss-toolagent-item:hover,
+    .tss-toolagent-item.tss-toolagent-item-highlight {
+        background: var(--tss-default-background-hover-color);
+    }
+
+    .tss-toolagent-item-input {
+        position: absolute;
+        opacity: 0;
+        width: 0;
+        height: 0;
+    }
+
+    .tss-toolagent-item-checkmark {
+        position: relative;
+        flex-shrink: 0;
+        width: 18px;
+        height: 18px;
+        margin-top: 1px;
+        border-radius: 4px;
+        border: 1px solid var(--tss-default-foreground-color);
+        background: var(--tss-default-background-color);
+        transition: all 0.1s ease-in-out;
+    }
+
+        .tss-toolagent-item-input:checked ~ .tss-toolagent-item-checkmark {
+            background: var(--tss-primary-background-color);
+            border-color: var(--tss-primary-background-color);
+        }
+
+        .tss-toolagent-item-input:checked ~ .tss-toolagent-item-checkmark:after {
+            content: "";
+            position: absolute;
+            display: block;
+            left: 5px;
+            top: 1px;
+            width: 5px;
+            height: 10px;
+            border: solid var(--tss-primary-foreground-color);
+            border-width: 0 2px 2px 0;
+            transform: rotate(45deg);
+        }
+
+    .tss-toolagent-item-icon {
+        flex-shrink: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 26px;
+        height: 26px;
+        border-radius: 6px;
+        background: var(--tss-secondary-background-color);
+        font-size: 13px;
+    }
+
+    .tss-toolagent-item-content {
+        flex: 1;
+        min-width: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+    }
+
+    .tss-toolagent-item-title {
+        font-size: var(--tss-font-size-small);
+        font-weight: 600;
+        color: var(--tss-default-foreground-color);
+    }
+
+    .tss-toolagent-item-description {
+        font-size: 12px;
+        color: var(--tss-secondary-foreground-color);
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+
+.tss-toolagent-compact .tss-toolagent-item-description {
+    display: none !important;
+}
+
+.tss-toolagent-compact .tss-toolagent-item {
+    padding: 6px 8px;
+}
+
+.tss-toolagent-empty {
+    display: none;
+    padding: 16px 12px;
+    text-align: center;
+    font-size: 13px;
+    color: var(--tss-secondary-foreground-color);
+}


### PR DESCRIPTION
## Summary

Introduces `ToolAgentSelector`, a new dropdown-style component for selecting agents and tools, along with chat mention integration in `OmniBox` to support "@mention" style inline pickers in chat inputs.

## Key Changes

- **New `ToolAgentSelector` component** (`Tesserae/src/Components/ToolAgentSelector.cs`):
  - Trigger button with searchable popup listing agents and tools in separate sections
  - Checkbox-based selection with count badge on trigger
  - Supports both anchored (below trigger) and inline (at explicit viewport position) display modes
  - Free-text filtering across item titles and descriptions
  - Keyboard navigation (Arrow Up/Down, Enter/Tab, Escape)
  - Compact mode to hide descriptions for denser lists
  - Nested `Item` class for individual selectable rows (icon + title + optional description)

- **Chat mention support in `OmniBox`** (`Tesserae/src/Components/OmniBox.cs`):
  - New `EnableChatMentions(ChatMention)` method to wire up "@mention" style pickers
  - Detects trigger character (`@` by default) at word boundaries in chat input
  - Forwards keyboard events (arrows, Enter/Tab, Escape) to picker callbacks
  - Provides caret position calculation for anchoring picker at text insertion point
  - Handles mention text replacement on commit
  - New `ChatMention` class with callbacks for show/hide, query changes, and item activation

- **Styling** (`Tesserae/tps/assets/css/tss.toolagentselector.css`):
  - Complete visual design for trigger button, popup, sections, items, and empty state
  - Supports hover, focus, and highlight states
  - Responsive positioning with viewport boundary detection

- **Documentation and samples**:
  - New skill reference (`Tesserae/skills/references/tool-agent-selector.md`)
  - Updated `OmniBox` skill reference with chat mention documentation
  - Sample usage in `OmniBoxSample.cs` demonstrating both search and chat modes
  - Factory methods added to `UI.Components.cs`

## Implementation Details

- Uses a static `_mentionCaretMirror` div to calculate caret position without canvas/measureText, mirroring textarea styling and measuring marker offset
- Popup positioning handles viewport boundaries (flips above trigger if insufficient space below, adjusts horizontally if too close to edge)
- Keyboard navigation maintains highlight state across filtered items with wrapping at list boundaries
- Selection changes trigger `SelectionChanged` event for reactive updates
- Integrates with existing `Layer` base class for modal/overlay behavior

https://claude.ai/code/session_012XVYgDkn9tLyGSHqdE8ZVu