### PR TITLE
Update compiler references from h5 to Transpose

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,14 +1,14 @@
 # AGENTS
 
 ## Repository overview
-- Tesserae is a C# UI toolkit compiled to JavaScript via the **h5** compiler (see `Tesserae/Tesserae.csproj` and `Tesserae/h5*.json`).
+- Tesserae is a C# UI toolkit compiled to JavaScript via the **Transpose** compiler (see `Tesserae/Tesserae.csproj` and `Tesserae/tps*.json`).
 - Core UI components live under `Tesserae/src`, with component factories and helpers in `Tesserae/src/Base/UI.Components.cs`.
 - Samples and demos live in `Tesserae.Tests` (referenced in `README.md`).
 
 ## Build & packaging notes
-- The main library project uses the `h5.Target` SDK and references `h5`, `h5.core`, and `h5.Newtonsoft.Json` packages.
-- H5 build configuration and resource bundling are defined in `Tesserae/h5.json` (includes JS/CSS bundling, minified and non-minified outputs, and resource packaging).
-- Local dev hosting is documented in `README.md` (build output under `bin/Debug/netstandard2.0/h5` and serve via `dotnet serve`).
+- The main library project uses the `Transpose.Build.Target` SDK and references `Transpose.BCL`, `Transpose.Core`, and `Transpose.Newtonsoft.Json` packages.
+- Transpose build configuration and resource bundling are defined in `Tesserae/tps.json` (includes JS/CSS bundling, minified and non-minified outputs, and resource packaging).
+- Local dev hosting is documented in `README.md` (build output under `bin/Debug/netstandard2.0/tps` and serve via `dotnet serve`).
 
 ## UI composition patterns
 - UI creation is centered around the static `UI` class in `UI.Components.cs`, which provides factory methods for components (e.g., `UI.Button`, `UI.TextBlock`, etc.).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,13 +2,13 @@
 
 ## Repository overview
 
-Tesserae is a C# UI toolkit for building web applications, compiled to JavaScript via the **h5** compiler.
+Tesserae is a C# UI toolkit for building web applications, compiled to JavaScript via the **Transpose** compiler.
 
 - Core UI components: `Tesserae/src/Components`
 - Component factories and helpers: `Tesserae/src/Base/UI.Components.cs`
 - Fluent extensions: `Tesserae/src/Extensions`
 - Samples and demos: `Tesserae.Tests/`
-- Project and build config: `Tesserae/Tesserae.csproj`, `Tesserae/h5.json`
+- Project and build config: `Tesserae/Tesserae.csproj`, `Tesserae/tps.json`
 
 ## Skills
 
@@ -79,25 +79,27 @@ it does and when to use it (no `<`/`>`). Keep `SKILL.md` a focused overview and
 push detail into `references/`. The same applies to the matching pages in the
 `documentation` repo under `tesserae/` — update them alongside the references.
 
-## Installing h5
+## Installing Transpose
 
-Install or update the h5 compiler and the dotnet serve tool globally before getting started:
+Install or update the Transpose compiler and the dotnet serve tool globally before getting started:
 
 ```bash
-dotnet tool update --global h5-compiler
+dotnet tool update --global Transpose.Compiler
 dotnet tool update --global dotnet-serve
+```
+
 ## Build
 
 ```bash
 dotnet build
 ```
 
-The h5 compiler translates C# to JavaScript. Output lands in `bin/Debug/netstandard2.0/h5/` (or `bin/Release/...`).
+The Transpose compiler translates C# to JavaScript. Output lands in `bin/Debug/netstandard2.0/tps/` (or `bin/Release/...`).
 
 To serve locally:
 
 ```bash
-cd bin/Debug/netstandard2.0/h5/
+cd bin/Debug/netstandard2.0/tps/
 dotnet serve --port 5000
 ```
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Tesserae
 
-**Tesserae** is a UI toolkit for building web applications entirely in C#, inspired by Microsoft's [Fluent UI](https://github.com/microsoft/fluentui) toolkit. It leverages the [h5 C# to JavaScript compiler](https://github.com/curiosity-ai/h5) to provide a strongly typed, easy-to-use UI development experience.
+**Tesserae** is a UI toolkit for building web applications entirely in C#, inspired by Microsoft's [Fluent UI](https://github.com/microsoft/fluentui) toolkit. It leverages the [Transpose C# to JavaScript compiler](https://github.com/curiosity-ai/transpose) to provide a strongly typed, easy-to-use UI development experience.
 
 > 📖 **Official Documentation:** [**docs.curiosity.ai/tesserae**](https://docs.curiosity.ai/tesserae) &nbsp;·&nbsp; 🎨 **Live Samples:** [curiosity.ai/tesserae](https://curiosity.ai/tesserae)
 >
@@ -14,19 +14,19 @@
 
 To create a new, blank Tesserae project from scratch, follow these steps:
 
-1.  **Update or install the h5-compiler:**
+1.  **Update or install the Transpose compiler:**
     ```bash
-    dotnet tool update --global h5-compiler
+    dotnet tool update --global Transpose.Compiler
     ```
 
-2.  **Install the h5 project templates:**
+2.  **Install the Transpose project templates:**
     ```bash
-    dotnet new install h5.Template
+    dotnet new install Transpose.Template
     ```
 
-3.  **Create a new h5 project:**
+3.  **Create a new Transpose project:**
     ```bash
-    dotnet new h5
+    dotnet new transpose
     ```
 
 4.  **Add the Tesserae package:**
@@ -36,18 +36,18 @@ To create a new, blank Tesserae project from scratch, follow these steps:
 
 ## Build Process
 
-Tesserae projects are compiled from C# to JavaScript using the **h5 compiler**.
+Tesserae projects are compiled from C# to JavaScript using the **Transpose compiler**.
 
-### h5.json Configuration
-The build process is controlled by the `h5.json` file located in your project root. This file defines:
--   **Output Directory**: Where the compiled files will be placed (e.g., `"output": "$(OutDir)/h5/"`).
+### tps.json Configuration
+The build process is controlled by the `tps.json` file located in your project root. This file defines:
+-   **Output Directory**: Where the compiled files will be placed (e.g., `"output": "$(OutDir)/tps/"`).
 -   **Entry Point**: The name of the generated JavaScript file (e.g., `"fileName": "app.js"`).
 -   **HTML Generation**: Whether to generate an `index.html` file and its title.
 -   **Resources**: Additional CSS, images, or JavaScript files to be included in the build output.
 
 ### Compilation Output
-When you build the project (e.g., via `dotnet build` or in Visual Studio), the h5 compiler translates your C# code into JavaScript and copies necessary assets to the output folder. By default, these files are located in:
-`bin/Debug/netstandard2.0/h5/` (or `bin/Release/...` depending on your configuration).
+When you build the project (e.g., via `dotnet build` or in Visual Studio), the Transpose compiler translates your C# code into JavaScript and copies necessary assets to the output folder. By default, these files are located in:
+`bin/Debug/netstandard2.0/tps/` (or `bin/Release/...` depending on your configuration).
 
 ## Local Testing
 
@@ -59,9 +59,9 @@ To test your application locally, we recommend using the `dotnet-serve` tool, wh
     ```
 
 2.  **Serve the compiled files:**
-    Navigate to the h5 output directory and start the server:
+    Navigate to the Transpose output directory and start the server:
     ```bash
-    cd bin/Debug/netstandard2.0/h5/
+    cd bin/Debug/netstandard2.0/tps/
     dotnet serve --port 5000
     ```
 

--- a/Tesserae/skills/SKILL.md
+++ b/Tesserae/skills/SKILL.md
@@ -1,19 +1,19 @@
 ---
 name: tesserae
-description: Build web UIs in C# with the Tesserae toolkit (compiled to JavaScript by the h5 compiler) — components, fluent configuration, layout with Stack/Grid, and sizing/spacing helpers. Use when writing or editing a Tesserae app, picking a component, laying out a UI, or looking up a component's API. Per-component references live in references/.
+description: Build web UIs in C# with the Tesserae toolkit (compiled to JavaScript by the Transpose compiler) — components, fluent configuration, layout with Stack/Grid, and sizing/spacing helpers. Use when writing or editing a Tesserae app, picking a component, laying out a UI, or looking up a component's API. Per-component references live in references/.
 ---
 
 # Tesserae
 
 Tesserae is a C# UI toolkit for building web applications. You write strongly-typed
-C#; the **h5** compiler translates it to JavaScript that runs in the browser. The
+C#; the **Transpose** compiler translates it to JavaScript that runs in the browser. The
 API is fluent and component-based, loosely inspired by Microsoft's Fluent UI.
 
 Bring the factories and DOM helpers into scope at the top of a file:
 
 ```csharp
 using static Tesserae.UI;     // component factories: Button(), Stack(), TextBlock()…
-using static H5.Core.dom;     // browser globals: document, window, console…
+using static Transpose.Core.dom;     // browser globals: document, window, console…
 ```
 
 ## Using components
@@ -139,7 +139,7 @@ references. Open the reference for whatever you are working with. The full set:
   `references/accessibility.md`, `references/project-setup.md`,
   `references/routing.md`.
 - `references/creating-a-component.md` — build your own `IComponent`.
-- `references/javascript-interop.md` — call JS/browser APIs from C# via h5.
+- `references/javascript-interop.md` — call JS/browser APIs from C# via Transpose.
 - `references/wrap-a-javascript-library.md` — wrap a third-party JS library.
 
 **Components** (plain widgets)

--- a/Tesserae/skills/references/accessibility.md
+++ b/Tesserae/skills/references/accessibility.md
@@ -1,6 +1,6 @@
 ---
 name: accessibility
-description: ARIA/accessibility fluent helpers that add roles, labels, and states to any Tesserae component. Use when adding ARIA attributes, labels, or screen-reader support in a Tesserae (C#/h5) app.
+description: ARIA/accessibility fluent helpers that add roles, labels, and states to any Tesserae component. Use when adding ARIA attributes, labels, or screen-reader support in a Tesserae (C#/Transpose) app.
 ---
 
 # Accessibility

--- a/Tesserae/skills/references/accordion.md
+++ b/Tesserae/skills/references/accordion.md
@@ -1,6 +1,6 @@
 ---
 name: accordion
-description: A vertical stack of expand/collapse sections (Expanders), with optional single-open behaviour. Use when building collapsible FAQ-style or grouped content in a Tesserae (C#/h5) app.
+description: A vertical stack of expand/collapse sections (Expanders), with optional single-open behaviour. Use when building collapsible FAQ-style or grouped content in a Tesserae (C#/Transpose) app.
 ---
 
 # Accordion / Expander

--- a/Tesserae/skills/references/action-button.md
+++ b/Tesserae/skills/references/action-button.md
@@ -1,6 +1,6 @@
 ---
 name: action-button
-description: A composite button with a main display area plus a separate action icon, each independently clickable. Use when you need a primary action and a secondary trigger (e.g. dropdown/callout) in one control in a Tesserae (C#/h5) app.
+description: A composite button with a main display area plus a separate action icon, each independently clickable. Use when you need a primary action and a secondary trigger (e.g. dropdown/callout) in one control in a Tesserae (C#/Transpose) app.
 ---
 
 # ActionButton

--- a/Tesserae/skills/references/annotated-text-editor.md
+++ b/Tesserae/skills/references/annotated-text-editor.md
@@ -1,6 +1,6 @@
 ---
 name: annotated-text-editor
-description: A multi-line text editor that highlights entity spans in place using a debounced async annotator callback. Use when building NLP/entity-tagging inputs or prompt editors that mark up text as the user types in a Tesserae (C#/h5) app.
+description: A multi-line text editor that highlights entity spans in place using a debounced async annotator callback. Use when building NLP/entity-tagging inputs or prompt editors that mark up text as the user types in a Tesserae (C#/Transpose) app.
 ---
 
 # AnnotatedTextEditor

--- a/Tesserae/skills/references/avatar.md
+++ b/Tesserae/skills/references/avatar.md
@@ -1,6 +1,6 @@
 ---
 name: avatar
-description: A circular user representation showing an image or initials with an optional presence dot; Persona pairs it with name/role text. Use when representing users, teams, or contacts in a Tesserae (C#/h5) app.
+description: A circular user representation showing an image or initials with an optional presence dot; Persona pairs it with name/role text. Use when representing users, teams, or contacts in a Tesserae (C#/Transpose) app.
 ---
 
 # Avatar / Persona

--- a/Tesserae/skills/references/background-area.md
+++ b/Tesserae/skills/references/background-area.md
@@ -1,6 +1,6 @@
 ---
 name: background-area
-description: A full-bleed themed container that hosts a single centered child, used as an app shell for splash, sign-in, or onboarding surfaces. Use when you need a full-screen background behind a centered card in a Tesserae (C#/h5) app.
+description: A full-bleed themed container that hosts a single centered child, used as an app shell for splash, sign-in, or onboarding surfaces. Use when you need a full-screen background behind a centered card in a Tesserae (C#/Transpose) app.
 ---
 
 # BackgroundArea

--- a/Tesserae/skills/references/badge.md
+++ b/Tesserae/skills/references/badge.md
@@ -1,6 +1,6 @@
 ---
 name: badge
-description: Small inline label tokens — Badge (status indicator), Tag (categorization), and Chip (removable) — sharing tone, shape, icon, and outline/filled styling. Use for status pills, tags, and dismissible chips in a Tesserae (C#/h5) app.
+description: Small inline label tokens — Badge (status indicator), Tag (categorization), and Chip (removable) — sharing tone, shape, icon, and outline/filled styling. Use for status pills, tags, and dismissible chips in a Tesserae (C#/Transpose) app.
 ---
 
 # Badge / Tag / Chip

--- a/Tesserae/skills/references/breadcrumb.md
+++ b/Tesserae/skills/references/breadcrumb.md
@@ -1,6 +1,6 @@
 ---
 name: breadcrumb
-description: A navigational trail showing the user's position within a hierarchy, collapsing extra levels into an overflow menu when space runs out. Use when building a hierarchical breadcrumb nav in a Tesserae (C#/h5) app.
+description: A navigational trail showing the user's position within a hierarchy, collapsing extra levels into an overflow menu when space runs out. Use when building a hierarchical breadcrumb nav in a Tesserae (C#/Transpose) app.
 ---
 
 # Breadcrumb

--- a/Tesserae/skills/references/button.md
+++ b/Tesserae/skills/references/button.md
@@ -1,6 +1,6 @@
 ---
 name: button
-description: The standard clickable button with tone variants, icons, link styling, and inline async spinner states. Use for any action trigger — submit, confirm, navigate, run — in a Tesserae (C#/h5) app.
+description: The standard clickable button with tone variants, icons, link styling, and inline async spinner states. Use for any action trigger — submit, confirm, navigate, run — in a Tesserae (C#/Transpose) app.
 ---
 
 # Button

--- a/Tesserae/skills/references/card-pivot.md
+++ b/Tesserae/skills/references/card-pivot.md
@@ -1,6 +1,6 @@
 ---
 name: card-pivot
-description: A pivot whose tabs render as connected cards with a shared border, suited to dashboard-style metric switching. Use when selectable metric cards control the view below them in a Tesserae (C#/h5) app.
+description: A pivot whose tabs render as connected cards with a shared border, suited to dashboard-style metric switching. Use when selectable metric cards control the view below them in a Tesserae (C#/Transpose) app.
 ---
 
 # CardPivot

--- a/Tesserae/skills/references/card.md
+++ b/Tesserae/skills/references/card.md
@@ -1,6 +1,6 @@
 ---
 name: card
-description: A bordered, shadowed surface that groups related content, with optional title header and footer. Use to present a single topic's content and actions as a self-contained block in a Tesserae (C#/h5) app.
+description: A bordered, shadowed surface that groups related content, with optional title header and footer. Use to present a single topic's content and actions as a self-contained block in a Tesserae (C#/Transpose) app.
 ---
 
 # Card

--- a/Tesserae/skills/references/carousel.md
+++ b/Tesserae/skills/references/carousel.md
@@ -1,6 +1,6 @@
 ---
 name: carousel
-description: A horizontal slideshow that cycles through one slide at a time with prev/next arrows and pagination dots; any component can be a slide. Use for image galleries, feature highlights, or onboarding sequences in a Tesserae (C#/h5) app.
+description: A horizontal slideshow that cycles through one slide at a time with prev/next arrows and pagination dots; any component can be a slide. Use for image galleries, feature highlights, or onboarding sequences in a Tesserae (C#/Transpose) app.
 ---
 
 # Carousel

--- a/Tesserae/skills/references/charts.md
+++ b/Tesserae/skills/references/charts.md
@@ -1,6 +1,6 @@
 ---
 name: charts
-description: Four dependency-free responsive SVG charts — LineChart, BarChart, AreaChart, PieChart — with a shared fluent series/palette API, tooltips, legend, and observable-driven updates. Use to plot trends, comparisons, or part-to-whole data in a Tesserae (C#/h5) app.
+description: Four dependency-free responsive SVG charts — LineChart, BarChart, AreaChart, PieChart — with a shared fluent series/palette API, tooltips, legend, and observable-driven updates. Use to plot trends, comparisons, or part-to-whole data in a Tesserae (C#/Transpose) app.
 ---
 
 # Charts

--- a/Tesserae/skills/references/chat.md
+++ b/Tesserae/skills/references/chat.md
@@ -1,6 +1,6 @@
 ---
 name: chat
-description: A chat transcript surface (ChatArea) holding aligned message bubbles (ChatMessage) with avatars, commands, and live-updatable content via DeltaComponent. Use to build chat or assistant UIs with streaming/typing messages in a Tesserae (C#/h5) app.
+description: A chat transcript surface (ChatArea) holding aligned message bubbles (ChatMessage) with avatars, commands, and live-updatable content via DeltaComponent. Use to build chat or assistant UIs with streaming/typing messages in a Tesserae (C#/Transpose) app.
 ---
 
 # Chat (ChatArea / ChatMessage)

--- a/Tesserae/skills/references/check-box.md
+++ b/Tesserae/skills/references/check-box.md
@@ -1,6 +1,6 @@
 ---
 name: check-box
-description: A two-state (checked/unchecked) labeled form control exposing its state as an observable. Use for boolean settings, opt-ins, and multi-select item lists in a Tesserae (C#/h5) app.
+description: A two-state (checked/unchecked) labeled form control exposing its state as an observable. Use for boolean settings, opt-ins, and multi-select item lists in a Tesserae (C#/Transpose) app.
 ---
 
 # CheckBox

--- a/Tesserae/skills/references/choice-group.md
+++ b/Tesserae/skills/references/choice-group.md
@@ -1,6 +1,6 @@
 ---
 name: choice-group
-description: A radio-style group where exactly one Choice can be selected, in vertical or horizontal layout, exposing the selection as an observable. Use for 2–7 mutually exclusive options that should all stay visible in a Tesserae (C#/h5) app.
+description: A radio-style group where exactly one Choice can be selected, in vertical or horizontal layout, exposing the selection as an observable. Use for 2–7 mutually exclusive options that should all stay visible in a Tesserae (C#/Transpose) app.
 ---
 
 # ChoiceGroup

--- a/Tesserae/skills/references/color-palette.md
+++ b/Tesserae/skills/references/color-palette.md
@@ -1,6 +1,6 @@
 ---
 name: color-palette
-description: A grid of named color swatches for picking from a predefined palette. Use when offering users a fixed set of brand/theme colors (not arbitrary colors) in a Tesserae (C#/h5) app.
+description: A grid of named color swatches for picking from a predefined palette. Use when offering users a fixed set of brand/theme colors (not arbitrary colors) in a Tesserae (C#/Transpose) app.
 ---
 
 # ColorPalette

--- a/Tesserae/skills/references/color-picker.md
+++ b/Tesserae/skills/references/color-picker.md
@@ -1,6 +1,6 @@
 ---
 name: color-picker
-description: A native browser color input wrapped as a Tesserae component, exposing the value as both a hex string and a Color. Use when users need to choose a color in a Tesserae (C#/h5) app.
+description: A native browser color input wrapped as a Tesserae component, exposing the value as both a hex string and a Color. Use when users need to choose a color in a Tesserae (C#/Transpose) app.
 ---
 
 # ColorPicker

--- a/Tesserae/skills/references/colors.md
+++ b/Tesserae/skills/references/colors.md
@@ -1,6 +1,6 @@
 ---
 name: colors
-description: The Theme color system — named palette constants, the Color helper, and runtime light/dark theming. Use when styling components with consistent colors or overriding the theme in a Tesserae (C#/h5) app.
+description: The Theme color system — named palette constants, the Color helper, and runtime light/dark theming. Use when styling components with consistent colors or overriding the theme in a Tesserae (C#/Transpose) app.
 ---
 
 # Colors

--- a/Tesserae/skills/references/command-bar.md
+++ b/Tesserae/skills/references/command-bar.md
@@ -1,6 +1,6 @@
 ---
 name: command-bar
-description: A horizontal toolbar of command buttons split into near (left) and far (right) sections. Use when building a page or item action bar in a Tesserae (C#/h5) app.
+description: A horizontal toolbar of command buttons split into near (left) and far (right) sections. Use when building a page or item action bar in a Tesserae (C#/Transpose) app.
 ---
 
 # CommandBar

--- a/Tesserae/skills/references/command-palette.md
+++ b/Tesserae/skills/references/command-palette.md
@@ -1,6 +1,6 @@
 ---
 name: command-palette
-description: A keyboard-driven full-screen command launcher (Ctrl/Cmd-K style) with search, nesting, and per-action shortcuts. Use when adding a quick-action/command search overlay to a Tesserae (C#/h5) app.
+description: A keyboard-driven full-screen command launcher (Ctrl/Cmd-K style) with search, nesting, and per-action shortcuts. Use when adding a quick-action/command search overlay to a Tesserae (C#/Transpose) app.
 ---
 
 # CommandPalette

--- a/Tesserae/skills/references/context-menu.md
+++ b/Tesserae/skills/references/context-menu.md
@@ -1,6 +1,6 @@
 ---
 name: context-menu
-description: A click/right-click popup menu of commands with headers, dividers, disabled items and nested submenus. Use when surfacing contextual actions relative to an element or coordinates in a Tesserae (C#/h5) app.
+description: A click/right-click popup menu of commands with headers, dividers, disabled items and nested submenus. Use when surfacing contextual actions relative to an element or coordinates in a Tesserae (C#/Transpose) app.
 ---
 
 # ContextMenu

--- a/Tesserae/skills/references/contribution-bar.md
+++ b/Tesserae/skills/references/contribution-bar.md
@@ -1,6 +1,6 @@
 ---
 name: contribution-bar
-description: A single stacked horizontal bar showing how weighted segments add up to a total, with an optional legend. Use when visualising a score breakdown or composition in a Tesserae (C#/h5) app.
+description: A single stacked horizontal bar showing how weighted segments add up to a total, with an optional legend. Use when visualising a score breakdown or composition in a Tesserae (C#/Transpose) app.
 ---
 
 # ContributionBar

--- a/Tesserae/skills/references/core-concepts.md
+++ b/Tesserae/skills/references/core-concepts.md
@@ -1,6 +1,6 @@
 ---
 name: core-concepts
-description: The four foundational ideas of Tesserae — IComponent, the fluent UI API, layout containers, and reactive state (observables + Defer). Use when learning how a Tesserae (C#/h5) app is structured or wiring up reactive UI.
+description: The four foundational ideas of Tesserae — IComponent, the fluent UI API, layout containers, and reactive state (observables + Defer). Use when learning how a Tesserae (C#/Transpose) app is structured or wiring up reactive UI.
 ---
 
 # Core Concepts

--- a/Tesserae/skills/references/creating-a-component.md
+++ b/Tesserae/skills/references/creating-a-component.md
@@ -1,6 +1,6 @@
 ---
 name: creating-a-component
-description: How to build a custom Tesserae UI component by implementing IComponent (or deriving from ComponentBase). Use when adding a new widget/control to the Tesserae toolkit or composing a reusable component in a Tesserae (C#/h5) app.
+description: How to build a custom Tesserae UI component by implementing IComponent (or deriving from ComponentBase). Use when adding a new widget/control to the Tesserae toolkit or composing a reusable component in a Tesserae (C#/Transpose) app.
 ---
 
 # Creating a component (IComponent)
@@ -29,12 +29,12 @@ keep the root in a field, and return it from `Render()`.
 Best for display-only widgets. Model after `Sparkline.cs` / `Raw.cs`.
 
 ```csharp
-using static H5.Core.dom;
+using static Transpose.Core.dom;
 using static Tesserae.UI;   // brings in Div/Span/I and the _( ) attributes helper
 
 namespace Tesserae
 {
-    [H5.Name("tss.MyBadge")]                 // names the generated JS class (conventional)
+    [Transpose.Name("tss.MyBadge")]                 // names the generated JS class (conventional)
     public class MyBadge : IComponent
     {
         private readonly HTMLElement _inner;
@@ -59,7 +59,7 @@ Best when you want click/focus/change events, margin/padding, ARIA, and a
 fluent `T`-returning API. Model after `Button.cs`.
 
 ```csharp
-[H5.Name("tss.MyToggle")]
+[Transpose.Name("tss.MyToggle")]
 public class MyToggle : ComponentBase<MyToggle, HTMLDivElement>
 {
     public MyToggle()

--- a/Tesserae/skills/references/cron-editor.md
+++ b/Tesserae/skills/references/cron-editor.md
@@ -1,6 +1,6 @@
 ---
 name: cron-editor
-description: A UI for editing cron expressions, with a simple daily/weekly/monthly schedule editor and a raw-cron fallback. Use when letting users schedule tasks in a Tesserae (C#/h5) app.
+description: A UI for editing cron expressions, with a simple daily/weekly/monthly schedule editor and a raw-cron fallback. Use when letting users schedule tasks in a Tesserae (C#/Transpose) app.
 ---
 
 # CronEditor

--- a/Tesserae/skills/references/custom-styles.md
+++ b/Tesserae/skills/references/custom-styles.md
@@ -1,6 +1,6 @@
 ---
 name: custom-styles
-description: Fluent helpers for attaching and removing custom CSS classes on any Tesserae component. Use when applying custom CSS classes or reusable stylesheet rules to components in a Tesserae (C#/h5) app.
+description: Fluent helpers for attaching and removing custom CSS classes on any Tesserae component. Use when applying custom CSS classes or reusable stylesheet rules to components in a Tesserae (C#/Transpose) app.
 ---
 
 # Custom CSS Classes

--- a/Tesserae/skills/references/date-picker.md
+++ b/Tesserae/skills/references/date-picker.md
@@ -1,6 +1,6 @@
 ---
 name: date-picker
-description: A form input for picking a single calendar date, backed by the browser's native date input. Use when collecting a date from the user in a Tesserae (C#/h5) app.
+description: A form input for picking a single calendar date, backed by the browser's native date input. Use when collecting a date from the user in a Tesserae (C#/Transpose) app.
 ---
 
 # DatePicker

--- a/Tesserae/skills/references/date-range-picker.md
+++ b/Tesserae/skills/references/date-range-picker.md
@@ -1,6 +1,6 @@
 ---
 name: date-range-picker
-description: A composite picker for a contiguous "from → to" date range, made of two synced DatePickers. Use when collecting a start/end date range in a Tesserae (C#/h5) app.
+description: A composite picker for a contiguous "from → to" date range, made of two synced DatePickers. Use when collecting a start/end date range in a Tesserae (C#/Transpose) app.
 ---
 
 # DateRangePicker

--- a/Tesserae/skills/references/date-time-picker.md
+++ b/Tesserae/skills/references/date-time-picker.md
@@ -1,6 +1,6 @@
 ---
 name: date-time-picker
-description: A form input for picking a single date together with a time-of-day, backed by the native datetime-local input. Use when collecting a precise date+time in a Tesserae (C#/h5) app.
+description: A form input for picking a single date together with a time-of-day, backed by the native datetime-local input. Use when collecting a precise date+time in a Tesserae (C#/Transpose) app.
 ---
 
 # DateTimePicker

--- a/Tesserae/skills/references/defer-with-progress.md
+++ b/Tesserae/skills/references/defer-with-progress.md
@@ -1,6 +1,6 @@
 ---
 name: defer-with-progress
-description: A Defer variant whose async generator reports progress (0–1) and a status message while loading. Use for long-running tasks that should show a progress bar in a Tesserae (C#/h5) app.
+description: A Defer variant whose async generator reports progress (0–1) and a status message while loading. Use for long-running tasks that should show a progress bar in a Tesserae (C#/Transpose) app.
 ---
 
 # DeferWithProgress

--- a/Tesserae/skills/references/defer.md
+++ b/Tesserae/skills/references/defer.md
@@ -1,6 +1,6 @@
 ---
 name: defer
-description: A placeholder that asynchronously loads its real content from a Task, optionally observing observables to refresh. Use when rendering heavy or async content without blocking initial UI in a Tesserae (C#/h5) app.
+description: A placeholder that asynchronously loads its real content from a Task, optionally observing observables to refresh. Use when rendering heavy or async content without blocking initial UI in a Tesserae (C#/Transpose) app.
 ---
 
 # Defer

--- a/Tesserae/skills/references/delta-component.md
+++ b/Tesserae/skills/references/delta-component.md
@@ -1,6 +1,6 @@
 ---
 name: delta-component
-description: A wrapper that diff-patches its DOM to match new content instead of fully re-rendering, animating only what changed. Use for incremental/streaming UI updates in a Tesserae (C#/h5) app.
+description: A wrapper that diff-patches its DOM to match new content instead of fully re-rendering, animating only what changed. Use for incremental/streaming UI updates in a Tesserae (C#/Transpose) app.
 ---
 
 # DeltaComponent

--- a/Tesserae/skills/references/details-list.md
+++ b/Tesserae/skills/references/details-list.md
@@ -1,6 +1,6 @@
 ---
 name: details-list
-description: A virtualised, sortable, multi-column table for typed items (Fluent-UI-style DetailsList) with column sorting, pagination, and an empty-state message. Use when building a data table / file-explorer-style list in a Tesserae (C#/h5) app.
+description: A virtualised, sortable, multi-column table for typed items (Fluent-UI-style DetailsList) with column sorting, pagination, and an empty-state message. Use when building a data table / file-explorer-style list in a Tesserae (C#/Transpose) app.
 ---
 
 # DetailsList

--- a/Tesserae/skills/references/dialog.md
+++ b/Tesserae/skills/references/dialog.md
@@ -1,6 +1,6 @@
 ---
 name: dialog
-description: A blocking modal dialog with a title, body and prebuilt action-button rows (Ok / OkCancel / YesNo / ...), plus awaitable variants. Use when prompting the user for a confirmation or quick decision in a Tesserae (C#/h5) app.
+description: A blocking modal dialog with a title, body and prebuilt action-button rows (Ok / OkCancel / YesNo / ...), plus awaitable variants. Use when prompting the user for a confirmation or quick decision in a Tesserae (C#/Transpose) app.
 ---
 
 # Dialog

--- a/Tesserae/skills/references/dropdown.md
+++ b/Tesserae/skills/references/dropdown.md
@@ -1,6 +1,6 @@
 ---
 name: dropdown
-description: A select-style input for picking one or many values from a list, with search, async loading, and validation. Use when offering a compact list-of-options chooser in a Tesserae (C#/h5) app.
+description: A select-style input for picking one or many values from a list, with search, async loading, and validation. Use when offering a compact list-of-options chooser in a Tesserae (C#/Transpose) app.
 ---
 
 # Dropdown

--- a/Tesserae/skills/references/editable-area.md
+++ b/Tesserae/skills/references/editable-area.md
@@ -1,6 +1,6 @@
 ---
 name: editable-area
-description: An inline-editable multi-line text surface that toggles between a read-only label and a textarea on click. Use for editing notes/descriptions in place in a Tesserae (C#/h5) app.
+description: An inline-editable multi-line text surface that toggles between a read-only label and a textarea on click. Use for editing notes/descriptions in place in a Tesserae (C#/Transpose) app.
 ---
 
 # EditableArea

--- a/Tesserae/skills/references/editable-label.md
+++ b/Tesserae/skills/references/editable-label.md
@@ -1,6 +1,6 @@
 ---
 name: editable-label
-description: An inline-editable single-line text surface that toggles between a read-only label and a textbox on click. Use for editing a title/name field in place in a Tesserae (C#/h5) app.
+description: An inline-editable single-line text surface that toggles between a read-only label and a textbox on click. Use for editing a title/name field in place in a Tesserae (C#/Transpose) app.
 ---
 
 # EditableLabel

--- a/Tesserae/skills/references/emoji.md
+++ b/Tesserae/skills/references/emoji.md
@@ -1,6 +1,6 @@
 ---
 name: emoji
-description: A strongly typed `Emoji` enum (backed by Emoji.css) rendered through the Icon component. Use when adding emoji glyphs with compile-time safety in a Tesserae (C#/h5) app.
+description: A strongly typed `Emoji` enum (backed by Emoji.css) rendered through the Icon component. Use when adding emoji glyphs with compile-time safety in a Tesserae (C#/Transpose) app.
 ---
 
 # Emoji

--- a/Tesserae/skills/references/expander.md
+++ b/Tesserae/skills/references/expander.md
@@ -1,6 +1,6 @@
 ---
 name: expander
-description: A single expand/collapse section with a clickable header that reveals its body. Use for "show more" affordances or as an item inside an Accordion in a Tesserae (C#/h5) app.
+description: A single expand/collapse section with a clickable header that reveals its body. Use for "show more" affordances or as an item inside an Accordion in a Tesserae (C#/Transpose) app.
 ---
 
 # Expander

--- a/Tesserae/skills/references/file-selector-and-drop-area.md
+++ b/Tesserae/skills/references/file-selector-and-drop-area.md
@@ -1,6 +1,6 @@
 ---
 name: file-selector-and-drop-area
-description: Two file-input components — FileSelector (dialog-style picker, validatable) and FileDropArea (drag-and-drop zone). Use when users need to pick or drop files in a Tesserae (C#/h5) app.
+description: Two file-input components — FileSelector (dialog-style picker, validatable) and FileDropArea (drag-and-drop zone). Use when users need to pick or drop files in a Tesserae (C#/Transpose) app.
 ---
 
 # FileSelector & FileDropArea

--- a/Tesserae/skills/references/float.md
+++ b/Tesserae/skills/references/float.md
@@ -1,6 +1,6 @@
 ---
 name: float
-description: An absolute-positioned overlay that anchors a child to a corner or edge of a relative-positioned parent. Use when overlaying a small element (badge, button, label) at a fixed spot inside a container in a Tesserae (C#/h5) app.
+description: An absolute-positioned overlay that anchors a child to a corner or edge of a relative-positioned parent. Use when overlaying a small element (badge, button, label) at a fixed spot inside a container in a Tesserae (C#/Transpose) app.
 ---
 
 # Float

--- a/Tesserae/skills/references/gestures.md
+++ b/Tesserae/skills/references/gestures.md
@@ -1,6 +1,6 @@
 ---
 name: gestures
-description: Fluent tap / double-tap / long-press / pan / pinch / rotate recognition on any IComponent, built on Pointer Events. Use when adding touch or pointer gestures to a Tesserae (C#/h5) app.
+description: Fluent tap / double-tap / long-press / pan / pinch / rotate recognition on any IComponent, built on Pointer Events. Use when adding touch or pointer gestures to a Tesserae (C#/Transpose) app.
 ---
 
 # Gestures

--- a/Tesserae/skills/references/gradients.md
+++ b/Tesserae/skills/references/gradients.md
@@ -1,6 +1,6 @@
 ---
 name: gradients
-description: Predefined theme gradients exposed as CSS-variable strings on `Theme.Gradients`. Use when applying consistent gradient backgrounds in a Tesserae (C#/h5) app.
+description: Predefined theme gradients exposed as CSS-variable strings on `Theme.Gradients`. Use when applying consistent gradient backgrounds in a Tesserae (C#/Transpose) app.
 ---
 
 # Gradients

--- a/Tesserae/skills/references/grid-picker.md
+++ b/Tesserae/skills/references/grid-picker.md
@@ -1,6 +1,6 @@
 ---
 name: grid-picker
-description: An interactive grid of multi-state buttons with drag-to-select, configured by column/row names and a per-state formatter. Use for schedule pickers or grid state selectors in a Tesserae (C#/h5) app.
+description: An interactive grid of multi-state buttons with drag-to-select, configured by column/row names and a per-state formatter. Use for schedule pickers or grid state selectors in a Tesserae (C#/Transpose) app.
 ---
 
 # GridPicker

--- a/Tesserae/skills/references/grid.md
+++ b/Tesserae/skills/references/grid.md
@@ -1,6 +1,6 @@
 ---
 name: grid
-description: A CSS-Grid container with explicit column/row tracks, gaps, alignment, and per-item placement. Use for two-dimensional layouts in a Tesserae (C#/h5) app.
+description: A CSS-Grid container with explicit column/row tracks, gaps, alignment, and per-item placement. Use for two-dimensional layouts in a Tesserae (C#/Transpose) app.
 ---
 
 # Grid

--- a/Tesserae/skills/references/horizontal-separator.md
+++ b/Tesserae/skills/references/horizontal-separator.md
@@ -1,6 +1,6 @@
 ---
 name: horizontal-separator
-description: A thin horizontal divider that can carry centered text or custom content, with left/center/right alignment. Use to separate stacked sections in a Tesserae (C#/h5) app.
+description: A thin horizontal divider that can carry centered text or custom content, with left/center/right alignment. Use to separate stacked sections in a Tesserae (C#/Transpose) app.
 ---
 
 # HorizontalSeparator

--- a/Tesserae/skills/references/horizontal-split-view.md
+++ b/Tesserae/skills/references/horizontal-split-view.md
@@ -1,6 +1,6 @@
 ---
 name: horizontal-split-view
-description: A two-pane container split into top and bottom areas by a thin divider that can be made draggable. Use for stacked editor/preview or header/body layouts in a Tesserae (C#/h5) app.
+description: A two-pane container split into top and bottom areas by a thin divider that can be made draggable. Use for stacked editor/preview or header/body layouts in a Tesserae (C#/Transpose) app.
 ---
 
 # HorizontalSplitView

--- a/Tesserae/skills/references/icomponent.md
+++ b/Tesserae/skills/references/icomponent.md
@@ -1,6 +1,6 @@
 ---
 name: icomponent
-description: The IComponent interface and the complete catalog of fluent extension methods available on every component (sizing, layout, spacing, text, styling, tooltips, accessibility, gestures, binding, visibility, lifecycle). Use when configuring any Tesserae component fluently or looking up which `.Method()` exists in a Tesserae (C#/h5) app.
+description: The IComponent interface and the complete catalog of fluent extension methods available on every component (sizing, layout, spacing, text, styling, tooltips, accessibility, gestures, binding, visibility, lifecycle). Use when configuring any Tesserae component fluently or looking up which `.Method()` exists in a Tesserae (C#/Transpose) app.
 ---
 
 # IComponent and its extension methods

--- a/Tesserae/skills/references/icon-toggle.md
+++ b/Tesserae/skills/references/icon-toggle.md
@@ -1,6 +1,6 @@
 ---
 name: icon-toggle
-description: A segmented control of icon buttons where exactly one is selected at a time, exposing the selection as a typed value. Use when building a view-mode switcher or single-choice icon toolbar in a Tesserae (C#/h5) app.
+description: A segmented control of icon buttons where exactly one is selected at a time, exposing the selection as a typed value. Use when building a view-mode switcher or single-choice icon toolbar in a Tesserae (C#/Transpose) app.
 ---
 
 # IconToggle

--- a/Tesserae/skills/references/icon.md
+++ b/Tesserae/skills/references/icon.md
@@ -1,6 +1,6 @@
 ---
 name: icon
-description: A single visual glyph rendered from the bundled UIcons set or an Emoji, with size, weight, color and tooltip control. Use when adding inline icons to reinforce actions or labels in a Tesserae (C#/h5) app.
+description: A single visual glyph rendered from the bundled UIcons set or an Emoji, with size, weight, color and tooltip control. Use when adding inline icons to reinforce actions or labels in a Tesserae (C#/Transpose) app.
 ---
 
 # Icon

--- a/Tesserae/skills/references/iconography.md
+++ b/Tesserae/skills/references/iconography.md
@@ -1,6 +1,6 @@
 ---
 name: iconography
-description: Strongly-typed icon and emoji set (UIcons + Emoji enums) plus helpers to render them in Tesserae components. Use when adding icons or emoji to components, buttons, or commands in a Tesserae (C#/h5) app.
+description: Strongly-typed icon and emoji set (UIcons + Emoji enums) plus helpers to render them in Tesserae components. Use when adding icons or emoji to components, buttons, or commands in a Tesserae (C#/Transpose) app.
 ---
 
 # Icons & Emoji
@@ -34,14 +34,14 @@ var party    = Icon(Emoji.ConfettiBall, TextSize.Medium);
 var save     = Button("Save").SetIcon(UIcons.Disk, color: Theme.Primary.Foreground);
 var celebrate = Button("Yay").SetIcon(Emoji.ConfettiBall);
 
-// Custom icon font (import its CSS in h5.json first):
+// Custom icon font (import its CSS in tps.json first):
 var faRocket = Icon(UIconHelper.AsUIcon("fa-solid fa-rocket"));
 ```
 
 ## Notes
 
 - `UIcons` is used throughout the library (sidebar buttons, dropdowns, toolbars).
-- For custom icon fonts, import the font/CSS files via your `h5.json` resources.
+- For custom icon fonts, import the font/CSS files via your `tps.json` resources.
 
 ## Related
 

--- a/Tesserae/skills/references/image.md
+++ b/Tesserae/skills/references/image.md
@@ -1,6 +1,6 @@
 ---
 name: image
-description: A responsive image element with fit-mode, sizing, fallback source and circle/crop helpers. Use when displaying screenshots, avatars, logos or any bitmap in a Tesserae (C#/h5) app.
+description: A responsive image element with fit-mode, sizing, fallback source and circle/crop helpers. Use when displaying screenshots, avatars, logos or any bitmap in a Tesserae (C#/Transpose) app.
 ---
 
 # Image

--- a/Tesserae/skills/references/infinite-scrolling-list.md
+++ b/Tesserae/skills/references/infinite-scrolling-list.md
@@ -1,6 +1,6 @@
 ---
 name: infinite-scrolling-list
-description: A list that lazily loads more items as the user scrolls toward the bottom, rendering as a wrapping stack or a grid depending on the column count. Use when paging through a large/unbounded result set in a Tesserae (C#/h5) app.
+description: A list that lazily loads more items as the user scrolls toward the bottom, rendering as a wrapping stack or a grid depending on the column count. Use when paging through a large/unbounded result set in a Tesserae (C#/Transpose) app.
 ---
 
 # InfiniteScrollingList

--- a/Tesserae/skills/references/items-list.md
+++ b/Tesserae/skills/references/items-list.md
@@ -1,6 +1,6 @@
 ---
 name: items-list
-description: A simple, non-virtualised list of arbitrary components, laid out as a wrapping stack (one column) or a grid (multiple columns), backed by an observable item list. Use when displaying a small set of items in a Tesserae (C#/h5) app.
+description: A simple, non-virtualised list of arbitrary components, laid out as a wrapping stack (one column) or a grid (multiple columns), backed by an observable item list. Use when displaying a small set of items in a Tesserae (C#/Transpose) app.
 ---
 
 # ItemsList

--- a/Tesserae/skills/references/javascript-interop.md
+++ b/Tesserae/skills/references/javascript-interop.md
@@ -1,19 +1,19 @@
 ---
 name: javascript-interop
-description: How to call JavaScript and browser APIs from C# in Tesserae via the h5 compiler (Script.Write, [H5.Name], [Template], [External], H5.Core.dom). Use when you need to reach a browser API or inline JS that h5 doesn't already expose.
+description: How to call JavaScript and browser APIs from C# in Tesserae via the Transpose compiler (Script.Write, [Transpose.Name], [Template], [External], Transpose.Core.dom). Use when you need to reach a browser API or inline JS that Transpose doesn't already expose.
 ---
 
-# Invoking JavaScript with h5
+# Invoking JavaScript with Transpose
 
-Tesserae compiles C# to JavaScript with the **h5** compiler. Most of the time
-you use the typed `H5.Core.dom` bindings, but when you need raw JS — a browser
-API h5 doesn't surface, or a global from a bundled library — h5 gives you
+Tesserae compiles C# to JavaScript with the **Transpose** compiler. Most of the time
+you use the typed `Transpose.Core.dom` bindings, but when you need raw JS — a browser
+API Transpose doesn't surface, or a global from a bundled library — Transpose gives you
 several escape hatches.
 
-## `H5.Script.Write` — inline JS
+## `Transpose.Script.Write` — inline JS
 
 ```csharp
-using H5;   // brings Script into scope
+using Transpose;   // brings Script into scope
 ```
 
 `Script.Write("…")` emits the JS verbatim; the generic form returns a value.
@@ -37,10 +37,10 @@ pointer capture in gestures, etc.
 ## Reaching the DOM and globals
 
 ```csharp
-using static H5.Core.dom;   // document, window, console, alert, navigator, …
+using static Transpose.Core.dom;   // document, window, console, alert, navigator, …
 ```
 
-`H5.Core.dom` exposes typed bindings for the standard DOM and `window`/
+`Transpose.Core.dom` exposes typed bindings for the standard DOM and `window`/
 `document` globals, so prefer it over `Script.Write` when a binding exists:
 
 ```csharp
@@ -56,16 +56,16 @@ Convert between C# and JS views of a value with `.As<T>()` when needed.
 When you want a *typed* C# surface over existing JS instead of scattering
 `Script.Write` calls:
 
-- `[H5.Name("globalName")]` on a type maps the C# type to that JS
-  global/namespace (e.g. `[H5.Name("tss.Button")]`). Used throughout Tesserae
+- `[Transpose.Name("globalName")]` on a type maps the C# type to that JS
+  global/namespace (e.g. `[Transpose.Name("tss.Button")]`). Used throughout Tesserae
   to keep generated class names stable.
 - `[External]` + `extern` members declare a binding with **no C# body** — the
   call compiles straight to the underlying JS member.
-- `[H5.Template("…")]` emits a specific JS expression for a member, with
+- `[Transpose.Template("…")]` emits a specific JS expression for a member, with
   `{this}`, `{index}`, argument names as placeholders.
 
 ```csharp
-[H5.Name("tss.ROA")]
+[Transpose.Name("tss.ROA")]
 public class ReadOnlyArray<T>
 {
     public extern ReadOnlyArray(T[] data);
@@ -83,7 +83,7 @@ public class ReadOnlyArray<T>
   runtime. Pass C# values as `{n}` placeholders rather than interpolating them
   into the string so they compile correctly under minification.
 - Property/feature checks: `Script.Write<bool>("(typeof {0}.disabled === 'undefined')", el)`.
-- h5 renames JS files between Debug/Release (`.min.js`); any external script you
+- Transpose renames JS files between Debug/Release (`.min.js`); any external script you
   call must be bundled so the global exists at runtime — see `wrap-a-javascript-library`.
 
 ## Related

--- a/Tesserae/skills/references/keyboard-shortcut.md
+++ b/Tesserae/skills/references/keyboard-shortcut.md
@@ -1,6 +1,6 @@
 ---
 name: keyboard-shortcut
-description: Renders key names as styled <kbd> chips, auto-adapting modifier labels to the current OS. Use when displaying keyboard shortcuts (e.g. Ctrl+K) in a Tesserae (C#/h5) app.
+description: Renders key names as styled <kbd> chips, auto-adapting modifier labels to the current OS. Use when displaying keyboard shortcuts (e.g. Ctrl+K) in a Tesserae (C#/Transpose) app.
 ---
 
 # KeyboardShortcut

--- a/Tesserae/skills/references/label.md
+++ b/Tesserae/skills/references/label.md
@@ -1,6 +1,6 @@
 ---
 name: label
-description: A non-interactive caption for a form field, with inline layout, auto-width alignment and a required marker. Use when captioning inputs (TextBox, NumberPicker, pickers) in a Tesserae (C#/h5) app.
+description: A non-interactive caption for a form field, with inline layout, auto-width alignment and a required marker. Use when captioning inputs (TextBox, NumberPicker, pickers) in a Tesserae (C#/Transpose) app.
 ---
 
 # Label

--- a/Tesserae/skills/references/layer.md
+++ b/Tesserae/skills/references/layer.md
@@ -1,6 +1,6 @@
 ---
 name: layer
-description: A technical container that renders its content at the end of the document so it escapes overflow:hidden and z-index stacking. Use as the projection primitive behind menus, tooltips and overlays in a Tesserae (C#/h5) app.
+description: A technical container that renders its content at the end of the document so it escapes overflow:hidden and z-index stacking. Use as the projection primitive behind menus, tooltips and overlays in a Tesserae (C#/Transpose) app.
 ---
 
 # Layer

--- a/Tesserae/skills/references/layout-alignment.md
+++ b/Tesserae/skills/references/layout-alignment.md
@@ -1,6 +1,6 @@
 ---
 name: layout-alignment
-description: Stack (flexbox) and Grid (CSS grid) layout primitives plus alignment, placement, and sizing extensions. Use when arranging, aligning, or placing components in a Tesserae (C#/h5) app.
+description: Stack (flexbox) and Grid (CSS grid) layout primitives plus alignment, placement, and sizing extensions. Use when arranging, aligning, or placing components in a Tesserae (C#/Transpose) app.
 ---
 
 # Layout & Alignment

--- a/Tesserae/skills/references/link.md
+++ b/Tesserae/skills/references/link.md
@@ -1,6 +1,6 @@
 ---
 name: link
-description: A hyperlink (anchor) component wrapping text or any component, with new-tab, pop-up-window, underline and icon support. Use when adding navigational or external links in a Tesserae (C#/h5) app.
+description: A hyperlink (anchor) component wrapping text or any component, with new-tab, pop-up-window, underline and icon support. Use when adding navigational or external links in a Tesserae (C#/Transpose) app.
 ---
 
 # Link

--- a/Tesserae/skills/references/markdown-block.md
+++ b/Tesserae/skills/references/markdown-block.md
@@ -1,6 +1,6 @@
 ---
 name: markdown-block
-description: Renders Markdown source as sanitized HTML using the bundled marked + DOMPurify libraries. Use when displaying user-supplied or stored Markdown safely in a Tesserae (C#/h5) app.
+description: Renders Markdown source as sanitized HTML using the bundled marked + DOMPurify libraries. Use when displaying user-supplied or stored Markdown safely in a Tesserae (C#/Transpose) app.
 ---
 
 # MarkdownBlock

--- a/Tesserae/skills/references/masonry.md
+++ b/Tesserae/skills/references/masonry.md
@@ -1,6 +1,6 @@
 ---
 name: masonry
-description: A Pinterest-style masonry layout that flows variable-height items into a fixed number of equal-width columns. Use when building a tile/card feed with uneven heights in a Tesserae (C#/h5) app.
+description: A Pinterest-style masonry layout that flows variable-height items into a fixed number of equal-width columns. Use when building a tile/card feed with uneven heights in a Tesserae (C#/Transpose) app.
 ---
 
 # Masonry

--- a/Tesserae/skills/references/menu.md
+++ b/Tesserae/skills/references/menu.md
@@ -1,6 +1,6 @@
 ---
 name: menu
-description: A popover menu of clickable items, headers, dividers and arbitrarily deep submenus, anchored to a trigger element. Use when building dropdown or action menus opened on an explicit click in a Tesserae (C#/h5) app.
+description: A popover menu of clickable items, headers, dividers and arbitrarily deep submenus, anchored to a trigger element. Use when building dropdown or action menus opened on an explicit click in a Tesserae (C#/Transpose) app.
 ---
 
 # Menu

--- a/Tesserae/skills/references/message.md
+++ b/Tesserae/skills/references/message.md
@@ -1,6 +1,6 @@
 ---
 name: message
-description: An inline informational message strip with an icon, title, body, optional note and tone variants (default/success/warning/error). Use for empty states, alerts and static status messages in a Tesserae (C#/h5) app.
+description: An inline informational message strip with an icon, title, body, optional note and tone variants (default/success/warning/error). Use for empty states, alerts and static status messages in a Tesserae (C#/Transpose) app.
 ---
 
 # Message

--- a/Tesserae/skills/references/metric.md
+++ b/Tesserae/skills/references/metric.md
@@ -1,6 +1,6 @@
 ---
 name: metric
-description: A KPI tile showing a large value with a title plus optional trend indicator and sparkline chart. Use when building dashboards or stat cards in a Tesserae (C#/h5) app.
+description: A KPI tile showing a large value with a title plus optional trend indicator and sparkline chart. Use when building dashboards or stat cards in a Tesserae (C#/Transpose) app.
 ---
 
 # Metric

--- a/Tesserae/skills/references/modal.md
+++ b/Tesserae/skills/references/modal.md
@@ -1,6 +1,6 @@
 ---
 name: modal
-description: A centered overlay surface that dims the page and hosts arbitrary content, with optional header, footer, command rows, blocking/non-blocking and light-dismiss modes. Use for dialogs, forms and detail overlays in a Tesserae (C#/h5) app.
+description: A centered overlay surface that dims the page and hosts arbitrary content, with optional header, footer, command rows, blocking/non-blocking and light-dismiss modes. Use for dialogs, forms and detail overlays in a Tesserae (C#/Transpose) app.
 ---
 
 # Modal

--- a/Tesserae/skills/references/month-picker.md
+++ b/Tesserae/skills/references/month-picker.md
@@ -1,6 +1,6 @@
 ---
 name: month-picker
-description: A form input for picking a single calendar month (year + month) via the browser's native month input, surfaced as a typed (year, month) tuple. Use for billing periods, report months or renewal dates in a Tesserae (C#/h5) app.
+description: A form input for picking a single calendar month (year + month) via the browser's native month input, surfaced as a typed (year, month) tuple. Use for billing periods, report months or renewal dates in a Tesserae (C#/Transpose) app.
 ---
 
 # MonthPicker

--- a/Tesserae/skills/references/navbar.md
+++ b/Tesserae/skills/references/navbar.md
@@ -1,6 +1,6 @@
 ---
 name: navbar
-description: A hierarchical vertical navigation tree (Nav) with nested sections, icons, badges and selection tracking; also the top-bar form of a Sidebar via AsNavbar(). Use when building app navigation in a Tesserae (C#/h5) app.
+description: A hierarchical vertical navigation tree (Nav) with nested sections, icons, badges and selection tracking; also the top-bar form of a Sidebar via AsNavbar(). Use when building app navigation in a Tesserae (C#/Transpose) app.
 ---
 
 # Navbar / Nav

--- a/Tesserae/skills/references/node-view.md
+++ b/Tesserae/skills/references/node-view.md
@@ -1,6 +1,6 @@
 ---
 name: node-view
-description: An interactive node-graph editor (wraps BaklavaJS) with typed inputs/outputs, static and dynamic nodes, and save/load state. Use when building flow/graph editors in a Tesserae (C#/h5) app.
+description: An interactive node-graph editor (wraps BaklavaJS) with typed inputs/outputs, static and dynamic nodes, and save/load state. Use when building flow/graph editors in a Tesserae (C#/Transpose) app.
 ---
 
 # NodeView

--- a/Tesserae/skills/references/notification-center.md
+++ b/Tesserae/skills/references/notification-center.md
@@ -1,6 +1,6 @@
 ---
 name: notification-center
-description: A bell button with an unread-count badge that opens a panel of recent notifications grouped by date. Use when adding an in-app notification inbox to a Tesserae (C#/h5) app.
+description: A bell button with an unread-count badge that opens a panel of recent notifications grouped by date. Use when adding an in-app notification inbox to a Tesserae (C#/Transpose) app.
 ---
 
 # NotificationCenter

--- a/Tesserae/skills/references/number-picker.md
+++ b/Tesserae/skills/references/number-picker.md
@@ -1,6 +1,6 @@
 ---
 name: number-picker
-description: A numeric input control over the native HTML number field, with min/max/step bounds, validation and an int Value. Use when a user must enter or pick a number in a Tesserae (C#/h5) app.
+description: A numeric input control over the native HTML number field, with min/max/step bounds, validation and an int Value. Use when a user must enter or pick a number in a Tesserae (C#/Transpose) app.
 ---
 
 # NumberPicker

--- a/Tesserae/skills/references/observable-stack.md
+++ b/Tesserae/skills/references/observable-stack.md
@@ -1,6 +1,6 @@
 ---
 name: observable-stack
-description: A Stack that renders a list of items and reconciles its DOM in place when an observable source changes, touching only inserted/removed/moved rows. Use when rendering a dynamic list where preserving scroll/focus matters in a Tesserae (C#/h5) app.
+description: A Stack that renders a list of items and reconciles its DOM in place when an observable source changes, touching only inserted/removed/moved rows. Use when rendering a dynamic list where preserving scroll/focus matters in a Tesserae (C#/Transpose) app.
 ---
 
 # ObservableStack

--- a/Tesserae/skills/references/observables.md
+++ b/Tesserae/skills/references/observables.md
@@ -1,6 +1,6 @@
 ---
 name: observables
-description: Lightweight reactive state containers (single values, constants, lists, dictionaries) that notify subscribers on change to drive UI updates. Use when wiring reactive state into components in a Tesserae (C#/h5) app.
+description: Lightweight reactive state containers (single values, constants, lists, dictionaries) that notify subscribers on change to drive UI updates. Use when wiring reactive state into components in a Tesserae (C#/Transpose) app.
 ---
 
 # Observables

--- a/Tesserae/skills/references/omni-box.md
+++ b/Tesserae/skills/references/omni-box.md
@@ -1,6 +1,6 @@
 ---
 name: omni-box
-description: A search/chat input that parses boolean operators (AND, OR, NOT, parentheses, quotes), supports inline filter chips, autocomplete suggestions and a chat mode with model selection. Use when building a unified search-and-chat bar in a Tesserae (C#/h5) app.
+description: A search/chat input that parses boolean operators (AND, OR, NOT, parentheses, quotes), supports inline filter chips, autocomplete suggestions and a chat mode with model selection. Use when building a unified search-and-chat bar in a Tesserae (C#/Transpose) app.
 ---
 
 # OmniBox

--- a/Tesserae/skills/references/option.md
+++ b/Tesserae/skills/references/option.md
@@ -1,6 +1,6 @@
 ---
 name: option
-description: A single radio-style choice (ChoiceGroup.Choice, created via Choice(...)) that lives inside a ChoiceGroup for mutually-exclusive selection. Use when building radio-button groups where exactly one option is active in a Tesserae (C#/h5) app.
+description: A single radio-style choice (ChoiceGroup.Choice, created via Choice(...)) that lives inside a ChoiceGroup for mutually-exclusive selection. Use when building radio-button groups where exactly one option is active in a Tesserae (C#/Transpose) app.
 ---
 
 # Option (Choice)

--- a/Tesserae/skills/references/overflow-set.md
+++ b/Tesserae/skills/references/overflow-set.md
@@ -1,6 +1,6 @@
 ---
 name: overflow-set
-description: A horizontal set of items that automatically collapses any items that don't fit into an overflow ("...") menu. Use when building a toolbar or command bar that must adapt to constrained widths in a Tesserae (C#/h5) app.
+description: A horizontal set of items that automatically collapses any items that don't fit into an overflow ("...") menu. Use when building a toolbar or command bar that must adapt to constrained widths in a Tesserae (C#/Transpose) app.
 ---
 
 # OverflowSet

--- a/Tesserae/skills/references/pagination.md
+++ b/Tesserae/skills/references/pagination.md
@@ -1,6 +1,6 @@
 ---
 name: pagination
-description: A page-number navigation strip for walking through pages of results. Use when paging a large result set into fixed-size pages in a Tesserae (C#/h5) app.
+description: A page-number navigation strip for walking through pages of results. Use when paging a large result set into fixed-size pages in a Tesserae (C#/Transpose) app.
 ---
 
 # Pagination

--- a/Tesserae/skills/references/panel.md
+++ b/Tesserae/skills/references/panel.md
@@ -1,6 +1,6 @@
 ---
 name: panel
-description: A side-anchored slide-in drawer with a title, content, footer and configurable size/side, light-dismiss and blocking modes. Use for property inspectors, detail views and side forms in a Tesserae (C#/h5) app.
+description: A side-anchored slide-in drawer with a title, content, footer and configurable size/side, light-dismiss and blocking modes. Use for property inspectors, detail views and side forms in a Tesserae (C#/Transpose) app.
 ---
 
 # Panel

--- a/Tesserae/skills/references/picker.md
+++ b/Tesserae/skills/references/picker.md
@@ -1,6 +1,6 @@
 ---
 name: picker
-description: A multi-select input that filters a list of typed items via a text box and renders selections as removable tags. Use when letting the user search and pick one or more items (recipients, tags) in a Tesserae (C#/h5) app.
+description: A multi-select input that filters a list of typed items via a text box and renders selections as removable tags. Use when letting the user search and pick one or more items (recipients, tags) in a Tesserae (C#/Transpose) app.
 ---
 
 # Picker

--- a/Tesserae/skills/references/pivot-selector.md
+++ b/Tesserae/skills/references/pivot-selector.md
@@ -1,6 +1,6 @@
 ---
 name: pivot-selector
-description: A pivot variant that drives tab navigation through a Dropdown instead of a tab strip, with optional command buttons. Use when you have many tabs or a mobile-first layout in a Tesserae (C#/h5) app.
+description: A pivot variant that drives tab navigation through a Dropdown instead of a tab strip, with optional command buttons. Use when you have many tabs or a mobile-first layout in a Tesserae (C#/Transpose) app.
 ---
 
 # PivotSelector

--- a/Tesserae/skills/references/pivot.md
+++ b/Tesserae/skills/references/pivot.md
@@ -1,6 +1,6 @@
 ---
 name: pivot
-description: A horizontal tabbed surface showing one panel at a time, with scrolling, an overflow menu, closeable tabs and keyboard nav. Use when organizing content into switchable tabs in a Tesserae (C#/h5) app.
+description: A horizontal tabbed surface showing one panel at a time, with scrolling, an overflow menu, closeable tabs and keyboard nav. Use when organizing content into switchable tabs in a Tesserae (C#/Transpose) app.
 ---
 
 # Pivot

--- a/Tesserae/skills/references/plan.md
+++ b/Tesserae/skills/references/plan.md
@@ -1,6 +1,6 @@
 ---
 name: plan
-description: A card that displays a multi-step task with checkable sub-tasks, header/footer commands, and an overall progress bar. Use when showing a running task plan or agent task list in a Tesserae (C#/h5) app.
+description: A card that displays a multi-step task with checkable sub-tasks, header/footer commands, and an overall progress bar. Use when showing a running task plan or agent task list in a Tesserae (C#/Transpose) app.
 ---
 
 # Plan

--- a/Tesserae/skills/references/popover.md
+++ b/Tesserae/skills/references/popover.md
@@ -1,6 +1,6 @@
 ---
 name: popover
-description: A manually-triggered, anchored overlay surface that shows arbitrary IComponent content next to an anchor. Use when building menus, dropdowns, or click-triggered transient surfaces in a Tesserae (C#/h5) app.
+description: A manually-triggered, anchored overlay surface that shows arbitrary IComponent content next to an anchor. Use when building menus, dropdowns, or click-triggered transient surfaces in a Tesserae (C#/Transpose) app.
 ---
 
 # Popover

--- a/Tesserae/skills/references/progress-indicator.md
+++ b/Tesserae/skills/references/progress-indicator.md
@@ -1,6 +1,6 @@
 ---
 name: progress-indicator
-description: A horizontal progress bar with determinate (0–100%) or indeterminate state. Use when showing the completion of a long-running operation in a Tesserae (C#/h5) app.
+description: A horizontal progress bar with determinate (0–100%) or indeterminate state. Use when showing the completion of a long-running operation in a Tesserae (C#/Transpose) app.
 ---
 
 # ProgressIndicator

--- a/Tesserae/skills/references/progress-modal.md
+++ b/Tesserae/skills/references/progress-modal.md
@@ -1,6 +1,6 @@
 ---
 name: progress-modal
-description: A blocking modal that shows a title, dynamic message, and either a spinner or a progress bar (determinate or indeterminate), with an optional cancel button. Use to report on a long-running operation in a Tesserae (C#/h5) app.
+description: A blocking modal that shows a title, dynamic message, and either a spinner or a progress bar (determinate or indeterminate), with an optional cancel button. Use to report on a long-running operation in a Tesserae (C#/Transpose) app.
 ---
 
 # ProgressModal

--- a/Tesserae/skills/references/progress-ring.md
+++ b/Tesserae/skills/references/progress-ring.md
@@ -1,6 +1,6 @@
 ---
 name: progress-ring
-description: A circular (donut-style) progress indicator with determinate value, indeterminate spin, and an optional centre label. Use when showing quota/usage or a compact loading state in a Tesserae (C#/h5) app.
+description: A circular (donut-style) progress indicator with determinate value, indeterminate spin, and an optional centre label. Use when showing quota/usage or a compact loading state in a Tesserae (C#/Transpose) app.
 ---
 
 # ProgressRing

--- a/Tesserae/skills/references/project-setup.md
+++ b/Tesserae/skills/references/project-setup.md
@@ -1,11 +1,11 @@
 ---
 name: project-setup
-description: How to create, configure, build, and run a Tesserae project compiled from C# to JavaScript via h5. Use when setting up a new Tesserae (C#/h5) app, configuring h5.json, or running it locally.
+description: How to create, configure, build, and run a Tesserae project compiled from C# to JavaScript via Transpose. Use when setting up a new Tesserae (C#/Transpose) app, configuring tps.json, or running it locally.
 ---
 
 # Project Setup
 
-Tesserae is a C# UI toolkit compiled to JavaScript by the **h5** compiler. A
+Tesserae is a C# UI toolkit compiled to JavaScript by the **Transpose** compiler. A
 minimal app is an `App.cs` with a `Main` entry point that builds components and
 mounts them to the DOM.
 
@@ -15,12 +15,12 @@ mounts them to the DOM.
 dotnet add package Tesserae
 ```
 
-This pulls in the required `h5` dependencies.
+This pulls in the required `Transpose` dependencies.
 
 ## First app
 
 ```csharp
-using static H5.Core.dom;
+using static Transpose.Core.dom;
 using static Tesserae.UI;
 
 namespace Tesserae.Tests
@@ -44,13 +44,13 @@ namespace Tesserae.Tests
 
 ```bash
 dotnet build
-cd bin/Debug/netstandard2.0/h5/
+cd bin/Debug/netstandard2.0/tps/
 dotnet serve --port 5000      # install: dotnet tool update --global dotnet-serve
 ```
 
 Then open `http://localhost:5000/`.
 
-## h5.json configuration
+## tps.json configuration
 
 Reflection must stay enabled — the `Router` and automatic sample loading depend
 on it:
@@ -67,13 +67,13 @@ are copied into the generated `index.html`:
 ```json
 {
   "resources": [
-    { "name": "images", "files": [ "h5/assets/img/*" ], "output": "assets/img" },
-    { "name": "custom-styles.css", "files": [ "h5/assets/css/site.css" ] }
+    { "name": "images", "files": [ "tps/assets/img/*" ], "output": "assets/img" },
+    { "name": "custom-styles.css", "files": [ "tps/assets/css/site.css" ] }
   ]
 }
 ```
 
-Place assets under an `assets/` folder in the output directory (e.g. `h5/assets/`).
+Place assets under an `assets/` folder in the output directory (e.g. `tps/assets/`).
 
 ## Related
 

--- a/Tesserae/skills/references/property-grid.md
+++ b/Tesserae/skills/references/property-grid.md
@@ -1,6 +1,6 @@
 ---
 name: property-grid
-description: A reflection-driven editor that auto-generates a two-way-bound form from a typed object's public properties. Use when you need a settings editor, model form, or debug inspector without writing per-property markup in a Tesserae (C#/h5) app.
+description: A reflection-driven editor that auto-generates a two-way-bound form from a typed object's public properties. Use when you need a settings editor, model form, or debug inspector without writing per-property markup in a Tesserae (C#/Transpose) app.
 ---
 
 # PropertyGrid

--- a/Tesserae/skills/references/rating.md
+++ b/Tesserae/skills/references/rating.md
@@ -1,6 +1,6 @@
 ---
 name: rating
-description: A star-rating control for collecting or displaying a 1-to-N value. Use when capturing or showing a star score in a Tesserae (C#/h5) app.
+description: A star-rating control for collecting or displaying a 1-to-N value. Use when capturing or showing a star score in a Tesserae (C#/Transpose) app.
 ---
 
 # Rating

--- a/Tesserae/skills/references/resource-card.md
+++ b/Tesserae/skills/references/resource-card.md
@@ -1,6 +1,6 @@
 ---
 name: resource-card
-description: A card tailored to summarising one resource (model, document, service) with icon, title, subtitle, tags, description, date, and a footer for actions. Use when rendering resource tiles, often inside a SearchableList grid, in a Tesserae (C#/h5) app.
+description: A card tailored to summarising one resource (model, document, service) with icon, title, subtitle, tags, description, date, and a footer for actions. Use when rendering resource tiles, often inside a SearchableList grid, in a Tesserae (C#/Transpose) app.
 ---
 
 # ResourceCard

--- a/Tesserae/skills/references/routing.md
+++ b/Tesserae/skills/references/routing.md
@@ -1,6 +1,6 @@
 ---
 name: routing
-description: The built-in lightweight hash-based Router for SPA-style navigation, route parameters, and guards. Use when setting up routing/navigation between views in a Tesserae (C#/h5) app.
+description: The built-in lightweight hash-based Router for SPA-style navigation, route parameters, and guards. Use when setting up routing/navigation between views in a Tesserae (C#/Transpose) app.
 ---
 
 # Routing
@@ -84,7 +84,7 @@ private static void Show(IComponent page) { Content.Clear(); Content.Add(page); 
   `Observable` and render it with `DeferSync` for reactive updates.
 - The History API is unavailable inside the sandboxed docs preview iframe — real
   pages use `Router.Push`/`Replace` directly.
-- `h5.json` reflection must stay enabled for the router to work.
+- `tps.json` reflection must stay enabled for the router to work.
 
 ## Related
 

--- a/Tesserae/skills/references/sandbox.md
+++ b/Tesserae/skills/references/sandbox.md
@@ -1,6 +1,6 @@
 ---
 name: sandbox
-description: A locked-down iframe for rendering untrusted HTML or external URLs in an isolated context, with a CSP, post-message channel, and error reporting. Use when embedding untrusted content or a third-party app in a Tesserae (C#/h5) app.
+description: A locked-down iframe for rendering untrusted HTML or external URLs in an isolated context, with a CSP, post-message channel, and error reporting. Use when embedding untrusted content or a third-party app in a Tesserae (C#/Transpose) app.
 ---
 
 # Sandbox

--- a/Tesserae/skills/references/save-button.md
+++ b/Tesserae/skills/references/save-button.md
@@ -1,6 +1,6 @@
 ---
 name: save-button
-description: A Button variant that drives itself through save states (pending, verifying, saving, saved, error) with matching icon, colour, and spinner. Use when wiring an async save action to a single button in a Tesserae (C#/h5) app.
+description: A Button variant that drives itself through save states (pending, verifying, saving, saved, error) with matching icon, colour, and spinner. Use when wiring an async save action to a single button in a Tesserae (C#/Transpose) app.
 ---
 
 # SaveButton

--- a/Tesserae/skills/references/saving-toast.md
+++ b/Tesserae/skills/references/saving-toast.md
@@ -1,6 +1,6 @@
 ---
 name: saving-toast
-description: A Toast variant that shows a "saving…" indicator and swaps to a success or error message, plus a Task extension that wraps an await in one. Use when giving feedback for a background save/async operation in a Tesserae (C#/h5) app.
+description: A Toast variant that shows a "saving…" indicator and swaps to a success or error message, plus a Task extension that wraps an await in one. Use when giving feedback for a background save/async operation in a Tesserae (C#/Transpose) app.
 ---
 
 # SavingToast

--- a/Tesserae/skills/references/search-box.md
+++ b/Tesserae/skills/references/search-box.md
@@ -1,6 +1,6 @@
 ---
 name: search-box
-description: A single-line search input with a leading magnifier, clear button, and search-on-Enter or debounced-as-you-type semantics. Use when adding a search field that fires a query callback in a Tesserae (C#/h5) app.
+description: A single-line search input with a leading magnifier, clear button, and search-on-Enter or debounced-as-you-type semantics. Use when adding a search field that fires a query callback in a Tesserae (C#/Transpose) app.
 ---
 
 # SearchBox

--- a/Tesserae/skills/references/searchable-grouped-list.md
+++ b/Tesserae/skills/references/searchable-grouped-list.md
@@ -1,6 +1,6 @@
 ---
 name: searchable-grouped-list
-description: A searchable, scrollable list whose items are organised into named groups with per-group headers, filtered live as the user types. Use when displaying a categorised, filterable list in a Tesserae (C#/h5) app.
+description: A searchable, scrollable list whose items are organised into named groups with per-group headers, filtered live as the user types. Use when displaying a categorised, filterable list in a Tesserae (C#/Transpose) app.
 ---
 
 # SearchableGroupedList

--- a/Tesserae/skills/references/searchable-list.md
+++ b/Tesserae/skills/references/searchable-list.md
@@ -1,6 +1,6 @@
 ---
 name: searchable-list
-description: A searchable, scrollable list whose items are filtered live as the user types into a built-in search box, with optional async background search. Use when displaying a filterable list of items in a Tesserae (C#/h5) app.
+description: A searchable, scrollable list whose items are filtered live as the user types into a built-in search box, with optional async background search. Use when displaying a filterable list of items in a Tesserae (C#/Transpose) app.
 ---
 
 # SearchableList

--- a/Tesserae/skills/references/section-stack.md
+++ b/Tesserae/skills/references/section-stack.md
@@ -1,6 +1,6 @@
 ---
 name: section-stack
-description: A vertical Stack that adds sections and titles with staggered mount animations and optional card styling. Use to present grouped, animated content blocks in a Tesserae (C#/h5) app.
+description: A vertical Stack that adds sections and titles with staggered mount animations and optional card styling. Use to present grouped, animated content blocks in a Tesserae (C#/Transpose) app.
 ---
 
 # SectionStack

--- a/Tesserae/skills/references/section-title.md
+++ b/Tesserae/skills/references/section-title.md
@@ -1,6 +1,6 @@
 ---
 name: section-title
-description: A heading that labels a section of a form or page with an icon, title, optional subtitle, and trailing action commands. Use when introducing a section in a form, card, or SectionStack in a Tesserae (C#/h5) app.
+description: A heading that labels a section of a form or page with an icon, title, optional subtitle, and trailing action commands. Use when introducing a section in a form, card, or SectionStack in a Tesserae (C#/Transpose) app.
 ---
 
 # SectionTitle

--- a/Tesserae/skills/references/segmented-pivot.md
+++ b/Tesserae/skills/references/segmented-pivot.md
@@ -1,6 +1,6 @@
 ---
 name: segmented-pivot
-description: A pivot styled as a connected segmented (pill) control for switching between a few closely related views, with horizontal scrolling and an overflow menu when the segments don't fit. Use when toggling related views or filters in limited space in a Tesserae (C#/h5) app.
+description: A pivot styled as a connected segmented (pill) control for switching between a few closely related views, with horizontal scrolling and an overflow menu when the segments don't fit. Use when toggling related views or filters in limited space in a Tesserae (C#/Transpose) app.
 ---
 
 # SegmentedPivot

--- a/Tesserae/skills/references/sidebar-separator.md
+++ b/Tesserae/skills/references/sidebar-separator.md
@@ -1,6 +1,6 @@
 ---
 name: sidebar-separator
-description: A visual separator for grouping items inside a Sidebar, optionally with a label. Use when separating or labelling groups of Sidebar items in a Tesserae (C#/h5) app.
+description: A visual separator for grouping items inside a Sidebar, optionally with a label. Use when separating or labelling groups of Sidebar items in a Tesserae (C#/Transpose) app.
 ---
 
 # SidebarSeparator

--- a/Tesserae/skills/references/sidebar.md
+++ b/Tesserae/skills/references/sidebar.md
@@ -1,6 +1,6 @@
 ---
 name: sidebar
-description: A collapsible side-navigation panel with header, scrollable middle, and footer sections holding sidebar items (buttons, separators, nav groups, pivots). Use when building app navigation that can collapse to icons in a Tesserae (C#/h5) app.
+description: A collapsible side-navigation panel with header, scrollable middle, and footer sections holding sidebar items (buttons, separators, nav groups, pivots). Use when building app navigation that can collapse to icons in a Tesserae (C#/Transpose) app.
 ---
 
 # Sidebar

--- a/Tesserae/skills/references/sidenav.md
+++ b/Tesserae/skills/references/sidenav.md
@@ -1,6 +1,6 @@
 ---
 name: sidenav
-description: A narrow vertical icon navigation rail (icon + small label) for the leftmost app navigation, often paired with a Sidebar. Use when building a top-level section switcher in a Tesserae (C#/h5) app.
+description: A narrow vertical icon navigation rail (icon + small label) for the leftmost app navigation, often paired with a Sidebar. Use when building a top-level section switcher in a Tesserae (C#/Transpose) app.
 ---
 
 # Sidenav

--- a/Tesserae/skills/references/skeleton.md
+++ b/Tesserae/skills/references/skeleton.md
@@ -1,6 +1,6 @@
 ---
 name: skeleton
-description: An animated placeholder shape (line, circle, or rectangle) shown while content loads. Use when reserving layout space for loading content in a Tesserae (C#/h5) app.
+description: An animated placeholder shape (line, circle, or rectangle) shown while content loads. Use when reserving layout space for loading content in a Tesserae (C#/Transpose) app.
 ---
 
 # Skeleton

--- a/Tesserae/skills/references/slider.md
+++ b/Tesserae/skills/references/slider.md
@@ -1,6 +1,6 @@
 ---
 name: slider
-description: A range input for picking an integer value between a min and max with a step, horizontal or vertical. Use when a user adjusts a numeric value along a track in a Tesserae (C#/h5) app.
+description: A range input for picking an integer value between a min and max with a step, horizontal or vertical. Use when a user adjusts a numeric value along a track in a Tesserae (C#/Transpose) app.
 ---
 
 # Slider

--- a/Tesserae/skills/references/sortable-stack.md
+++ b/Tesserae/skills/references/sortable-stack.md
@@ -1,6 +1,6 @@
 ---
 name: sortable-stack
-description: A Stack whose child items can be reordered by drag-and-drop, reporting the new order via a callback. Use when the visual order matters and must be persisted or reacted to in a Tesserae (C#/h5) app.
+description: A Stack whose child items can be reordered by drag-and-drop, reporting the new order via a callback. Use when the visual order matters and must be persisted or reacted to in a Tesserae (C#/Transpose) app.
 ---
 
 # SortableStack

--- a/Tesserae/skills/references/sparkline.md
+++ b/Tesserae/skills/references/sparkline.md
@@ -1,6 +1,6 @@
 ---
 name: sparkline
-description: A compact inline SVG area chart that shows the shape of a trend without axes or labels. Use when embedding a tiny trend chart beside a metric, table cell, or dashboard card in a Tesserae (C#/h5) app.
+description: A compact inline SVG area chart that shows the shape of a trend without axes or labels. Use when embedding a tiny trend chart beside a metric, table cell, or dashboard card in a Tesserae (C#/Transpose) app.
 ---
 
 # Sparkline

--- a/Tesserae/skills/references/spinner.md
+++ b/Tesserae/skills/references/spinner.md
@@ -1,6 +1,6 @@
 ---
 name: spinner
-description: An animated indeterminate loading indicator with an optional positioned label and optional determinate progress. Use when signalling a running background task in a Tesserae (C#/h5) app.
+description: An animated indeterminate loading indicator with an optional positioned label and optional determinate progress. Use when signalling a running background task in a Tesserae (C#/Transpose) app.
 ---
 
 # Spinner

--- a/Tesserae/skills/references/split-view.md
+++ b/Tesserae/skills/references/split-view.md
@@ -1,6 +1,6 @@
 ---
 name: split-view
-description: A two-pane container with left/right panels separated by an optionally draggable splitter. Use when building side-by-side resizable layouts in a Tesserae (C#/h5) app.
+description: A two-pane container with left/right panels separated by an optionally draggable splitter. Use when building side-by-side resizable layouts in a Tesserae (C#/Transpose) app.
 ---
 
 # SplitView

--- a/Tesserae/skills/references/stack.md
+++ b/Tesserae/skills/references/stack.md
@@ -1,6 +1,6 @@
 ---
 name: stack
-description: A flexbox container that lays out child components vertically or horizontally with alignment, wrapping, gap, and per-child sizing. Use as the default one-axis layout container in a Tesserae (C#/h5) app.
+description: A flexbox container that lays out child components vertically or horizontally with alignment, wrapping, gap, and per-child sizing. Use as the default one-axis layout container in a Tesserae (C#/Transpose) app.
 ---
 
 # Stack

--- a/Tesserae/skills/references/stepper.md
+++ b/Tesserae/skills/references/stepper.md
@@ -1,6 +1,6 @@
 ---
 name: stepper
-description: A multi-step wizard that shows numbered steps with titles, swaps content per step, and provides Back/Next navigation. Use when guiding the user through a sequential flow (forms, onboarding) in a Tesserae (C#/h5) app.
+description: A multi-step wizard that shows numbered steps with titles, swaps content per step, and provides Back/Next navigation. Use when guiding the user through a sequential flow (forms, onboarding) in a Tesserae (C#/Transpose) app.
 ---
 
 # Stepper

--- a/Tesserae/skills/references/steps-slider.md
+++ b/Tesserae/skills/references/steps-slider.md
@@ -1,6 +1,6 @@
 ---
 name: steps-slider
-description: A generic slider that snaps to a fixed set of named, ordered values instead of a continuous range. Use when a user picks from a small ordered set (sizes, tiers, priorities) in a Tesserae (C#/h5) app.
+description: A generic slider that snaps to a fixed set of named, ordered values instead of a continuous range. Use when a user picks from a small ordered set (sizes, tiers, priorities) in a Tesserae (C#/Transpose) app.
 ---
 
 # StepsSlider

--- a/Tesserae/skills/references/styling.md
+++ b/Tesserae/skills/references/styling.md
@@ -1,6 +1,6 @@
 ---
 name: styling
-description: Fluent strongly-typed styling for text formatting, spacing, sizing, UnitSize, and direct DOM styles. Use when styling components — text size/weight, padding/margin, sizes, or inline CSS — in a Tesserae (C#/h5) app.
+description: Fluent strongly-typed styling for text formatting, spacing, sizing, UnitSize, and direct DOM styles. Use when styling components — text size/weight, padding/margin, sizes, or inline CSS — in a Tesserae (C#/Transpose) app.
 ---
 
 # Styling

--- a/Tesserae/skills/references/tabbed-modal.md
+++ b/Tesserae/skills/references/tabbed-modal.md
@@ -1,6 +1,6 @@
 ---
 name: tabbed-modal
-description: A pattern (not a distinct class) that hosts Modals as tabs inside a Pivot, using closeable tabs and the Pivot's caching/lifecycle. Use to present several modal-style panels as switchable, closeable tabs in a Tesserae (C#/h5) app.
+description: A pattern (not a distinct class) that hosts Modals as tabs inside a Pivot, using closeable tabs and the Pivot's caching/lifecycle. Use to present several modal-style panels as switchable, closeable tabs in a Tesserae (C#/Transpose) app.
 ---
 
 # TabbedModal

--- a/Tesserae/skills/references/tags-input.md
+++ b/Tesserae/skills/references/tags-input.md
@@ -1,6 +1,6 @@
 ---
 name: tags-input
-description: A free-form multi-value field where the user types short string values ("tags"/"chips") confirmed with a delimiter key, removable by backspace or click. Use when collecting an open-ended list of labels, categories, or keywords in a Tesserae (C#/h5) app.
+description: A free-form multi-value field where the user types short string values ("tags"/"chips") confirmed with a delimiter key, removable by backspace or click. Use when collecting an open-ended list of labels, categories, or keywords in a Tesserae (C#/Transpose) app.
 ---
 
 # TagsInput

--- a/Tesserae/skills/references/task-board.md
+++ b/Tesserae/skills/references/task-board.md
@@ -1,6 +1,6 @@
 ---
 name: task-board
-description: A Kanban board of named columns holding draggable cards, with drag-and-drop reordering between and within columns. Use when building a Trello-style task/Kanban board in a Tesserae (C#/h5) app.
+description: A Kanban board of named columns holding draggable cards, with drag-and-drop reordering between and within columns. Use when building a Trello-style task/Kanban board in a Tesserae (C#/Transpose) app.
 ---
 
 # TaskBoard

--- a/Tesserae/skills/references/teaching.md
+++ b/Tesserae/skills/references/teaching.md
@@ -1,6 +1,6 @@
 ---
 name: teaching
-description: A guided onboarding walkthrough that highlights UI elements one at a time with a tooltip, advancing on a Next click or after a fixed delay. Use when introducing first-time users to features in a Tesserae (C#/h5) app.
+description: A guided onboarding walkthrough that highlights UI elements one at a time with a tooltip, advancing on a Next click or after a fixed delay. Use when introducing first-time users to features in a Tesserae (C#/Transpose) app.
 ---
 
 # Teaching

--- a/Tesserae/skills/references/text-area.md
+++ b/Tesserae/skills/references/text-area.md
@@ -1,6 +1,6 @@
 ---
 name: text-area
-description: A multi-line text input with placeholder, validation, read-only/disabled states, and optional auto-resize. Use when collecting multi-line text (comments, descriptions) in a Tesserae (C#/h5) app.
+description: A multi-line text input with placeholder, validation, read-only/disabled states, and optional auto-resize. Use when collecting multi-line text (comments, descriptions) in a Tesserae (C#/Transpose) app.
 ---
 
 # TextArea

--- a/Tesserae/skills/references/text-block.md
+++ b/Tesserae/skills/references/text-block.md
@@ -1,6 +1,6 @@
 ---
 name: text-block
-description: A display component for rendering styled text. Use when showing static or dynamic labels, headings, or inline text in a Tesserae (C#/h5) app.
+description: A display component for rendering styled text. Use when showing static or dynamic labels, headings, or inline text in a Tesserae (C#/Transpose) app.
 ---
 
 # TextBlock

--- a/Tesserae/skills/references/text-box.md
+++ b/Tesserae/skills/references/text-box.md
@@ -1,6 +1,6 @@
 ---
 name: text-box
-description: A single-line text input. Use when collecting string input in forms or any field in a Tesserae (C#/h5) app.
+description: A single-line text input. Use when collecting string input in forms or any field in a Tesserae (C#/Transpose) app.
 ---
 
 # TextBox

--- a/Tesserae/skills/references/text-breadcrumbs.md
+++ b/Tesserae/skills/references/text-breadcrumbs.md
@@ -1,6 +1,6 @@
 ---
 name: text-breadcrumbs
-description: A breadcrumb trail rendering a path as clickable text links. Use when showing hierarchical navigation/location in a Tesserae (C#/h5) app.
+description: A breadcrumb trail rendering a path as clickable text links. Use when showing hierarchical navigation/location in a Tesserae (C#/Transpose) app.
 ---
 
 # TextBreadcrumbs

--- a/Tesserae/skills/references/theme-colors.md
+++ b/Tesserae/skills/references/theme-colors.md
@@ -1,6 +1,6 @@
 ---
 name: theme-colors
-description: The static `Theme` class for switching light/dark mode and overriding primary/background colors at runtime. Use when toggling themes or recoloring a Tesserae (C#/h5) app.
+description: The static `Theme` class for switching light/dark mode and overriding primary/background colors at runtime. Use when toggling themes or recoloring a Tesserae (C#/Transpose) app.
 ---
 
 # Theme Colors

--- a/Tesserae/skills/references/time-histogram-picker.md
+++ b/Tesserae/skills/references/time-histogram-picker.md
@@ -1,6 +1,6 @@
 ---
 name: time-histogram-picker
-description: A histogram with draggable thumbs for selecting a time range over a set of timestamps. Use when filtering data by date/time range visually in a Tesserae (C#/h5) app.
+description: A histogram with draggable thumbs for selecting a time range over a set of timestamps. Use when filtering data by date/time range visually in a Tesserae (C#/Transpose) app.
 ---
 
 # TimeHistogramPicker

--- a/Tesserae/skills/references/time-picker.md
+++ b/Tesserae/skills/references/time-picker.md
@@ -1,6 +1,6 @@
 ---
 name: time-picker
-description: A native browser time input that stores its value as a DateTimeOffset. Use when collecting a time-only value (schedules, reminders, cut-offs) in a Tesserae (C#/h5) app.
+description: A native browser time input that stores its value as a DateTimeOffset. Use when collecting a time-only value (schedules, reminders, cut-offs) in a Tesserae (C#/Transpose) app.
 ---
 
 # TimePicker

--- a/Tesserae/skills/references/timeline.md
+++ b/Tesserae/skills/references/timeline.md
@@ -1,6 +1,6 @@
 ---
 name: timeline
-description: A vertical timeline that arranges items in sequence, alternating left/right by default or pinned to one side, with an optional per-item marker color. Use when visualising events or steps in chronological order in a Tesserae (C#/h5) app.
+description: A vertical timeline that arranges items in sequence, alternating left/right by default or pinned to one side, with an optional per-item marker color. Use when visualising events or steps in chronological order in a Tesserae (C#/Transpose) app.
 ---
 
 # Timeline

--- a/Tesserae/skills/references/tippy.md
+++ b/Tesserae/skills/references/tippy.md
@@ -1,6 +1,6 @@
 ---
 name: tippy
-description: Tooltip support for any IComponent (wraps Tippy.js), accepting text or component content. Use when attaching hover tooltips/popovers in a Tesserae (C#/h5) app.
+description: Tooltip support for any IComponent (wraps Tippy.js), accepting text or component content. Use when attaching hover tooltips/popovers in a Tesserae (C#/Transpose) app.
 ---
 
 # Tippy

--- a/Tesserae/skills/references/toast.md
+++ b/Tesserae/skills/references/toast.md
@@ -1,6 +1,6 @@
 ---
 name: toast
-description: Short-lived overlay notifications (success/info/warning/error) with configurable position and optional banner mode. Use when showing transient feedback messages in a Tesserae (C#/h5) app.
+description: Short-lived overlay notifications (success/info/warning/error) with configurable position and optional banner mode. Use when showing transient feedback messages in a Tesserae (C#/Transpose) app.
 ---
 
 # Toast

--- a/Tesserae/skills/references/toggle-button.md
+++ b/Tesserae/skills/references/toggle-button.md
@@ -1,6 +1,6 @@
 ---
 name: toggle-button
-description: A button that maintains an on/off checked state. Use when you need a pressable toolbar-style toggle (bold, mute, pin) in a Tesserae (C#/h5) app.
+description: A button that maintains an on/off checked state. Use when you need a pressable toolbar-style toggle (bold, mute, pin) in a Tesserae (C#/Transpose) app.
 ---
 
 # ToggleButton

--- a/Tesserae/skills/references/toggle.md
+++ b/Tesserae/skills/references/toggle.md
@@ -1,6 +1,6 @@
 ---
 name: toggle
-description: A switch control for an on/off (boolean) setting with an auto-updating label. Use when a setting should take effect immediately on flip in a Tesserae (C#/h5) app.
+description: A switch control for an on/off (boolean) setting with an auto-updating label. Use when a setting should take effect immediately on flip in a Tesserae (C#/Transpose) app.
 ---
 
 # Toggle

--- a/Tesserae/skills/references/tool-call.md
+++ b/Tesserae/skills/references/tool-call.md
@@ -1,6 +1,6 @@
 ---
 name: tool-call
-description: An inline, accordion-style indicator of an AI tool invocation, plus a ToolsUsed summary that opens a list-and-detail modal. Use when surfacing tool calls in a chat/assistant UI in a Tesserae (C#/h5) app.
+description: An inline, accordion-style indicator of an AI tool invocation, plus a ToolsUsed summary that opens a list-and-detail modal. Use when surfacing tool calls in a chat/assistant UI in a Tesserae (C#/Transpose) app.
 ---
 
 # ToolCall / ToolsUsed

--- a/Tesserae/skills/references/tree.md
+++ b/Tesserae/skills/references/tree.md
@@ -1,6 +1,6 @@
 ---
 name: tree
-description: A hierarchical tree view with expand/collapse, selection, keyboard nav, and sync or async child loading. Use when displaying nested/hierarchical data (file trees, org charts) in a Tesserae (C#/h5) app.
+description: A hierarchical tree view with expand/collapse, selection, keyboard nav, and sync or async child loading. Use when displaying nested/hierarchical data (file trees, org charts) in a Tesserae (C#/Transpose) app.
 ---
 
 # Tree

--- a/Tesserae/skills/references/tutorial-modal.md
+++ b/Tesserae/skills/references/tutorial-modal.md
@@ -1,6 +1,6 @@
 ---
 name: tutorial-modal
-description: A split-layout modal with an explanation/illustration column on the left and a content/form column on the right, plus footer commands. Use for onboarding, guided steps or multi-field intro forms in a Tesserae (C#/h5) app.
+description: A split-layout modal with an explanation/illustration column on the left and a content/form column on the right, plus footer commands. Use for onboarding, guided steps or multi-field intro forms in a Tesserae (C#/Transpose) app.
 ---
 
 # TutorialModal

--- a/Tesserae/skills/references/uicons.md
+++ b/Tesserae/skills/references/uicons.md
@@ -1,6 +1,6 @@
 ---
 name: uicons
-description: A strongly typed `UIcons` enum (Flaticon UIcons set) rendered through the Icon component. Use when adding icon glyphs with compile-time safety in a Tesserae (C#/h5) app.
+description: A strongly typed `UIcons` enum (Flaticon UIcons set) rendered through the Icon component. Use when adding icon glyphs with compile-time safety in a Tesserae (C#/Transpose) app.
 ---
 
 # UIcons

--- a/Tesserae/skills/references/uptime.md
+++ b/Tesserae/skills/references/uptime.md
@@ -1,6 +1,6 @@
 ---
 name: uptime
-description: Status-history visualisations — UptimeBars (a horizontal strip of per-period status bars) and UptimeCalendar (a month grid of daily status). Use when showing service availability/health over time in a Tesserae (C#/h5) app.
+description: Status-history visualisations — UptimeBars (a horizontal strip of per-period status bars) and UptimeCalendar (a month grid of daily status). Use when showing service availability/health over time in a Tesserae (C#/Transpose) app.
 ---
 
 # Uptime (UptimeBars / UptimeCalendar)

--- a/Tesserae/skills/references/validator.md
+++ b/Tesserae/skills/references/validator.md
@@ -1,6 +1,6 @@
 ---
 name: validator
-description: Coordinates validation across multiple form components, tracking user interaction and updating visual state. Use when validating forms or groups of inputs in a Tesserae (C#/h5) app.
+description: Coordinates validation across multiple form components, tracking user interaction and updating visual state. Use when validating forms or groups of inputs in a Tesserae (C#/Transpose) app.
 ---
 
 # Validator

--- a/Tesserae/skills/references/virtualized-list.md
+++ b/Tesserae/skills/references/virtualized-list.md
@@ -1,6 +1,6 @@
 ---
 name: virtualized-list
-description: A list that renders only the pages of items currently in (or near) the viewport, recycling DOM as the user scrolls, for very large datasets. Use when displaying thousands of equal-height items in a Tesserae (C#/h5) app.
+description: A list that renders only the pages of items currently in (or near) the viewport, recycling DOM as the user scrolls, for very large datasets. Use when displaying thousands of equal-height items in a Tesserae (C#/Transpose) app.
 ---
 
 # VirtualizedList

--- a/Tesserae/skills/references/visibility-sensor.md
+++ b/Tesserae/skills/references/visibility-sensor.md
@@ -1,6 +1,6 @@
 ---
 name: visibility-sensor
-description: An invisible marker that fires a callback when it scrolls into the viewport. Use when triggering lazy loading, telemetry, or infinite-scroll pagination in a Tesserae (C#/h5) app.
+description: An invisible marker that fires a callback when it scrolls into the viewport. Use when triggering lazy loading, telemetry, or infinite-scroll pagination in a Tesserae (C#/Transpose) app.
 ---
 
 # VisibilitySensor

--- a/Tesserae/skills/references/week-picker.md
+++ b/Tesserae/skills/references/week-picker.md
@@ -1,6 +1,6 @@
 ---
 name: week-picker
-description: A native browser week input that surfaces the selection as a (year, weekNumber) tuple. Use when choosing an ISO week for scheduling, sprints, or weekly reports in a Tesserae (C#/h5) app.
+description: A native browser week input that surfaces the selection as a (year, weekNumber) tuple. Use when choosing an ISO week for scheduling, sprints, or weekly reports in a Tesserae (C#/Transpose) app.
 ---
 
 # WeekPicker

--- a/Tesserae/skills/references/wrap-a-javascript-library.md
+++ b/Tesserae/skills/references/wrap-a-javascript-library.md
@@ -1,6 +1,6 @@
 ---
 name: wrap-a-javascript-library
-description: How to bundle an existing JavaScript library into Tesserae and wrap it as an IComponent (h5.json resources + Script.Write against the global). Use when adding a feature backed by a third-party JS library (charting, layout, editors, etc.).
+description: How to bundle an existing JavaScript library into Tesserae and wrap it as an IComponent (tps.json resources + Script.Write against the global). Use when adding a feature backed by a third-party JS library (charting, layout, editors, etc.).
 ---
 
 # Wrapping an existing JavaScript library
@@ -13,19 +13,19 @@ global from C# through `Script.Write`.**
 
 ## 1. Bundle the library
 
-Put the minified library under `Tesserae/h5/assets/js/` and add it to the
-resource bundles in `Tesserae/h5.json`. It must appear in **both** the
+Put the minified library under `Tesserae/tps/assets/js/` and add it to the
+resource bundles in `Tesserae/tps.json`. It must appear in **both** the
 `tss-dep.js` and `tss-dep.min.js` bundles (keep the two file lists in sync —
-h5 swaps between them for Debug vs Release builds):
+Transpose swaps between them for Debug vs Release builds):
 
 ```jsonc
 {
   "name": "tss-dep.js",
   "files": [
-    "h5/assets/js/popper.min.js",
-    "h5/assets/js/tippy.min.js",
-    "h5/assets/js/masonry.min.js",
-    "h5/assets/js/yourlib.min.js"     // <-- add here
+    "tps/assets/js/popper.min.js",
+    "tps/assets/js/tippy.min.js",
+    "tps/assets/js/masonry.min.js",
+    "tps/assets/js/yourlib.min.js"     // <-- add here
   ],
   "output": "assets/js"
 }
@@ -43,11 +43,11 @@ instance in an `object` field so you can call back into it. `Masonry.cs` is the
 canonical example:
 
 ```csharp
-using H5;
-using static H5.Core.dom;
+using Transpose;
+using static Transpose.Core.dom;
 using static Tesserae.UI;
 
-[H5.Name("tss.Masonry")]
+[Transpose.Name("tss.Masonry")]
 public class Masonry : IContainer<Masonry, IComponent>, ISpecialCaseStyling
 {
     private readonly HTMLElement _host;
@@ -94,7 +94,7 @@ public class Masonry : IContainer<Masonry, IComponent>, ISpecialCaseStyling
 - **Hold the instance as `object`** and reach its methods/properties via
   `Script.Write("{0}.method({1})", _instance, arg)`.
 - For a *typed* surface over the library instead of inline strings, declare an
-  `[External]` / `[H5.Name]` binding — see `javascript-interop`.
+  `[External]` / `[Transpose.Name]` binding — see `javascript-interop`.
 - Add a `UI.Components.cs` factory and a sample, like any other component.
 
 ## Related


### PR DESCRIPTION
This PR updates all documentation and configuration references throughout the repository to reflect the migration from the **h5 compiler** to the **Transpose compiler**.

## Summary
The Tesserae toolkit has migrated its C#-to-JavaScript compilation toolchain from h5 to Transpose. This change updates all user-facing documentation, configuration file references, code examples, and internal guidance to use the new compiler name and associated tooling.

## Key changes

- **README.md**: Updated compiler name, installation instructions (h5-compiler → Transpose.Compiler), project template references (h5.Template → Transpose.Template), and configuration file names (h5.json → tps.json)
- **Configuration references**: Changed all references from `h5.json` to `tps.json` and output paths from `h5/` to `tps/`
- **Code examples**: Updated using statements and attributes from `H5` namespace to `Transpose` namespace (e.g., `[H5.Name]` → `[Transpose.Name]`, `using H5` → `using Transpose`)
- **Skill documentation**: Updated all skill descriptions and examples in `Tesserae/skills/` to reference Transpose instead of h5
- **Setup guides**: Updated project setup, build process, and JavaScript interop documentation to reflect Transpose compiler usage
- **Internal documentation**: Updated CLAUDE.md and AGENTS.md to reference Transpose and tps.json configuration

## Notable details

- All namespace references changed from `H5` to `Transpose` (e.g., `H5.Core.dom` → `Transpose.Core.dom`, `H5.Script` → `Transpose.Script`)
- Output directory paths updated from `bin/Debug/netstandard2.0/h5/` to `bin/Debug/netstandard2.0/tps/`
- Asset bundling configuration updated to reference `tps/assets/` instead of `h5/assets/`
- All skill metadata descriptions updated to maintain consistency across the documentation

https://claude.ai/code/session_01KrYhKfqFE5Nkx1pgoH79fF