### PR TITLE
Fix method overload naming conflicts in JavaScript interop

### DIFF
--- a/Tesserae/src/Components/NodeView/NodeView.cs
+++ b/Tesserae/src/Components/NodeView/NodeView.cs
@@ -742,7 +742,8 @@ namespace Tesserae
             public readonly bool isSubgraph;
             public IViewSettings settings;
             [Template("{this}.switchGraph({0})")] public void switchGraph(Graph newGraph) { }
-            [Template("{this}.switchGraph({0})")] public void switchGraph(GraphTemplate newGraph) { }
+            // JS has no overloads, so the second one needs a distinct emitted name - the [Template] is what's written at the call site anyway
+            [Name("switchGraphFromTemplate")] [Template("{this}.switchGraph({0})")] public void switchGraph(GraphTemplate newGraph) { }
 
             //    clipboard: IClipboard;
             //    commandHandler: ICommandHandler;
@@ -787,7 +788,8 @@ namespace Tesserae
             [Template("{this}.name()")] public string name() { return null; }
             [Template("{this}.outputs()")] public ReadOnlyArray<IGraphInterface> outputs() { return null; }
             [Template("{this}.createGraph()")] public Graph createGraph() { return null; }
-            [Template("{this}.createGraph({0})")] public Graph createGraph(Graph graph) { return null; }
+            // JS has no overloads, so the second one needs a distinct emitted name - the [Template] is what's written at the call site anyway
+            [Name("createGraphInto")] [Template("{this}.createGraph({0})")] public Graph createGraph(Graph graph) { return null; }
             [Template("{this}.save()")] public IGraphTemplateState save() { return null; }
             [Template("{this}.update({0})")] public void update(NodeViewGraphState state) { }
             [Template("{this}.fromGraph({0}, {1})")] public static GraphTemplate fromGraph(Graph graph, Editor editor) { return null; }
@@ -880,7 +882,8 @@ namespace Tesserae
             public int connectionCount() { return 0; }
             public void connectionCount(int value) { }
             [Template("{this}.value()")] public object value() { return null; }
-            [Template("{this}.value({0})")] public void value(object value) { }
+            // JS has no overloads, so the setter needs a distinct emitted name - the [Template] is what's written at the call site anyway
+            [Name("setValue")] [Template("{this}.value({0})")] public void value(object value) { }
             [Template("{this}.load({0})")] public void load(INodeInterfaceState state) { }
             [Template("{this}.save()")] public INodeInterfaceState save() {  return null; }
             [Template("{this}.setComponent({0})")] public void setComponent(object component) { }


### PR DESCRIPTION
## Summary

The Transpose compiler does not support method overloads in the generated JavaScript. This change adds explicit `[Name]` attributes to overloaded methods in the `NodeView`, `GraphTemplate`, and `NodeInterface` classes to ensure each overload emits a distinct JavaScript function name while preserving the `[Template]` attribute for correct call-site code generation.

## Changes

- **NodeView.switchGraph(GraphTemplate)**: Added `[Name("switchGraphFromTemplate")]` to distinguish from the `Graph` overload
- **GraphTemplate.createGraph(Graph)**: Added `[Name("createGraphInto")]` to distinguish from the parameterless overload
- **NodeInterface.value(object)**: Added `[Name("setValue")]` to distinguish from the getter overload

Each change includes a comment explaining that JavaScript has no overload support and that the `[Template]` attribute controls the call-site code generation while `[Name]` controls the emitted function name.

## Implementation Details

The `[Template]` attributes remain unchanged, ensuring that call sites continue to emit the correct JavaScript code (e.g., `.switchGraph({0})`, `.createGraph({0})`, `.value({0})`). The `[Name]` attributes provide distinct identifiers in the compiled JavaScript output to prevent naming collisions that would occur if both overloads emitted the same function name.

https://claude.ai/code/session_01Ge18WnowAjJKHbef1SZ1oj