### PR TITLE
ContextCard: right-click menus, and non-selectable text

### DIFF
--- a/Tesserae.Tests/src/Samples/Components/ContextCardSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/ContextCardSample.cs
@@ -81,6 +81,7 @@ namespace Tesserae.Tests.Samples
                 .FlatSection(VStack().WS().Children(Compact()))
                 .FlatSection(VStack().WS().Children(Badges()))
                 .FlatSection(VStack().WS().Children(Clickable()))
+                .FlatSection(VStack().WS().Children(RightClick()))
                 .FlatSection(VStack().WS().Children(Grouped()))
                 .FlatSection(VStack().WS().Children(CompactRow()))
                 .FlatSection(VStack().WS().Children(LongNames()))
@@ -197,6 +198,50 @@ namespace Tesserae.Tests.Samples
                         .OnClick((c, _) => Toast().Information($"Opening {c.Label}"))
                         .OnRemove(c => Toast().Information($"Removing {c.Label}"))));
         }
+
+        // ---------- Right-click ----------
+
+        private IComponent RightClick()
+        {
+            return FeatureCard("Right-click", "A menu of actions on the card",
+                "OnContextMenu(() => items) attaches a ContextMenu that opens at the pointer, in place of the browser's own. The generator runs on every right-click, so the items can describe the card as it stands — the one below offers to show or hide its own ✕. A card carrying a menu also takes a tab stop, and answers the keyboard menu key (or Shift+F10) with the same menu anchored to itself. The Action and Action<ContextCard> overloads hand the right-click to a plain handler instead, and the (card, event) overload leaves the browser menu alone so a handler can decide for itself. Text on a card is not selectable, so a right-click never leaves half a file name highlighted; Selectable() opts back in for a label worth copying.",
+                HStack().Wrap().Gap(8.px()).Children(
+                    WithMenu(ContextCard("Q3 revenue model", UIcons.Table)
+                        .SetSubLabel("finance/q3-model.xlsx · 4 sheets")
+                        .MonospaceSubLabel()
+                        .IconTint("#16a34a")
+                        .W(340.px())
+                        .OnRemove(c => Toast().Information($"Detached {c.Label}"))),
+                    WithMenu(ContextCard("architecture.md", UIcons.FileCode).IconTint("#6366f1").Compact())),
+                HStack().Wrap().Gap(8.px()).PT(8).Children(
+                    ContextCard("tesserae.dev/components", UIcons.Globe)
+                        .SetSubLabel("Web page")
+                        .IconTint("#0ea5e9")
+                        .Compact()
+                        .OnContextMenu(c => Toast().Information($"Right-clicked {c.Label}")),
+                    ContextCard("release-notes.txt", UIcons.File)
+                        .SetSubLabel("Selectable(): the label can be copied")
+                        .Compact()
+                        .Selectable()));
+        }
+
+        // The menu is generated on every open, so it can describe the card as it stands right now.
+        private static ContextCard WithMenu(ContextCard card)
+        {
+            return card.OnContextMenu(() => new[]
+            {
+                ContextMenuItem(card.Label).Header(),
+                ContextMenuItem(MenuLine(UIcons.FolderOpen, "Open")).OnClick(() => Toast().Information($"Opening {card.Label}")),
+                ContextMenuItem(MenuLine(UIcons.Copy, "Copy name")).OnClick(() => Toast().Success($"Copied \"{card.Label}\"")),
+                ContextMenuItem().Divider(),
+                ContextMenuItem(MenuLine(card.IsRemovable ? UIcons.EyeCrossed : UIcons.Eye, card.IsRemovable ? "Hide the ✕" : "Show the ✕"))
+                    .OnClick(() => card.Removable(!card.IsRemovable)),
+                ContextMenuItem(MenuLine(UIcons.Trash, "Detach", Theme.Danger.Background)).OnClick(() => Toast().Error($"Detached {card.Label}"))
+            });
+        }
+
+        private static IComponent MenuLine(UIcons icon, string text, string color = null)
+            => HStack().Children(Icon(icon, color: color), TextBlock(text).ML(8));
 
         // ---------- Grouped ----------
 

--- a/Tesserae/skills/references/context-card.md
+++ b/Tesserae/skills/references/context-card.md
@@ -1,6 +1,6 @@
 ---
 name: context-card
-description: A compact card naming one piece of context attached to a conversation (a file, a page, a dataset) with a colored icon or image tile, a label, an optional second line, and a hover-revealed remove button. Use for the attachment row above a chat composer in a Tesserae (C#/Transpose) app.
+description: A compact card naming one piece of context attached to a conversation (a file, a page, a dataset) with a colored icon or image tile, a label, an optional second line, a hover-revealed remove button and an optional right-click menu. Use for the attachment row above a chat composer in a Tesserae (C#/Transpose) app.
 ---
 
 # ContextCard
@@ -15,6 +15,10 @@ while the card is hovered or focused — and stays visible on touch screens, whe
 button is absolutely positioned and overhangs the card by a few pixels, so revealing it never shifts
 the layout; if the row lives in a container that clips (`overflow: hidden`), give the row a few
 pixels of padding so the disc isn't cut off.
+
+Right-clicking a card opens the `ContextMenu` given to `OnContextMenu`, at the pointer. The text on a
+card is not selectable, so a right-click (or a drag across a row of cards) never leaves half a file
+name highlighted — `Selectable()` opts back in.
 
 ## Create
 
@@ -60,6 +64,18 @@ Bring factories into scope with `using static Tesserae.UI;`.
   For a composer carrying many pieces of context at once, or one file named inline.
 - `.OnClick(...)` — makes the whole card open the context it stands for, and makes it keyboard
   reachable (Enter or Space). Clicking the remove button never reads as a click on the card.
+- `.OnContextMenu(Func<ContextMenu.Item[]>)` — attaches a `ContextMenu` opened by right-clicking the
+  card, at the pointer, in place of the browser's own. The generator runs on every open, so the items
+  can describe the card as it stands. The card also takes a tab stop and answers the keyboard menu key
+  (or Shift+F10) with the same menu, anchored to the card. Returning `null` or an empty array opens
+  nothing.
+- `.OnContextMenu(Action<ContextCard>)` / `.OnContextMenu(Action)` — hand the right-click to a plain
+  handler instead, suppressing the browser menu. The inherited `(card, event)` overload leaves the
+  browser menu alone, for a handler that would rather decide for itself (call `StopEvent(e)` in it).
+- `.ShowMenu()` — open the attached menu anchored to the card, the way the keyboard menu key does.
+- `.Selectable(bool = true)` — let the text on the card be selected. It cannot be by default: a card
+  is a token standing for one piece of context, not prose, so dragging across a row of them or
+  right-clicking one never leaves half a file name highlighted.
 - `Label`, `SubLabel`, `IsRemovable` — read state.
 
 Sizing helpers work as usual: `.MaxWidth(260.px())` is the normal way to cap a card whose label may
@@ -83,6 +99,18 @@ void Attach(string name, string kind, UIcons icon, string color)
 
 Attach("Kindersonnenschutzmittel-NEU.pdf", "PDF",     UIcons.FilePdf,   "#ef4444");
 Attach("customers",                        "Dataset", UIcons.Database,  "#f59e0b");
+
+// Right-click a card for the actions on the context it stands for. The items are generated per open,
+// so they can reflect the card's current state.
+var doc = ContextCard("Q3-forecast.xlsx", UIcons.FileExcel).SetSubLabel("Spreadsheet").IconTint("#16a34a");
+
+doc.OnContextMenu(() => new[]
+{
+    ContextMenuItem(doc.Label).Header(),
+    ContextMenuItem("Open").OnClick(() => Open(doc.Tag)),
+    ContextMenuItem().Divider(),
+    ContextMenuItem("Detach").OnClick(() => attached.Remove(doc))
+});
 
 // A thumbnail instead of a glyph, and a compact card for a crowded composer.
 var shot = ContextCard("screenshot.png", UIcons.FileImage).SetSubLabel("Image").SetImage(url);
@@ -108,6 +136,7 @@ list of rows, or a compact row of pills with a "+N more". See `context-cards.md`
 ## Related
 
 - ContextCards — the group — `context-cards.md`
+- ContextMenu — the menu `OnContextMenu` opens, and its items — `context-menu.md`
 - Chat (ChatArea / ChatMessage) — `chat.md`
 - OmniBox — hosts a row of these below its chat input via `WithContextToAdd` — `omni-box.md`
 - ResourceCard (the larger, full resource summary) — `resource-card.md`

--- a/Tesserae/skills/references/context-menu.md
+++ b/Tesserae/skills/references/context-menu.md
@@ -47,4 +47,5 @@ btn = Button("Open menu").OnClick((s, e) => menu.ShowFor(btn));
 
 - Dialog — `dialog.md`
 - Panel — `panel.md`
+- ContextCard — attaches one of these to a card's right-click via `OnContextMenu` — `context-card.md`
 - Full docs & API: `/tesserae/surfaces/context-menu`

--- a/Tesserae/src/Components/ContextCard.cs
+++ b/Tesserae/src/Components/ContextCard.cs
@@ -18,7 +18,9 @@ namespace Tesserae
     /// </para>
     /// <para>
     /// <see cref="Compact(bool)"/> turns it into a one-line pill, and <see cref="ContextCards"/> groups
-    /// several of them behind one expandable summary.
+    /// several of them behind one expandable summary. Right-clicking a card is handled by
+    /// <see cref="OnContextMenu(Func{ContextMenu.Item[]})"/>, which opens a <see cref="ContextMenu"/> of
+    /// actions at the pointer.
     /// </para>
     /// </summary>
     [Transpose.Name("tss.ContextCard")]
@@ -41,6 +43,9 @@ namespace Tesserae
         private          string            _subLabel;
         private          bool              _keepExtensionVisible = true;
         private          bool              _waitingForMount;
+        private          bool              _menuKeyHooked;
+
+        private Func<ContextMenu.Item[]> _menuGenerator;
 
         private event Action<ContextCard> RemoveRequested;
 
@@ -421,6 +426,119 @@ namespace Tesserae
             }
 
             return base.OnClick(onClick, clearPrevious);
+        }
+
+        /// <summary>
+        /// Registers a callback invoked when the user right-clicks the card, suppressing the browser's own
+        /// menu. The card is handed to the callback, so a shared handler can read its
+        /// <see cref="Label"/> or <see cref="Tag"/> without a closure per card.
+        /// <para>
+        /// The (card, event) overload inherited from the base class leaves the browser menu alone, for a
+        /// handler that would rather decide for itself - call <c>StopEvent(e)</c> from it to suppress it.
+        /// </para>
+        /// </summary>
+        public ContextCard OnContextMenu(Action<ContextCard> onContextMenu) => OnContextMenu((c, e) =>
+        {
+            StopEvent(e);
+            onContextMenu?.Invoke(c);
+        });
+
+        /// <summary>
+        /// Registers a callback invoked when the user right-clicks the card, suppressing the browser's own
+        /// menu.
+        /// </summary>
+        public ContextCard OnContextMenu(Action onContextMenu) => OnContextMenu(_ => onContextMenu?.Invoke());
+
+        /// <summary>
+        /// Attaches a <see cref="ContextMenu"/> of actions to the card: the generator runs on every
+        /// right-click, and the items it returns are shown at the pointer - so a menu can reflect the state
+        /// the card is in when it is opened. The card is also given a tab stop and answers the keyboard menu
+        /// key (and Shift+F10) with the same menu, anchored to the card itself.
+        /// <para>
+        /// Returning null or an empty array opens nothing, which is how a card opts out of the menu without
+        /// the browser's showing up in its place.
+        /// </para>
+        /// </summary>
+        public ContextCard OnContextMenu(Func<ContextMenu.Item[]> menu)
+        {
+            _menuGenerator = menu;
+
+            EnsureMenuKeyboardShortcut();
+
+            return OnContextMenu((_, e) =>
+            {
+                StopEvent(e);
+                ShowMenuAt((int)e.clientX, (int)e.clientY);
+            });
+        }
+
+        /// <summary>
+        /// Opens the menu registered with <see cref="OnContextMenu(Func{ContextMenu.Item[]})"/> anchored to
+        /// the card, the way the keyboard menu key does. Does nothing when the card has no menu.
+        /// </summary>
+        public ContextCard ShowMenu()
+        {
+            var menu = BuildMenu();
+
+            if (menu != null) menu.ShowFor(this);
+
+            return this;
+        }
+
+        /// <summary>
+        /// Configures whether the text on the card can be selected. It cannot by default: a card is a token
+        /// standing for one piece of context, not prose, and dragging or right-clicking one should not leave
+        /// half its label highlighted.
+        /// </summary>
+        public ContextCard Selectable(bool value = true)
+        {
+            InnerElement.style.userSelect = value ? "text" : "none";
+            return this;
+        }
+
+        private void ShowMenuAt(int x, int y)
+        {
+            var menu = BuildMenu();
+
+            if (menu != null) menu.ShowAt(x, y, 0);
+        }
+
+        // Built fresh on every open, so the items can describe the state the card is in right now. The card
+        // is marked while the menu is up, as the pointer has left it by then and the hover styling is gone.
+        private ContextMenu BuildMenu()
+        {
+            if (_menuGenerator == null) return null;
+
+            var items = _menuGenerator();
+
+            if (items == null || items.Length == 0) return null;
+
+            InnerElement.classList.add("tss-contextcard-menu-open");
+
+            // Qualified, as the base class has a `ContextMenu` event of its own that the bare name would find.
+            return UI.ContextMenu().Items(items).OnHide(() => InnerElement.classList.remove("tss-contextcard-menu-open"));
+        }
+
+        // A right-click has no keyboard equivalent unless the card can be focused, so a card carrying a menu
+        // takes the same tab stop a clickable one does.
+        private void EnsureMenuKeyboardShortcut()
+        {
+            if (_menuKeyHooked) return;
+
+            _menuKeyHooked = true;
+
+            if (!InnerElement.hasAttribute("tabindex")) InnerElement.setAttribute("tabindex", "0");
+
+            InnerElement.addEventListener("keydown", e =>
+            {
+                var ev = e.As<KeyboardEvent>();
+
+                if (ev.key == "ContextMenu" || (ev.shiftKey && ev.key == "F10"))
+                {
+                    StopEvent(ev);
+                    ShowMenu();
+                }
+            });
         }
 
         private void EnsureRemoveButton()

--- a/Tesserae/tps/assets/css/tss.contextcard.css
+++ b/Tesserae/tps/assets/css/tss.contextcard.css
@@ -14,6 +14,17 @@
     color: var(--tss-default-foreground-color);
     /* Cards usually sit in a wrapping row above a composer, so they never grow to fill it. */
     flex: 0 0 auto;
+    /* A card is a token standing for one piece of context, not prose: dragging across a row of them, or
+       right-clicking one for its menu, should not leave half a file name highlighted. Selectable() opts
+       back in for a card whose label is worth copying. */
+    -webkit-user-select: none;
+    user-select: none;
+}
+
+/* The pointer has left the card by the time its context menu is up, so the hover styling is gone with
+   it - this keeps the card marked as the one the menu belongs to. */
+.tss-contextcard-menu-open {
+    background: var(--tss-default-background-hover-color);
 }
 
 .tss-contextcard-clickable {


### PR DESCRIPTION
Right-clicking a card now goes somewhere. OnContextMenu takes a
Func<ContextMenu.Item[]> and opens that menu at the pointer in place of the
browser's own, regenerating the items on every open so they can describe the
card as it stands; a card carrying a menu also takes a tab stop and answers the
keyboard menu key (or Shift+F10) with the same menu anchored to itself, and
ShowMenu() opens it programmatically. Action and Action<ContextCard> overloads
hand the right-click to a plain handler instead (suppressing the browser menu),
while the inherited (card, event) overload keeps its own semantics and leaves
the browser menu to the handler.

The card is marked with tss-contextcard-menu-open while its menu is up, as the
pointer has left it by then and the hover styling is gone with it.

Text on a card is no longer selectable: a card is a token standing for one piece
of context, not prose, so a right-click or a drag across a row should not leave
half a file name highlighted. Selectable() opts back in for a label worth
copying.

Adds a "Right-click" section to the sample and updates the skill reference.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GCvmzMVThmnBVuP6idLMEQ