### PR TITLE
Add ContextCard component for chat attachment context

### DIFF
--- a/Tesserae.Tests/src/Samples/Components/ContextBarSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/ContextBarSample.cs
@@ -7,12 +7,26 @@ namespace Tesserae.Tests.Samples
     [SampleDetails(Group = "Components", Order = 211, Icon = UIcons.OfficePaperclip)]
     public class ContextBarSample : IComponent, ISample
     {
+        private static readonly (string name, UIcons icon)[] _documents =
+        {
+            ("Q3 revenue breakdown.xlsx", UIcons.FileExcel),
+            ("Supplier audit 2026.pdf",   UIcons.FilePdf),
+            ("Onboarding checklist.docx", UIcons.FileWord),
+            ("Kickoff deck.pptx",         UIcons.Presentation),
+            ("Ada Lovelace",              UIcons.UserPen)
+        };
+
         private readonly IComponent _content;
         private readonly TextBlock  _lastAction;
 
+        private readonly ContextBar _composerBar = ContextBar();
+        private readonly TextBlock  _composerState;
+        private          int        _attached;
+
         public ContextBarSample()
         {
-            _lastAction = TextBlock("Nothing removed yet.").Small();
+            _lastAction    = TextBlock("Nothing removed yet.").Small();
+            _composerState = TextBlock("").Small();
 
             _content = SectionStack().Secondary()
                 .SampleTitle(typeof(ContextBarSample), UIcons.OfficePaperclip, "Small bubbles naming the context something is scoped to")
@@ -24,41 +38,49 @@ namespace Tesserae.Tests.Samples
                 .FlatSection(Stack().Children(
                     Card(VStack().WS().Children(
                         SampleSubTitle("A bubble per context item"),
-                        TextBlock("Clicking a bubble opens what it names. Without an OnClick handler a bubble is not interactive."),
-                        Bar(Bubble("Q3 revenue breakdown.xlsx", UIcons.FileExcel),
-                            Bubble("Ada Lovelace",              UIcons.UserPen)),
+                        TextBlock("Clicking a bubble opens what it names. Without an OnClick handler a bubble is not interactive. The ✕ stays quiet until its bubble is hovered, so a row reads as names rather than as a row of delete buttons."),
+                        Bar(Bubble(0), Bubble(4)),
 
                         SampleSubTitle("Overflow behind \"+N more\""),
                         TextBlock("Five bubbles, three visible. The button reports how many are collapsed and hands over to the host, which is where the full context belongs — a search restricted to it, a list, a panel."),
-                        Bar(Bubble("Q3 revenue breakdown.xlsx", UIcons.FileExcel),
-                            Bubble("Supplier audit 2026.pdf",   UIcons.FilePdf),
-                            Bubble("Onboarding checklist.docx", UIcons.FileWord),
-                            Bubble("Kickoff deck.pptx",         UIcons.Presentation),
-                            Bubble("Ada Lovelace",              UIcons.UserPen)),
+                        Bar(Bubble(0), Bubble(1), Bubble(2), Bubble(3), Bubble(4)),
                         _lastAction,
 
                         SampleSubTitle("Every bubble visible"),
                         TextBlock("MaxVisible controls where the row stops; a large value renders everything and never shows the button."),
-                        Bar(Bubble("Q3 revenue breakdown.xlsx", UIcons.FileExcel),
-                            Bubble("Supplier audit 2026.pdf",   UIcons.FilePdf),
-                            Bubble("Onboarding checklist.docx", UIcons.FileWord),
-                            Bubble("Kickoff deck.pptx",         UIcons.Presentation),
-                            Bubble("Ada Lovelace",              UIcons.UserPen)).MaxVisible(10),
+                        Bar(Bubble(0), Bubble(1), Bubble(2), Bubble(3), Bubble(4)).MaxVisible(10),
 
                         SampleSubTitle("Wider names, custom overflow text"),
                         TextBlock("MaxNameWidth widens (or narrows) where a name is cut, and MoreText replaces the button's wording."),
-                        Bar(Bubble("Q3 revenue breakdown.xlsx", UIcons.FileExcel).MaxNameWidth(160.px()),
-                            Bubble("Supplier audit 2026.pdf",   UIcons.FilePdf).MaxNameWidth(160.px()),
-                            Bubble("Onboarding checklist.docx", UIcons.FileWord).MaxNameWidth(160.px()),
-                            Bubble("Kickoff deck.pptx",         UIcons.Presentation).MaxNameWidth(160.px()))
+                        Bar(Bubble(0).MaxNameWidth(160.px()),
+                            Bubble(1).MaxNameWidth(160.px()),
+                            Bubble(2).MaxNameWidth(160.px()),
+                            Bubble(3).MaxNameWidth(160.px()))
                            .MaxVisible(2)
                            .MoreText("Show {0} more documents")
-                    )).SetTitle("Usage")));
+                    )).SetTitle("Usage")))
+                .FlatSection(Stack().Children(
+                    Card(VStack().WS().Children(
+                        TextBlock("Where the bar usually belongs: inside the chat box itself, above the text being typed, so the message being written says what it will be answered from. OmniBox has a slot for exactly this — pass the bar as Config.ChatHeader, or hand it over later with SetChatHeader. The slot takes up no space while it is empty, so a chat with no context looks untouched."),
+                        BuildComposer().PT(8),
+                        _composerState.PT(4),
+                        HStack().WS().Wrap().PT(8).Children(
+                            Button("Attach a document").SetIcon(UIcons.OfficePaperclip).OnClick(() => AttachToComposer()),
+                            Button("Detach everything").SetIcon(UIcons.Broom).OnClick(() =>
+                            {
+                                _composerBar.Clear();
+                                ReportComposerState();
+                            }))
+                    )).SetTitle("In a chat composer")));
         }
 
-        private ContextBar.Item Bubble(string name, UIcons icon)
+        private ContextBar.Item Bubble(int document)
         {
-            return ContextBarItem(name, icon).OnClick(i => Toast().Information($"Opening {i.Name}"));
+            var doc = _documents[document % _documents.Length];
+
+            return ContextBarItem(doc.name, doc.icon)
+               .Tooltip(doc.name)
+               .OnClick(i => Toast().Information($"Opening {i.Name}"));
         }
 
         // The bar is what knows which bubbles it holds, so removal is wired once the bar exists.
@@ -76,6 +98,46 @@ namespace Tesserae.Tests.Samples
             }
 
             return bar;
+        }
+
+        // A chat box whose context lives inside it, above the text being typed.
+        private IComponent BuildComposer()
+        {
+            _composerBar.OnShowAll(() => Toast().Information("A host opens the full context here."));
+
+            AttachToComposer();
+            AttachToComposer();
+
+            return OmniBox(new OmniBox.Config(OmniBox.Mode.Chat)
+            {
+                PlaceholderChat = "Ask about the attached documents",
+                ChatHeader      = _composerBar,
+                ChatFooter      = new OmniBox.FooterItems
+                {
+                    LeftSide = new[] { Button(UIcons.OfficePaperclip).Tooltip("Attach a document").OnClick(() => AttachToComposer()) }
+                }
+            }).WS().OnChat((s, m) => Toast().Success($"Sent, with {_composerBar.Count} document(s) attached"));
+        }
+
+        private void AttachToComposer()
+        {
+            var bubble = Bubble(_attached++);
+
+            bubble.OnRemove(i =>
+            {
+                _composerBar.Remove(i);
+                ReportComposerState();
+            });
+
+            _composerBar.Add(bubble);
+            ReportComposerState();
+        }
+
+        private void ReportComposerState()
+        {
+            _composerState.Text = _composerBar.IsEmpty
+                ? "No context: the slot above the input is empty, and collapsed."
+                : $"This chat is scoped to {_composerBar.Count} document(s).";
         }
 
         public HTMLElement Render() => _content.Render();

--- a/Tesserae.Tests/src/Samples/Components/ContextBarSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/ContextBarSample.cs
@@ -33,7 +33,7 @@ namespace Tesserae.Tests.Samples
                 .FlatSection(Stack().Children(
                     Card(VStack().WS().Children(
                         TextBlock("ContextBar shows what a chat, a search or a generated answer is scoped to: one bubble per document or record, each with an icon, an ellipsized name and an optional remove button. It is the indicator that survives closing whatever panel the context was picked in."),
-                        TextBlock("A name is ellipsized at 50px, but a trailing file extension is held outside that width — a bubble reads \"Quarterly repo….pdf\", never \"Quarterly repor…\". Bubbles past MaxVisible (3 by default) are not rendered at all: they collapse into a \"+N more\" button that calls OnShowAll.")
+                        TextBlock("A name is ellipsized at 80px, but a trailing file extension is held outside that width — a bubble reads \"Quarterly repo….pdf\", never \"Quarterly repor…\". Bubbles past MaxVisible (3 by default) are not rendered at all: they collapse into a \"+N more\" button that calls OnShowAll.")
                     )).SetTitle("Overview")))
                 .FlatSection(Stack().Children(
                     Card(VStack().WS().Children(

--- a/Tesserae.Tests/src/Samples/Components/ContextBarSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/ContextBarSample.cs
@@ -1,0 +1,83 @@
+using static Transpose.Core.dom;
+using static Tesserae.UI;
+using static Tesserae.Tests.Samples.SamplesHelper;
+
+namespace Tesserae.Tests.Samples
+{
+    [SampleDetails(Group = "Components", Order = 211, Icon = UIcons.OfficePaperclip)]
+    public class ContextBarSample : IComponent, ISample
+    {
+        private readonly IComponent _content;
+        private readonly TextBlock  _lastAction;
+
+        public ContextBarSample()
+        {
+            _lastAction = TextBlock("Nothing removed yet.").Small();
+
+            _content = SectionStack().Secondary()
+                .SampleTitle(typeof(ContextBarSample), UIcons.OfficePaperclip, "Small bubbles naming the context something is scoped to")
+                .FlatSection(Stack().Children(
+                    Card(VStack().WS().Children(
+                        TextBlock("ContextBar shows what a chat, a search or a generated answer is scoped to: one bubble per document or record, each with an icon, an ellipsized name and an optional remove button. It is the indicator that survives closing whatever panel the context was picked in."),
+                        TextBlock("A name is ellipsized at 50px, but a trailing file extension is held outside that width — a bubble reads \"Quarterly repo….pdf\", never \"Quarterly repor…\". Bubbles past MaxVisible (3 by default) are not rendered at all: they collapse into a \"+N more\" button that calls OnShowAll.")
+                    )).SetTitle("Overview")))
+                .FlatSection(Stack().Children(
+                    Card(VStack().WS().Children(
+                        SampleSubTitle("A bubble per context item"),
+                        TextBlock("Clicking a bubble opens what it names. Without an OnClick handler a bubble is not interactive."),
+                        Bar(Bubble("Q3 revenue breakdown.xlsx", UIcons.FileExcel),
+                            Bubble("Ada Lovelace",              UIcons.UserPen)),
+
+                        SampleSubTitle("Overflow behind \"+N more\""),
+                        TextBlock("Five bubbles, three visible. The button reports how many are collapsed and hands over to the host, which is where the full context belongs — a search restricted to it, a list, a panel."),
+                        Bar(Bubble("Q3 revenue breakdown.xlsx", UIcons.FileExcel),
+                            Bubble("Supplier audit 2026.pdf",   UIcons.FilePdf),
+                            Bubble("Onboarding checklist.docx", UIcons.FileWord),
+                            Bubble("Kickoff deck.pptx",         UIcons.Presentation),
+                            Bubble("Ada Lovelace",              UIcons.UserPen)),
+                        _lastAction,
+
+                        SampleSubTitle("Every bubble visible"),
+                        TextBlock("MaxVisible controls where the row stops; a large value renders everything and never shows the button."),
+                        Bar(Bubble("Q3 revenue breakdown.xlsx", UIcons.FileExcel),
+                            Bubble("Supplier audit 2026.pdf",   UIcons.FilePdf),
+                            Bubble("Onboarding checklist.docx", UIcons.FileWord),
+                            Bubble("Kickoff deck.pptx",         UIcons.Presentation),
+                            Bubble("Ada Lovelace",              UIcons.UserPen)).MaxVisible(10),
+
+                        SampleSubTitle("Wider names, custom overflow text"),
+                        TextBlock("MaxNameWidth widens (or narrows) where a name is cut, and MoreText replaces the button's wording."),
+                        Bar(Bubble("Q3 revenue breakdown.xlsx", UIcons.FileExcel).MaxNameWidth(160.px()),
+                            Bubble("Supplier audit 2026.pdf",   UIcons.FilePdf).MaxNameWidth(160.px()),
+                            Bubble("Onboarding checklist.docx", UIcons.FileWord).MaxNameWidth(160.px()),
+                            Bubble("Kickoff deck.pptx",         UIcons.Presentation).MaxNameWidth(160.px()))
+                           .MaxVisible(2)
+                           .MoreText("Show {0} more documents")
+                    )).SetTitle("Usage")));
+        }
+
+        private ContextBar.Item Bubble(string name, UIcons icon)
+        {
+            return ContextBarItem(name, icon).OnClick(i => Toast().Information($"Opening {i.Name}"));
+        }
+
+        // The bar is what knows which bubbles it holds, so removal is wired once the bar exists.
+        private ContextBar Bar(params ContextBar.Item[] items)
+        {
+            var bar = ContextBar(items).OnShowAll(() => Toast().Information("A host opens the full context here."));
+
+            foreach (var item in items)
+            {
+                item.OnRemove(i =>
+                {
+                    bar.Remove(i);
+                    _lastAction.Text = $"Removed {i.Name}.";
+                });
+            }
+
+            return bar;
+        }
+
+        public HTMLElement Render() => _content.Render();
+    }
+}

--- a/Tesserae.Tests/src/Samples/Components/ContextCardSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/ContextCardSample.cs
@@ -1,0 +1,113 @@
+using System;
+using static Transpose.Core.dom;
+using static Tesserae.UI;
+using static Tesserae.Tests.Samples.SamplesHelper;
+
+namespace Tesserae.Tests.Samples
+{
+    [SampleDetails(Group = "Components", Order = 104, Icon = UIcons.Clip)]
+    public class ContextCardSample : IComponent, ISample
+    {
+        private readonly IComponent _content;
+
+        private readonly Stack _attached;
+        private          int   _nextAttachment;
+
+        private static readonly ContextSpec[] Attachments =
+        {
+            new ContextSpec("Kindersonnenschutzmittel-NEU.pdf", "PDF",         UIcons.FilePdf,   "#ef4444"),
+            new ContextSpec("Q3-forecast.xlsx",                 "Spreadsheet", UIcons.FileExcel, "#16a34a"),
+            new ContextSpec("architecture.md",                  "Markdown",    UIcons.FileCode,  "#6366f1"),
+            new ContextSpec("tesserae.dev/components",          "Web page",    UIcons.Globe,     "#0ea5e9"),
+            new ContextSpec("customers",                        "Dataset",     UIcons.Database,  "#f59e0b")
+        };
+
+        public ContextCardSample()
+        {
+            _attached = HStack().Wrap().Gap(8.px()).WS();
+
+            AttachNext();
+
+            _content = SectionStack().Secondary()
+                .SampleTitle(typeof(ContextCardSample), UIcons.Clip, "Cards describing the context attached to a conversation")
+                .FlatSection(Stack().Children(
+                    Card(VStack().WS().Children(
+                        TextBlock("A ContextCard names one piece of context attached to a conversation — a file, a page, a dataset. It is an icon tile on a colored background, a label, and an optional second line, sized to sit in a wrapping row above a ChatArea composer."),
+                        TextBlock("The tile takes a UIcons glyph, any component (an Icon with its own color, an emoji, a badge), or an image thumbnail that covers it. Passing a handler to OnRemove adds a round (x) button over the card's top-right corner that fades in while the card is hovered or focused — and stays visible on touch devices, where nothing hovers.")
+                    )).SetTitle("Overview")))
+                .FlatSection(Stack().Children(
+                    Card(VStack().WS().Children(
+                        SampleSubTitle("Attached context above a composer"),
+                        TextBlock("Hover a card to reveal its remove button. OnRemove does not remove the card by itself — the handler owns the list the cards live in, so it can drop the underlying context at the same time."),
+                        _attached.PT(8).PB(8),
+                        HStack().Gap(8.px()).Children(
+                            Button("Attach context").SetIcon(UIcons.Clip).Primary().OnClick(() => AttachNext()),
+                            Button("Remove all").SetIcon(UIcons.Trash).OnClick(() => _attached.Clear())),
+
+                        SampleSubTitle("Tiles"),
+                        TextBlock("The tile's background and glyph colors are set with IconBackground / IconForeground, SetImage fills it with a thumbnail, and NoIconBackground drops the colored square entirely."),
+                        HStack().Wrap().Gap(8.px()).PT(8).Children(
+                            ContextCard("report-2026.pdf", UIcons.FilePdf).SetSubLabel("PDF").IconBackground("#ef4444"),
+                            ContextCard("curiosity-logo.svg", UIcons.FileImage).SetSubLabel("Image")
+                                .SetImage("./assets/img/curiosity-logo.svg"),
+                            ContextCard("Design review", Icon(UIcons.Palette, color: "#a855f7")).SetSubLabel("Note").NoIconBackground(),
+                            ContextCard("Sunny days", Icon(Emoji.SunWithFace)).SetSubLabel("Emoji").NoIconBackground(),
+                            ContextCard("customers", UIcons.Database).SetSubLabel("42.109 rows").IconBackground("#f59e0b")),
+
+                        SampleSubTitle("Label only"),
+                        TextBlock("Without a second line the card collapses to a single centered row."),
+                        HStack().Wrap().Gap(8.px()).PT(8).Children(
+                            ContextCard("notes.txt", UIcons.File),
+                            ContextCard("tesserae.dev", UIcons.Globe).IconBackground("#0ea5e9"),
+                            ContextCard("A label long enough that it has to be ellipsized to fit the width the card was given", UIcons.FileCode)
+                                .IconBackground("#6366f1").MaxWidth(260.px()).OnRemove(() => { })),
+
+                        SampleSubTitle("Compact"),
+                        TextBlock("Compact() tightens the card into one row, with the second line beside the label — for a composer carrying many pieces of context at once."),
+                        HStack().Wrap().Gap(6.px()).PT(8).Children(
+                            ContextCard("report-2026.pdf", UIcons.FilePdf).SetSubLabel("PDF").IconBackground("#ef4444").Compact().OnRemove(() => { }),
+                            ContextCard("Q3-forecast.xlsx", UIcons.FileExcel).SetSubLabel("Spreadsheet").IconBackground("#16a34a").Compact().OnRemove(() => { }),
+                            ContextCard("architecture.md", UIcons.FileCode).IconBackground("#6366f1").Compact().OnRemove(() => { })),
+
+                        SampleSubTitle("Clickable"),
+                        TextBlock("OnClick makes the whole card open the context it stands for (and makes it keyboard reachable, activated with Enter or Space). Clicking the remove button never reads as opening the card."),
+                        HStack().Wrap().Gap(8.px()).PT(8).Children(
+                            ContextCard("Kindersonnenschutzmittel-NEU.pdf", UIcons.FilePdf)
+                                .SetSubLabel("PDF")
+                                .IconBackground("#ef4444")
+                                .OnClick((c, _) => Toast().Information($"Opening {c.Label}"))
+                                .OnRemove(c => Toast().Information($"Removing {c.Label}")))
+                    )).SetTitle("Usage")));
+        }
+
+        private void AttachNext()
+        {
+            var spec = Attachments[_nextAttachment % Attachments.Length];
+            _nextAttachment++;
+
+            var card = ContextCard(spec.Label, spec.Icon).SetSubLabel(spec.Kind).IconBackground(spec.Color);
+
+            card.OnRemove(c => _attached.Remove(c));
+
+            _attached.Add(card);
+        }
+
+        public HTMLElement Render() => _content.Render();
+
+        private class ContextSpec
+        {
+            public string Label { get; }
+            public string Kind  { get; }
+            public UIcons Icon  { get; }
+            public string Color { get; }
+
+            public ContextSpec(string label, string kind, UIcons icon, string color)
+            {
+                Label = label;
+                Kind  = kind;
+                Icon  = icon;
+                Color = color;
+            }
+        }
+    }
+}

--- a/Tesserae.Tests/src/Samples/Components/OmniBoxSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/OmniBoxSample.cs
@@ -332,6 +332,52 @@ namespace Tesserae.Tests.Samples
                 IsOpen         = ()      => toolAgentSelectorForChat.IsVisible
             });
 
+            // Context to add: ContextCards rendered inside the box, just below the input.
+            var contextSpecs = new[]
+            {
+                new[] { "Kindersonnenschutzmittel-NEU.pdf", "PDF",         "#ef4444" },
+                new[] { "Q3-forecast.xlsx",                 "Spreadsheet", "#16a34a" },
+                new[] { "architecture.md",                  "Markdown",    "#6366f1" },
+                new[] { "tesserae.dev/components",          "Web page",    "#0ea5e9" },
+                new[] { "customers",                        "Dataset",     "#f59e0b" }
+            };
+
+            var contextIcons = new[] { UIcons.FilePdf, UIcons.FileExcel, UIcons.FileCode, UIcons.Globe, UIcons.Database };
+
+            var nextContext = 1; // the first one is attached up front, below
+
+            OmniBox contextChatSample = null;
+
+            var addContextBtn = Button(UIcons.Clip).Tooltip("Add context").OnClick(() =>
+            {
+                var i    = nextContext++ % contextSpecs.Length;
+                var spec = contextSpecs[i];
+
+                contextChatSample.AddContext(
+                    ContextCard(spec[0], contextIcons[i]).SetSubLabel(spec[1]).IconBackground(spec[2]));
+            });
+
+            contextChatSample = OmniBox(new OmniBox.Config(OmniBox.Mode.Chat)
+            {
+                PlaceholderChat = "Ask me anything about the attached context",
+                ChatFooter      = new OmniBox.FooterItems { LeftSide = new IComponent[] { addContextBtn } }
+            })
+            .WS()
+            .WithContextToAdd(
+                ContextCard(contextSpecs[0][0], contextIcons[0]).SetSubLabel(contextSpecs[0][1]).IconBackground(contextSpecs[0][2]))
+            .OnChat((s, q) =>
+            {
+                var sent = s.ContextToAdd.Select(c => c.Label).ToArray();
+
+                // The box keeps the context until it is told otherwise, so the handler is where it gets
+                // sent along with the message and cleared.
+                s.ClearContext();
+
+                Toast().Information(sent.Length > 0
+                    ? $"{q.Text} (with {sent.Length} context: {string.Join(", ", sent)})"
+                    : q.Text);
+            });
+
             _content = SectionStack().Secondary()
                .SampleTitle(typeof(OmniBoxSample), UIcons.Search, "An omnibox search component")
                .FlatSection(VStack().Children(
@@ -360,7 +406,14 @@ namespace Tesserae.Tests.Samples
                     Label("Search mode (trigger button, compact)").SetContent(toolAgentSearchSample).MB(6),
                     TextBlock("In chat mode, the same selector also backs an inline \"@mention\" picker: type @ in the box below to open it anchored at the caret, keep typing to filter, use Arrow Up/Down to navigate, Enter/Tab to select, and Escape to close.").MT(6).MB(8),
                     Label("Chat mode (trigger button + @ mentions)").SetContent(toolAgentChatSample)
-                )).SetTitle("Tools & Agents")));
+                )).SetTitle("Tools & Agents")))
+               .FlatSection(VStack().WS().Children(
+                    Card(VStack().WS().Children(
+                    SampleSubTitle("Context to add"),
+                    TextBlock("In chat mode, WithContextToAdd renders ContextCards inside the box, in a wrapping row just below the input and above the footer — the context that will go with the next message. AddContext appends one card, RemoveContext / ClearContext take them out, and ContextToAdd reads the current list.").MB(8),
+                    TextBlock("Each card's remove button is wired to the row, so hovering a card and clicking its (x) detaches it. Click the clip button below to attach more, then send: the handler reports what went along with the message and clears the row.").MB(8),
+                    Label("Chat with attached context").SetContent(contextChatSample)
+                )).SetTitle("Context")));
         }
 
         private static string DescribeFilterSnap(OmniBox.FilterSnap f)

--- a/Tesserae.Tests/src/Samples/Components/OmniBoxSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/OmniBoxSample.cs
@@ -13,210 +13,241 @@ namespace Tesserae.Tests.Samples
     {
         private readonly IComponent _content;
 
+        // Every box on the page, so the "Disabled" toggle in the overview can switch all of them at once.
+        private readonly List<OmniBox> _allBoxes = new List<OmniBox>();
+
         public OmniBoxSample()
         {
-            var attBtnForSearch = Button(UIcons.PaperclipVertical).Tooltip("Add attachment");
-            var searchModeSample = OmniBox(new OmniBox.Config(OmniBox.Mode.Search)
+            _content = SectionStack().Secondary()
+               .SampleTitle(typeof(OmniBoxSample), UIcons.Search, "One input for search and chat, feature by feature")
+               .FlatSection(VStack().WS().Children(Overview()))
+               .FlatSection(VStack().WS().Children(Modes()))
+               .FlatSection(VStack().WS().Children(QuerySyntax()))
+               .FlatSection(VStack().WS().Children(Suggestions()))
+               .FlatSection(VStack().WS().Children(History()))
+               .FlatSection(VStack().WS().Children(Snaps()))
+               .FlatSection(VStack().WS().Children(FilterSnaps()))
+               .FlatSection(VStack().WS().Children(Help()))
+               .FlatSection(VStack().WS().Children(InlineChips()))
+               .FlatSection(VStack().WS().Children(FooterItems()))
+               .FlatSection(VStack().WS().Children(KeyboardShortcut()))
+               .FlatSection(VStack().WS().Children(FileDrop()))
+               .FlatSection(VStack().WS().Children(Models()))
+               .FlatSection(VStack().WS().Children(Generating()))
+               .FlatSection(VStack().WS().Children(ToolsAndAgents()))
+               .FlatSection(VStack().WS().Children(ContextToAdd()));
+        }
+
+        // ---------- Section helpers ----------
+
+        // One feature per card: a subtitle, one or two lines saying what to try, then the box itself.
+        private static Card FeatureCard(string title, string subTitle, string description, params IComponent[] content)
+        {
+            var stack = VStack().WS().Children(SampleSubTitle(subTitle), TextBlock(description).MB(8));
+
+            foreach (var c in content)
             {
-                PlaceholderSearch =    "Type something like: potato AND ( tomato OR banana) AND NOT apple",
-                SearchFooter = new OmniBox.FooterItems
+                stack.Add(c);
+            }
+
+            return Card(stack).SetTitle(title);
+        }
+
+        // Registers a box with the page-wide "Disabled" toggle and returns it, so a section can write
+        // Track(OmniBox(...)) inline.
+        private OmniBox Track(OmniBox box)
+        {
+            _allBoxes.Add(box);
+            return box;
+        }
+
+        // ---------- Overview ----------
+
+        private IComponent Overview()
+        {
+            var toggle = Toggle("Disabled").OnChange((s, e) =>
+            {
+                foreach (var box in _allBoxes)
                 {
-                    LeftSide = new[]
-                    {
-                        Button(UIcons.Rocket).OnClick(() => Toast().Success("Lift off 🚀"))
-                    },
-                    RightSide = new[]
-                    {
-                        attBtnForSearch
-                    } 
-                },
+                    box.Disabled(s.IsChecked);
+                }
+            });
+
+            return FeatureCard("Overview", "What OmniBox is",
+                "OmniBox is one input that can act as a search box, a chat composer, or both with a toggle between them. On top of the input it layers query parsing (AND / OR / NOT, parentheses, quotes), async suggestions, recent-search history, inline chips, '@' snaps and 'field:' filter snaps, a footer for custom actions, a model selector, a generating state, and a context row. Each section below turns on one of those features on its own, so it is clear which method produces what.",
+                toggle.MB(8),
+                TextBlock("The toggle above disables every box on this page — a disabled OmniBox keeps its content but stops taking input.").Small().Foreground(Theme.Secondary.Foreground));
+        }
+
+        // ---------- Modes ----------
+
+        private IComponent Modes()
+        {
+            var search = Track(OmniBox(new OmniBox.Config(OmniBox.Mode.Search)
+            {
+                PlaceholderSearch = "Search — one line, a search button, no footer"
+            })
+            .WS()
+            .OnSearch((s, q) => Toast().Information($"Searched for: {q.RawQuery}")));
+
+            var chat = Track(OmniBox(new OmniBox.Config(OmniBox.Mode.Chat)
+            {
+                PlaceholderChat = "Chat — a growing text area with a footer and a send button"
+            })
+            .WS()
+            .OnChat((s, q) => Toast().Information(q.Text)));
+
+            var both = Track(OmniBox(new OmniBox.Config(OmniBox.Mode.SearchAndChat, initialMode: OmniBox.Mode.Chat)
+            {
+                PlaceholderSearch = "Search & Chat — switch with the toggle on the left of the footer",
+                PlaceholderChat   = "Search & Chat — switch with the toggle on the left of the footer"
+            })
+            .WS()
+            .OnSearch((s, q) => Toast().Information($"Searched for: {q.RawQuery}"))
+            .OnChat((s, q) => Toast().Information(q.Text)));
+
+            var expanding = Track(OmniBox(new OmniBox.Config(OmniBox.Mode.Chat)
+            {
+                PlaceholderChat = "ExpandOnFocus — click me and the box grows",
+                ExpandOnFocus   = true
+            })
+            .WS()
+            .OnChat((s, q) => Toast().Information(q.Text)));
+
+            return FeatureCard("Modes", "Search, Chat and both",
+                "The mode is fixed at construction: new OmniBox.Config(OmniBox.Mode.Search | Chat | SearchAndChat). In SearchAndChat the footer gets a toggle between the two, and whatever is typed carries over when switching; initialMode picks the side it starts on. ExpandOnFocus makes a chat box grow while it has focus.",
+                Label("Mode.Search").SetContent(search),
+                Label("Mode.Chat").SetContent(chat).MT(6),
+                Label("Mode.SearchAndChat (starting in chat)").SetContent(both).MT(6),
+                Label("Mode.Chat with ExpandOnFocus").SetContent(expanding).MT(6));
+        }
+
+        // ---------- Query parsing ----------
+
+        private IComponent QuerySyntax()
+        {
+            var parsed = TextBlock("").Small().BreakSpaces();
+
+            var box = Track(OmniBox(new OmniBox.Config(OmniBox.Mode.Search)
+            {
+                PlaceholderSearch = "potato AND ( tomato OR banana) AND NOT apple"
+            })
+            .WS()
+            .SetSearchText("potato AND ( tomato OR banana) AND NOT \"granny smith\"")
+            .OnSearch((s, q) =>
+            {
+                parsed.Text = q.Tokens == null || q.Tokens.Count == 0
+                    ? "(no tokens)"
+                    : string.Join("\n", q.Tokens
+                        .Where(t => t.Type != OmniBox.SearchToken.TokenType.Whitespace)
+                        .Select(t => $"{t.Type}: {t.Value}"));
+            }));
+
+            return FeatureCard("Query syntax", "Operators, grouping and quotes",
+                "The search input highlights the boolean operators (AND, OR, NOT), parentheses and quoted phrases as they are typed, and hands OnSearch a SearchQuery whose Tokens are the parsed query. OmniBox.ParseQuery(string) does the same parsing without a component — useful to build the history entries below. Press Enter to see the tokens.",
+                box,
+                TextBlock("Parsed tokens").SemiBold().Small().MT(8),
+                parsed);
+        }
+
+        // ---------- Suggestions ----------
+
+        private IComponent Suggestions()
+        {
+            var box = Track(OmniBox(new OmniBox.Config(OmniBox.Mode.Search)
+            {
+                PlaceholderSearch  = "Start typing — suggestions are fetched async and grouped",
                 SuggestionsFetcher = async (query) =>
                 {
                     if (string.IsNullOrWhiteSpace(query)) return Array.Empty<OmniBox.OmniBoxSuggestionItem>();
 
                     await Task.Delay(150); // Simulate network
 
-                    var items = new List<OmniBox.OmniBoxSuggestionItem>();
-                    var q = query.ToLower();
-
-                    if ("dataset / curiosity-prod".Contains(q) || "dataset / tesserae-docs".Contains(q) || "dataset / build-logs".Contains(q))
+                    var items = new List<OmniBox.OmniBoxSuggestionItem>
                     {
-                        items.Add(new OmniBox.OmniBoxSuggestionItem(TextBlock("dataset / curiosity-prod"), Icon(UIcons.Table), Icon(UIcons.Check).Foreground(Theme.Primary.Foreground), null, "DATASETS"));
-                        items.Add(new OmniBox.OmniBoxSuggestionItem(TextBlock("dataset / tesserae-docs"), Icon(UIcons.Table), null, null, "DATASETS"));
-                        items.Add(new OmniBox.OmniBoxSuggestionItem(TextBlock("dataset / build-logs"), Icon(UIcons.Table), Icon(UIcons.Check).Foreground(Theme.Primary.Foreground), null, "DATASETS"));
-                    }
-
-                    items.Add(new OmniBox.OmniBoxSuggestionItem(TextBlock("a-model / Document.v3"), Icon(UIcons.Document), null, null, "SCHEMAS"));
-                    items.Add(new OmniBox.OmniBoxSuggestionItem(TextBlock("a-model / Embedding.v1"), Icon(UIcons.Document), null, null, "SCHEMAS"));
+                        new OmniBox.OmniBoxSuggestionItem(TextBlock("dataset / curiosity-prod"), Icon(UIcons.Table), Icon(UIcons.Check).Foreground(Theme.Primary.Foreground), null, "DATASETS"),
+                        new OmniBox.OmniBoxSuggestionItem(TextBlock("dataset / tesserae-docs"), Icon(UIcons.Table), null, null, "DATASETS"),
+                        new OmniBox.OmniBoxSuggestionItem(TextBlock("dataset / build-logs"),    Icon(UIcons.Table), Icon(UIcons.Check).Foreground(Theme.Primary.Foreground), null, "DATASETS"),
+                        new OmniBox.OmniBoxSuggestionItem(TextBlock("a-model / Document.v3"),   Icon(UIcons.Document), null, null, "SCHEMAS"),
+                        new OmniBox.OmniBoxSuggestionItem(TextBlock("a-model / Embedding.v1"),  Icon(UIcons.Document), null, null, "SCHEMAS")
+                    };
 
                     return items.ToArray();
                 }
             })
             .WS()
-            .WithHistory(async () => {
-                return new[] 
+            .OnSearch((s, q) => Toast().Information($"Searched for: {q.RawQuery}")));
+
+            return FeatureCard("Suggestions", "Async suggestions with categories",
+                "Config.SuggestionsFetcher is an async Func<string, Task<OmniBoxSuggestionItem[]>> called as the user types. Each item takes a content component, a leading icon, an optional right-hand component (a checkmark, a count), an onSelected callback, and a category that groups it under a header. Arrow Up/Down moves through the list, Enter picks the highlighted one.",
+                box);
+        }
+
+        // ---------- History ----------
+
+        private IComponent History()
+        {
+            var box = Track(OmniBox(new OmniBox.Config(OmniBox.Mode.Search)
+            {
+                PlaceholderSearch = "Click the clock button on the left to see recent searches"
+            })
+            .WS()
+            .WithHistory(async () =>
+            {
+                await Task.Delay(100); // Simulate network
+
+                return new[]
                 {
                     OmniBox.ParseQuery("apple"),
                     OmniBox.ParseQuery("orange"),
                     OmniBox.ParseQuery("tomato"),
                     OmniBox.ParseQuery("banana"),
-                    OmniBox.ParseQuery("potato AND ( tomato OR banana) AND NOT apple"),
+                    OmniBox.ParseQuery("potato AND ( tomato OR banana) AND NOT apple")
                 };
             })
+            .OnSearch((s, q) => Toast().Information($"Searched for: {q.RawQuery}")));
+
+            return FeatureCard("History", "Recent searches",
+                "WithHistory(Func<Task<SearchQuery[]>>) shows a history button on the left of the search input; clicking it opens the list the fetcher returns, and picking an entry puts it back in the box. Build the entries with OmniBox.ParseQuery so they keep their operator highlighting.",
+                box);
+        }
+
+        // ---------- Snaps ----------
+
+        private IComponent Snaps()
+        {
+            var box = Track(OmniBox(new OmniBox.Config(OmniBox.Mode.Search)
+            {
+                PlaceholderSearch = "Type @ to pick a snap — @docs, @wiki, @code, @ai"
+            })
+            .WS()
+            .RegisterSnaps(
+                new OmniBox.SnapHandler("docs", "Docs",      new[] { "docs", "documentation" }, Icon(UIcons.Book),     "Search the documentation", exampleValue: "documentation pages"),
+                new OmniBox.SnapHandler("wiki", "Wikipedia", new[] { "wiki", "wikipedia" },     Icon(UIcons.Globe),    "Search Wikipedia",         exampleValue: "encyclopedia articles"),
+                new OmniBox.SnapHandler("code", "Code",      new[] { "code", "src", "source" }, Icon(UIcons.FileCode), "Search source code",       exampleValue: "src/, repo files"),
+                new OmniBox.SnapHandler("ai",   "AI Assist", new[] { "ai", "ask" },             Icon(UIcons.MagicWand), "Switch to AI search (exclusive)", exclusive: true))
             .OnSearch((s, q) =>
             {
                 var snapInfo = q.Snaps != null && q.Snaps.Length > 0
-                    ? $" — snaps: {string.Join(", ", q.Snaps.Select(sn => sn.SnapId))}"
-                    : "";
-                Toast().Information($"Searched for: {q.RawQuery} (Parsed into {q.Tokens?.Count ?? 0} tokens){snapInfo}");
-            })
-            .RegisterSnaps(
-                new OmniBox.SnapHandler("docs", "Docs", new[] { "docs", "documentation" }, Icon(UIcons.Book), "Search the documentation"),
-                new OmniBox.SnapHandler("wiki", "Wikipedia", new[] { "wiki", "wikipedia" }, Icon(UIcons.Globe), "Search Wikipedia"),
-                new OmniBox.SnapHandler("code", "Code", new[] { "code", "src", "source" }, Icon(UIcons.FileCode), "Search source code"),
-                new OmniBox.SnapHandler("ai", "AI Assist", new[] { "ai", "ask" }, Icon(UIcons.MagicWand), "Switch to AI search (exclusive)", exclusive: true))
-            .SetKeyboardShortcut("Ctrl", "K")
-            .SetSearchText("potato AND ( tomato OR banana) AND NOT apple");
+                    ? string.Join(", ", q.Snaps.Select(sn => sn.SnapId))
+                    : "none";
+                Toast().Information($"Searched for: {q.RawQuery} — snaps: {snapInfo}");
+            }));
 
-            var fileDropAreaOnSearch = FileDropArea(searchModeSample).OnFilesDropped((s, files) =>
+            return FeatureCard("Snaps", "'@' scopes that become chips",
+                "RegisterSnaps declares scopes the user reaches by typing @: each SnapHandler has an id, a title, the trigger words that match it, an icon and a description. Committing one turns it into a removable chip in front of the query, and the selected snaps come back on SearchQuery.Snaps. A snap marked exclusive replaces any other (e.g. @ai here).",
+                box);
+        }
+
+        // ---------- Filter snaps ----------
+
+        private IComponent FilterSnaps()
+        {
+            var box = Track(OmniBox(new OmniBox.Config(OmniBox.Mode.Search)
             {
-                Toast().Information($"Dropped files on search box: {string.Join(", ", files.Select(f => f.name))}");
-            }).SetAccepts("*");
-
-            searchModeSample.InlineFilterChips.Add(new OmniBox.InlineFilterChip("Tag: Red", "var(--tss-danger-background-color)", "var(--tss-danger-foreground-color)"));
-            searchModeSample.InlineFilterChips.Add(new OmniBox.InlineFilterChip("Author: Jules", onClick:(_)=> Toast().Success("hi!")));
-            searchModeSample.InlineFilterChips.Add(new OmniBox.InlineFilterChip(Button("IComponent")));
-            searchModeSample.SetSearchRightText("124 results");
-
-            attBtnForSearch.OnClick((s, e) => fileDropAreaOnSearch.OpenFileSelection());
-
-            var attBtnForChat = Button(UIcons.PaperclipVertical).Tooltip("Add attachment");
-
-            var chatModeSample = OmniBox(new OmniBox.Config(OmniBox.Mode.Chat)
-            {
-                PlaceholderChat = "Ask me anything",
-                ChatFooter = new OmniBox.FooterItems
-                {
-                    LeftSide = new[]
-                    {
-                        Button(UIcons.Rocket).OnClick(() => Toast().Success("Lift off 🚀"))
-                    },
-                    RightSide = new[]
-                    {
-                        attBtnForChat
-                    }
-                }
-
+                PlaceholderSearch = "Type 'ext:', 'lang:' or 'modified:' to autocomplete a filter value"
             })
             .WS()
-            .SetModels(
-                new OmniBox.ModelOption("Opus 4.7"),
-                new OmniBox.ModelOption("Opus 4.7", "1M"),
-                new OmniBox.ModelOption("Sonnet 4.6"),
-                new OmniBox.ModelOption("Haiku 4.5"))
-            .SetThinkingEffort(OmniBox.ThinkingEffort.High)
-            .OnModelChanged((s, model, effort) =>
-            {
-                Toast().Information($"Selected {model.Name} with {effort} thinking effort");
-            })
-            .OnChat((s, q) =>
-            {
-                s.IsGenerating = true;
-                window.setTimeout((_) =>
-                {
-                    if (s.IsGenerating) // Make sure it wasn't cancelled
-                    {
-                        s.IsGenerating = false;
-                        Toast().Information(q.Text);
-                    }
-                }, 5000);
-            })
-            .OnStop(s =>
-            {
-                s.IsGenerating = false;
-            });
-
-            var lockedModel = new OmniBox.ModelOption("Sonnet 4.6");
-            var lockedChatModeSample = OmniBox(new OmniBox.Config(OmniBox.Mode.Chat)
-            {
-                PlaceholderChat = "This chat has a locked model"
-            })
-            .WS()
-            .LockModel(lockedModel)
-            .SetThinkingEffort(OmniBox.ThinkingEffort.Medium);
-
-            var fileDropAreaOnChat = FileDropArea(chatModeSample).OnFilesDropped((s, files) =>
-            {
-                Toast().Information($"Dropped files on chat box: {string.Join(", ", files.Select(f => f.name))}");
-            }).SetAccepts("*");
-
-            attBtnForChat.OnClick((s, e) => fileDropAreaOnChat.OpenFileSelection());
-
-            var searchAndChatModeSample = OmniBox(new OmniBox.Config(OmniBox.Mode.SearchAndChat)
-            {
-                PlaceholderChat   = "Ask me anything",
-                PlaceholderSearch = "Search for anything",
-                ChatFooter = new OmniBox.FooterItems { LeftSide = new IComponent[]
-                {
-                    Dropdown().ML(16).Searchable().Items(DropdownItem("Consult Documents", icon: UIcons.Book).Selected(),
-                                                  DropdownItem("Find a flight", icon: UIcons.AirplaneJourney),
-                                                  DropdownItem("Book a hotel", icon: UIcons.Hotel))
-                }
-                } 
-            })
-            .WS()
-            .OnSearch((s, q) =>
-            {
-                Toast().Information($"Searched for: {q.RawQuery} (Parsed into {q.Tokens?.Count ?? 0} tokens)");
-            })
-            .OnChat((s, q) =>
-            {
-                s.IsGenerating = true;
-                window.setTimeout((_) => 
-                { 
-                    if (s.IsGenerating) // Make sure it wasn't cancelled
-                    {
-                        s.IsGenerating = false;
-                        Toast().Information(q.Text);
-                    }
-                }, 5000);
-            })
-            .OnStop(s =>
-            {
-                s.IsGenerating = false;
-            })
-            .WithHistory(async () => {
-                return new OmniBox.SearchQuery[0];
-            })
-            .SetKeyboardShortcut("Ctrl", "Shift", "K");
-
-
-            var toggle = Toggle("Disabled").OnChange((s, e) =>
-            {
-                var disabled = s.IsChecked;
-                if (disabled)
-                {
-                    searchModeSample.Disabled();
-                    chatModeSample.Disabled();
-                    searchAndChatModeSample.Disabled();
-                }
-                else
-                {
-                    searchModeSample.Disabled(false);
-                    chatModeSample.Disabled(false);
-                    searchAndChatModeSample.Disabled(false);
-                }
-            });
-
-            var snapAndFilterSample = OmniBox(new OmniBox.Config(OmniBox.Mode.Search)
-            {
-                PlaceholderSearch = "Type @ for snaps, 'ext:' / 'lang:' for filter values, or 'modified:' for a date range",
-            })
-            .WS()
-            .RegisterSnaps(
-                new OmniBox.SnapHandler("docs",  "Docs",      new[] { "docs", "documentation" }, Icon(UIcons.Book),   "Search the documentation",   exampleValue: "documentation pages"),
-                new OmniBox.SnapHandler("wiki",  "Wikipedia", new[] { "wiki", "wikipedia" },     Icon(UIcons.Globe),  "Search Wikipedia",            exampleValue: "encyclopedia articles"),
-                new OmniBox.SnapHandler("code",  "Code",      new[] { "code", "src", "source" }, Icon(UIcons.FileCode), "Search source code",        exampleValue: "src/, repo files"))
             .RegisterFilterSnaps(
                 new OmniBox.FilterSnapHandler(
                     "ext",
@@ -233,12 +264,13 @@ namespace Tesserae.Tests.Samples
                     async (input) =>
                     {
                         await Task.Delay(120); // Simulate network
+
                         var all = new[] { "csharp", "typescript", "javascript", "python", "ruby", "go", "rust", "java", "kotlin", "swift", "html", "css" };
                         if (string.IsNullOrEmpty(input)) return all;
                         return all.Where(v => v.IndexOf(input, StringComparison.OrdinalIgnoreCase) >= 0).ToArray();
                     },
                     icon: Icon(UIcons.Globe),
-                    description: "Filter results by language (async)",
+                    description: "Filter results by language (async values)",
                     exampleValue: "csharp, typescript…"),
                 OmniBox.FilterSnapHandler.TimeRange(
                     "modified",
@@ -247,28 +279,236 @@ namespace Tesserae.Tests.Samples
                     icon: Icon(UIcons.Calendar),
                     description: "Filter results by a date range (yyyy-MM-dd:yyyy-MM-dd)",
                     exampleValue: "2025-01-01"))
-            .WithHistory(async () =>
-            {
-                return new[]
-                {
-                    OmniBox.ParseQuery("test AND deploy"),
-                    OmniBox.ParseQuery("\"load testing\" NOT staging"),
-                    OmniBox.ParseQuery("ext:cs lang:csharp"),
-                };
-            })
-            .WithHelp(showSyntax: true)
             .OnSearch((s, q) =>
             {
-                var snapInfo = q.Snaps != null && q.Snaps.Length > 0
-                    ? $" — snaps: {string.Join(", ", q.Snaps.Select(sn => sn.SnapId))}"
-                    : "";
                 var filterInfo = q.FilterSnaps != null && q.FilterSnaps.Length > 0
-                    ? $" — filters: {string.Join(", ", q.FilterSnaps.Select(DescribeFilterSnap))}"
-                    : "";
-                Toast().Information($"Searched for: {q.RawQuery}{snapInfo}{filterInfo}");
-            });
+                    ? string.Join(", ", q.FilterSnaps.Select(DescribeFilterSnap))
+                    : "none";
+                Toast().Information($"Searched for: {q.RawQuery} — filters: {filterInfo}");
+            }));
 
-            var toolAgentSelectorForSearch = ToolAgentSelector()
+            return FeatureCard("Filter snaps", "'field:value' filters, including date ranges",
+                "RegisterFilterSnaps declares 'field:' filters. Values come either from a fixed list, or from an async fetcher for a live source. FilterSnapHandler.TimeRange builds a date-range filter instead: typing 'modified:' opens a picker with shortcuts (last week, last month, last 90 days, last year), and the range can also be typed as yyyy-MM-dd:yyyy-MM-dd. Committed filters become chips and arrive on SearchQuery.FilterSnaps, where TryGetDateRange unpacks a range one.",
+                box);
+        }
+
+        // ---------- Help ----------
+
+        private IComponent Help()
+        {
+            var box = Track(OmniBox(new OmniBox.Config(OmniBox.Mode.Search)
+            {
+                PlaceholderSearch = "Click the ? button on the left"
+            })
+            .WS()
+            .RegisterSnaps(
+                new OmniBox.SnapHandler("docs", "Docs", new[] { "docs", "documentation" }, Icon(UIcons.Book), "Search the documentation", exampleValue: "documentation pages"))
+            .RegisterFilterSnaps(
+                new OmniBox.FilterSnapHandler(
+                    "ext",
+                    "File extension",
+                    new[] { "ext", "filetype" },
+                    new[] { "cs", "ts", "md", "json" },
+                    icon: Icon(UIcons.FileCode),
+                    description: "Filter results by file extension",
+                    exampleValue: "cs, ts, json…"))
+            .WithHelp(showSyntax: true)
+            .OnSearch((s, q) => Toast().Information($"Searched for: {q.RawQuery}")));
+
+            return FeatureCard("Help", "A panel listing what the box understands",
+                "WithHelp() adds a ? button that opens a panel listing the registered filters (with their example values) and snaps, so the syntax is discoverable without documentation. WithHelp(showSyntax: true) also documents the boolean operators, grouping and exact-phrase quoting, with an example next to each.",
+                box);
+        }
+
+        // ---------- Inline chips + right text ----------
+
+        private IComponent InlineChips()
+        {
+            var box = Track(OmniBox(new OmniBox.Config(OmniBox.Mode.Search)
+            {
+                PlaceholderSearch = "Chips sit inside the input, before the text"
+            })
+            .WS()
+            .OnSearch((s, q) => Toast().Information($"Searched for: {q.RawQuery}")));
+
+            box.InlineFilterChips.Add(new OmniBox.InlineFilterChip("Tag: Red", "var(--tss-danger-background-color)", "var(--tss-danger-foreground-color)"));
+            box.InlineFilterChips.Add(new OmniBox.InlineFilterChip("Author: Jules", onClick: (_) => Toast().Success("hi!")));
+            box.InlineFilterChips.Add(new OmniBox.InlineFilterChip(Button("IComponent")));
+            box.SetSearchRightText("124 results");
+
+            var addChip = Button("Add a chip").SetIcon(UIcons.Plus).OnClick(() =>
+                box.InlineFilterChips.Add(new OmniBox.InlineFilterChip($"Filter {box.InlineFilterChips.Count + 1}")));
+
+            var clearChips = Button("Clear chips").SetIcon(UIcons.Trash).OnClick(() => box.InlineFilterChips.Clear());
+
+            return FeatureCard("Inline chips", "Filters pinned inside the input, and a result count",
+                "InlineFilterChips is an observable list rendered at the head of the search input — use it for filters the app owns (a selected tag, an author, a facet from elsewhere in the UI) rather than ones the user typed. A chip takes a text with optional background/foreground colors, an onClick, or an arbitrary IComponent. SetSearchRightText puts a label at the far end of the input, e.g. a result count.",
+                box,
+                HStack().Gap(8.px()).MT(8).Children(addChip, clearChips));
+        }
+
+        // ---------- Footer items ----------
+
+        private IComponent FooterItems()
+        {
+            var searchBox = Track(OmniBox(new OmniBox.Config(OmniBox.Mode.Search)
+            {
+                PlaceholderSearch = "Search with footer actions",
+                SearchFooter = new OmniBox.FooterItems
+                {
+                    LeftSide  = new IComponent[] { Button(UIcons.Rocket).Tooltip("Left side").OnClick(() => Toast().Success("Lift off 🚀")) },
+                    RightSide = new IComponent[] { Button("Feeling lucky").SetIcon(UIcons.Dice).OnClick(() => Toast().Information("🎲")) }
+                }
+            })
+            .WS()
+            .OnSearch((s, q) => Toast().Information($"Searched for: {q.RawQuery}")));
+
+            var chatBox = Track(OmniBox(new OmniBox.Config(OmniBox.Mode.Chat)
+            {
+                PlaceholderChat = "Chat with footer actions",
+                ChatFooter = new OmniBox.FooterItems
+                {
+                    LeftSide = new IComponent[]
+                    {
+                        Dropdown().ML(16).Searchable().Items(
+                            DropdownItem("Consult Documents", icon: UIcons.Book).Selected(),
+                            DropdownItem("Find a flight", icon: UIcons.AirplaneJourney),
+                            DropdownItem("Book a hotel", icon: UIcons.Hotel))
+                    },
+                    RightSide = new IComponent[] { Button(UIcons.Microphone).Tooltip("Dictate").OnClick(() => Toast().Information("🎤")) }
+                }
+            })
+            .WS()
+            .OnChat((s, q) => Toast().Information(q.Text)));
+
+            return FeatureCard("Footer items", "Your own actions around the input",
+                "Config.SearchFooter and Config.ChatFooter each take LeftSide / RightSide arrays of components, placed beside the built-in buttons of that mode — an attachment button, a mode dropdown, a dictate button. In SearchAndChat mode the items of the side that isn't active are hidden along with the rest of that mode's chrome.",
+                Label("Search footer").SetContent(searchBox),
+                Label("Chat footer").SetContent(chatBox).MT(6));
+        }
+
+        // ---------- Keyboard shortcut ----------
+
+        private IComponent KeyboardShortcut()
+        {
+            var box = Track(OmniBox(new OmniBox.Config(OmniBox.Mode.Search)
+            {
+                PlaceholderSearch = "Press Ctrl+K anywhere on this page to focus me"
+            })
+            .WS()
+            .SetKeyboardShortcut("Ctrl", "K")
+            .OnSearch((s, q) => Toast().Information($"Searched for: {q.RawQuery}")));
+
+            return FeatureCard("Keyboard shortcut", "A global key that focuses the box",
+                "SetKeyboardShortcut(\"Ctrl\", \"K\") registers a document-level shortcut that focuses the input, and shows the keys as a hint at the end of the search input (the hint is hidden in chat mode). Focus() does the same thing programmatically.",
+                box,
+                Button("Focus() it").SetIcon(UIcons.Cursor).MT(8).OnClick(() => box.Focus()));
+        }
+
+        // ---------- File drop ----------
+
+        private IComponent FileDrop()
+        {
+            var attachBtn = Button(UIcons.PaperclipVertical).Tooltip("Add attachment");
+
+            var box = Track(OmniBox(new OmniBox.Config(OmniBox.Mode.Chat)
+            {
+                PlaceholderChat = "Drop files on me, or click the paperclip",
+                ChatFooter      = new OmniBox.FooterItems { RightSide = new IComponent[] { attachBtn } }
+            })
+            .WS()
+            .OnChat((s, q) => Toast().Information(q.Text)));
+
+            var dropArea = FileDropArea(box).OnFilesDropped((s, files) =>
+            {
+                Toast().Information($"Dropped: {string.Join(", ", files.Select(f => f.name))}");
+            }).SetAccepts("*");
+
+            attachBtn.OnClick((s, e) => dropArea.OpenFileSelection());
+
+            return FeatureCard("Files", "Drag & drop, and a file picker",
+                "OmniBox has no file handling of its own — wrap it in a FileDropArea to accept drops over the box, and call OpenFileSelection() from a footer button for the click path. Pair it with the context row further down to show what was attached.",
+                dropArea.WS());
+        }
+
+        // ---------- Models ----------
+
+        private IComponent Models()
+        {
+            var box = Track(OmniBox(new OmniBox.Config(OmniBox.Mode.Chat)
+            {
+                PlaceholderChat = "Pick a model in the footer, on the right"
+            })
+            .WS()
+            .SetModels(
+                new OmniBox.ModelOption("Opus 4.7"),
+                new OmniBox.ModelOption("Opus 4.7", "1M"),
+                new OmniBox.ModelOption("Sonnet 4.6"),
+                new OmniBox.ModelOption("Haiku 4.5"))
+            .SetThinkingEffort(OmniBox.ThinkingEffort.High)
+            .OnModelChanged((s, model, effort) => Toast().Information($"Selected {model.Name} with {effort} thinking effort"))
+            .OnChat((s, q) => Toast().Information(q.Text)));
+
+            var locked = Track(OmniBox(new OmniBox.Config(OmniBox.Mode.Chat)
+            {
+                PlaceholderChat = "This chat has a locked model"
+            })
+            .WS()
+            .LockModel(new OmniBox.ModelOption("Sonnet 4.6"))
+            .SetThinkingEffort(OmniBox.ThinkingEffort.Medium)
+            .OnChat((s, q) => Toast().Information(q.Text)));
+
+            return FeatureCard("Models", "A model selector with thinking effort",
+                "SetModels(params ModelOption[]) adds a selector to the chat footer; a ModelOption can carry a variant label (e.g. a 1M context window) shown next to its name. SetThinkingEffort picks the initial effort, OnModelChanged reports both back. LockModel pins one choice: the button shows it with a lock and the popover stops opening — for a chat where the model is decided elsewhere.",
+                Label("Selectable model + effort").SetContent(box),
+                Label("Locked model").SetContent(locked).MT(6));
+        }
+
+        // ---------- Generating ----------
+
+        private IComponent Generating()
+        {
+            var box = Track(OmniBox(new OmniBox.Config(OmniBox.Mode.Chat)
+            {
+                PlaceholderChat = "Send something — the footer shows a spinner and the send button becomes a stop button",
+                GeneratingText  = "Thinking"
+            })
+            .WS()
+            .OnChat((s, q) =>
+            {
+                s.IsGenerating = true;
+
+                // Rewrite the label while it runs, the way a real reply reports its phases.
+                window.setTimeout((_) => { if (s.IsGenerating) s.GeneratingText = "Reading documents"; }, 1500);
+                window.setTimeout((_) => { if (s.IsGenerating) s.GeneratingText = "Writing the answer"; }, 3000);
+
+                window.setTimeout((_) =>
+                {
+                    if (s.IsGenerating) // Make sure it wasn't cancelled
+                    {
+                        s.IsGenerating   = false;
+                        s.GeneratingText = "Thinking";
+                        Toast().Information(q.Text);
+                    }
+                }, 5000);
+            })
+            .OnStop(s =>
+            {
+                s.IsGenerating   = false;
+                s.GeneratingText = "Thinking";
+                Toast().Warning("Stopped");
+            }));
+
+            return FeatureCard("Generating", "The state while a reply streams",
+                "Setting IsGenerating = true swaps the send button for a stop button and shows a spinner in the footer with the elapsed time appended to the label; OnStop fires when the user presses stop, and it is the handler's job to set IsGenerating back to false. GeneratingText (on the config, or written live) is that label — send a message below to watch it change.",
+                box);
+        }
+
+        // ---------- Tools & agents ----------
+
+        private IComponent ToolsAndAgents()
+        {
+            var selectorForSearch = ToolAgentSelector()
                 .Agents(
                     ToolAgentSelectorItem("deep-researcher", "Deep Researcher", "Multi-step web research with citations", UIcons.Search).Selected(),
                     ToolAgentSelectorItem("code-assistant", "Code Assistant", "Plans, writes and debugs code end to end", UIcons.FileCode),
@@ -282,15 +522,15 @@ namespace Tesserae.Tests.Samples
                 .Compact()
                 .OnChange(s => Toast().Information($"{s.SelectedCount} tool(s)/agent(s) enabled"));
 
-            var toolAgentSearchSample = OmniBox(new OmniBox.Config(OmniBox.Mode.Search)
+            var searchBox = Track(OmniBox(new OmniBox.Config(OmniBox.Mode.Search)
             {
                 PlaceholderSearch = "Search anything",
-                SearchFooter = new OmniBox.FooterItems { RightSide = new IComponent[] { toolAgentSelectorForSearch } }
+                SearchFooter = new OmniBox.FooterItems { RightSide = new IComponent[] { selectorForSearch } }
             })
             .WS()
-            .OnSearch((s, q) => Toast().Information($"Searched for: {q.RawQuery}"));
+            .OnSearch((s, q) => Toast().Information($"Searched for: {q.RawQuery}")));
 
-            var toolAgentSelectorForChat = ToolAgentSelector()
+            var selectorForChat = ToolAgentSelector()
                 .Agents(
                     ToolAgentSelectorItem("deep-researcher", "Deep Researcher", "Multi-step web research with citations", UIcons.Search),
                     ToolAgentSelectorItem("code-assistant", "Code Assistant", "Plans, writes and debugs code end to end", UIcons.FileCode).Selected(),
@@ -303,36 +543,33 @@ namespace Tesserae.Tests.Samples
                     ToolAgentSelectorItem("calculator", "Calculator", "Evaluate math expressions", UIcons.Calculator))
                 .OnChange(s => Toast().Information($"{s.SelectedCount} tool(s)/agent(s) enabled"));
 
-            var toolAgentChatSample = OmniBox(new OmniBox.Config(OmniBox.Mode.Chat)
+            var chatBox = Track(OmniBox(new OmniBox.Config(OmniBox.Mode.Chat)
             {
                 PlaceholderChat = "Ask me anything — type @ to mention a tool or agent",
-                ChatFooter = new OmniBox.FooterItems { LeftSide = new IComponent[] { toolAgentSelectorForChat } }
+                ChatFooter = new OmniBox.FooterItems { LeftSide = new IComponent[] { selectorForChat } }
             })
             .WS()
-            .OnChat((s, q) =>
-            {
-                s.IsGenerating = true;
-                window.setTimeout((_) =>
-                {
-                    if (s.IsGenerating)
-                    {
-                        s.IsGenerating = false;
-                        Toast().Information(q.Text);
-                    }
-                }, 5000);
-            })
-            .OnStop(s => s.IsGenerating = false)
+            .OnChat((s, q) => Toast().Information(q.Text))
             .EnableChatMentions(new OmniBox.ChatMention
             {
-                OnShow         = (x, y) => toolAgentSelectorForChat.ShowInlineAt(x, y),
-                OnQueryChanged = text    => toolAgentSelectorForChat.Filter(text),
-                OnMove         = dir     => toolAgentSelectorForChat.MoveHighlight(dir),
-                OnCommit       = ()      => toolAgentSelectorForChat.ActivateHighlighted(),
-                OnHide         = ()      => toolAgentSelectorForChat.Hide(),
-                IsOpen         = ()      => toolAgentSelectorForChat.IsVisible
-            });
+                OnShow         = (x, y) => selectorForChat.ShowInlineAt(x, y),
+                OnQueryChanged = text    => selectorForChat.Filter(text),
+                OnMove         = dir     => selectorForChat.MoveHighlight(dir),
+                OnCommit       = ()      => selectorForChat.ActivateHighlighted(),
+                OnHide         = ()      => selectorForChat.Hide(),
+                IsOpen         = ()      => selectorForChat.IsVisible
+            }));
 
-            // Context to add: ContextCards rendered inside the box, just below the input.
+            return FeatureCard("Tools & agents", "A selector in the footer, and '@' mentions",
+                "ToolAgentSelector is a trigger button plus a searchable popup for enabling agents and tools, grouped into \"Agents\" and \"Tools\" with an icon, a title and an optional description per row; the trigger shows a count badge, and .Compact() drops the descriptions for a denser list. In chat mode, EnableChatMentions turns typing @ into the same picker anchored at the caret: keep typing to filter, Arrow Up/Down to move, Enter/Tab to pick, Escape to close. ChatMention is a set of plain callbacks, so any anchored popup can be wired to it.",
+                Label("Search mode (trigger button, compact)").SetContent(searchBox),
+                Label("Chat mode (trigger button + @ mentions)").SetContent(chatBox).MT(6));
+        }
+
+        // ---------- Context to add ----------
+
+        private IComponent ContextToAdd()
+        {
             var contextSpecs = new[]
             {
                 new[] { "Kindersonnenschutzmittel-NEU.pdf", "PDF",         "#ef4444" },
@@ -346,25 +583,25 @@ namespace Tesserae.Tests.Samples
 
             var nextContext = 1; // the first one is attached up front, below
 
-            OmniBox contextChatSample = null;
+            OmniBox box = null;
 
-            var addContextBtn = Button(UIcons.Clip).Tooltip("Add context").OnClick(() =>
+            ContextCard CardFor(int index)
             {
-                var i    = nextContext++ % contextSpecs.Length;
+                var i    = index % contextSpecs.Length;
                 var spec = contextSpecs[i];
 
-                contextChatSample.AddContext(
-                    ContextCard(spec[0], contextIcons[i]).SetSubLabel(spec[1]).IconBackground(spec[2]));
-            });
+                return ContextCard(spec[0], contextIcons[i]).SetSubLabel(spec[1]).IconBackground(spec[2]);
+            }
 
-            contextChatSample = OmniBox(new OmniBox.Config(OmniBox.Mode.Chat)
+            var addContextBtn = Button(UIcons.Clip).Tooltip("Add context").OnClick(() => box.AddContext(CardFor(nextContext++)));
+
+            box = Track(OmniBox(new OmniBox.Config(OmniBox.Mode.Chat)
             {
                 PlaceholderChat = "Ask me anything about the attached context",
                 ChatFooter      = new OmniBox.FooterItems { LeftSide = new IComponent[] { addContextBtn } }
             })
             .WS()
-            .WithContextToAdd(
-                ContextCard(contextSpecs[0][0], contextIcons[0]).SetSubLabel(contextSpecs[0][1]).IconBackground(contextSpecs[0][2]))
+            .WithContextToAdd(CardFor(0))
             .OnChat((s, q) =>
             {
                 var sent = s.ContextToAdd.Select(c => c.Label).ToArray();
@@ -376,44 +613,11 @@ namespace Tesserae.Tests.Samples
                 Toast().Information(sent.Length > 0
                     ? $"{q.Text} (with {sent.Length} context: {string.Join(", ", sent)})"
                     : q.Text);
-            });
+            }));
 
-            _content = SectionStack().Secondary()
-               .SampleTitle(typeof(OmniBoxSample), UIcons.Search, "An omnibox search component")
-               .FlatSection(VStack().Children(
-                    Card(VStack().WS().Children(
-                    toggle.MB(16),
-                    TextBlock("Omnibox provides a powerful input field for switching between a chat and a search interaction. For search, it also provides support for parsing and visual rendering of logical operators like AND, OR, NOT, parenthesis, and quotes."))).SetTitle("Overview")))
-               .FlatSection(VStack().WS().Children(
-                    Card(VStack().WS().Children(
-                    SampleSubTitle("Modes"),
-                        Label("Search (with FileDropArea)").SetContent(fileDropAreaOnSearch.WS()),
-                        Label("Chat").SetContent(fileDropAreaOnChat.WS()).MT(6),
-                        Label("Chat with locked model").SetContent(lockedChatModeSample.WS()).MT(6),
-                        Label("Search & Chat").SetContent(searchAndChatModeSample.WS()).MT(6)
-                )).SetTitle("Usage")))
-               .FlatSection(VStack().WS().Children(
-                    Card(VStack().WS().Children(
-                    SampleSubTitle("Snaps and filter snaps"),
-                    TextBlock("Type @ to insert a snap (e.g. @docs, @wiki, @code). Type 'ext:', 'filetype:', or 'lang:' to autocomplete filter values. Type 'modified:' (or 'date:' / 'between:') for a time-based filter snap — a date-range picker with shortcuts (last week, last month, last 90 days, last year), or type the range directly as yyyy-MM-dd:yyyy-MM-dd. When committed they become removable chips. All snap and filter selections are passed through with the search query.").MB(8),
-                    TextBlock("Click the ? button on the left of the input to open the help panel — it lists the registered field filters (with their example values) and the registered snaps. It can also include a 'Query syntax' section describing AND / OR / NOT / parentheses / quotes when configured with WithHelp(showSyntax: true). Recent searches are reached via the separate history button enabled with WithHistory(...).").MB(8),
-                    Label("Snaps + filter snaps + help").SetContent(snapAndFilterSample.Class("tss-omnibox-snap-and-filter-sample"))
-                )).SetTitle("Snaps & Filter Snaps")))
-               .FlatSection(VStack().WS().Children(
-                    Card(VStack().WS().Children(
-                    SampleSubTitle("Tool / agent selector"),
-                    TextBlock("ToolAgentSelector is a Dropdown-style trigger button + searchable popup for enabling agents and tools, grouped into \"Agents\" and \"Tools\" sections with a leading icon, a title and an optional description per row. Selecting items shows a count badge on the trigger button, and .Compact() hides the descriptions for a denser list.").MB(8),
-                    Label("Search mode (trigger button, compact)").SetContent(toolAgentSearchSample).MB(6),
-                    TextBlock("In chat mode, the same selector also backs an inline \"@mention\" picker: type @ in the box below to open it anchored at the caret, keep typing to filter, use Arrow Up/Down to navigate, Enter/Tab to select, and Escape to close.").MT(6).MB(8),
-                    Label("Chat mode (trigger button + @ mentions)").SetContent(toolAgentChatSample)
-                )).SetTitle("Tools & Agents")))
-               .FlatSection(VStack().WS().Children(
-                    Card(VStack().WS().Children(
-                    SampleSubTitle("Context to add"),
-                    TextBlock("In chat mode, WithContextToAdd renders ContextCards inside the box, in a wrapping row just below the input and above the footer — the context that will go with the next message. AddContext appends one card, RemoveContext / ClearContext take them out, and ContextToAdd reads the current list.").MB(8),
-                    TextBlock("Each card's remove button is wired to the row, so hovering a card and clicking its (x) detaches it. Click the clip button below to attach more, then send: the handler reports what went along with the message and clears the row.").MB(8),
-                    Label("Chat with attached context").SetContent(contextChatSample)
-                )).SetTitle("Context")));
+            return FeatureCard("Context", "The context the next message carries",
+                "In chat mode, WithContextToAdd renders ContextCards inside the box — a wrapping row just below the input and above the footer. AddContext appends one, RemoveContext / ClearContext take them out, ContextToAdd reads the current list, and each card's remove button is already wired to the row, so hovering a card and clicking its (x) detaches it. Click the clip button to attach more, then send: the handler reports what went with the message and clears the row.",
+                box);
         }
 
         private static string DescribeFilterSnap(OmniBox.FilterSnap f)

--- a/Tesserae/skills/SKILL.md
+++ b/Tesserae/skills/SKILL.md
@@ -145,7 +145,7 @@ references. Open the reference for whatever you are working with. The full set:
 **Components** (plain widgets)
 accordion · action-button · annotated-text-editor · avatar · background-area ·
 badge · button · card · carousel · charts · chat · check-box · choice-group ·
-color-picker · command-bar · contribution-bar · cron-editor · date-picker ·
+color-picker · command-bar · context-card · contribution-bar · cron-editor · date-picker ·
 date-range-picker · date-time-picker · delta-component · dropdown ·
 editable-area · editable-label · expander · grid-picker · horizontal-separator ·
 icon · icon-toggle · image · label · link · live-progress · markdown-block ·

--- a/Tesserae/skills/SKILL.md
+++ b/Tesserae/skills/SKILL.md
@@ -145,7 +145,7 @@ references. Open the reference for whatever you are working with. The full set:
 **Components** (plain widgets)
 accordion · action-button · annotated-text-editor · avatar · background-area ·
 badge · button · card · carousel · charts · chat · check-box · choice-group ·
-color-picker · command-bar · contribution-bar · cron-editor · date-picker ·
+color-picker · command-bar · context-bar · contribution-bar · cron-editor · date-picker ·
 date-range-picker · date-time-picker · delta-component · dropdown ·
 editable-area · editable-label · expander · grid-picker · horizontal-separator ·
 icon · icon-toggle · image · label · link · live-progress · markdown-block ·

--- a/Tesserae/skills/references/chat.md
+++ b/Tesserae/skills/references/chat.md
@@ -76,4 +76,5 @@ chat.Busy(false);
 - Pixel-art cats as chat avatars — `pixel-avatar.md`
 
 - Avatar — `avatar.md`
+- ContextBar — bubbles for the sources a reply cites, usable with `WithReferences` — `context-bar.md`
 - Full docs & API: `/tesserae/components/chat`

--- a/Tesserae/skills/references/chat.md
+++ b/Tesserae/skills/references/chat.md
@@ -76,4 +76,5 @@ chat.Busy(false);
 - Pixel-art cats as chat avatars — `pixel-avatar.md`
 
 - Avatar — `avatar.md`
+- ContextCard (the attachment row above the composer) — `context-card.md`
 - Full docs & API: `/tesserae/components/chat`

--- a/Tesserae/skills/references/context-bar.md
+++ b/Tesserae/skills/references/context-bar.md
@@ -12,7 +12,7 @@ its composer.
 
 Two details it handles that a hand-rolled chip row usually gets wrong:
 
-- **The extension stays readable.** The name is ellipsized at a narrow width (50px by default), but a
+- **The extension stays readable.** The name is ellipsized at a narrow width (80px by default), but a
   trailing file extension is held outside that width, so a bubble reads `Quarterly repo….pdf` rather
   than `Quarterly repor…`. The truncation is measured once the bubble is in the DOM, so the ellipsis
   lands right where the name stops and the extension butts up against it.

--- a/Tesserae/skills/references/context-bar.md
+++ b/Tesserae/skills/references/context-bar.md
@@ -1,0 +1,104 @@
+---
+name: context-bar
+description: A row of small bubbles naming the context something is scoped to - the files a chat can read, the records a search is limited to, the sources an answer cites - with an ellipsized name that keeps the file extension readable, an optional remove button, and overflow collapsed behind a "+N more" button. Use in a Tesserae (C#/Transpose) app to show attached context above a composer or under a reply.
+---
+
+# ContextBar
+
+`ContextBar` is a wrapping row of small bubbles that say what something is scoped to. Each bubble
+carries an icon, a name, and optionally a remove button. It is the indicator that survives closing
+whatever panel the context was picked in: a chat that can read three documents keeps saying so above
+its composer.
+
+Two details it handles that a hand-rolled chip row usually gets wrong:
+
+- **The extension stays readable.** The name is ellipsized at a narrow width (50px by default), but a
+  trailing file extension is held outside that width, so a bubble reads `Quarterly repo….pdf` rather
+  than `Quarterly repor…`.
+- **Overflow costs nothing.** Only the first `MaxVisible` bubbles are put in the DOM. The rest collapse
+  into a `+N more` button, so a host can hand over everything it has without paying to render it.
+
+An empty bar renders nothing and takes up no space, so it can sit permanently in a layout.
+
+## Create
+
+`UI.ContextBar(params ContextBar.Item[] items)`
+`UI.ContextBarItem(string name, UIcons icon = UIcons.File, bool keepExtensionVisible = true)`
+`using static Tesserae.UI;`.
+
+## Key configuration
+
+On the bar:
+
+- `.Items(params Item[])` — set the bubbles, replacing any it had.
+- `.Add(Item)` / `.Remove(Item)` / `.Clear()` — incremental updates.
+- `.MaxVisible(int)` — how many bubbles render before the rest collapse. `3` by default.
+- `.OnShowAll(Action)` — what the `+N more` button does, typically opening the full context (a search
+  restricted to it, a list, a panel). Without a handler the button still reports the count but is not
+  clickable.
+- `.MoreText(string format)` — the button's wording; `{0}` is the number of hidden bubbles.
+  `"+{0} more"` by default.
+- `Count`, `IsEmpty` — read state.
+
+On a bubble (`ContextBar.Item`):
+
+- `.OnClick(Action<Item>)` — makes the bubble interactive (keyboard included); typically opens what it
+  names.
+- `.OnRemove(Action<Item>, string tooltip = "Remove")` — adds the ✕. Activating it never also fires
+  `OnClick`. The handler decides what removal means — call `bar.Remove(item)` to drop it from the row.
+- `.SetName(string)` / `.SetIcon(UIcons)` / `.IconColor(string)` — update a bubble in place, e.g. once
+  an async lookup resolves its real label.
+- `.MaxNameWidth(UnitSize)` — widen or narrow where the name is cut.
+- `Name`, `Tag` — the current name, and an arbitrary payload (the record's id, say).
+- Being an `IComponent`, `.Tooltip("…")` works on a bubble — worth attaching the untruncated name.
+
+## Example
+
+```csharp
+using static Tesserae.UI;
+
+var bar = ContextBar().MaxVisible(3);
+
+foreach (var doc in chat.Documents)
+{
+    var bubble = ContextBarItem(doc.FileName, IconFor(doc)).Tooltip(doc.FileName);
+
+    bubble.Tag = doc.Id;
+    bubble.OnClick(_ => OpenPreview(doc));
+    bubble.OnRemove(i =>
+    {
+        bar.Remove(i);
+        DetachFromChat(doc.Id);
+    });
+
+    bar.Add(bubble);
+}
+
+// The host owns what "show all" means.
+bar.OnShowAll(() => OpenContextPanel(chat.Documents));
+```
+
+Above a chat composer, put it directly over the `OmniBox`:
+
+```csharp
+VStack().WS().Children(
+    bar,
+    OmniBox(new OmniBox.Config(OmniBox.Mode.Chat)).WS()
+);
+```
+
+The same bubbles work as citations under a reply, since `ChatMessage.WithReferences` takes any
+components:
+
+```csharp
+message.WithReferences(sources.Select(s => ContextBarItem(s.Title, UIcons.FilePdf).OnClick(_ => Open(s))));
+```
+
+## Related
+
+- OmniBox (the chat composer it usually sits above) — `.omni-box.md`
+- Chat / ChatMessage (`WithReferences`) — `.chat.md`
+- ToolAgentSelector (picking tools & agents in the same composer) — `.tool-agent-selector.md`
+- Badge (a static label, no removal or overflow) — `.badge.md`
+- TagsInput (free-text tags the user types) — `.tags-input.md`
+- Full docs & API: `/tesserae/components/context-bar`

--- a/Tesserae/skills/references/context-bar.md
+++ b/Tesserae/skills/references/context-bar.md
@@ -14,7 +14,8 @@ Two details it handles that a hand-rolled chip row usually gets wrong:
 
 - **The extension stays readable.** The name is ellipsized at a narrow width (50px by default), but a
   trailing file extension is held outside that width, so a bubble reads `Quarterly repo….pdf` rather
-  than `Quarterly repor…`.
+  than `Quarterly repor…`. The truncation is measured once the bubble is in the DOM, so the ellipsis
+  lands right where the name stops and the extension butts up against it.
 - **Overflow costs nothing.** Only the first `MaxVisible` bubbles are put in the DOM. The rest collapse
   into a `+N more` button, so a host can hand over everything it has without paying to render it.
 
@@ -44,8 +45,10 @@ On a bubble (`ContextBar.Item`):
 
 - `.OnClick(Action<Item>)` — makes the bubble interactive (keyboard included); typically opens what it
   names.
-- `.OnRemove(Action<Item>, string tooltip = "Remove")` — adds the ✕. Activating it never also fires
-  `OnClick`. The handler decides what removal means — call `bar.Remove(item)` to drop it from the row.
+- `.OnRemove(Action<Item>, string tooltip = "Remove")` — adds the ✕, which stays quiet until its bubble
+  is hovered (or it takes focus) and turns red on its own hover, so a row reads as names rather than as
+  a row of delete buttons. Activating it never also fires `OnClick`. The handler decides what removal
+  means — call `bar.Remove(item)` to drop it from the row.
 - `.SetName(string)` / `.SetIcon(UIcons)` / `.IconColor(string)` — update a bubble in place, e.g. once
   an async lookup resolves its real label.
 - `.MaxNameWidth(UnitSize)` — widen or narrow where the name is cut.
@@ -78,14 +81,22 @@ foreach (var doc in chat.Documents)
 bar.OnShowAll(() => OpenContextPanel(chat.Documents));
 ```
 
-Above a chat composer, put it directly over the `OmniBox`:
+Inside a chat composer, hand it to the `OmniBox`'s header slot so it sits above the text being typed,
+within the box's own border:
 
 ```csharp
-VStack().WS().Children(
-    bar,
-    OmniBox(new OmniBox.Config(OmniBox.Mode.Chat)).WS()
-);
+var box = OmniBox(new OmniBox.Config(OmniBox.Mode.Chat)
+{
+    PlaceholderChat = "Ask about the attached documents",
+    ChatHeader      = bar
+}).WS();
+
+box.SetChatHeader(bar);   // or hand it over later
+box.SetChatHeader(null);  // and take it away again
 ```
+
+The slot collapses while it is empty, and an empty bar renders nothing, so a chat with no context looks
+exactly as it would without either.
 
 The same bubbles work as citations under a reply, since `ChatMessage.WithReferences` takes any
 components:

--- a/Tesserae/skills/references/context-card.md
+++ b/Tesserae/skills/references/context-card.md
@@ -1,0 +1,81 @@
+---
+name: context-card
+description: A compact card naming one piece of context attached to a conversation (a file, a page, a dataset) with a colored icon or image tile, a label, an optional second line, and a hover-revealed remove button. Use for the attachment row above a chat composer in a Tesserae (C#/Transpose) app.
+---
+
+# ContextCard
+
+`ContextCard` is the small card an assistant UI shows for each piece of context the user attached:
+an icon tile on a colored background, a label, and an optional second line ("PDF", "Dataset",
+"42.109 rows"). It sizes itself to its content (`inline-flex`, never grows), so a wrapping
+`HStack` above a `ChatArea` composer is the usual home for a row of them.
+
+Give it a remove handler and it grows a round (x) button over its top-right corner that fades in
+while the card is hovered or focused — and stays visible on touch screens, where nothing hovers.
+The button overlays the card, so revealing it never shifts the layout.
+
+## Create
+
+`UI.ContextCard(string label, UIcons icon = UIcons.File, UIconsWeight weight = UIconsWeight.Regular)`
+`UI.ContextCard(string label, IComponent iconOrImage)` — any component on the tile: an `Icon` with
+its own color, an emoji (`Icon(Emoji.Sparkles)`), a small badge.
+Bring factories into scope with `using static Tesserae.UI;`.
+
+## Key configuration
+
+- `.SetLabel(string)` — the main line. Ellipsized to the width the card has, with the full text as
+  its native tooltip.
+- `.SetSubLabel(string)` — the second line. Null or empty hides it, leaving one centered row.
+- `.SetIcon(UIcons, UIconsWeight = Regular)` / `.SetIcon(IComponent)` — what sits on the tile.
+- `.SetImage(string url)` — fill the tile with a thumbnail (cropped to cover it) for context that
+  has a preview of its own: an image, a screenshot, a favicon.
+- `.IconBackground(string)` / `.IconForeground(string)` — tile colors, any CSS color
+  (`"#ef4444"`, `"var(--tss-danger-background-color)"`). Defaults to the theme's primary colors.
+- `.NoIconBackground()` — drop the colored square, letting the glyph sit on the card.
+- `.Background(string)` — the card's own background.
+- `.OnRemove(Action<ContextCard>)` / `.OnRemove(Action)` — adds the (x) button and calls back when
+  it is clicked. The card does **not** remove itself: the handler owns the list it lives in, so it
+  usually calls `stack.Remove(card)` and drops the underlying context at the same time.
+- `.Removable(bool = true)` / `.NoRemove()` — show or hide the button without forgetting the handler.
+- `.Compact()` — one tighter row, with the second line beside the label instead of below it. For a
+  composer carrying many pieces of context at once.
+- `.OnClick(...)` — makes the whole card open the context it stands for, and makes it keyboard
+  reachable (Enter or Space). Clicking the remove button never reads as a click on the card.
+- `Label`, `SubLabel`, `IsRemovable` — read state.
+
+Sizing helpers work as usual: `.MaxWidth(260.px())` is the normal way to cap a card whose label may
+be long, since the label ellipsizes to whatever width the card ends up with.
+
+## Example
+
+```csharp
+using static Tesserae.UI;
+
+var attached = HStack().Wrap().Gap(8.px()).WS();
+
+void Attach(string name, string kind, UIcons icon, string color)
+{
+    var card = ContextCard(name, icon).SetSubLabel(kind).IconBackground(color);
+
+    card.OnRemove(c => attached.Remove(c));   // the handler owns the row
+
+    attached.Add(card);
+}
+
+Attach("Kindersonnenschutzmittel-NEU.pdf", "PDF",     UIcons.FilePdf,   "#ef4444");
+Attach("customers",                        "Dataset", UIcons.Database,  "#f59e0b");
+
+// A thumbnail instead of a glyph, and a compact card for a crowded composer.
+var shot = ContextCard("screenshot.png", UIcons.FileImage).SetSubLabel("Image").SetImage(url);
+var page = ContextCard("tesserae.dev/components", UIcons.Globe).SetSubLabel("Web page").Compact();
+
+var composer = VStack().WS().Children(attached, OmniBox());
+```
+
+## Related
+
+- Chat (ChatArea / ChatMessage) — `chat.md`
+- ResourceCard (the larger, full resource summary) — `resource-card.md`
+- Badge / Tag / Chip (removable inline tokens) — `badge.md`
+- Icon and UIcons — `icon.md`, `uicons.md`
+- Full docs & API: `/tesserae/components/context-card`

--- a/Tesserae/skills/references/context-card.md
+++ b/Tesserae/skills/references/context-card.md
@@ -10,9 +10,11 @@ an icon tile on a colored background, a label, and an optional second line ("PDF
 "42.109 rows"). It sizes itself to its content (`inline-flex`, never grows), so a wrapping
 `HStack` above a `ChatArea` composer is the usual home for a row of them.
 
-Give it a remove handler and it grows a round (x) button over its top-right corner that fades in
-while the card is hovered or focused — and stays visible on touch screens, where nothing hovers.
-The button overlays the card, so revealing it never shifts the layout.
+Give it a remove handler and it grows a round (x) button just off its top-right corner that fades in
+while the card is hovered or focused — and stays visible on touch screens, where nothing hovers. The
+button is absolutely positioned and overhangs the card by a few pixels, so revealing it never shifts
+the layout; if the row lives in a container that clips (`overflow: hidden`), give the row a few
+pixels of padding so the disc isn't cut off.
 
 ## Create
 
@@ -35,7 +37,9 @@ Bring factories into scope with `using static Tesserae.UI;`.
 - `.Background(string)` — the card's own background.
 - `.OnRemove(Action<ContextCard>)` / `.OnRemove(Action)` — adds the (x) button and calls back when
   it is clicked. The card does **not** remove itself: the handler owns the list it lives in, so it
-  usually calls `stack.Remove(card)` and drops the underlying context at the same time.
+  usually calls `stack.Remove(card)` and drops the underlying context at the same time. The disc is a
+  solid neutral (`--tss-colors-neutral-1000`, a mid grey in the dark theme) with a white glyph, and
+  turns `--tss-danger-background-color` while hovered.
 - `.Removable(bool = true)` / `.NoRemove()` — show or hide the button without forgetting the handler.
 - `.Compact()` — one tighter row, with the second line beside the label instead of below it. For a
   composer carrying many pieces of context at once.

--- a/Tesserae/skills/references/context-card.md
+++ b/Tesserae/skills/references/context-card.md
@@ -76,9 +76,21 @@ var page = ContextCard("tesserae.dev/components", UIcons.Globe).SetSubLabel("Web
 var composer = VStack().WS().Children(attached, OmniBox());
 ```
 
+An `OmniBox` in chat mode hosts the row itself, inside the box below the input — that is the usual
+place for these cards, and it wires each card's (x) to the row for you:
+
+```csharp
+var omni = new OmniBox(new OmniBox.Config(OmniBox.Mode.Chat))
+    .WithContextToAdd(ContextCard("report-2026.pdf", UIcons.FilePdf).SetSubLabel("PDF").IconBackground("#ef4444"))
+    .OnChat((s, m) => { Send(m.Text, s.ContextToAdd); s.ClearContext(); });
+
+omni.AddContext(ContextCard("customers", UIcons.Database).SetSubLabel("Dataset"));
+```
+
 ## Related
 
 - Chat (ChatArea / ChatMessage) — `chat.md`
+- OmniBox — hosts a row of these below its chat input via `WithContextToAdd` — `omni-box.md`
 - ResourceCard (the larger, full resource summary) — `resource-card.md`
 - Badge / Tag / Chip (removable inline tokens) — `badge.md`
 - Icon and UIcons — `icon.md`, `uicons.md`

--- a/Tesserae/skills/references/omni-box.md
+++ b/Tesserae/skills/references/omni-box.md
@@ -70,4 +70,5 @@ var omni = new OmniBox(config)
 - TextBox — `/tesserae/components/text-box`
 - SearchBox — `/tesserae/components/search-box`
 - ToolAgentSelector — the tool/agent picker `EnableChatMentions` is commonly wired to — `tool-agent-selector.md`
+- ContextBar — bubbles naming the context attached to the chat, shown above the box — `context-bar.md`
 - Full docs & API: `/tesserae/components/omni-box`

--- a/Tesserae/skills/references/omni-box.md
+++ b/Tesserae/skills/references/omni-box.md
@@ -22,6 +22,7 @@ Config (set via object initializer):
 - `PlaceholderSearch` / `PlaceholderChat`, `ExpandOnFocus`, `TokenIgnoreCase`.
 - `SuggestionsFetcher = async input => OmniBoxSuggestionItem[]` — autocomplete source.
 - `IconSearch` / `IconChat` / `IconStop`, `SearchFooter` / `ChatFooter` (`FooterItems`).
+- `ChatHeader` (`IComponent`) — rendered inside the box above the chat input: what the message is being written against, e.g. a `ContextBar` of the attached documents. Swap it later with `.SetChatHeader(component)`, or pass `null` to empty the slot — it takes up no space while empty.
 - `GeneratingText` — label shown in the footer while generating (default `"Generating"`); the live elapsed time is appended, e.g. `"Generating, 1m 25s"`.
 
 OmniBox:
@@ -29,6 +30,7 @@ OmniBox:
 - `.OnChat((sender, ChatMessage) => ...)`, `.OnStop(...)`, `.OnModelChanged(...)`.
 - `.IsGenerating` (bool) — toggles the footer spinner + elapsed-time indicator and swaps the send button for a stop button. `.GeneratingText` (string) — read/write the indicator label; setting it updates the footer live.
 - `.SearchText` / `.ChatText` / `.SetSearchText(string)` — read/write input text.
+- `.SetChatHeader(IComponent)` — replace (or clear, with `null`) whatever sits above the chat input.
 - `.RegisterSnap(SnapHandler)` / `.RegisterFilterSnap(FilterSnapHandler)` — turn recognized input into inline filter chips (search modes only).
 - `.WithHistory(Func<Task<SearchQuery[]>>)` — enable the history button.
 - `.EnableChatMentions(ChatMention)` — turns typing `@` at a word boundary in the chat input into an
@@ -70,5 +72,5 @@ var omni = new OmniBox(config)
 - TextBox — `/tesserae/components/text-box`
 - SearchBox — `/tesserae/components/search-box`
 - ToolAgentSelector — the tool/agent picker `EnableChatMentions` is commonly wired to — `tool-agent-selector.md`
-- ContextBar — bubbles naming the context attached to the chat, shown above the box — `context-bar.md`
+- ContextBar — bubbles naming the context attached to the chat, mounted in the box's `ChatHeader` slot — `context-bar.md`
 - Full docs & API: `/tesserae/components/omni-box`

--- a/Tesserae/skills/references/omni-box.md
+++ b/Tesserae/skills/references/omni-box.md
@@ -38,6 +38,14 @@ OmniBox:
   `ShowInlineAt`/`Filter`/`MoveHighlight`/`ActivateHighlighted`/`Hide`/`IsVisible` (see
   `tool-agent-selector.md`). Arrow Up/Down, Enter/Tab and Escape are forwarded to the callbacks
   while the picker is open; a `true` return from `OnCommit` removes the typed `@mention` text.
+- `.WithContextToAdd(params ContextCard[])` — the context that will go with the next message, rendered
+  as a wrapping row of `ContextCard`s **inside the box**, just below the input and above the footer
+  (chat/search-and-chat modes only; it hides itself while the box is in search mode, and the row is
+  invisible while empty). `.AddContext(card)` appends one, `.RemoveContext(card)` / `.ClearContext()`
+  take them out, `.ContextToAdd` (read-only list) and `.HasContextToAdd` read the current state. Each
+  card's (x) is wired to the row, so removing a card from the box needs no extra code — a handler the
+  caller registered with `ContextCard.OnRemove` still runs, which is where the underlying context gets
+  dropped. Cards survive sending: clear the row from `OnChat`. See `context-card.md`.
 - `.Focus()`.
 - `.CaretClientX()` — the viewport x of the text caret in whichever input is focused, clamped to that input's bounds, or `double.NaN` when there is nothing to measure. Used to point something at where the user is typing, e.g. the `PixelAvatar` companion walking over to the caret.
 - `OmniBox.ParseQuery(string, bool tokenIgnoreCase = false)` — static parser returning a `SearchQuery`.
@@ -61,6 +69,22 @@ var config = new OmniBox.Config(OmniBox.Mode.SearchAndChat)
 var omni = new OmniBox(config)
     .OnSearch((s, q) => Console.WriteLine($"Search: {q.Tokens.Count} tokens"))
     .OnChat((s, m) => Console.WriteLine("Chat sent"));
+```
+
+Context attached to the next message, shown inside the box below the input:
+
+```csharp
+var omni = new OmniBox(new OmniBox.Config(OmniBox.Mode.Chat))
+    .WithContextToAdd(
+        ContextCard("Kindersonnenschutzmittel-NEU.pdf", UIcons.FilePdf).SetSubLabel("PDF").IconBackground("#ef4444"))
+    .OnChat((s, m) =>
+    {
+        Send(m.Text, s.ContextToAdd.Select(c => c.Label));   // read it before clearing
+        s.ClearContext();                                    // the box keeps it until told otherwise
+    });
+
+// Later, e.g. from an attach button or a FileDropArea:
+omni.AddContext(ContextCard("Q3-forecast.xlsx", UIcons.FileExcel).SetSubLabel("Spreadsheet").IconBackground("#16a34a"));
 ```
 
 ## Related

--- a/Tesserae/skills/references/omni-box.md
+++ b/Tesserae/skills/references/omni-box.md
@@ -31,6 +31,18 @@ OmniBox:
 - `.SearchText` / `.ChatText` / `.SetSearchText(string)` — read/write input text.
 - `.RegisterSnap(SnapHandler)` / `.RegisterFilterSnap(FilterSnapHandler)` — turn recognized input into inline filter chips (search modes only).
 - `.WithHistory(Func<Task<SearchQuery[]>>)` — enable the history button.
+- `.WithHelp(bool showSyntax = false)` — a `?` button opening a panel that lists the registered filter
+  snaps and snaps (with their example values); `showSyntax: true` also documents `AND` / `OR` / `NOT`,
+  grouping and quoting (search modes only).
+- `.InlineFilterChips` — observable list of `InlineFilterChip`s rendered at the head of the search
+  input, for filters the app owns rather than ones the user typed. A chip takes a text (with optional
+  background/foreground colors and an `onClick`) or an arbitrary `IComponent`.
+- `.SetSearchRightText(string)` — a label at the far end of the search input, e.g. a result count.
+- `.SetModels(params ModelOption[])` / `.LockModel(ModelOption)` / `.SetThinkingEffort(ThinkingEffort)`
+  — the chat footer's model selector; a locked model shows with a lock and stops opening the popover.
+- `.SetKeyboardShortcut(params string[] keys)` — e.g. `("Ctrl", "K")`: a document-level shortcut that
+  focuses the box, shown as a hint at the end of the search input.
+- `.Disabled(bool value = true)` — keeps the content but stops taking input.
 - `.EnableChatMentions(ChatMention)` — turns typing `@` at a word boundary in the chat input into an
   "@mention" style picker (chat/search-and-chat modes only). `ChatMention` is a set of UI-agnostic
   callbacks (`OnShow(x, y)`, `OnQueryChanged(text)`, `OnMove(direction)`, `OnCommit()`, `OnHide()`,

--- a/Tesserae/skills/references/resource-card.md
+++ b/Tesserae/skills/references/resource-card.md
@@ -43,4 +43,5 @@ var card = ResourceCard()
 ## Related
 
 - Card — `.card.md`
+- ContextCard (the compact chat-attachment variant) — `.context-card.md`
 - Full docs & API: `/tesserae/components/resource-card`

--- a/Tesserae/skills/references/tool-agent-selector.md
+++ b/Tesserae/skills/references/tool-agent-selector.md
@@ -76,4 +76,5 @@ var chatSample = OmniBox(new OmniBox.Config(OmniBox.Mode.Chat)
 - OmniBox, `OmniBox.EnableChatMentions` — `omni-box.md`
 - Dropdown — a single/multi-select combobox with a similar Layer-based popup — `dropdown.md`
 - NotificationCenter — the count-badge-on-a-trigger pattern this reuses — `notification-center.md`
+- ContextBar — bubbles for the documents/records the same composer is scoped to — `context-bar.md`
 - Full docs & API: `/tesserae/components/tool-agent-selector`

--- a/Tesserae/src/Base/UI.Components.cs
+++ b/Tesserae/src/Base/UI.Components.cs
@@ -1467,6 +1467,17 @@ namespace Tesserae
         public static ToolAgentSelector.Item ToolAgentSelectorItem(string id, string title, string description = null, UIcons? icon = null) => new ToolAgentSelector.Item(id, title, description, icon);
 
         /// <summary>
+        /// Creates a <see cref="Tesserae.ContextBar"/> row of bubbles naming the context something is
+        /// scoped to, collapsing everything past the third into a "+N more" button.
+        /// </summary>
+        public static ContextBar ContextBar(params ContextBar.Item[] items) => new ContextBar(items);
+
+        /// <summary>
+        /// Creates a <see cref="Tesserae.ContextBar.Item"/> context bubble.
+        /// </summary>
+        public static ContextBar.Item ContextBarItem(string name, UIcons icon = UIcons.File, bool keepExtensionVisible = true) => new ContextBar.Item(name, icon, keepExtensionVisible);
+
+        /// <summary>
         /// Converts a <see cref="Tesserae.Button"/> to a <see cref="Tesserae.ToggleButton"/>.
         /// </summary>
         public static ToggleButton ToToggle(this Button button) => new ToggleButton(button);

--- a/Tesserae/src/Base/UI.Components.cs
+++ b/Tesserae/src/Base/UI.Components.cs
@@ -1100,6 +1100,19 @@ namespace Tesserae
         public static LiveProgress LiveProgress(string text = null) => new LiveProgress(text);
 
         /// <summary>
+        /// Creates a <see cref="Tesserae.ContextCard"/>: a compact card describing one piece of context
+        /// attached to a conversation (a file, a page, a dataset), showing the given icon on a colored
+        /// tile beside the label.
+        /// </summary>
+        public static ContextCard ContextCard(string label, UIcons icon = UIcons.File, UIconsWeight weight = UIconsWeight.Regular) => new ContextCard(label, icon, weight);
+
+        /// <summary>
+        /// Creates a <see cref="Tesserae.ContextCard"/> whose tile shows the given icon or image
+        /// component instead of a <see cref="UIcons"/> glyph.
+        /// </summary>
+        public static ContextCard ContextCard(string label, IComponent iconOrImage) => new ContextCard(label, iconOrImage);
+
+        /// <summary>
         /// Creates a <see cref="Tesserae.Questionnaire"/> component that
         /// shows the given question and answer options. When the user
         /// picks an option (or one is set programmatically) the component

--- a/Tesserae/src/Components/ContextBar.cs
+++ b/Tesserae/src/Components/ContextBar.cs
@@ -198,6 +198,8 @@ namespace Tesserae
 
             private readonly bool _keepExtensionVisible;
 
+            private string       _stem;
+            private bool         _waitingForMount;
             private HTMLElement  _remove;
             private Action<Item> _onClick;
             private Action<Item> _onRemove;
@@ -243,9 +245,12 @@ namespace Tesserae
 
                 var (stem, extension) = SplitExtension(Name, _keepExtensionVisible);
 
-                _name.textContent          = stem;
-                _extension.textContent     = extension ?? string.Empty;
-                _extension.style.display   = string.IsNullOrEmpty(extension) ? "none" : "";
+                _stem                    = stem;
+                _name.textContent        = stem;
+                _extension.textContent   = extension ?? string.Empty;
+                _extension.style.display = string.IsNullOrEmpty(extension) ? "none" : "";
+
+                FitNameWhenMeasurable();
 
                 return this;
             }
@@ -276,6 +281,7 @@ namespace Tesserae
             public Item MaxNameWidth(UnitSize size)
             {
                 _name.style.maxWidth = size is null ? "" : size.ToString();
+                FitNameWhenMeasurable();
                 return this;
             }
 
@@ -326,7 +332,7 @@ namespace Tesserae
 
                 if (_remove is null)
                 {
-                    _remove          = Div(Att("tss-contextbar-item-remove", role: "button"), I(UIcons.Cross));
+                    _remove          = Div(Att("tss-contextbar-item-remove", role: "button"), I(UIcons.CrossSmall));
                     _remove.tabIndex = 0;
 
                     _remove.addEventListener("click", e =>
@@ -360,6 +366,54 @@ namespace Tesserae
             /// Renders the component's root HTML element.
             /// </summary>
             public HTMLElement Render() => _root;
+
+            // CSS alone leaves the tail of the (fixed-width) name box unused, which shows up as a gap
+            // between the ellipsis and the extension - "Q3 rev... .xlsx". Truncating the text ourselves
+            // puts the ellipsis right where the name stops, so the two read as one file name and the
+            // bubble hugs its content. `text-overflow: ellipsis` still covers us until this can measure.
+            private void FitNameWhenMeasurable()
+            {
+                if (_name.isConnected)
+                {
+                    FitName();
+                    return;
+                }
+
+                if (_waitingForMount) return;
+
+                _waitingForMount = true;
+
+                DomObserver.WhenMounted(_root, () =>
+                {
+                    _waitingForMount = false;
+                    FitName();
+                });
+            }
+
+            private void FitName()
+            {
+                _name.textContent = _stem ?? string.Empty;
+
+                var limit = _name.clientWidth;
+
+                if (limit <= 0 || _name.scrollWidth <= limit) return;
+
+                // Longest prefix that still fits once the ellipsis is appended.
+                var low  = 0;
+                var high = _stem.Length;
+
+                while (low < high)
+                {
+                    var middle = (low + high + 1) / 2;
+
+                    _name.textContent = _stem.Substring(0, middle) + "\u2026";
+
+                    if (_name.scrollWidth <= limit) low = middle;
+                    else                            high = middle - 1;
+                }
+
+                _name.textContent = low <= 0 ? "\u2026" : _stem.Substring(0, low) + "\u2026";
+            }
 
             private static (string name, string extension) SplitExtension(string label, bool keepExtensionVisible)
             {

--- a/Tesserae/src/Components/ContextBar.cs
+++ b/Tesserae/src/Components/ContextBar.cs
@@ -275,7 +275,7 @@ namespace Tesserae
             }
 
             /// <summary>
-            /// Configures the width the name is ellipsized at (50px by default, set in CSS). The
+            /// Configures the width the name is ellipsized at (80px by default, set in CSS). The
             /// extension, when kept visible, sits outside this width.
             /// </summary>
             public Item MaxNameWidth(UnitSize size)
@@ -412,7 +412,10 @@ namespace Tesserae
                     else                            high = middle - 1;
                 }
 
-                _name.textContent = low <= 0 ? "\u2026" : _stem.Substring(0, low) + "\u2026";
+                // Trimmed so a cut landing on a space doesn't read as "Q3 revenue ….xlsx".
+                var kept = low <= 0 ? string.Empty : _stem.Substring(0, low).TrimEnd();
+
+                _name.textContent = kept + "\u2026";
             }
 
             private static (string name, string extension) SplitExtension(string label, bool keepExtensionVisible)

--- a/Tesserae/src/Components/ContextBar.cs
+++ b/Tesserae/src/Components/ContextBar.cs
@@ -1,0 +1,380 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using static Transpose.Core.dom;
+using static Tesserae.UI;
+
+namespace Tesserae
+{
+    /// <summary>
+    /// A row of small bubbles naming the context something is scoped to — the documents a chat can
+    /// read from, the records a search is restricted to, the sources an answer cites.
+    /// <para>
+    /// A bubble carries an icon, a name ellipsized to a narrow fixed width, and an optional remove
+    /// button. A trailing file extension is kept out of the ellipsis, so a bubble reads
+    /// "Quarterly repo….pdf" rather than "Quarterly repor…".
+    /// </para>
+    /// <para>
+    /// Only the first <see cref="MaxVisible"/> bubbles are rendered; the remainder collapse into a
+    /// "+N more" button that hands over to <see cref="OnShowAll"/>, where a host typically opens the
+    /// full list of what the context is. Bubbles behind that button are never added to the DOM, so a
+    /// host can hand over everything it has without paying to render it.
+    /// </para>
+    /// <para>
+    /// Meant to sit above a chat composer (see <see cref="OmniBox"/>) or under a reply
+    /// (<see cref="ChatMessage.WithReferences(IEnumerable{IComponent})"/>), but it is a plain row and
+    /// works anywhere.
+    /// </para>
+    /// </summary>
+    [Transpose.Name("tss.ContextBar")]
+    public sealed class ContextBar : ComponentBase<ContextBar, HTMLElement>
+    {
+        private readonly List<Item>  _items = new List<Item>();
+        private readonly HTMLElement _more;
+
+        private int    _maxVisible = 3;
+        private string _moreFormat = "+{0} more";
+        private Action _onShowAll;
+
+        /// <summary>
+        /// Initializes a new instance of this class.
+        /// </summary>
+        public ContextBar(params Item[] items)
+        {
+            _more = Div(Att("tss-contextbar-more", role: "button"), Span(Att("tss-contextbar-more-text")));
+            _more.tabIndex = 0;
+
+            _more.addEventListener("click", e =>
+            {
+                StopEvent(e);
+                _onShowAll?.Invoke();
+            });
+
+            _more.addEventListener("keydown", e =>
+            {
+                var ke = e.As<KeyboardEvent>();
+
+                if (ke.key == "Enter" || ke.key == " ")
+                {
+                    StopEvent(e);
+                    _onShowAll?.Invoke();
+                }
+            });
+
+            InnerElement = Div(Att("tss-contextbar"));
+
+            Items(items);
+        }
+
+        /// <summary>
+        /// Gets the number of bubbles in the bar, including the ones collapsed behind "+N more".
+        /// </summary>
+        public int Count => _items.Count;
+
+        /// <summary>
+        /// Returns a value indicating whether the bar has no bubbles, in which case it renders nothing
+        /// and takes up no space.
+        /// </summary>
+        public bool IsEmpty => _items.Count == 0;
+
+        /// <summary>
+        /// Sets the bubbles the bar shows, replacing any it already had.
+        /// </summary>
+        public ContextBar Items(params Item[] items)
+        {
+            _items.Clear();
+
+            if (items is object) _items.AddRange(items.Where(i => i is object));
+
+            Rebuild();
+            return this;
+        }
+
+        /// <summary>
+        /// Appends a bubble to the bar.
+        /// </summary>
+        public ContextBar Add(Item item)
+        {
+            if (item is null) return this;
+
+            _items.Add(item);
+            Rebuild();
+            return this;
+        }
+
+        /// <summary>
+        /// Drops a bubble from the bar. Removing a bubble the bar doesn't have does nothing.
+        /// </summary>
+        public ContextBar Remove(Item item)
+        {
+            if (item is null || !_items.Remove(item)) return this;
+
+            Rebuild();
+            return this;
+        }
+
+        /// <summary>
+        /// Drops every bubble, leaving the bar empty (and invisible) until the next one is added.
+        /// </summary>
+        public ContextBar Clear()
+        {
+            _items.Clear();
+            Rebuild();
+            return this;
+        }
+
+        /// <summary>
+        /// Configures how many bubbles are rendered before the rest collapse behind "+N more".
+        /// Three by default.
+        /// </summary>
+        public ContextBar MaxVisible(int count)
+        {
+            _maxVisible = count < 0 ? 0 : count;
+            Rebuild();
+            return this;
+        }
+
+        /// <summary>
+        /// Configures the text of the button standing in for the collapsed bubbles, as a format string
+        /// whose <c>{0}</c> is the number of bubbles it hides. <c>"+{0} more"</c> by default.
+        /// </summary>
+        public ContextBar MoreText(string format)
+        {
+            _moreFormat = string.IsNullOrEmpty(format) ? "+{0} more" : format;
+            Rebuild();
+            return this;
+        }
+
+        /// <summary>
+        /// Configures what happens when the "+N more" button is activated — typically opening the full
+        /// list of what the context is. Without a handler the button still reports how many bubbles are
+        /// collapsed, but does not respond to clicks.
+        /// </summary>
+        public ContextBar OnShowAll(Action handler)
+        {
+            _onShowAll = handler;
+            Rebuild();
+            return this;
+        }
+
+        private void Rebuild()
+        {
+            InnerElement.innerHTML = string.Empty;
+            InnerElement.UpdateClassIf(_items.Count == 0, "tss-contextbar-empty");
+
+            var visible = Math.Min(_items.Count, _maxVisible);
+
+            for (int i = 0; i < visible; i++)
+            {
+                InnerElement.appendChild(_items[i].Render());
+            }
+
+            var hidden = _items.Count - visible;
+
+            if (hidden <= 0) return;
+
+            _more.firstElementChild.textContent = string.Format(_moreFormat, hidden);
+            _more.UpdateClassIf(_onShowAll is null, "tss-contextbar-more-static");
+            InnerElement.appendChild(_more);
+        }
+
+        /// <summary>
+        /// Renders the component's root HTML element.
+        /// </summary>
+        public override HTMLElement Render() => InnerElement;
+
+        /// <summary>
+        /// One context bubble: an icon, a name, and an optional remove button.
+        /// </summary>
+        public sealed class Item : IComponent
+        {
+            // A longer tail than this isn't a file extension worth keeping out of the ellipsis.
+            private const int maxExtensionLength = 7;
+
+            private readonly HTMLElement _root;
+            private readonly HTMLElement _icon;
+            private readonly HTMLElement _name;
+            private readonly HTMLElement _extension;
+
+            private readonly bool _keepExtensionVisible;
+
+            private HTMLElement  _remove;
+            private Action<Item> _onClick;
+            private Action<Item> _onRemove;
+
+            /// <summary>
+            /// Initializes a new instance of this class.
+            /// </summary>
+            /// <param name="name">Text shown on the bubble, e.g. a file name or a record's title.</param>
+            /// <param name="icon">Icon shown in front of the name.</param>
+            /// <param name="keepExtensionVisible">
+            /// Whether a trailing file extension is held out of the ellipsis so it stays readable when
+            /// the name is too long for the bubble. On by default.
+            /// </param>
+            public Item(string name, UIcons icon = UIcons.File, bool keepExtensionVisible = true)
+            {
+                _keepExtensionVisible = keepExtensionVisible;
+
+                _icon      = Span(Att("tss-contextbar-item-icon"), I(icon));
+                _name      = Span(Att("tss-contextbar-item-name"));
+                _extension = Span(Att("tss-contextbar-item-extension"));
+
+                _root = Div(Att("tss-contextbar-item"), _icon, _name, _extension);
+
+                SetName(name);
+            }
+
+            /// <summary>
+            /// Gets the name currently shown on the bubble.
+            /// </summary>
+            public string Name { get; private set; }
+
+            /// <summary>
+            /// Gets or sets an arbitrary payload associated with this bubble.
+            /// </summary>
+            public object Tag { get; set; }
+
+            /// <summary>
+            /// Writes a new name into the bubble already on screen, re-splitting the file extension.
+            /// </summary>
+            public Item SetName(string name)
+            {
+                Name = name ?? string.Empty;
+
+                var (stem, extension) = SplitExtension(Name, _keepExtensionVisible);
+
+                _name.textContent          = stem;
+                _extension.textContent     = extension ?? string.Empty;
+                _extension.style.display   = string.IsNullOrEmpty(extension) ? "none" : "";
+
+                return this;
+            }
+
+            /// <summary>
+            /// Replaces the bubble's icon.
+            /// </summary>
+            public Item SetIcon(UIcons icon)
+            {
+                _icon.innerHTML = string.Empty;
+                _icon.appendChild(I(icon));
+                return this;
+            }
+
+            /// <summary>
+            /// Colors the bubble's icon, e.g. to follow a file type.
+            /// </summary>
+            public Item IconColor(string color)
+            {
+                _icon.style.color = color ?? "";
+                return this;
+            }
+
+            /// <summary>
+            /// Configures the width the name is ellipsized at (50px by default, set in CSS). The
+            /// extension, when kept visible, sits outside this width.
+            /// </summary>
+            public Item MaxNameWidth(UnitSize size)
+            {
+                _name.style.maxWidth = size is null ? "" : size.ToString();
+                return this;
+            }
+
+            /// <summary>
+            /// Configures what happens when the bubble is activated — typically opening whatever the
+            /// bubble names. A bubble without a handler is not interactive.
+            /// </summary>
+            public Item OnClick(Action<Item> handler)
+            {
+                if (_onClick is null && handler is object)
+                {
+                    _root.tabIndex = 0;
+                    _root.setAttribute("role", "button");
+
+                    _root.addEventListener("click", _ => _onClick?.Invoke(this));
+
+                    _root.addEventListener("keydown", e =>
+                    {
+                        var ke = e.As<KeyboardEvent>();
+
+                        if (ke.key == "Enter" || ke.key == " ")
+                        {
+                            StopEvent(e);
+                            _onClick?.Invoke(this);
+                        }
+                    });
+                }
+
+                _onClick = handler;
+                _root.UpdateClassIf(handler is object, "tss-contextbar-item-clickable");
+
+                return this;
+            }
+
+            /// <summary>
+            /// Adds a remove button to the bubble and configures what happens when it is activated.
+            /// Activating it never also activates <see cref="OnClick"/>.
+            /// </summary>
+            public Item OnRemove(Action<Item> handler, string tooltip = "Remove")
+            {
+                _onRemove = handler;
+
+                if (handler is null)
+                {
+                    if (_remove is object) _remove.style.display = "none";
+                    return this;
+                }
+
+                if (_remove is null)
+                {
+                    _remove          = Div(Att("tss-contextbar-item-remove", role: "button"), I(UIcons.Cross));
+                    _remove.tabIndex = 0;
+
+                    _remove.addEventListener("click", e =>
+                    {
+                        StopEvent(e);
+                        _onRemove?.Invoke(this);
+                    });
+
+                    _remove.addEventListener("keydown", e =>
+                    {
+                        var ke = e.As<KeyboardEvent>();
+
+                        if (ke.key == "Enter" || ke.key == " ")
+                        {
+                            StopEvent(e);
+                            _onRemove?.Invoke(this);
+                        }
+                    });
+
+                    _root.appendChild(_remove);
+                }
+
+                _remove.style.display = "";
+                _remove.setAttribute("title", tooltip ?? string.Empty);
+                _remove.setAttribute("aria-label", tooltip ?? string.Empty);
+
+                return this;
+            }
+
+            /// <summary>
+            /// Renders the component's root HTML element.
+            /// </summary>
+            public HTMLElement Render() => _root;
+
+            private static (string name, string extension) SplitExtension(string label, bool keepExtensionVisible)
+            {
+                if (!keepExtensionVisible || string.IsNullOrEmpty(label)) return (label, null);
+
+                var dot = label.LastIndexOf('.');
+
+                if (dot <= 0 || dot == label.Length - 1) return (label, null);
+
+                var extension = label.Substring(dot);
+
+                if (extension.Length > maxExtensionLength || extension.Contains(" ")) return (label, null);
+
+                return (label.Substring(0, dot), extension);
+            }
+        }
+    }
+}

--- a/Tesserae/src/Components/ContextCard.cs
+++ b/Tesserae/src/Components/ContextCard.cs
@@ -11,9 +11,9 @@ namespace Tesserae
     /// <para>
     /// It is an icon tile (a <see cref="UIcons"/> glyph, an arbitrary component, or an image
     /// thumbnail) on a colored background, followed by a label and an optional second line. Passing
-    /// a remove handler to <see cref="OnRemove(Action{ContextCard})"/> adds a round (x) button in the
-    /// card's top-right corner that fades in while the card is hovered, focused, or on touch devices
-    /// where there is no hover to speak of.
+    /// a remove handler to <see cref="OnRemove(Action{ContextCard})"/> adds a round (x) button hanging
+    /// just off the card's top-right corner that fades in while the card is hovered, focused, or on
+    /// touch devices where there is no hover to speak of.
     /// </para>
     /// </summary>
     [Transpose.Name("tss.ContextCard")]

--- a/Tesserae/src/Components/ContextCard.cs
+++ b/Tesserae/src/Components/ContextCard.cs
@@ -1,0 +1,309 @@
+using System;
+using static Transpose.Core.dom;
+using Transpose.Core;
+using static Tesserae.UI;
+
+namespace Tesserae
+{
+    /// <summary>
+    /// A compact card describing one piece of context attached to a conversation — a file, a page, a
+    /// dataset — meant to sit above (or inside) a <see cref="ChatArea"/> composer.
+    /// <para>
+    /// It is an icon tile (a <see cref="UIcons"/> glyph, an arbitrary component, or an image
+    /// thumbnail) on a colored background, followed by a label and an optional second line. Passing
+    /// a remove handler to <see cref="OnRemove(Action{ContextCard})"/> adds a round (x) button in the
+    /// card's top-right corner that fades in while the card is hovered, focused, or on touch devices
+    /// where there is no hover to speak of.
+    /// </para>
+    /// </summary>
+    [Transpose.Name("tss.ContextCard")]
+    public sealed class ContextCard : ComponentBase<ContextCard, HTMLElement>
+    {
+        private readonly HTMLElement       _iconContainer;
+        private readonly HTMLElement       _labelContainer;
+        private readonly HTMLElement       _subLabelContainer;
+        private readonly HTMLElement       _textContainer;
+        private          HTMLButtonElement _removeButton;
+        private          string            _label;
+        private          string            _subLabel;
+
+        private event Action<ContextCard> RemoveRequested;
+
+        /// <summary>
+        /// Initializes a new instance of this class showing the given icon.
+        /// </summary>
+        public ContextCard(string label, UIcons icon = UIcons.File, UIconsWeight weight = UIconsWeight.Regular)
+            : this()
+        {
+            SetLabel(label);
+            SetIcon(icon, weight);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of this class showing the given icon or image component - an
+        /// <see cref="Icon"/>, an <see cref="Image"/>, an emoji, or anything else that renders small.
+        /// </summary>
+        public ContextCard(string label, IComponent iconOrImage)
+            : this()
+        {
+            SetLabel(label);
+            SetIcon(iconOrImage);
+        }
+
+        private ContextCard()
+        {
+            _iconContainer     = Div(Att("tss-contextcard-icon"));
+            _labelContainer    = Div(Att("tss-contextcard-label"));
+            _subLabelContainer = Div(Att("tss-contextcard-sublabel"));
+
+            _textContainer = Div(Att("tss-contextcard-text"), _labelContainer, _subLabelContainer);
+
+            InnerElement = Div(Att("tss-contextcard"), _iconContainer, _textContainer);
+
+            SetLabel(null);
+            SetSubLabel(null);
+
+            AttachClick();
+            AttachContextMenu();
+        }
+
+        /// <summary>
+        /// Gets the label shown by the component.
+        /// </summary>
+        public string Label    => _label;
+
+        /// <summary>
+        /// Gets the secondary line shown below the label, or null when the card has none.
+        /// </summary>
+        public string SubLabel => _subLabel;
+
+        /// <summary>
+        /// Returns a value indicating whether the component shows a remove button.
+        /// </summary>
+        public bool IsRemovable => _removeButton != null;
+
+        /// <summary>
+        /// Sets the label of the component. The label is ellipsized to the width the card is given,
+        /// and carries the full text as its native tooltip.
+        /// </summary>
+        public ContextCard SetLabel(string label)
+        {
+            _label = label ?? string.Empty;
+
+            _labelContainer.innerText = _label;
+            // The card is narrow by design and the interesting part of a file name is often its tail,
+            // so the untruncated text stays reachable on hover.
+            _labelContainer.setAttribute("title", _label);
+
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the secondary line shown below the label ("PDF", "3 pages", a folder). A null or empty
+        /// value hides the line and leaves the card as a single centered row.
+        /// </summary>
+        public ContextCard SetSubLabel(string subLabel)
+        {
+            _subLabel = subLabel;
+
+            var isEmpty = string.IsNullOrEmpty(subLabel);
+
+            _subLabelContainer.innerText = isEmpty ? string.Empty : subLabel;
+            _subLabelContainer.UpdateClassIf(isEmpty, "tss-contextcard-empty");
+
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the icon shown on the tile.
+        /// </summary>
+        public ContextCard SetIcon(UIcons icon, UIconsWeight weight = UIconsWeight.Regular)
+        {
+            ClearChildren(_iconContainer);
+            _iconContainer.classList.remove("tss-contextcard-icon-image");
+            _iconContainer.appendChild(I(icon, weight));
+
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the icon of the component to an arbitrary component - an <see cref="Icon"/> with its own
+        /// color, an emoji, an <see cref="Image"/>, a file-type badge. A null value empties the tile,
+        /// keeping its background as a plain colored square.
+        /// </summary>
+        public ContextCard SetIcon(IComponent iconOrImage)
+        {
+            ClearChildren(_iconContainer);
+            _iconContainer.classList.remove("tss-contextcard-icon-image");
+
+            if (iconOrImage != null)
+            {
+                _iconContainer.appendChild(iconOrImage.Render());
+            }
+
+            return this;
+        }
+
+        /// <summary>
+        /// Sets a thumbnail that fills the whole tile (cropped to cover it), for context that has a
+        /// preview of its own - an image, a screenshot, a site favicon. The tile's background color is
+        /// dropped, as the image covers it.
+        /// </summary>
+        public ContextCard SetImage(string url)
+        {
+            ClearChildren(_iconContainer);
+
+            if (!string.IsNullOrEmpty(url))
+            {
+                _iconContainer.appendChild(Image(Att("tss-contextcard-image", src: url)));
+            }
+
+            _iconContainer.UpdateClassIf(!string.IsNullOrEmpty(url), "tss-contextcard-icon-image");
+
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the background color of the icon tile (any CSS color, e.g. "#ef4444" or
+        /// "var(--tss-danger-background-color)").
+        /// </summary>
+        public ContextCard IconBackground(string color)
+        {
+            _iconContainer.style.background = color ?? string.Empty;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the color of the glyph on the icon tile.
+        /// </summary>
+        public ContextCard IconForeground(string color)
+        {
+            _iconContainer.style.color = color ?? string.Empty;
+            return this;
+        }
+
+        /// <summary>
+        /// Configures the icon tile to have no background, letting the glyph or image sit directly on
+        /// the card.
+        /// </summary>
+        public ContextCard NoIconBackground()
+        {
+            _iconContainer.classList.add("tss-contextcard-icon-nobackground");
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the background color of the card itself.
+        /// </summary>
+        public ContextCard Background(string color)
+        {
+            InnerElement.style.background = color ?? string.Empty;
+            return this;
+        }
+
+        /// <summary>
+        /// Registers a callback invoked when the user clicks the remove button, and adds that button to
+        /// the card if it isn't there yet. The card does not remove itself - the handler owns whatever
+        /// list the card lives in, and can also drop the context it stands for.
+        /// </summary>
+        public ContextCard OnRemove(Action<ContextCard> onRemove)
+        {
+            RemoveRequested += onRemove;
+            EnsureRemoveButton();
+
+            return this;
+        }
+
+        /// <summary>
+        /// Registers a callback invoked when the user clicks the remove button, and adds that button to
+        /// the card if it isn't there yet.
+        /// </summary>
+        public ContextCard OnRemove(Action onRemove) => OnRemove(_ => onRemove?.Invoke());
+
+        /// <summary>
+        /// Configures whether the card shows its remove button. Turning it off keeps any handler
+        /// registered with <see cref="OnRemove(Action{ContextCard})"/>, so turning it back on restores
+        /// the same behaviour.
+        /// </summary>
+        public ContextCard Removable(bool value = true)
+        {
+            if (value)
+            {
+                EnsureRemoveButton();
+            }
+            else if (_removeButton != null)
+            {
+                InnerElement.classList.remove("tss-contextcard-removable");
+                InnerElement.removeChild(_removeButton);
+                _removeButton = null;
+            }
+
+            return this;
+        }
+
+        /// <summary>
+        /// Configures the component to show no remove button.
+        /// </summary>
+        public ContextCard NoRemove() => Removable(false);
+
+        /// <summary>
+        /// Configures the card as a single, tighter row: the icon tile shrinks and the secondary line
+        /// (if any) moves in beside the label. Use it when many cards share the composer.
+        /// </summary>
+        public ContextCard Compact()
+        {
+            InnerElement.classList.add("tss-contextcard-compact");
+            return this;
+        }
+
+        /// <summary>
+        /// Registers a callback invoked when the click event fires. A clickable card also becomes
+        /// keyboard reachable and is activated with Enter or Space.
+        /// </summary>
+        public override ContextCard OnClick(ComponentEventHandler<ContextCard, MouseEvent> onClick, bool clearPrevious = true)
+        {
+            if (!InnerElement.classList.contains("tss-contextcard-clickable"))
+            {
+                InnerElement.classList.add("tss-contextcard-clickable");
+                InnerElement.setAttribute("role",     "button");
+                InnerElement.setAttribute("tabindex", "0");
+
+                InnerElement.addEventListener("keydown", e =>
+                {
+                    var ev = e.As<KeyboardEvent>();
+
+                    if (ev.key == "Enter" || ev.key == " ")
+                    {
+                        StopEvent(ev);
+                        InnerElement.click();
+                    }
+                });
+            }
+
+            return base.OnClick(onClick, clearPrevious);
+        }
+
+        private void EnsureRemoveButton()
+        {
+            if (_removeButton != null) return;
+
+            _removeButton = Button(Att("tss-contextcard-remove", type: "button", ariaLabel: "Remove"), I(UIcons.CrossSmall));
+
+            _removeButton.addEventListener("click", ev =>
+            {
+                // The card itself can be clickable (opening the context it stands for), so removing it
+                // must not read as opening it.
+                StopEvent(ev);
+                RemoveRequested?.Invoke(this);
+            });
+
+            InnerElement.appendChild(_removeButton);
+            InnerElement.classList.add("tss-contextcard-removable");
+        }
+
+        /// <summary>
+        /// Renders the component's root HTML element.
+        /// </summary>
+        public override HTMLElement Render() => InnerElement;
+    }
+}

--- a/Tesserae/src/Components/OmniBox.cs
+++ b/Tesserae/src/Components/OmniBox.cs
@@ -566,6 +566,8 @@ namespace Tesserae
 
         private readonly HTMLTextAreaElement _chatInput;
         private readonly HTMLDivElement   _chatContainer;
+        private readonly HTMLDivElement   _contextContainer;
+        private readonly List<ContextCard> _contextCards = new List<ContextCard>();
         private readonly Button           _chatTriggerBtn;
         private Button                    _modelSelectorBtn;
         private List<ModelOption>         _models = new List<ModelOption>();
@@ -1049,6 +1051,10 @@ namespace Tesserae
 
                 _chatContainer = Div(Att("tss-omnibox-chat-container"), _chatInput);
 
+                // The context row sits between the input and the footer, inside the box. It stays empty
+                // (and, being :empty, invisible) until WithContextToAdd / AddContext put a card in it.
+                _contextContainer = Div(Att("tss-omnibox-context"));
+
                 // Size the input to its content once it's in the DOM (and whenever it's re-shown).
                 DomObserver.WhenMounted(_chatInput, ResizeChatInput);
 
@@ -1151,12 +1157,12 @@ namespace Tesserae
                 }
                 case Mode.Chat:
                 {
-                    _container = Div(Att("tss-omnibox-container"), _chatContainer, _footer);
+                    _container = Div(Att("tss-omnibox-container"), _chatContainer, _contextContainer, _footer);
                     break;
                 }
                 case Mode.SearchAndChat:
                 {
-                    _container = Div(Att("tss-omnibox-container tss-omnibox-chat-and-search"), _searchContainer, _chatContainer, _footer);
+                    _container = Div(Att("tss-omnibox-container tss-omnibox-chat-and-search"), _searchContainer, _chatContainer, _contextContainer, _footer);
                     break;
                 }
             }
@@ -1731,6 +1737,103 @@ namespace Tesserae
             _chatMention = mention;
             return this;
         }
+
+        /// <summary>
+        /// Shows the given <see cref="ContextCard"/>s as the context that will go with the next message,
+        /// in a wrapping row inside the box just below the input and above the footer. Chat modes only.
+        /// <para>
+        /// Each card's remove button is wired to this row, so the (x) takes the card out of the box (any
+        /// handler the caller registered with <see cref="ContextCard.OnRemove(Action{ContextCard})"/> still
+        /// runs, which is where the underlying context gets dropped). A card that should not be removable
+        /// can call <see cref="ContextCard.NoRemove"/> after being handed over. The row is left alone when
+        /// a message is sent - call <see cref="ClearContext"/> from the chat handler to empty it.
+        /// </para>
+        /// </summary>
+        public OmniBox WithContextToAdd(params ContextCard[] context)
+        {
+            if (_mode != Mode.Chat && _mode != Mode.SearchAndChat)
+            {
+                throw new InvalidOperationException("WithContextToAdd can only be called when OmniBox is in Chat or SearchAndChat mode.");
+            }
+
+            ClearContext();
+
+            if (context == null) return this;
+
+            foreach (var card in context)
+            {
+                AddContext(card);
+            }
+
+            return this;
+        }
+
+        /// <summary>
+        /// Shows the given context cards as the context for the next message, replacing whatever the row
+        /// held before.
+        /// </summary>
+        public OmniBox WithContextToAdd(IEnumerable<ContextCard> context) => WithContextToAdd(context?.ToArray());
+
+        /// <summary>
+        /// Adds one more card to the context row, keeping the cards already there.
+        /// </summary>
+        public OmniBox AddContext(ContextCard card)
+        {
+            if (_contextContainer == null)
+            {
+                throw new InvalidOperationException("AddContext can only be called when OmniBox is in Chat or SearchAndChat mode.");
+            }
+
+            if (card == null || _contextCards.Contains(card)) return this;
+
+            _contextCards.Add(card);
+            _contextContainer.appendChild(card.Render());
+
+            // The row owns which cards are in it, so it is the row that takes one out when its (x) is
+            // clicked - the caller's own handler, if any, still runs alongside this one.
+            card.OnRemove(c => RemoveContext(c));
+
+            return this;
+        }
+
+        /// <summary>
+        /// Takes one card out of the context row. Does nothing if the card isn't in it.
+        /// </summary>
+        public OmniBox RemoveContext(ContextCard card)
+        {
+            if (card == null || _contextContainer == null) return this;
+
+            if (_contextCards.Remove(card))
+            {
+                TryRemoveChild(_contextContainer, card.Render());
+            }
+
+            return this;
+        }
+
+        /// <summary>
+        /// Empties the context row. Call it from the chat handler once the context has been sent along
+        /// with the message.
+        /// </summary>
+        public OmniBox ClearContext()
+        {
+            if (_contextContainer == null) return this;
+
+            _contextCards.Clear();
+            ClearChildren(_contextContainer);
+
+            return this;
+        }
+
+        /// <summary>
+        /// Gets the cards currently shown in the context row, in the order they were added.
+        /// </summary>
+        public IReadOnlyList<ContextCard> ContextToAdd => _contextCards;
+
+        /// <summary>
+        /// Returns a value indicating whether the context row currently holds any card.
+        /// </summary>
+        public bool HasContextToAdd => _contextCards.Count > 0;
 
         private void TryUpdateChatMention()
         {

--- a/Tesserae/src/Components/OmniBox.cs
+++ b/Tesserae/src/Components/OmniBox.cs
@@ -472,6 +472,13 @@ namespace Tesserae
             /// Gets or sets the chat footer.
             /// </summary>
             public FooterItems ChatFooter { get; set; }
+
+            /// <summary>
+            /// Gets or sets a component rendered inside the box, above the chat input — the place for
+            /// whatever the message is being written against, e.g. a <see cref="ContextBar"/> of the
+            /// attached documents. Can be replaced later with <see cref="OmniBox.SetChatHeader"/>.
+            /// </summary>
+            public IComponent ChatHeader { get; set; }
             /// <summary>
             /// Gets or sets the search footer.
             /// </summary>
@@ -566,6 +573,7 @@ namespace Tesserae
 
         private readonly HTMLTextAreaElement _chatInput;
         private readonly HTMLDivElement   _chatContainer;
+        private readonly HTMLDivElement   _chatHeader;
         private readonly Button           _chatTriggerBtn;
         private Button                    _modelSelectorBtn;
         private List<ModelOption>         _models = new List<ModelOption>();
@@ -1049,6 +1057,10 @@ namespace Tesserae
 
                 _chatContainer = Div(Att("tss-omnibox-chat-container"), _chatInput);
 
+                _chatHeader = Div(Att("tss-omnibox-chat-header"));
+
+                if (config.ChatHeader is object) _chatHeader.appendChild(config.ChatHeader.Render());
+
                 // Size the input to its content once it's in the DOM (and whenever it's re-shown).
                 DomObserver.WhenMounted(_chatInput, ResizeChatInput);
 
@@ -1151,12 +1163,12 @@ namespace Tesserae
                 }
                 case Mode.Chat:
                 {
-                    _container = Div(Att("tss-omnibox-container"), _chatContainer, _footer);
+                    _container = Div(Att("tss-omnibox-container"), _chatHeader, _chatContainer, _footer);
                     break;
                 }
                 case Mode.SearchAndChat:
                 {
-                    _container = Div(Att("tss-omnibox-container tss-omnibox-chat-and-search"), _searchContainer, _chatContainer, _footer);
+                    _container = Div(Att("tss-omnibox-container tss-omnibox-chat-and-search"), _searchContainer, _chatHeader, _chatContainer, _footer);
                     break;
                 }
             }
@@ -3560,6 +3572,22 @@ namespace Tesserae
         public OmniBox SetChatPlaceholder(string text)
         {
             ChatPlaceholder = text;
+            return this;
+        }
+
+        /// <summary>
+        /// Replaces the component rendered inside the box above the chat input — the place for whatever
+        /// the message is being written against, e.g. a <see cref="ContextBar"/> of the attached
+        /// documents. Passing <c>null</c> empties the slot, which then takes up no space.
+        /// </summary>
+        public OmniBox SetChatHeader(IComponent component)
+        {
+            if (_chatHeader is null) return this;
+
+            _chatHeader.innerHTML = string.Empty;
+
+            if (component is object) _chatHeader.appendChild(component.Render());
+
             return this;
         }
 

--- a/Tesserae/tps.json
+++ b/Tesserae/tps.json
@@ -104,6 +104,7 @@
                 "tps/assets/css/tss.chat.css",
                 "tps/assets/css/tss.toolcall.css",
                 "tps/assets/css/tss.liveprogress.css",
+                "tps/assets/css/tss.contextbar.css",
                 "tps/assets/css/tss.questionnaire.css",
                 "tps/assets/css/tss.rating.css",
                 "tps/assets/css/tss.progressring.css",

--- a/Tesserae/tps.json
+++ b/Tesserae/tps.json
@@ -104,6 +104,7 @@
                 "tps/assets/css/tss.chat.css",
                 "tps/assets/css/tss.toolcall.css",
                 "tps/assets/css/tss.liveprogress.css",
+                "tps/assets/css/tss.contextcard.css",
                 "tps/assets/css/tss.questionnaire.css",
                 "tps/assets/css/tss.rating.css",
                 "tps/assets/css/tss.progressring.css",

--- a/Tesserae/tps/assets/css/tss.contextbar.css
+++ b/Tesserae/tps/assets/css/tss.contextbar.css
@@ -51,7 +51,7 @@
 /* The name is the only part that shrinks: a long one is ellipsized at this width while the icon,
    the extension and the remove button stay whole. */
 .tss-contextbar-item-name {
-    max-width: 50px;
+    max-width: 80px;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;

--- a/Tesserae/tps/assets/css/tss.contextbar.css
+++ b/Tesserae/tps/assets/css/tss.contextbar.css
@@ -1,0 +1,111 @@
+/* ContextBar — a row of small bubbles naming the context something is scoped to */
+
+.tss-contextbar {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 6px;
+    width: 100%;
+    min-width: 0;
+}
+
+/* An empty bar keeps its element (so the next bubble finds it in place) but takes up no space. */
+.tss-contextbar-empty {
+    display: none;
+}
+
+.tss-contextbar-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    max-width: 100%;
+    height: 24px;
+    padding: 2px 4px 2px 8px;
+    border: 1px solid var(--tss-default-border-color);
+    border-radius: 999px;
+    background: var(--tss-secondary-background-color);
+    color: var(--tss-default-foreground-color);
+    font-size: 12px;
+    line-height: 1;
+    white-space: nowrap;
+}
+
+.tss-contextbar-item-clickable {
+    cursor: pointer;
+}
+
+.tss-contextbar-item-clickable:hover,
+.tss-contextbar-item-clickable:focus-visible {
+    border-color: var(--tss-primary-background-color);
+}
+
+.tss-contextbar-item-icon {
+    display: inline-flex;
+    flex-shrink: 0;
+    font-size: 12px;
+    line-height: 1;
+}
+
+/* The name is the only part that shrinks: a long one is ellipsized at this width while the icon,
+   the extension and the remove button stay whole. */
+.tss-contextbar-item-name {
+    max-width: 50px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.tss-contextbar-item-extension {
+    flex-shrink: 0;
+    opacity: 0.6;
+}
+
+.tss-contextbar-item-remove {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    width: 16px;
+    height: 16px;
+    border-radius: 999px;
+    font-size: 10px;
+    line-height: 1;
+    opacity: 0.6;
+    cursor: pointer;
+}
+
+.tss-contextbar-item-remove:hover,
+.tss-contextbar-item-remove:focus-visible {
+    opacity: 1;
+    background: var(--tss-danger-background-color);
+    color: var(--tss-danger-foreground-color);
+}
+
+.tss-contextbar-more {
+    display: inline-flex;
+    align-items: center;
+    height: 24px;
+    padding: 0 10px;
+    border: 1px solid var(--tss-default-border-color);
+    border-radius: 999px;
+    background: transparent;
+    color: var(--tss-secondary-foreground-color);
+    font-size: 12px;
+    line-height: 1;
+    white-space: nowrap;
+    cursor: pointer;
+}
+
+.tss-contextbar-more:hover,
+.tss-contextbar-more:focus-visible {
+    border-color: var(--tss-primary-background-color);
+    color: var(--tss-default-foreground-color);
+}
+
+/* No OnShowAll handler: the button is just a count of what is collapsed. */
+.tss-contextbar-more-static,
+.tss-contextbar-more-static:hover {
+    cursor: default;
+    border-color: var(--tss-default-border-color);
+    color: var(--tss-secondary-foreground-color);
+}

--- a/Tesserae/tps/assets/css/tss.contextbar.css
+++ b/Tesserae/tps/assets/css/tss.contextbar.css
@@ -14,10 +14,11 @@
     display: none;
 }
 
+/* Spacing is per-child rather than a flex `gap`: the extension has to butt right up against the
+   ellipsized name so the two read as one file name. */
 .tss-contextbar-item {
     display: inline-flex;
     align-items: center;
-    gap: 4px;
     max-width: 100%;
     height: 24px;
     padding: 2px 4px 2px 8px;
@@ -42,6 +43,7 @@
 .tss-contextbar-item-icon {
     display: inline-flex;
     flex-shrink: 0;
+    margin-right: 5px;
     font-size: 12px;
     line-height: 1;
 }
@@ -60,18 +62,34 @@
     opacity: 0.6;
 }
 
+/* The ✕ is quiet until the bubble is hovered (or it is focused), so a row of bubbles reads as names
+   rather than as a row of delete buttons. Its own hover is what turns it red. */
 .tss-contextbar-item-remove {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    flex-shrink: 0;
+    flex: 0 0 auto;
     width: 16px;
     height: 16px;
+    margin-left: 5px;
     border-radius: 999px;
-    font-size: 10px;
+    font-size: 8px;
     line-height: 1;
-    opacity: 0.6;
+    color: var(--tss-secondary-foreground-color);
+    background: transparent;
+    opacity: 0.45;
     cursor: pointer;
+    transition: opacity 0.12s ease, background-color 0.12s ease, color 0.12s ease;
+}
+
+/* The glyph is centered by the flexbox above; its own line box must not add to that. */
+.tss-contextbar-item-remove > i {
+    display: block;
+    line-height: 1;
+}
+
+.tss-contextbar-item:hover .tss-contextbar-item-remove {
+    opacity: 1;
 }
 
 .tss-contextbar-item-remove:hover,
@@ -79,6 +97,22 @@
     opacity: 1;
     background: var(--tss-danger-background-color);
     color: var(--tss-danger-foreground-color);
+}
+
+.tss-contextbar-item-remove:focus-visible {
+    outline: 2px solid var(--tss-primary-background-color);
+    outline-offset: 1px;
+}
+
+.tss-contextbar-item-remove:active {
+    transform: scale(0.92);
+}
+
+/* Touch and keyboard-only users never hover, so the ✕ stays visible for them. */
+@media (hover: none) {
+    .tss-contextbar-item-remove {
+        opacity: 0.75;
+    }
 }
 
 .tss-contextbar-more {

--- a/Tesserae/tps/assets/css/tss.contextcard.css
+++ b/Tesserae/tps/assets/css/tss.contextcard.css
@@ -85,42 +85,53 @@
     display: none;
 }
 
-/* The remove button overlays the card's top-right corner, so it costs no layout: only the text
-   column is inset (below) to keep a long label from running underneath it. */
+/* The remove button hangs slightly off the card's top-right corner, so it costs no layout and never
+   sits over the label. It is a solid neutral disc with a white glyph that turns danger-colored while
+   hovered. The z-index keeps it above the next card in a wrapping row, which the overhang can
+   otherwise reach. */
 .tss-contextcard-remove {
     position: absolute;
-    top: 4px;
-    right: 4px;
+    top: -6px;
+    right: -6px;
+    z-index: 1;
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 20px;
-    height: 20px;
+    width: 18px;
+    height: 18px;
     padding: 0;
-    border: 1px solid var(--tss-default-border-color);
+    border: none;
     border-radius: 50%;
-    background: var(--tss-default-background-color);
-    color: var(--tss-default-foreground-color);
-    box-shadow: var(--tss-box-shadow);
+    background: var(--tss-colors-neutral-1000);
+    color: var(--tss-colors-neutral-0);
     cursor: pointer;
     opacity: 0;
     pointer-events: none;
-    transition: opacity 0.12s ease-in-out;
+    transition: opacity 0.12s ease-in-out, background 0.12s ease-in-out;
+}
+
+/* The neutral scale flips with the theme, so in dark mode it takes a mid grey to stay visible on a
+   dark card, and the white glyph comes from the inverted scale (which is light there). */
+.tss-dark-mode .tss-contextcard-remove {
+    background: var(--tss-colors-neutral-500);
+    color: var(--tss-colors-dark-neutral-0);
 }
 
 .tss-contextcard-remove i {
-    font-size: 12px;
+    font-size: 11px;
     line-height: 1;
 }
 
-.tss-contextcard-remove:hover {
-    background: var(--tss-default-background-hover-color);
-    color: var(--tss-default-foreground-hover-color);
+.tss-contextcard-remove:hover,
+.tss-dark-mode .tss-contextcard-remove:hover {
+    background: var(--tss-danger-background-color);
+    color: var(--tss-danger-foreground-color);
 }
 
-.tss-contextcard-removable .tss-contextcard-text {
-    /* Room for the overlay circle, so the label ellipsizes before it reaches the button. */
-    padding-right: 18px;
+.tss-contextcard-remove:active,
+.tss-dark-mode .tss-contextcard-remove:active {
+    background: var(--tss-danger-background-active-color);
+    color: var(--tss-danger-foreground-active-color);
 }
 
 .tss-contextcard:hover > .tss-contextcard-remove,
@@ -167,17 +178,12 @@
 }
 
 .tss-contextcard-compact .tss-contextcard-remove {
-    top: 50%;
-    right: 4px;
-    width: 16px;
-    height: 16px;
-    transform: translateY(-50%);
+    top: -5px;
+    right: -5px;
+    width: 15px;
+    height: 15px;
 }
 
 .tss-contextcard-compact .tss-contextcard-remove i {
     font-size: 9px;
-}
-
-.tss-contextcard-compact.tss-contextcard-removable .tss-contextcard-text {
-    padding-right: 14px;
 }

--- a/Tesserae/tps/assets/css/tss.contextcard.css
+++ b/Tesserae/tps/assets/css/tss.contextcard.css
@@ -1,0 +1,183 @@
+/* ContextCard — a compact card for one piece of context attached to a conversation */
+
+.tss-contextcard {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    max-width: 100%;
+    box-sizing: border-box;
+    padding: 8px 12px;
+    border: 1px solid var(--tss-default-border-color);
+    border-radius: var(--tss-border-radius-lg, 8px);
+    background: var(--tss-default-background-color);
+    color: var(--tss-default-foreground-color);
+    /* Cards usually sit in a wrapping row above a composer, so they never grow to fill it. */
+    flex: 0 0 auto;
+}
+
+.tss-contextcard-clickable {
+    cursor: pointer;
+}
+
+.tss-contextcard-clickable:hover {
+    background: var(--tss-default-background-hover-color);
+}
+
+.tss-contextcard-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    width: 36px;
+    height: 36px;
+    border-radius: 10px;
+    overflow: hidden;
+    font-size: 16px;
+    background: var(--tss-primary-background-color);
+    color: var(--tss-primary-foreground-color);
+}
+
+.tss-contextcard-icon-nobackground {
+    background: transparent;
+    color: inherit;
+}
+
+/* A thumbnail covers the tile, so whatever background color was set stops showing through. */
+.tss-contextcard-icon-image {
+    background: transparent;
+}
+
+.tss-contextcard-image {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+}
+
+.tss-contextcard-text {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    min-width: 0;
+    overflow: hidden;
+}
+
+.tss-contextcard-label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: var(--tss-font-size-small, 14px);
+    font-weight: var(--tss-font-weight-semibold, 600);
+    line-height: 1.3;
+}
+
+.tss-contextcard-sublabel {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: var(--tss-font-size-xsmall, 12px);
+    line-height: 1.3;
+    color: var(--tss-colors-neutral-600, #4b5563);
+}
+
+.tss-contextcard-empty {
+    display: none;
+}
+
+/* The remove button overlays the card's top-right corner, so it costs no layout: only the text
+   column is inset (below) to keep a long label from running underneath it. */
+.tss-contextcard-remove {
+    position: absolute;
+    top: 4px;
+    right: 4px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 20px;
+    height: 20px;
+    padding: 0;
+    border: 1px solid var(--tss-default-border-color);
+    border-radius: 50%;
+    background: var(--tss-default-background-color);
+    color: var(--tss-default-foreground-color);
+    box-shadow: var(--tss-box-shadow);
+    cursor: pointer;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.12s ease-in-out;
+}
+
+.tss-contextcard-remove i {
+    font-size: 12px;
+    line-height: 1;
+}
+
+.tss-contextcard-remove:hover {
+    background: var(--tss-default-background-hover-color);
+    color: var(--tss-default-foreground-hover-color);
+}
+
+.tss-contextcard-removable .tss-contextcard-text {
+    /* Room for the overlay circle, so the label ellipsizes before it reaches the button. */
+    padding-right: 18px;
+}
+
+.tss-contextcard:hover > .tss-contextcard-remove,
+.tss-contextcard:focus-within > .tss-contextcard-remove,
+.tss-contextcard-remove:focus-visible {
+    opacity: 1;
+    pointer-events: auto;
+}
+
+/* Nothing hovers on a touch screen, so there the button is simply always visible. */
+@media (hover: none) {
+    .tss-contextcard-remove {
+        opacity: 1;
+        pointer-events: auto;
+    }
+}
+
+.tss-contextcard-compact {
+    gap: 8px;
+    padding: 4px 8px;
+}
+
+.tss-contextcard-compact .tss-contextcard-icon {
+    width: 22px;
+    height: 22px;
+    border-radius: 6px;
+    font-size: 12px;
+}
+
+/* A compact card is one row: the secondary line moves in beside the label. */
+.tss-contextcard-compact .tss-contextcard-text {
+    flex-direction: row;
+    align-items: baseline;
+    gap: 6px;
+}
+
+.tss-contextcard-compact .tss-contextcard-label {
+    font-size: var(--tss-font-size-xsmall, 12px);
+}
+
+.tss-contextcard-compact .tss-contextcard-sublabel {
+    flex-shrink: 0;
+    font-size: var(--tss-font-size-tiny, 11px);
+}
+
+.tss-contextcard-compact .tss-contextcard-remove {
+    top: 50%;
+    right: 4px;
+    width: 16px;
+    height: 16px;
+    transform: translateY(-50%);
+}
+
+.tss-contextcard-compact .tss-contextcard-remove i {
+    font-size: 9px;
+}
+
+.tss-contextcard-compact.tss-contextcard-removable .tss-contextcard-text {
+    padding-right: 14px;
+}

--- a/Tesserae/tps/assets/css/tss.omnibox.css
+++ b/Tesserae/tps/assets/css/tss.omnibox.css
@@ -119,6 +119,21 @@
     border-radius: var(--tss-border-radius-md);
 }
 
+/* Slot above the chat input, inside the box: what the message is being written against (a
+   ContextBar of attached documents, say). Padded to line up with the input's text, and taking up
+   no space at all while nothing is in it. */
+.tss-omnibox-chat-header {
+    display: flex;
+    width: 100%;
+    box-sizing: border-box;
+    padding: 10px 13px 0 13px;
+}
+
+.tss-omnibox-chat-header:empty {
+    display: none;
+    padding: 0;
+}
+
 .tss-omnibox-chat-container,
 .tss-omnibox-container.tss-omnibox-chat-and-search .tss-omnibox-search-container {
     position: relative;

--- a/Tesserae/tps/assets/css/tss.omnibox.css
+++ b/Tesserae/tps/assets/css/tss.omnibox.css
@@ -315,10 +315,26 @@
 }
 
 .tss-omnibox-container.tss-omnibox-mode-search .tss-omnibox-chat-container,
+.tss-omnibox-container.tss-omnibox-mode-search .tss-omnibox-context,
 .tss-omnibox-container.tss-omnibox-mode-search .tss-omnibox-chat-btn,
 .tss-omnibox-container.tss-omnibox-mode-search .tss-omnibox-chat-footer-item {
     display: none;
 }
+
+/* Context attached to the next message: a wrapping row of ContextCards between the chat input and the
+   footer. The top padding leaves room for the cards' remove discs, which overhang their top edge. */
+.tss-omnibox-context {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 12px 4px 12px;
+}
+
+    /* No context, no row - so an OmniBox that never gets one looks exactly as it did before. */
+    .tss-omnibox-context:empty {
+        display: none;
+    }
 /* Expanded state for Chat and SearchAndChat modes */
 .tss-omnibox-container.tss-omnibox-expanded .tss-omnibox-chat-container,
 .tss-omnibox-container.tss-omnibox-expanded.tss-omnibox-mode-search .tss-omnibox-search-container,


### PR DESCRIPTION
## Summary

Introduces `ContextCard`, a new compact card component for displaying context attached to a conversation (files, pages, datasets, etc.), and integrates it into `OmniBox` for chat modes. Also significantly refactors the `OmniBoxSample` to demonstrate features individually rather than as monolithic examples.

## Key Changes

### New Component: ContextCard
- **New file**: `Tesserae/src/Components/ContextCard.cs` — a compact card showing:
  - An icon tile (UIcons glyph, arbitrary component, or image thumbnail) on a colored background
  - A label (ellipsized with tooltip) and optional secondary line
  - A hover/focus-revealed remove button (round × disc) that stays visible on touch devices
  - Fluent configuration: `.SetLabel()`, `.SetSubLabel()`, `.SetIcon()`, `.SetImage()`, `.IconBackground()`, `.IconForeground()`, `.NoIconBackground()`, `.OnRemove()`, `.Removable()`
  - Compact variant via `.Compact()` for inline display
- **Styling**: `Tesserae/tps/assets/css/tss.contextcard.css` — positioned remove button, theme-aware colors, touch-friendly visibility
- **Sample**: `Tesserae.Tests/src/Samples/Components/ContextCardSample.cs` — demonstrates tiles, colors, images, removal, and compact mode
- **Documentation**: `Tesserae/skills/references/context-card.md` — reference guide for consumers
- **Factory method**: Added `UI.ContextCard()` overloads in `UI.Components.cs`

### OmniBox Integration
- **Chat modes only**: Added `_contextContainer` (a wrapping row) and `_contextCards` list to `OmniBox`
- **New fluent methods**:
  - `.WithContextToAdd(params ContextCard[])` — displays cards in the row below the input, above the footer
  - `.AddContext(ContextCard)` — appends a single card
  - `.RemoveContext(ContextCard)` — removes a card
  - `.ClearContext()` — empties the row
  - `.GetContext()` — returns the current cards
- **Remove wiring**: Cards' remove buttons automatically call back to the OmniBox to remove themselves from the row
- **Layout**: Context row is `:empty`-invisible when no cards are present, positioned between input and footer in the DOM

### OmniBoxSample Refactor
- **Restructured from monolithic examples to feature-by-feature cards**:
  - `Overview()` — what OmniBox is, page-wide "Disabled" toggle
  - `Modes()` — Search, Chat, SearchAndChat, ExpandOnFocus
  - `QuerySyntax()` — boolean operators, grouping, quotes with token display
  - `Suggestions()` — async suggestions with categories
  - `History()` — recent searches via history button
  - `Snaps()` — @ scopes that become chips
  - `FilterSnaps()` — field: autocomplete filters
  - `Help()` — ? button with syntax and snap documentation
  - `InlineChips()` — app-owned filter chips at the search head
  - `FooterItems()` — custom buttons in the footer
  - `KeyboardShortcut()` — Ctrl+K / Ctrl+Shift+K registration
  - `FileDrop()` — drag-and-drop file attachment
  - `Models()` — model selector and thinking effort
  - `Generating()` — chat generation state with stop button
  - `ToolsAndAgents()` — tool calls and agent mode
  - `ContextToAdd()` — context cards above the chat composer
- **Helper methods**:
  - `FeatureCard()` — wraps each section in a titled card with subtitle and description
  - `Track()` — registers boxes with the page-wide disabled toggle
- **Disabled toggle**: Single toggle at the top disables/enables all boxes on the page at once

### Documentation Updates
- Updated `Tesserae/skills/SKILL.md` to include `context-card` in the component

https://claude.ai/code/session_016zkFqWJnsqa4K7rQmicFBi