### PR TITLE
Replace ContextCard.SetKind with a generic SetBadge slot

### DIFF
--- a/Tesserae.Tests/src/Samples/Components/ContextCardSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/ContextCardSample.cs
@@ -77,11 +77,14 @@ namespace Tesserae.Tests.Samples
                             ContextCard("Q3-forecast.xlsx", UIcons.FileExcel).SetSubLabel("Spreadsheet").IconBackground("#16a34a").Compact().OnRemove(() => { }),
                             ContextCard("architecture.md", UIcons.FileCode).IconBackground("#6366f1").Compact().OnRemove(() => { })),
 
-                        SampleSubTitle("Kinds"),
-                        TextBlock("SetKind puts a small pill at the end of the card saying what sort of context it is. It comes into its own inside a ContextCards list, where every row ends with one."),
+                        SampleSubTitle("Badge"),
+                        TextBlock("SetBadge puts a small pill at the end of the card. The card says nothing about what belongs there — what a piece of context is is already carried by the icon you pass — so it takes whatever the app wants: a source, a count, a status. The IComponent overload takes a component instead of plain text, and drops the pill chrome so that component's own styling shows."),
                         HStack().Wrap().Gap(8.px()).PT(8).Children(
-                            ContextCard("Q3 revenue model", UIcons.Table).SetSubLabel("finance/q3-model.xlsx · 4 sheets").MonospaceSubLabel().SetKind("Sheet").IconBackground("#16a34a").W(340.px()),
-                            ContextCard("events.request_log", UIcons.Database).SetSubLabel("warehouse · 2.1M rows").MonospaceSubLabel().SetKind("Table").IconBackground("#10b981").W(340.px())),
+                            ContextCard("Q3 revenue model", UIcons.Table).SetSubLabel("finance/q3-model.xlsx · 4 sheets").MonospaceSubLabel().SetBadge("SharePoint").IconTint("#16a34a").W(340.px()),
+                            ContextCard("events.request_log", UIcons.Database).SetSubLabel("warehouse · 2.1M rows").MonospaceSubLabel().SetBadge("2.1M rows").IconTint("#10b981").W(340.px())),
+                        HStack().Wrap().Gap(8.px()).PT(8).Children(
+                            ContextCard("Supplier audit 2026.pdf", UIcons.FilePdf).SetSubLabel("shared with you").SetBadge(Badge("New").Primary()).IconTint("#ef4444").W(340.px()),
+                            ContextCard("design-review/", UIcons.Folder).SetSubLabel("indexing…").SetBadge(Spinner().Small()).IconTint("#94a3b8").W(340.px())),
 
                         SampleSubTitle("Long file names"),
                         TextBlock("MaxLabelWidth caps where the label is cut, and a trailing file extension is held outside that width — the ellipsis is placed by measuring the text, so the card reads \"Quarterly repo….pdf\" rather than \"Quarterly repor…\". KeepExtensionVisible(false) opts out."),

--- a/Tesserae.Tests/src/Samples/Components/ContextCardsSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/ContextCardsSample.cs
@@ -14,14 +14,14 @@ namespace Tesserae.Tests.Samples
         private readonly TextBlock    _composerState;
         private          int          _attached;
 
-        // The five items of the grouped list, each with the kind of thing it is.
+        // The five items of the grouped list; the third column is what goes in the badge slot.
         private static readonly string[][] Items =
         {
-            new[] { "Q3 revenue model",       "finance/q3-model.xlsx · 4 sheets",   "Sheet",  "#16a34a" },
-            new[] { "Incident 482 postmortem", "docs/postmortem-482.md",            "Doc",    "#3b82f6" },
-            new[] { "Re: migration window",    "from ops@needle.dev · Nov 14",      "Email",  "#f59e0b" },
-            new[] { "events.request_log",      "warehouse · 2.1M rows",             "Table",  "#10b981" },
-            new[] { "design-review/",          "14 files · 62 MB",                  "Folder", "#94a3b8" }
+            new[] { "Q3 revenue model",        "finance/q3-model.xlsx · 4 sheets",  "SharePoint", "#16a34a" },
+            new[] { "Incident 482 postmortem", "docs/postmortem-482.md",            "Wiki",       "#3b82f6" },
+            new[] { "Re: migration window",    "from ops@needle.dev · Nov 14",      "Inbox",      "#f59e0b" },
+            new[] { "events.request_log",      "warehouse · 2.1M rows",             "Snowflake",  "#10b981" },
+            new[] { "design-review/",          "14 files · 62 MB",                  "Drive",      "#94a3b8" }
         };
 
         private static readonly UIcons[] ItemIcons = { UIcons.Table, UIcons.FileInvoice, UIcons.Envelope, UIcons.Database, UIcons.Folder };
@@ -90,7 +90,7 @@ namespace Tesserae.Tests.Samples
                 .OnToggle(g => Toast().Information(g.IsExpanded ? "Expanded" : "Collapsed"));
 
             return FeatureCard("Grouped", "A summary pill that expands into a list",
-                "Clicking the pill toggles the list; the chevron follows. Rows are the same ContextCards, laid out as list rows — full width, one divider between each, the kind pill and the ✕ at the end. SetSummary replaces the auto-generated \"Added N items to context\" (which keeps itself up to date as cards come and go), SetIcon replaces the layers glyph, and OnToggle reports the state.",
+                "Clicking the pill toggles the list; the chevron follows. Rows are the same ContextCards, laid out as list rows — full width, one divider between each, the badge and the ✕ at the end. SetSummary replaces the auto-generated \"Added N items to context\" (which keeps itself up to date as cards come and go), SetIcon replaces the layers glyph, and OnToggle reports the state.",
                 expanded,
                 _lastRemoved.MT(4),
                 TextBlock("Starting collapsed, with its own summary and icon:").Small().MT(12).MB(8),
@@ -183,7 +183,7 @@ namespace Tesserae.Tests.Samples
                     })));
         }
 
-        // A group of the five items above, each a row with a mono second line and a kind pill.
+        // A group of the five items above, each a row with a mono second line and a badge.
         private ContextCards Group()
         {
             var group = ContextCards();
@@ -195,7 +195,7 @@ namespace Tesserae.Tests.Samples
                 var card = ContextCard(item[0], ItemIcons[i])
                     .SetSubLabel(item[1])
                     .MonospaceSubLabel()
-                    .SetKind(item[2])
+                    .SetBadge(item[2])
                     .IconTint(item[3])
                     .OnRemove(c => _lastRemoved.Text = $"Detached {c.Label}.");
 

--- a/Tesserae/skills/references/context-card.md
+++ b/Tesserae/skills/references/context-card.md
@@ -30,9 +30,10 @@ Bring factories into scope with `using static Tesserae.UI;`.
 - `.SetSubLabel(string)` — the second line. Null or empty hides it, leaving one centered row.
   `.MonospaceSubLabel()` renders it in the monospace font, for a path, a table name or a size — the
   same treatment `ToolCall` gives the command it names.
-- `.SetKind(string)` — a small pill at the end of the card saying what sort of context it is ("Doc",
-  "Sheet", "Table", "Folder"). Comes into its own inside a `ContextCards` list, where every row ends
-  with one.
+- `.SetBadge(string)` / `.SetBadge(IComponent)` — a small pill at the end of the card. The card says
+  nothing about what belongs there — what a piece of context *is* is carried by the icon you pass — so
+  it takes whatever the app wants: a source, a count, a status. The `IComponent` overload drops the pill
+  chrome so a `Badge`, a `Spinner` or a small button keeps its own styling.
 - `.SetIcon(UIcons, UIconsWeight = Regular)` / `.SetIcon(IComponent)` — what sits on the tile.
 - `.SetImage(string url)` — fill the tile with a thumbnail (cropped to cover it) for context that
   has a preview of its own: an image, a screenshot, a favicon.

--- a/Tesserae/skills/references/context-cards.md
+++ b/Tesserae/skills/references/context-cards.md
@@ -11,7 +11,7 @@ shapes:
 - **Grouped** (default) — a summary pill ("Added 5 items to context") that expands into a bordered list
   of rows and collapses back. Same pill shape and chevron as `ToolsUsed`, so a transcript reads as one
   family of disclosures. In the list, cards render as full-width rows with a divider between each and
-  the ✕ in the row rather than hovering over a corner.
+  the badge and the ✕ in the row rather than hovering over a corner.
 - **Compact** (`.Compact()`) — no header, just a wrapping row of pills. The first `MaxVisible` (5 by
   default) are shown; the rest collapse behind a dashed "+N more" pill.
 
@@ -51,9 +51,9 @@ using static Tesserae.UI;
 
 // Grouped: one pill that opens into a list of rows.
 var sources = ContextCards(
-    ContextCard("Q3 revenue model", UIcons.Table).SetSubLabel("finance/q3-model.xlsx · 4 sheets").MonospaceSubLabel().SetKind("Sheet").IconTint("#16a34a"),
-    ContextCard("Incident 482 postmortem", UIcons.FileInvoice).SetSubLabel("docs/postmortem-482.md").MonospaceSubLabel().SetKind("Doc").IconTint("#3b82f6"),
-    ContextCard("events.request_log", UIcons.Database).SetSubLabel("warehouse · 2.1M rows").MonospaceSubLabel().SetKind("Table").IconTint("#10b981"))
+    ContextCard("Q3 revenue model", UIcons.Table).SetSubLabel("finance/q3-model.xlsx · 4 sheets").MonospaceSubLabel().SetBadge("SharePoint").IconTint("#16a34a"),
+    ContextCard("Incident 482 postmortem", UIcons.FileInvoice).SetSubLabel("docs/postmortem-482.md").MonospaceSubLabel().SetBadge("Wiki").IconTint("#3b82f6"),
+    ContextCard("events.request_log", UIcons.Database).SetSubLabel("warehouse · 2.1M rows").MonospaceSubLabel().SetBadge("Snowflake").IconTint("#10b981"))
    .SetSummary("3 sources for this answer")
    .OnToggle(g => Console.WriteLine(g.IsExpanded));
 

--- a/Tesserae/src/Components/ContextCard.cs
+++ b/Tesserae/src/Components/ContextCard.cs
@@ -11,7 +11,7 @@ namespace Tesserae
     /// <para>
     /// It is an icon tile (a <see cref="UIcons"/> glyph, an arbitrary component, or an image
     /// thumbnail) on a colored background, followed by a label, an optional second line, and an optional
-    /// kind pill ("Doc", "Sheet", "Table"). Passing a remove handler to
+    /// badge pill. Passing a remove handler to
     /// <see cref="OnRemove(Action{ContextCard})"/> adds a round (x) button hanging just off the card's
     /// top-right corner that fades in while the card is hovered, focused, or on touch devices where there
     /// is no hover to speak of.
@@ -33,7 +33,7 @@ namespace Tesserae
         private readonly HTMLElement       _labelExtension;
         private readonly HTMLElement       _subLabelContainer;
         private readonly HTMLElement       _textContainer;
-        private readonly HTMLElement       _kindContainer;
+        private readonly HTMLElement       _badgeContainer;
         private readonly HTMLElement       _chevron;
         private          HTMLButtonElement _removeButton;
         private          string            _label;
@@ -80,14 +80,14 @@ namespace Tesserae
 
             _textContainer = Div(Att("tss-contextcard-text"), _labelContainer, _subLabelContainer);
 
-            _kindContainer = Div(Att("tss-contextcard-kind"));
+            _badgeContainer = Div(Att("tss-contextcard-badge"));
             _chevron       = I(UIcons.AngleDown, cssClass: "tss-contextcard-chevron");
 
-            InnerElement = Div(Att("tss-contextcard"), _iconContainer, _textContainer, _kindContainer, _chevron);
+            InnerElement = Div(Att("tss-contextcard"), _iconContainer, _textContainer, _badgeContainer, _chevron);
 
             SetLabel(null);
             SetSubLabel(null);
-            SetKind(null);
+            SetBadge((string)null);
             WithChevron(false);
 
             AttachClick();
@@ -165,15 +165,38 @@ namespace Tesserae
         }
 
         /// <summary>
-        /// Sets the kind of context this card stands for - "Doc", "Sheet", "Email", "Table", "Folder" -
-        /// shown as a small pill at the end of the card. A null or empty value hides it.
+        /// Puts a small pill at the end of the card. The card says nothing about what belongs in it - what
+        /// the context *is* is already carried by the icon - so it takes whatever the host wants there: a
+        /// count, a status, a source. A null or empty value hides it.
         /// </summary>
-        public ContextCard SetKind(string kind)
+        public ContextCard SetBadge(string text)
         {
-            var isEmpty = string.IsNullOrEmpty(kind);
+            ClearChildren(_badgeContainer);
 
-            _kindContainer.innerText = isEmpty ? string.Empty : kind;
-            _kindContainer.UpdateClassIf(isEmpty, "tss-contextcard-empty");
+            var isEmpty = string.IsNullOrEmpty(text);
+
+            if (!isEmpty) _badgeContainer.innerText = text;
+
+            _badgeContainer.UpdateClassIf(isEmpty, "tss-contextcard-empty");
+            _badgeContainer.classList.remove("tss-contextcard-badge-custom");
+
+            return this;
+        }
+
+        /// <summary>
+        /// Puts the given component at the end of the card, in place of the plain pill - a
+        /// <see cref="Badge"/> with a tone of its own, a <see cref="Spinner"/> while the context loads, a
+        /// small button. A null value empties the slot.
+        /// </summary>
+        public ContextCard SetBadge(IComponent badge)
+        {
+            ClearChildren(_badgeContainer);
+
+            if (badge != null) _badgeContainer.appendChild(badge.Render());
+
+            // A component brings its own chrome, so the slot drops the pill border it draws for plain text.
+            _badgeContainer.UpdateClassIf(badge == null, "tss-contextcard-empty");
+            _badgeContainer.UpdateClassIf(badge != null, "tss-contextcard-badge-custom");
 
             return this;
         }

--- a/Tesserae/tps/assets/css/tss.contextcard.css
+++ b/Tesserae/tps/assets/css/tss.contextcard.css
@@ -100,8 +100,8 @@
     font-family: var(--tss-monospace-font-family, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
 }
 
-/* What kind of context this is: "Doc", "Sheet", "Table". Quiet, and never shrinks. */
-.tss-contextcard-kind {
+/* Whatever the host wants at the end of the card - a count, a status, a source. Quiet, never shrinks. */
+.tss-contextcard-badge {
     flex-shrink: 0;
     margin-left: auto;
     padding: 2px 10px;
@@ -112,6 +112,13 @@
     font-size: var(--tss-font-size-xsmall, 12px);
     line-height: 1.4;
     white-space: nowrap;
+}
+
+/* A component in the slot brings its own chrome (a Badge, a Spinner), so the pill drops out of the way. */
+.tss-contextcard-badge-custom {
+    padding: 0;
+    border: none;
+    background: transparent;
 }
 
 .tss-contextcard-chevron {
@@ -220,7 +227,7 @@
     font-size: var(--tss-font-size-xsmall, 11px);
 }
 
-.tss-contextcard-compact .tss-contextcard-kind {
+.tss-contextcard-compact .tss-contextcard-badge {
     padding: 1px 8px;
     font-size: var(--tss-font-size-tiny, 10px);
 }

--- a/Tesserae/tps/assets/css/tss.contextcards.css
+++ b/Tesserae/tps/assets/css/tss.contextcards.css
@@ -126,8 +126,8 @@
     font-size: 12px;
 }
 
-/* The kind pill and the ✕ share the row's end, so the pill stops claiming the leftover space. */
-.tss-contextcards-list > .tss-contextcard .tss-contextcard-kind {
+/* The badge and the ✕ share the row's end, so the badge stops claiming the leftover space. */
+.tss-contextcards-list > .tss-contextcard .tss-contextcard-badge {
     margin-left: 8px;
 }
 


### PR DESCRIPTION
SetKind implied the card knew a vocabulary of context types - "Doc", "Sheet", "Email" - which is not the card's business: what a piece of context is is already said by the icon the caller passes, and a second, redundant label for it invited a taxonomy the component would then have to own.

The slot at the end of the card stays, because a row of context does want something there, but it now says nothing about what: SetBadge(string) takes whatever the app has - a source, a count, a status - and SetBadge(IComponent) takes a component instead, dropping the pill chrome so a Badge with its own tone, a Spinner while the context loads, or a small button keeps its styling.

The samples follow the same line: the icon carries the type, and the badge carries where the context came from ("SharePoint", "Wiki", "Snowflake").


Claude-Session: https://claude.ai/code/session_016zkFqWJnsqa4K7rQmicFBi