### PR TITLE
Add AsButton() method to PixelAvatar component

### DIFF
--- a/Tesserae.Tests/src/Samples/Components/PixelAvatarSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/PixelAvatarSample.cs
@@ -44,6 +44,9 @@ namespace Tesserae.Tests.Samples
                         SampleSubTitle("Pixel size and facing"),
                         TextBlock("The sprite is 10x8 pixels; PixelSize sets how many CSS pixels each of them takes. Facing mirrors the artwork, which is drawn facing right."),
                         SizeGallery(),
+                        SampleSubTitle("As a button"),
+                        TextBlock("AsButton() wraps the avatar in a Button with no background, border, padding or minimum size, so the button hugs the cat exactly instead of the usual button chrome - the avatar becomes the clickable surface via ReplaceContent. Click a cat to play an animation."),
+                        AsButtonGallery(),
                         SampleSubTitle("Turning around"),
                         TextBlock("Turn() changes direction by pivoting the sprite about its vertical axis, under a perspective scaled to the avatar's own width, so it reads as the cat physically turning rather than its pixels swapping sides. Facing() does the same change instantly."),
                         TurnGallery(),
@@ -220,6 +223,20 @@ namespace Tesserae.Tests.Samples
                     TextBlock("Speed 3").Tiny().Secondary().PT(8)));
 
             return VStack().WS().Children(sizes, facing.PT(24));
+        }
+
+        private static IComponent AsButtonGallery()
+        {
+            var row = HStack().AlignItemsCenter().Children();
+
+            foreach (var design in new[] { PixelAvatarDesign.Black, PixelAvatarDesign.Orange, PixelAvatarDesign.Tuxedo, PixelAvatarDesign.Sudo })
+            {
+                var avatar = PixelAvatar(42, design, PixelAvatarAnimation.SitIdle).PixelSize(8);
+
+                row.Add(avatar.AsButton().Tooltip($"{design}: click to play Stretch").MR(16).OnClick(() => avatar.Play(PixelAvatarAnimation.Stretch)));
+            }
+
+            return row;
         }
 
         private static IComponent OutlineGallery()

--- a/Tesserae/skills/references/pixel-avatar.md
+++ b/Tesserae/skills/references/pixel-avatar.md
@@ -235,6 +235,23 @@ are handed to the header and footer directly. `Overlap(false)` puts the cat back
 band inside the dialog, above the header — which is what `ShowEmbedded()` does for you, since an
 embedded modal is a box in someone else's layout and that layout usually clips.
 
+## As a button
+
+`.AsButton()` wraps the avatar in a `Button` with no background, border, padding or minimum
+size, so the button hugs the cat exactly instead of the button's usual chrome — the avatar
+becomes the button's content via `Button.ReplaceContent`, so the cat itself is the clickable
+surface. The button's size tracks `RenderedWidth` / `RenderedHeight`, so it stays a perfect fit
+if `PixelSize` changes later.
+
+```csharp
+var avatar = PixelAvatar(SpriteKey.Value, PixelAvatarDesign.Orange, PixelAvatarAnimation.SitIdle).PixelSize(8);
+var button = avatar.AsButton().OnClick(() => avatar.Play(PixelAvatarAnimation.Stretch));
+```
+
+This claims the same pixel-size tracking slot `AttachTo` uses, so don't call both on the same
+avatar — perch it on a button with `AttachTo` for a mascot next to the click target, or make the
+cat itself the click target with `AsButton`, not both.
+
 ## Attaching to another component
 
 `.AttachTo(IComponent target, PixelAvatarAnchor anchor = PixelAvatarAnchor.TopLeft)` — or

--- a/Tesserae/src/Components/PixelAvatar.cs
+++ b/Tesserae/src/Components/PixelAvatar.cs
@@ -485,6 +485,32 @@ namespace Tesserae
         }
 
         /// <summary>
+        /// Wraps the avatar in a <see cref="Button"/> that has no background, border, padding or
+        /// minimum size, so it hugs the avatar exactly instead of the button's usual chrome. The
+        /// avatar becomes the button's content via <see cref="Button.ReplaceContent"/> - the cat
+        /// itself is the clickable surface - and the button's size tracks <see cref="RenderedWidth"/>
+        /// / <see cref="RenderedHeight"/>, so it stays a perfect fit if <see cref="PixelSize"/> later
+        /// changes.
+        ///
+        /// This claims the same pixel-size tracking slot <see cref="AttachTo"/> uses, so an avatar
+        /// already attached to another component should not also be turned into a button.
+        /// </summary>
+        public Button AsButton()
+        {
+            var button = UI.Button()
+               .ReplaceContent(this)
+               .NoBackground()
+               .NoBorder()
+               .NoPadding()
+               .NoMinSize()
+               .NoMargin();
+
+            TrackPixelSize(() => button.Width(RenderedWidth.px()).Height(RenderedHeight.px()));
+
+            return button;
+        }
+
+        /// <summary>
         /// Renders the component's root HTML element.
         /// </summary>
         public override HTMLElement Render() => InnerElement;


### PR DESCRIPTION
## Summary

Adds a new `AsButton()` fluent method to `PixelAvatar` that wraps the avatar in a `Button` with no background, border, padding, or minimum size, making the avatar itself the clickable surface.

## Changes

- **PixelAvatar.cs**: Added `AsButton()` method that:
  - Creates a button with no chrome (background, border, padding, minimum size, margin)
  - Uses `Button.ReplaceContent()` to make the avatar the button's content
  - Tracks pixel size changes via `TrackPixelSize()` to keep the button a perfect fit when `PixelSize` changes
  - Includes comprehensive XML documentation explaining the feature and its interaction with `AttachTo()`

- **PixelAvatarSample.cs**: Added `AsButtonGallery()` sample demonstrating:
  - Creating avatars with `AsButton()`
  - Attaching click handlers to play animations
  - Using tooltips on the button

- **pixel-avatar.md**: Added "As a button" reference section documenting:
  - The purpose and behavior of `AsButton()`
  - Code example showing typical usage
  - Clarification that `AsButton()` and `AttachTo()` use the same pixel-size tracking slot and shouldn't be used together on the same avatar

## Implementation Details

The method reuses the existing `TrackPixelSize()` mechanism (same as `AttachTo()`) to ensure the button dimensions stay synchronized with the avatar's rendered size, providing a seamless experience if the pixel size is adjusted after button creation.

https://claude.ai/code/session_01G7y1m18tohmqJa4BtmmKnY