### PR TITLE
PixelAvatar: perch an avatar on a modal's own box

### DIFF
--- a/Tesserae.Tests/src/Samples/Components/PixelAvatarSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/PixelAvatarSample.cs
@@ -70,6 +70,12 @@ namespace Tesserae.Tests.Samples
                        .SetTitle("As an OmniBox companion")))
                .FlatSection(Stack().Children(
                     Card(VStack().WS().Children(
+                        TextBlock("A modal is the one target that is not wrapped. It centers itself inside its own full-screen container and is put on screen by Show(), so a wrapper around it would simply be dropped - it lends its own box to the avatar instead, growing the anchored side by the avatar's height and perching the cat in that band, above the header and inside the rounded corners."),
+                        TextBlock("A cat on top of a modal roams the same way an OmniBox one does. There is nothing to type into, so it only wanders and plays the odd animation rather than following a caret."),
+                        ModalGallery()))
+                       .SetTitle("On a modal")))
+               .FlatSection(Stack().Children(
+                    Card(VStack().WS().Children(
                         TextBlock("Every index below is one color of the sprite. Indices 1 to 3 are the artwork's highlight shade, 4 to 9 the base shade and 10 to 11 the shadow shade, which is why the single-hue designs are just three colors repeated - and why pasting three colors is enough to build a whole coat."),
                         PaletteEditor()))
                        .SetTitle("Edit the palette")));
@@ -291,6 +297,29 @@ namespace Tesserae.Tests.Samples
                     Button("Sleep in 2s").Compact().ML(8).OnClick(() => companion.SleepAfter(2000)),
                     Button("Sleep after 60s").Compact().ML(8).OnClick(() => companion.SleepAfter(60000)),
                     status.PL(16)));
+        }
+
+        private static IComponent ModalGallery()
+        {
+            var anchors = new[] { PixelAvatarAnchor.TopLeft, PixelAvatarAnchor.TopCenter, PixelAvatarAnchor.TopRight };
+            var labels  = new[] { "TopLeft", "TopCenter", "TopRight" };
+            var row     = HStack().WS().Wrap().Children();
+
+            for (var i = 0; i < anchors.Length; i++)
+            {
+                var anchor = anchors[i];
+
+                row.Add(Button($"Open a modal ({labels[i]})").Compact().MR(8).OnClick(() =>
+                    Modal("Sudo has opinions about this dialog")
+                       .Content(VStack().Children(
+                            TextBlock("The cat is perched on the modal's own top edge, so it stays inside the rounded corners and moves with the modal when you drag it."),
+                            TextBlock("Give it a few seconds and it will wander along the header.").Tiny().Secondary().PT(8)))
+                       .WithPixelAvatar(42, PixelAvatarDesign.Sudo, anchor)
+                       .Width(460.px())
+                       .Show()));
+            }
+
+            return row;
         }
 
         private static IComponent TurnGallery()

--- a/Tesserae/skills/references/modal.md
+++ b/Tesserae/skills/references/modal.md
@@ -25,6 +25,7 @@ into scope with `using static Tesserae.UI;`.
 - `.Draggable()` / `.Dark()` / `.ShowCloseButton()` / `.HideCloseButton()`.
 - `.Show()`, `.ShowAt(fromTop, fromLeft, fromRight, fromBottom)`, `.ShowAsync()` (Task), `.ShowEmbedded()` (return as an embeddable `IComponent`).
 - `.Hide(Action onHidden = null)`, `.OnShow(...)`, `.OnHide(...)`.
+- `.WithPixelAvatar(avatar | key + design, anchor)` — perch an animated pixel cat on one of the modal's own edges and get the modal back to go on configuring. See `pixel-avatar.md`.
 
 ## Example
 
@@ -45,4 +46,5 @@ modal.Show();
 - Dialog — `dialog.md` (prebuilt confirmation buttons)
 - Panel — `panel.md` (side drawer)
 - Float — `float.md`
+- PixelAvatar — `pixel-avatar.md` (a cat perched on the modal's top edge)
 - Full docs & API: `/tesserae/surfaces/modal`

--- a/Tesserae/skills/references/pixel-avatar.md
+++ b/Tesserae/skills/references/pixel-avatar.md
@@ -204,18 +204,46 @@ Every one of those is jittered or drawn from its range on use. `.WakeUp()`, `.Fi
 The caret position comes from `OmniBox.CaretClientX()`, which measures whichever of the two
 inputs is focused and is public, so a different companion can use it too.
 
+## On a modal
+
+A `Modal` is the one target that is **not wrapped**. It centers itself inside its own
+full-screen container and is put on screen by `Show()`, so a wrapper around it would simply be
+dropped. It lends its own box to the avatar instead: the anchored side of the modal grows by the
+avatar's size and the cat perches in that band, above the header and inside the modal's rounded
+corners. `PixelAvatarAttachment.IsAdopted` reports it, and `Render()` returns the modal's own
+element rather than a wrapper.
+
+Because the modal stays the component you go on using, the extension returns the modal:
+
+```csharp
+Modal("Configure the endpoint")
+   .Content(editor)
+   .WithPixelAvatar(SpriteKey.Value, PixelAvatarDesign.Sudo, PixelAvatarAnchor.TopLeft)
+   .Width(640.px())
+   .Show();
+```
+
+A `Top*` anchor gets a `PixelAvatarCompanion` here too, so the cat roams the modal's top edge
+the way it roams an `OmniBox`. There is nothing to type into, so it only wanders and plays the
+odd animation — `CursorDelay` is ignored. Use `avatar.AttachTo(modal, anchor)` instead of the
+extension when you need the attachment back to reach that companion.
+
+Keep the reserved room on a modal: `.Overlap()` hangs the avatar outside the box, and a modal
+scrolls its own content, so an overlapping cat is clipped.
+
 ## Attaching to another component
 
 `.AttachTo(IComponent target, PixelAvatarAnchor anchor = PixelAvatarAnchor.TopLeft)` — or
 the equivalent extension `target.WithPixelAvatar(avatar, anchor)` — returns a
 `PixelAvatarAttachment` that renders the target with the avatar perched on one of its
-edges. An `OmniBox` target with a `Top*` anchor also gets a companion — see above.
+edges. An `OmniBox` or `Modal` target with a `Top*` anchor also gets a companion — see above.
 
 - `PixelAvatarAnchor` values: `TopLeft`, `TopCenter`, `TopRight`, `BottomLeft`, `BottomCenter`, `BottomRight`, `LeftCenter`, `RightCenter`.
 - `.Anchor(PixelAvatarAnchor)` — move it to a different edge later.
 - `.Offset(int x, int y)` — nudge it in CSS pixels; positive values move right and down.
 - `.Overlap(bool = true)` — by default the wrapper reserves room for the avatar on the anchored side, so it can never be clipped by a scrolling ancestor. Overlap mode drops that room and lets the avatar hang outside the wrapper, keeping the target's footprint identical to the bare component — but any ancestor that scrolls or hides overflow will then clip it.
 - `.Avatar` / `.Target` — the two wrapped components.
+- `.IsAdopted` — whether the target lent its own box instead of being wrapped, which is what a `Modal` does.
 
 The attachment implements `ISpecialCaseStyling`, so sizing helpers such as `.WS()` apply
 to the wrapper and the avatar stays anchored.

--- a/Tesserae/src/Components/PixelAvatar.Companion.cs
+++ b/Tesserae/src/Components/PixelAvatar.Companion.cs
@@ -4,20 +4,20 @@ using static Transpose.Core.dom;
 namespace Tesserae
 {
     /// <summary>
-    /// Gives a <see cref="PixelAvatar"/> perched on top of an <see cref="OmniBox"/> a life of its
-    /// own: while you leave the box alone the cat wanders along the top edge and plays the odd
-    /// animation, when you type it settles back down and, a little later, pads over to the text
-    /// caret to watch you type.
+    /// Gives a <see cref="PixelAvatar"/> perched on top of another component a life of its own:
+    /// while you leave it alone the cat wanders along the top edge and plays the odd animation,
+    /// and on an <see cref="OmniBox"/> it also settles back down when you type and, a little
+    /// later, pads over to the text caret to watch you type.
     ///
     /// Resting - drifting between the idle, sitting and crouching poses, and eventually falling
     /// asleep - belongs to the avatar itself, through
     /// <see cref="PixelAvatarAnimation.AutoIdle"/>; the companion only supplies the activity in
     /// between and wakes the cat up when you come back to the box.
     ///
-    /// Created automatically by <see cref="PixelAvatar.AttachTo"/> when the target is an
-    /// <see cref="OmniBox"/> and the anchor is one of the <c>Top*</c> ones, and reachable through
-    /// <see cref="PixelAvatarAttachment.Companion"/> to tune the timings. Every delay below is
-    /// jittered on use, so nothing the cat does lands on a stopwatch.
+    /// Created automatically by <see cref="PixelAvatar.AttachTo"/> when the anchor is one of the
+    /// <c>Top*</c> ones and the target is an <see cref="OmniBox"/> or a <see cref="Modal"/>, and
+    /// reachable through <see cref="PixelAvatarAttachment.Companion"/> to tune the timings. Every
+    /// delay below is jittered on use, so nothing the cat does lands on a stopwatch.
     /// </summary>
     [Transpose.Name("tss.PixelAvatarCompanion")]
     public sealed class PixelAvatarCompanion
@@ -81,6 +81,10 @@ namespace Tesserae
         private bool   _returnToIdle;
         private bool   _running;
 
+        /// <param name="omniBox">
+        /// The box the cat reacts to, or null when there is none - a companion without one only
+        /// roams, since there is nothing to be typed into and no caret to walk to.
+        /// </param>
         internal PixelAvatarCompanion(OmniBox omniBox, PixelAvatar avatar, HTMLElement host, PixelAvatarAnchor anchor)
         {
             _omniBox = omniBox;
@@ -95,8 +99,11 @@ namespace Tesserae
             // is also where the follow-up chains land (Stretch ends sitting, Crouch ends crouched).
             _avatar.TrackAnimation(OnAnimationStarted);
 
-            omniBox.OnInput((_, __) => Poke(true));
-            omniBox.OnFocus((_, __) => Poke(false));
+            if (omniBox != null)
+            {
+                omniBox.OnInput((_, __) => Poke(true));
+                omniBox.OnFocus((_, __) => Poke(false));
+            }
 
             TrackMounting();
         }
@@ -131,7 +138,8 @@ namespace Tesserae
 
         /// <summary>
         /// Sets how long the cat waits after your last keystroke before padding over to the text
-        /// caret. Pass zero to leave the caret alone entirely.
+        /// caret. Pass zero to leave the caret alone entirely. Ignored by a companion with no box
+        /// to watch.
         /// </summary>
         public PixelAvatarCompanion CursorDelay(int milliseconds)
         {
@@ -307,6 +315,12 @@ namespace Tesserae
 
             if (!_running || _avatar.IsAsleep) return;
 
+            if (_omniBox == null)
+            {
+                ScheduleAction(true);
+                return;
+            }
+
             var caret = _omniBox.CaretClientX();
 
             // Nothing focused, or the box is not laid out yet - just carry on as usual.
@@ -422,7 +436,7 @@ namespace Tesserae
             ClearCursorWalk();
             ClearActionTimer();
 
-            if (!_running || _cursorMs == 0) return;
+            if (!_running || _cursorMs == 0 || _omniBox == null) return;
 
             _cursorTimer = window.setTimeout(_ => WalkToCursor(), PixelAvatarRandom.Jittered(_cursorMs));
         }

--- a/Tesserae/src/Components/PixelAvatar.cs
+++ b/Tesserae/src/Components/PixelAvatar.cs
@@ -475,6 +475,9 @@ namespace Tesserae
         /// <summary>
         /// Wraps <paramref name="target"/> so that this avatar is anchored to one of its edges. The
         /// returned component renders the target as usual, with the avatar perched next to it.
+        ///
+        /// A <see cref="Modal"/> target is not wrapped - see
+        /// <see cref="PixelAvatarAttachment.IsAdopted"/>.
         /// </summary>
         public PixelAvatarAttachment AttachTo(IComponent target, PixelAvatarAnchor anchor = PixelAvatarAnchor.TopLeft)
         {
@@ -761,6 +764,8 @@ namespace Tesserae
     /// stays inside the wrapper's box and cannot be clipped by a scrolling ancestor. Call
     /// <see cref="Overlap"/> to hang it outside the box instead, leaving the target's own footprint
     /// untouched.
+    ///
+    /// A <see cref="Modal"/> is the one target that is not wrapped: see <see cref="IsAdopted"/>.
     /// </summary>
     [Transpose.Name("tss.PixelAvatarAttachment")]
     public sealed class PixelAvatarAttachment : IComponent, ISpecialCaseStyling
@@ -783,15 +788,35 @@ namespace Tesserae
             Avatar  = avatar;
             _anchor = anchor;
 
-            _host = Div(Att($"tss-pixelavatar-host {anchor}"), target.Render(), avatar.Render());
+            // A modal is not laid out by whoever builds it - it centers itself inside its own
+            // full-screen container and is put on screen by Show() - so a wrapper around it would
+            // simply be dropped. It lends its own box instead: the anchored side of the modal grows
+            // by the avatar's size and the avatar perches in that band, above the header and inside
+            // the modal's rounded corners.
+            var modal = target as Modal;
+
+            IsAdopted = modal != null;
+
+            if (IsAdopted)
+            {
+                _host = target.Render();
+                _host.classList.add("tss-pixelavatar-adopted");
+                _host.classList.add($"{anchor}");
+                _host.appendChild(avatar.Render());
+            }
+            else
+            {
+                _host = Div(Att($"tss-pixelavatar-host {anchor}"), target.Render(), avatar.Render());
+            }
 
             avatar.TrackPixelSize(UpdateReservedSpace);
 
-            // An avatar perched on top of an OmniBox gets to wander along it and react to typing.
-            // Only the top anchors, because that is the only edge with room to walk along.
+            // An avatar perched on a top edge with room to walk along gets a life of its own. An
+            // OmniBox additionally gives the companion something to react to - typing, and a caret
+            // to pad over to - which a modal does not, so that cat only roams.
             var omniBox = Target as OmniBox;
 
-            if (omniBox != null && IsTopAnchor(anchor))
+            if ((omniBox != null || IsAdopted) && IsTopAnchor(anchor))
             {
                 Companion = new PixelAvatarCompanion(omniBox, avatar, _host, anchor);
             }
@@ -804,8 +829,17 @@ namespace Tesserae
         public IComponent Target { get; }
 
         /// <summary>
-        /// Gets the behaviour driving the avatar, or null when there is none. Only set when the
-        /// target is an <see cref="OmniBox"/> and the anchor is one of the <c>Top*</c> ones.
+        /// Gets whether the target lends its own box to the avatar instead of being wrapped, which
+        /// is what a <see cref="Modal"/> target does. An adopted target is still the component the
+        /// application goes on using - <see cref="Modal.Show"/> and the rest all still apply - and
+        /// this attachment's <see cref="Render"/> returns the target's own element.
+        /// </summary>
+        public bool IsAdopted { get; }
+
+        /// <summary>
+        /// Gets the behaviour driving the avatar, or null when there is none. Set when the anchor is
+        /// one of the <c>Top*</c> ones and the target is either an <see cref="OmniBox"/> or a
+        /// <see cref="Modal"/>.
         /// </summary>
         public PixelAvatarCompanion Companion { get; }
 
@@ -831,7 +865,8 @@ namespace Tesserae
         /// <summary>
         /// Lets the avatar hang outside the wrapper's box instead of reserving room for it, so the
         /// target keeps exactly the footprint it would have on its own. Beware that an avatar in
-        /// overlap mode is clipped by any ancestor that scrolls or hides its overflow.
+        /// overlap mode is clipped by any ancestor that scrolls or hides its overflow - which
+        /// includes a <see cref="Modal"/>, so an adopted avatar should keep its reserved room.
         /// </summary>
         public PixelAvatarAttachment Overlap(bool value = true)
         {
@@ -892,6 +927,27 @@ namespace Tesserae
         public static PixelAvatarAttachment WithPixelAvatar(this IComponent component, byte key, PixelAvatarDesign design, PixelAvatarAnchor anchor = PixelAvatarAnchor.TopLeft)
         {
             return new PixelAvatarAttachment(component, new PixelAvatar(key, design), anchor);
+        }
+
+        /// <summary>
+        /// Perches an avatar on one of the modal's own edges. A modal lends its box to the avatar
+        /// rather than being wrapped, so the modal itself is returned and the caller goes on using
+        /// it as usual. Reach the attachment - and its companion - through
+        /// <see cref="PixelAvatar.AttachTo"/> when you need to tune it.
+        /// </summary>
+        public static Modal WithPixelAvatar(this Modal modal, PixelAvatar avatar, PixelAvatarAnchor anchor = PixelAvatarAnchor.TopLeft)
+        {
+            avatar.AttachTo(modal, anchor);
+            return modal;
+        }
+
+        /// <summary>
+        /// Perches a new avatar with the given design on one of the modal's own edges. See
+        /// <see cref="PixelAvatar(byte, PixelAvatarDesign, PixelAvatarAnimation)"/> for the key.
+        /// </summary>
+        public static Modal WithPixelAvatar(this Modal modal, byte key, PixelAvatarDesign design, PixelAvatarAnchor anchor = PixelAvatarAnchor.TopLeft)
+        {
+            return modal.WithPixelAvatar(new PixelAvatar(key, design), anchor);
         }
     }
 }

--- a/Tesserae/tps/assets/css/tss.pixelavatar.css
+++ b/Tesserae/tps/assets/css/tss.pixelavatar.css
@@ -70,7 +70,8 @@
     display: inline-block;
 }
 
-.tss-pixelavatar-host > .tss-pixelavatar {
+.tss-pixelavatar-host > .tss-pixelavatar,
+.tss-pixelavatar-adopted > .tss-pixelavatar {
     position: absolute;
     z-index: 1;
     translate: var(--tss-pxav-dx) var(--tss-pxav-dy);
@@ -138,6 +139,39 @@
     right: 0;
     top: 50%;
     transform: translateY(-50%);
+}
+
+/* --- adopting a target's own box ------------------------------------------------------------
+   A modal centers itself inside a full-screen container and is put on screen by Show(), so a
+   wrapper around it would simply be dropped. It lends its own box instead: the same reserve and
+   anchor rules apply, written onto the modal element itself. The two-class selectors below are
+   what lets the reserved room win over the modal's own `padding: 0`, and nothing here touches
+   `position` or `display` since .tss-modal is already a relatively positioned flex column. */
+
+.tss-pixelavatar-adopted {
+    --tss-pxav-dx: 0px;
+    --tss-pxav-dy: 0px;
+    --tss-pxav-reserve: 0px;
+}
+
+.tss-pixelavatar-adopted.tss-pixelavatar-anchor-topleft,
+.tss-pixelavatar-adopted.tss-pixelavatar-anchor-topcenter,
+.tss-pixelavatar-adopted.tss-pixelavatar-anchor-topright {
+    padding-top: var(--tss-pxav-reserve);
+}
+
+.tss-pixelavatar-adopted.tss-pixelavatar-anchor-bottomleft,
+.tss-pixelavatar-adopted.tss-pixelavatar-anchor-bottomcenter,
+.tss-pixelavatar-adopted.tss-pixelavatar-anchor-bottomright {
+    padding-bottom: var(--tss-pxav-reserve);
+}
+
+.tss-pixelavatar-adopted.tss-pixelavatar-anchor-leftcenter {
+    padding-left: var(--tss-pxav-reserve);
+}
+
+.tss-pixelavatar-adopted.tss-pixelavatar-anchor-rightcenter {
+    padding-right: var(--tss-pxav-reserve);
 }
 
 /* Roaming: the companion drives `left` itself, so the anchor's own horizontal placement is


### PR DESCRIPTION
A modal centers itself inside its own full-screen container and is put on screen by Show(), so the wrapper PixelAvatarAttachment builds for an ordinary target is simply dropped. Attaching to a Modal now adopts the modal's own element instead: the anchored side grows by the avatar's size and the cat perches in that band, above the header and inside the rounded corners.

A Top* anchor gets a PixelAvatarCompanion here too, so the cat roams the modal's top edge the way it roams an OmniBox. The companion now accepts a null OmniBox and skips the typing / caret behaviour when there is none.

Modal.WithPixelAvatar(...) returns the modal so it keeps chaining into Content()/Width()/Show().


Claude-Session: https://claude.ai/code/session_015KdCdHxRTrpdyFjKBf7HvE