### PR TITLE
Use generic Enum.GetValues<T>() instead of cast

### DIFF
--- a/Tesserae.Tests/src/Samples/Utilities/EmojiSample.cs
+++ b/Tesserae.Tests/src/Samples/Utilities/EmojiSample.cs
@@ -37,7 +37,7 @@ namespace Tesserae.Tests.Samples
 
         private IEnumerable<IconItem> GetAllIcons()
         {
-            var     names  = Enum.GetNames(typeof(Emoji));
+            var     names  = Enum.GetNames<Emoji>();
             Emoji[] values = Enum.GetValues<Emoji>();
 
             for (int i = 0; i < values.Length; i++)

--- a/Tesserae.Tests/src/Samples/Utilities/EmojiSample.cs
+++ b/Tesserae.Tests/src/Samples/Utilities/EmojiSample.cs
@@ -38,7 +38,7 @@ namespace Tesserae.Tests.Samples
         private IEnumerable<IconItem> GetAllIcons()
         {
             var     names  = Enum.GetNames(typeof(Emoji));
-            Emoji[] values = (Emoji[])Enum.GetValues(typeof(Emoji));
+            Emoji[] values = Enum.GetValues<Emoji>();
 
             for (int i = 0; i < values.Length; i++)
             {

--- a/Tesserae.Tests/src/Samples/Utilities/UIconsSample.cs
+++ b/Tesserae.Tests/src/Samples/Utilities/UIconsSample.cs
@@ -38,7 +38,7 @@ namespace Tesserae.Tests.Samples
 
         private IEnumerable<IconItem> GetAllIcons()
         {
-            var      names  = Enum.GetNames(typeof(UIcons));
+            var      names  = Enum.GetNames<UIcons>();
             UIcons[] values = Enum.GetValues<UIcons>();
 
             for (int i = 0; i < values.Length; i++)

--- a/Tesserae.Tests/src/Samples/Utilities/UIconsSample.cs
+++ b/Tesserae.Tests/src/Samples/Utilities/UIconsSample.cs
@@ -39,7 +39,7 @@ namespace Tesserae.Tests.Samples
         private IEnumerable<IconItem> GetAllIcons()
         {
             var      names  = Enum.GetNames(typeof(UIcons));
-            UIcons[] values = (UIcons[])Enum.GetValues(typeof(UIcons));
+            UIcons[] values = Enum.GetValues<UIcons>();
 
             for (int i = 0; i < values.Length; i++)
             {


### PR DESCRIPTION
## Summary
Modernize enum value retrieval in sample code by using the generic `Enum.GetValues<T>()` method instead of the non-generic version with explicit casting.

## Changes
- **EmojiSample.cs**: Replace `(Emoji[])Enum.GetValues(typeof(Emoji))` with `Enum.GetValues<Emoji>()`
- **UIconsSample.cs**: Replace `(UIcons[])Enum.GetValues(typeof(UIcons))` with `Enum.GetValues<UIcons>()`

## Details
The generic `Enum.GetValues<T>()` method (available in .NET 5+) provides type-safe enum value retrieval without requiring explicit casting. This improves code clarity and reduces the risk of casting errors. The change is applied to both icon sample utilities that enumerate enum values for display.

https://claude.ai/code/session_01BUanesfMmhwW1rxYSCHT8m