### PR TITLE
Add inline mode to ToolsUsed for in-place tool expansion

### DIFF
--- a/Tesserae.Tests/src/Samples/Components/ToolCallSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/ToolCallSample.cs
@@ -19,15 +19,23 @@ namespace Tesserae.Tests.Samples
         private readonly ToolCall                     _runningCall;
         private readonly LiveProgress                 _standaloneProgress;
         private readonly DeltaComponent               _diffedBubble;
+        private readonly ToolsUsed                    _inlineTools;
         private readonly SettableObservable<string>   _streamedProgress = new SettableObservable<string>(string.Empty);
         private          double                       _timer;
         private          bool                         _diffedCallOpen;
+        private          int                          _addedTools;
 
         public ToolCallSample()
         {
             _runningCall        = ToolCall(UIcons.Search, "Search documentation \"tesserae popover\"", () => TextBlock("3 pages matched.").BreakSpaces());
             _standaloneProgress = LiveProgress().Stream(_streamedProgress);
             _diffedBubble       = DeltaComponent(BuildDiffedBubbleContent()).Animated();
+
+            _inlineTools = ToolsUsed(
+                    ToolCall(UIcons.Search, "Grep \"Inline\" Tesserae/src/", () => TextBlock("Tesserae/src/Components/ToolCall.cs:  public ToolsUsed Inline(bool value = true)").BreakSpaces()),
+                    ToolCall(UIcons.Terminal, "Bash git log --oneline -3", () => TextBlock("a1b2c3d Add inline mode to ToolsUsed\n4e5f6a7 Add ToolCallInspect\n8b9c0d1 Add ToolCall").BreakSpaces()))
+               .Inline()
+               .Expanded();
 
             _runningCall.SetProgress(_streamedProgress);
 
@@ -36,7 +44,7 @@ namespace Tesserae.Tests.Samples
                 .FlatSection(Stack().Children(
                     Card(VStack().WS().Children(
                         TextBlock("ToolCall renders a single tool invocation inline. It behaves like an accordion: a compact header with an icon and label, expanding to reveal arbitrary content the first time it is clicked (the content component is created lazily). A ToolCall without content automatically renders as a plain, non-expandable chip — no chevron is shown until content is set."),
-                        TextBlock("ToolsUsed groups many ToolCalls behind a compact summary. Clicking it opens a popup with the list of tools on the left; selecting one slides to the detail view on the right, with a back button to return to the list."),
+                        TextBlock("ToolsUsed groups many ToolCalls behind a compact summary. Clicking it opens a popup with the list of tools on the left; selecting one slides to the detail view on the right, with a back button to return to the list. Inline() keeps it all in place instead: the summary expands into the calls underneath itself, each one opening its own content inline."),
                         TextBlock("ToolCallInspect is the ready-made body for a call: the arguments it was called with, one row per property, above the response it returned in a read-only code block. Each section scrolls on its own, and inside a ToolsUsed detail pane the arguments take at most half the height so a long response never scrolls them away.")
                     )).SetTitle("Overview")))
                 .FlatSection(Stack().Children(
@@ -74,6 +82,19 @@ namespace Tesserae.Tests.Samples
                             ToolCall(UIcons.Eye, "Read /home/user/needle/src/Needle/Tokenizer/Nee...", () => TextBlock("namespace Needle.Tokenizer;\n\npublic class NeedleTokenizer { ... }").BreakSpaces())
                         ).SetSummary("Ran 14 commands, read 9 files, used a tool").SetTitle("Tools used"),
 
+                        SampleSubTitle("Inline instead of a popup"),
+                        TextBlock("Inline() keeps the group where it is: the summary becomes an accordion that expands into the list of calls underneath itself, each one opening its own content inline the way a standalone ToolCall does. For a transcript where sending the reader to a modal for a one-line result is too much ceremony."),
+                        ToolsUsed(
+                            ToolCall(UIcons.Terminal, "Bash dotnet build", () => TextBlock("Build succeeded.\n    0 Warning(s)\n    0 Error(s)").BreakSpaces()),
+                            ToolCall(UIcons.Eye, "Read /home/user/needle/README.md", () => TextBlock("# Needle\n\nA tiny ML library written in C#.").BreakSpaces()),
+                            ToolCall(UIcons.FilePdf, "Consult 'SETR2025_web-240128.pdf'", () => ToolCallInspect(CONSULT_ARGUMENTS, CONSULT_RESPONSE)),
+                            ToolCall(UIcons.ListCheck, "Update todos") // still a plain, non-expandable row inside the list
+                        ).SetSummary("Used 4 tools").Inline(),
+
+                        TextBlock("Expanded() opens the list from the start, and a call arriving while it is open joins the list on screen - the way a live transcript appends to it as the calls come in."),
+                        _inlineTools,
+                        Button("Add a tool").OnClick(() => AddInlineTool()),
+
                         SampleSubTitle("Live progress while a call runs"),
                         TextBlock("A ToolCall can carry a LiveProgress line on its header row: SetProgress writes into the line already on screen, so a stream of updates never re-renders the call and never replays an animation. Hovering the line shows its full text; expanding the call still opens the content full width underneath."),
                         _runningCall,
@@ -106,6 +127,19 @@ namespace Tesserae.Tests.Samples
             if (_diffedCallOpen) call.Expanded();
 
             return VStack().NoDefaultMargin().Children(call);
+        }
+
+        // A call appended to a group that is already open inline lands in the list on screen, without the
+        // group being rebuilt around it.
+        private void AddInlineTool()
+        {
+            _addedTools++;
+
+            _inlineTools
+               .Add(ToolCall(UIcons.Globe, $"Fetch https://api.example.com/v1/items?page={_addedTools}",
+                             () => ToolCallInspect($@"{{ ""page"": {_addedTools}, ""timeoutMs"": 30000 }}", @"{ ""items"": [], ""hasMore"": false }")))
+               .SetSummary($"Used {2 + _addedTools} tools")
+               .Expand();
         }
 
         // Walks the demo through a few stages and then ends it with an empty progress. The lines on

--- a/Tesserae/skills/references/tool-call.md
+++ b/Tesserae/skills/references/tool-call.md
@@ -1,11 +1,11 @@
 ---
 name: tool-call
-description: An inline, accordion-style indicator of an AI tool invocation, a ToolsUsed summary that opens a list-and-detail modal, and ToolCallInspect for showing a call's arguments and response. Use when surfacing tool calls in a chat/assistant UI in a Tesserae (C#/Transpose) app.
+description: An inline, accordion-style indicator of an AI tool invocation, a ToolsUsed summary that opens a list-and-detail modal or expands its tools inline, and ToolCallInspect for showing a call's arguments and response. Use when surfacing tool calls in a chat/assistant UI in a Tesserae (C#/Transpose) app.
 ---
 
 # ToolCall / ToolsUsed / ToolCallInspect
 
-`ToolCall` is an inline tool-call row (icon + label + chevron) that expands to show its content; the content is built lazily the first time it expands. `ToolsUsed` is a compact "Used N tools" summary that opens a modal listing the tools, with a back/detail slide. `ToolCallInspect` is the ready-made body for a call — its arguments above its response — for use as either one's content.
+`ToolCall` is an inline tool-call row (icon + label + chevron) that expands to show its content; the content is built lazily the first time it expands. `ToolsUsed` is a compact "Used N tools" summary that opens a modal listing the tools, with a back/detail slide — or, with `.Inline()`, expands into the calls right where it stands. `ToolCallInspect` is the ready-made body for a call — its arguments above its response — for use as either one's content.
 
 Both carry an 8px bottom margin, so when you stack a pill above the answer text in a chat message you don't need to add your own top padding on the text.
 
@@ -45,7 +45,31 @@ the line on screen keeps the last text it was given.
 - `.SetSummary(label)` / `.SetTitle(title)` / `.SetIcon(icon)` — customise.
 - `.SetProgress(string)` / `.SetProgress(IObservable<string>)` / `.ClearProgress()` / `Progress` —
   same live progress line, on the summary pill.
-- `.Show()` / `.Hide()` — open/close the modal.
+- `.Inline()` — render the tools in place instead of in the modal (see below).
+- `.Show()` / `.Hide()` — open/close (the modal, or the inline list when `.Inline()` is set).
+- `.Expand()` / `.Collapse()` / `.Toggle()` / `.Expanded(bool)` / `.OnToggle(tu => ...)` —
+  the inline list's state; without `.Inline()` expanding opens the modal instead.
+- `IsInline`, `IsExpanded` — read state.
+
+### Inline instead of a modal
+
+`.Inline()` turns the summary into an accordion: it expands underneath itself into the list of
+`ToolCall`s, each one opening its own content inline the way a standalone call does — the calls
+themselves are what the list holds, so a reference you kept still drives the row on screen. Use it in a
+transcript where sending the reader to a modal for a one-line result is too much ceremony, and keep the
+modal for groups whose bodies need the room. A call added while the list is open joins it in place, so
+a live transcript can append as the calls come in.
+
+```csharp
+var tools = ToolsUsed(
+    ToolCall(UIcons.Terminal, "Bash dotnet build",
+        () => TextBlock("Build succeeded.").BreakSpaces()),
+    ToolCall(UIcons.Eye, "Read README.md",
+        () => TextBlock("# Needle").BreakSpaces())
+).Inline().Expanded();
+
+tools.Add(ToolCall(UIcons.Globe, "Fetch /v1/items", () => ToolCallInspect("{}", "{}")));
+```
 
 `ToolCallInspect`:
 

--- a/Tesserae/src/Components/ToolCall.cs
+++ b/Tesserae/src/Components/ToolCall.cs
@@ -288,18 +288,27 @@ namespace Tesserae
     /// list of tools on the left. Clicking a tool slides the list to the left
     /// and shows that tool's content on the right with a back button to
     /// return to the list.
+    /// <para>
+    /// <see cref="Inline()"/> swaps the popup for an in-place disclosure: the summary expands
+    /// underneath itself into the list of <see cref="ToolCall"/>s, each one opening its own content
+    /// inline the way a standalone call does.
+    /// </para>
     /// </summary>
     [Transpose.Name("tss.ToolsUsed")]
     public sealed class ToolsUsed : ComponentBase<ToolsUsed, HTMLElement>
     {
+        private readonly HTMLElement      _header;
         private readonly HTMLElement      _summaryIcon;
         private readonly HTMLElement      _summaryText;
         private readonly HTMLElement      _summaryChevron;
+        private readonly HTMLElement      _inlineList;
         private readonly List<ToolCall>   _tools;
         private          LiveProgress     _progress;
         private          string           _summaryLabel;
         private          UIcons           _summaryIconKind = UIcons.Tools;
         private          string           _modalTitle      = "Tools used";
+        private          bool             _inline;
+        private          bool             _isExpanded;
         private          Modal            _modal;
         private          HTMLElement      _slider;
         private          HTMLElement      _listPanel;
@@ -309,6 +318,8 @@ namespace Tesserae
         private          HTMLElement      _detailIconHolder;
         private          HTMLElement      _backButton;
         private          HTMLElement      _titleEl;
+
+        private event Action<ToolsUsed> Toggled;
 
         /// <summary>
         /// Initializes a new instance of this class.
@@ -321,15 +332,37 @@ namespace Tesserae
             _summaryText    = Div(Att("tss-toolsused-text"));
             _summaryChevron = I(UIcons.AngleRight, cssClass: "tss-toolsused-chevron");
 
-            InnerElement = Div(Att("tss-toolsused", role: "button", ariaLabel: "Show tools used"),
-                               _summaryIcon, _summaryText, _summaryChevron);
+            _header = Div(Att("tss-toolsused-header", role: "button", ariaLabel: "Show tools used"),
+                          _summaryIcon, _summaryText, _summaryChevron);
+
+            // Only ever filled in inline mode, but the element is always there so the list has a place to
+            // land whenever Inline() is called - before or after the summary is on screen.
+            _inlineList = Div(Att("tss-toolsused-inline-list"));
+            _inlineList.style.display = "none";
+
+            InnerElement = Div(Att("tss-toolsused"), _header, _inlineList);
 
             // Open on a tap gesture rather than a raw "click": in a live-streaming chat the surrounding
             // content re-renders and auto-scrolls under the pointer, which moves this element between
             // mousedown and mouseup so the browser never fires a "click" and the summary looked dead.
             // OnTapped captures the pointer and keys off the (stationary) pointer position, so a press-
             // release still opens the popup while the page scrolls, and a scroll-drag off the pill does not.
-            this.OnTapped(() => Show());
+            // The gesture is on the header rather than the root, so tapping an expanded inline list does
+            // not fold it back up.
+            Raw(_header).OnTapped(() => Toggle());
+
+            _header.tabIndex = 0;
+
+            _header.addEventListener("keydown", ev =>
+            {
+                var ke = ev.As<KeyboardEvent>();
+
+                if (ke.key == "Enter" || ke.key == " ")
+                {
+                    StopEvent(ev);
+                    Toggle();
+                }
+            });
 
             if (tools != null)
             {
@@ -350,6 +383,9 @@ namespace Tesserae
             if (tool == null) return this;
             _tools.Add(tool);
             UpdateSummary();
+            // A call arriving while the group is open inline joins the list on screen, the way a live
+            // transcript appends to it as the calls come in.
+            if (_inline && _isExpanded) RebuildInlineList();
             return this;
         }
 
@@ -386,6 +422,7 @@ namespace Tesserae
         {
             _tools.Clear();
             UpdateSummary();
+            ClearChildren(_inlineList);
             return this;
         }
 
@@ -420,6 +457,94 @@ namespace Tesserae
             {
                 _titleEl.innerText = _modalTitle;
             }
+            return this;
+        }
+
+        /// <summary>
+        /// Renders the tools in place instead of in a popup: the summary becomes an accordion that
+        /// expands into the list of <see cref="ToolCall"/>s underneath itself, each one opening its own
+        /// content inline the way a standalone call does. For a transcript where sending the reader to a
+        /// modal for a one-line result is too much ceremony.
+        /// </summary>
+        public ToolsUsed Inline(bool value = true)
+        {
+            _inline = value;
+            InnerElement.UpdateClassIf(value, "tss-toolsused-inline");
+
+            // Sideways for "this opens somewhere else", down-and-rotating for a disclosure that happens
+            // right here.
+            _summaryChevron.className = $"{Tesserae.Icon.Transform(value ? UIcons.AngleDown : UIcons.AngleRight, UIconsWeight.Regular)} tss-toolsused-chevron";
+            _header.setAttribute("aria-label", value ? "Toggle tools used" : "Show tools used");
+
+            if (!value)
+            {
+                _isExpanded = false;
+                ClearChildren(_inlineList);
+            }
+
+            UpdateExpandedState();
+
+            return this;
+        }
+
+        /// <summary>
+        /// Returns a value indicating whether the group renders its tools in place rather than in a popup.
+        /// </summary>
+        public bool IsInline   => _inline;
+
+        /// <summary>
+        /// Returns a value indicating whether the inline list is open. Always false while the group opens
+        /// its tools in the popup instead.
+        /// </summary>
+        public bool IsExpanded => _isExpanded;
+
+        /// <summary>
+        /// Expands or collapses the group.
+        /// </summary>
+        public ToolsUsed Expanded(bool value = true) => value ? Expand() : Collapse();
+
+        /// <summary>
+        /// Opens the group: the inline list when <see cref="Inline()"/> is set, the popup otherwise.
+        /// </summary>
+        public ToolsUsed Expand()
+        {
+            if (!_inline) return ShowModal();
+            if (_isExpanded) return this;
+
+            _isExpanded = true;
+            RebuildInlineList();
+            UpdateExpandedState();
+            Toggled?.Invoke(this);
+
+            return this;
+        }
+
+        /// <summary>
+        /// Closes the group: the inline list when <see cref="Inline()"/> is set, the popup otherwise.
+        /// </summary>
+        public ToolsUsed Collapse()
+        {
+            if (!_inline) return HideModal();
+            if (!_isExpanded) return this;
+
+            _isExpanded = false;
+            UpdateExpandedState();
+            Toggled?.Invoke(this);
+
+            return this;
+        }
+
+        /// <summary>
+        /// Toggles the group between open and closed.
+        /// </summary>
+        public ToolsUsed Toggle() => _isExpanded ? Collapse() : Expand();
+
+        /// <summary>
+        /// Registers a callback invoked whenever the inline list is expanded or collapsed.
+        /// </summary>
+        public ToolsUsed OnToggle(Action<ToolsUsed> onToggle)
+        {
+            Toggled += onToggle;
             return this;
         }
 
@@ -462,16 +587,29 @@ namespace Tesserae
             if (_progress is null)
             {
                 _progress = new LiveProgress().Class("tss-toolsused-progress");
-                InnerElement.insertBefore(_progress.Render(), _summaryChevron);
+                _header.insertBefore(_progress.Render(), _summaryChevron);
             }
 
             return _progress;
         }
 
         /// <summary>
-        /// Shows the component.
+        /// Shows the component: the popup, or the inline list when <see cref="Inline()"/> is set.
         /// </summary>
         public ToolsUsed Show()
+        {
+            return _inline ? Expand() : ShowModal();
+        }
+
+        /// <summary>
+        /// Hides the component: the popup, or the inline list when <see cref="Inline()"/> is set.
+        /// </summary>
+        public ToolsUsed Hide()
+        {
+            return _inline ? Collapse() : HideModal();
+        }
+
+        private ToolsUsed ShowModal()
         {
             BuildModalIfNeeded();
             RebuildList();
@@ -480,13 +618,29 @@ namespace Tesserae
             return this;
         }
 
-        /// <summary>
-        /// Hides the component.
-        /// </summary>
-        public ToolsUsed Hide()
+        private ToolsUsed HideModal()
         {
             _modal?.Hide();
             return this;
+        }
+
+        // The inline list holds the calls themselves, so each one carries its own accordion and builds its
+        // content lazily on first open - the same element the caller holds a reference to.
+        private void RebuildInlineList()
+        {
+            ClearChildren(_inlineList);
+
+            foreach (var tool in _tools)
+            {
+                _inlineList.appendChild(tool.Render());
+            }
+        }
+
+        private void UpdateExpandedState()
+        {
+            InnerElement.UpdateClassIf(_isExpanded, "tss-expanded");
+            _header.setAttribute("aria-expanded", _isExpanded ? "true" : "false");
+            _inlineList.style.display = _isExpanded ? "" : "none";
         }
 
         private void UpdateSummary()

--- a/Tesserae/tps/assets/css/tss.toolcall.css
+++ b/Tesserae/tps/assets/css/tss.toolcall.css
@@ -80,12 +80,24 @@
     background: var(--tss-default-background-color);
 }
 
-/* ToolsUsed — clickable summary that opens a list/detail modal */
+/* ToolsUsed — clickable summary that opens a list/detail modal, or expands in place when inline */
 
+/* The root only stacks the summary above the inline list; the pill lives on the header row, so it looks
+   the same whether or not there is a list underneath it. */
 .tss-toolsused {
+    display: inline-flex;
+    flex-direction: column;
+    align-items: flex-start;
+    max-width: 100%;
+    min-width: 0;
+    margin-bottom: 8px;
+}
+
+.tss-toolsused-header {
     display: inline-flex;
     align-items: center;
     gap: 10px;
+    max-width: 100%;
     padding: 6px 12px;
     border-radius: 999px;
     border: 1px solid var(--tss-default-border-color);
@@ -94,11 +106,15 @@
     user-select: none;
     color: var(--tss-colors-neutral-800, #1f2937);
     font-size: 13px;
-    margin-bottom: 8px;
 }
 
-.tss-toolsused:hover {
+.tss-toolsused-header:hover {
     background: var(--tss-default-background-hover-color);
+}
+
+.tss-toolsused-header:focus-visible {
+    outline: 2px solid var(--tss-primary-background-color);
+    outline-offset: 1px;
 }
 
 .tss-toolsused-icon {
@@ -127,6 +143,56 @@
 .tss-toolsused-chevron {
     color: var(--tss-colors-neutral-500, #6b7280);
     font-size: 12px;
+    flex-shrink: 0;
+}
+
+/* ToolsUsed inline mode — the tools expand under the summary instead of in a modal */
+
+.tss-toolsused-inline {
+    display: flex;
+    width: 100%;
+}
+
+.tss-toolsused-inline .tss-toolsused-chevron {
+    transition: transform 200ms ease;
+}
+
+.tss-toolsused-inline.tss-expanded .tss-toolsused-chevron {
+    transform: rotate(180deg);
+}
+
+/* Expanded, the calls are rows of one bordered list rather than separate chips - the same shape the
+   ContextCards list uses, so a transcript reads as one family of disclosures. */
+.tss-toolsused-inline-list {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    min-width: 0;
+    margin-top: 8px;
+    border: 1px solid var(--tss-default-border-color);
+    border-radius: var(--tss-border-radius-lg, 8px);
+    background: var(--tss-default-background-color);
+    overflow: hidden;
+}
+
+.tss-toolsused-inline-list > .tss-toolcall {
+    display: flex;
+    width: 100%;
+    margin-bottom: 0;
+    border: none;
+    border-radius: 0;
+}
+
+.tss-toolsused-inline-list > .tss-toolcall + .tss-toolcall {
+    border-top: 1px solid var(--tss-default-border-color);
+}
+
+.tss-toolsused-inline-list > .tss-toolcall > .tss-toolcall-header {
+    padding: 8px 12px;
+}
+
+.tss-toolsused-inline-list > .tss-toolcall > .tss-toolcall-content {
+    padding: 8px 12px 10px 12px;
 }
 
 /* ToolsUsed modal layout */


### PR DESCRIPTION
## Summary

Adds an inline disclosure mode to `ToolsUsed` that expands the tool list in place beneath the summary, rather than opening a modal. Each tool in the inline list behaves like a standalone `ToolCall`, opening its content inline. This is useful in transcripts where a modal is too much ceremony for single-line results.

## Key Changes

- **New `Inline()` method** — switches `ToolsUsed` from modal to accordion mode; the summary expands/collapses the list underneath itself
- **Expansion state management** — added `Expand()`, `Collapse()`, `Toggle()`, `Expanded(bool)`, and `OnToggle()` methods to control the inline list; `Show()`/`Hide()` now delegate to these when inline
- **Live list updates** — calls added via `Add()` while the inline list is open join the list on screen, enabling live transcripts to append as calls arrive
- **Keyboard and tap support** — the summary header now responds to Enter/Space keys and tap gestures; tapping an expanded inline list does not fold it back up
- **Accessibility** — added `aria-expanded` and `aria-label` attributes; the header is now focusable with `tabIndex`
- **CSS for inline layout** — the inline list renders as a bordered column of calls (like a `ContextCards` list), with the chevron rotating to indicate state; calls lose their individual margins and borders inside the list
- **Sample and documentation** — updated `ToolCallSample` with examples of inline mode, including a live-append demo; updated `tool-call.md` reference with signatures and usage patterns

## Implementation Details

- The root element now wraps both a header (the pill) and an inline list container; the list is hidden by default and shown when expanded
- `RebuildInlineList()` re-renders the tool list on demand, and `UpdateExpandedState()` syncs the DOM and ARIA attributes with the internal state
- The progress line is now inserted into the header rather than the root, so it stays on the pill whether or not the list is expanded
- `Show()`/`Hide()` are now public facades that dispatch to either modal or inline methods based on `_inline`; the modal logic moved to private `ShowModal()`/`HideModal()`

https://claude.ai/code/session_01Bk11ZTibkuvCFBVxwgBHpS