### PR TITLE
Fix ToolAgentSelector popup: scroll Agents/Tools as one list

### DIFF
--- a/Tesserae/src/Components/ToolAgentSelector.cs
+++ b/Tesserae/src/Components/ToolAgentSelector.cs
@@ -88,7 +88,9 @@ namespace Tesserae
             _emptyState = Div(Att("tss-toolagent-empty", text: "No matches"));
             _emptyState.style.display = "none";
 
-            _popup = Div(Att("tss-toolagent-popup"), _searchBox.Render(), _agentsSection, _toolsSection, _emptyState);
+            var scrollArea = Div(Att("tss-toolagent-scroll"), _agentsSection, _toolsSection, _emptyState);
+
+            _popup = Div(Att("tss-toolagent-popup"), _searchBox.Render(), scrollArea);
 
             UpdateSectionVisibility();
         }

--- a/Tesserae/tps/assets/css/tss.toolagentselector.css
+++ b/Tesserae/tps/assets/css/tss.toolagentselector.css
@@ -90,10 +90,18 @@
         flex-shrink: 0;
     }
 
+.tss-toolagent-scroll {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+}
+
 .tss-toolagent-section {
     display: flex;
     flex-direction: column;
-    overflow-y: auto;
+    flex-shrink: 0;
 }
 
 .tss-toolagent-section-title {


### PR DESCRIPTION
The Agents and Tools sections each had their own overflow-y: auto, so they scrolled independently within the popup instead of the whole list scrolling together. Wrap both sections in a single scrollable container and keep the search box pinned above it.


Claude-Session: https://claude.ai/code/session_012XVYgDkn9tLyGSHqdE8ZVu