### PR TITLE
Update packages

### DIFF
--- a/Tesserae.Tests/Tesserae.Tests.csproj
+++ b/Tesserae.Tests/Tesserae.Tests.csproj
@@ -1,11 +1,11 @@
-﻿<Project Sdk="Transpose.Build.Target/26.7.2692">
+﻿<Project Sdk="Transpose.Build.Target/26.7.3049">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Transpose.BCL" Version="26.7.3104" />
-    <PackageReference Include="Transpose.Core" Version="26.7.3106" />
+    <PackageReference Include="Transpose.BCL" Version="26.7.3120" />
+    <PackageReference Include="Transpose.Core" Version="26.7.3122" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tesserae/Tesserae.csproj
+++ b/Tesserae/Tesserae.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Transpose.Build.Target/26.7.2692">
+﻿<Project Sdk="Transpose.Build.Target/26.7.3049">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>tss</AssemblyName>


### PR DESCRIPTION
## Summary
- Bump the `Transpose.Build.Target` SDK from `26.7.2692` to `26.7.3049` in `Tesserae/Tesserae.csproj` and `Tesserae.Tests/Tesserae.Tests.csproj`.
- Align `Tesserae.Tests`' `Transpose.BCL`/`Transpose.Core` package versions (`26.7.3120`/`26.7.3122`) with the ones already used in `Tesserae/Tesserae.csproj`.
- Updated the global `Transpose.Compiler` CLI tool to `26.7.3119`.

## Test plan
- `dotnet build Tesserae/Tesserae.csproj` — succeeds, 0 warnings/errors.
- `dotnet build Tesserae.Tests/Tesserae.Tests.csproj` — succeeds, 0 warnings/errors.
- No automated tests added per request.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WvKDxanSgorKfVivvnJ6xg)_