### PR TITLE
Add a remove (x) button to ChatMessage, and let the OmniBox send mid-reply

### DIFF
--- a/Tesserae.Tests/src/Samples/Components/ChatSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/ChatSample.cs
@@ -31,6 +31,56 @@ namespace Tesserae.Tests.Samples
 
             OmniBox input = null;
 
+            // A message typed while the reply is still arriving is parked here instead of interrupting it,
+            // and sent as soon as the reply finishes. Only the latest one is kept.
+            var    queuedStack = VStack().WS().NoDefaultMargin().Style(s => s.opacity = "0.6");
+            string queuedText  = null;
+
+            void RenderQueue()
+            {
+                queuedStack.Clear();
+
+                if (string.IsNullOrEmpty(queuedText))
+                {
+                    queuedStack.Collapse();
+                    return;
+                }
+
+                queuedStack.Show();
+
+                // The (x) drops the queued message; clicking the bubble takes it back into the composer.
+                queuedStack.Add(ChatMessage(TextBlock("Queued: " + queuedText), Avatar(null, "U"))
+                   .RightAligned()
+                   .MaxWidth()
+                   .OnRemove(() => { queuedText = null; RenderQueue(); })
+                   .OnTapped(() =>
+                    {
+                        input.ChatText = queuedText;
+                        queuedText     = null;
+                        RenderQueue();
+                    }));
+            }
+
+            void SendUserMessage(string text)
+            {
+                // Anchor the user's turn: it settles near the top and the reply grows into the screen below it.
+                chatArea.Add(ChatMessage(TextBlock(text), Avatar(null, "U")).RightAligned().MaxWidth().ScrollAnchor());
+
+                input.IsGenerating = true;
+                AddAIAnswer();
+            }
+
+            void FlushQueue()
+            {
+                if (string.IsNullOrEmpty(queuedText)) return;
+
+                var next = queuedText;
+                queuedText = null;
+                RenderQueue();
+
+                SendUserMessage(next);
+            }
+
             void AddAIAnswer()
             {
                 cancelled = false;
@@ -62,6 +112,8 @@ namespace Tesserae.Tests.Samples
                     {
                         input.IsGenerating = false;
                         chatArea.Busy(false);
+                        // The reply is done, so whatever was typed while it streamed goes out now.
+                        FlushQueue();
                         return;
                     }
 
@@ -112,22 +164,30 @@ namespace Tesserae.Tests.Samples
                 TextBlock("I scanned the project, ran the build, and looked at routing options. Here's what I found:")
             ), Avatar(null, "AI")).MaxWidth());
 
+            RenderQueue();
+
             input = OmniBox(new OmniBox.Config(OmniBox.Mode.Chat)
             {
                 PlaceholderChat = "Ask anything...",
                 IconStop = UIcons.Stop,
-                IconChat = UIcons.ArrowRight
+                IconChat = UIcons.ArrowRight,
+                // With this on, sending while a reply is arriving no longer stops it — the trigger keeps
+                // offering "send" as long as there is text, and this sample queues what it hands over.
+                AllowSendWhileGenerating = true
             })
             .OnChat((sender, msg) =>
             {
                 var text = msg.Text;
                 if (string.IsNullOrWhiteSpace(text)) return;
 
-                // Anchor the user's turn: it settles near the top and the reply grows into the screen below it.
-                chatArea.Add(ChatMessage(TextBlock(text), Avatar(null, "U")).RightAligned().MaxWidth().ScrollAnchor());
+                if (sender.IsGenerating)
+                {
+                    queuedText = text;
+                    RenderQueue();
+                    return;
+                }
 
-                sender.IsGenerating = true;
-                AddAIAnswer();
+                SendUserMessage(text);
             })
             .OnStop((sender) =>
             {
@@ -137,6 +197,7 @@ namespace Tesserae.Tests.Samples
 
             var chatContainer = VStack().WS().H(10).Grow().Children(
                 chatArea.WS().H(10).Grow(),
+                queuedStack,
                 input.WS().H(150)
             );
 

--- a/Tesserae/skills/references/chat.md
+++ b/Tesserae/skills/references/chat.md
@@ -52,6 +52,14 @@ ChatMessage:
 - `.KeepVisible()` — keep this message at the live edge while it streams (respects the reader's
   scroll — a no-op if they scrolled away).
 - `.Background(string)` — this bubble's background.
+- `.OnRemove(Action)` / `.OnRemove(Action<ChatMessage>)` — adds a round (x) button hanging off the
+  bubble's outer top corner (fading in while the message is hovered or focused, always visible on
+  touch) and calls the handler when it is clicked. The message does **not** remove itself: the
+  handler owns the list it came from. `.Removable(bool)` toggles the button without dropping the
+  handler, `.NoRemove()` takes it away, `.IsRemovable` reads the state. Use it for a message the
+  reader can take back — a queued message that hasn't been sent yet, a host notice they can clear.
+  The click is stopped on the button, so a bubble that is itself clickable (`.OnTapped(...)`) does
+  not also fire.
 
 ## Example
 
@@ -69,6 +77,21 @@ chat.Busy(true);
 reply.ReplaceContent(TextBlock("Hello, how can I help?")); // call repeatedly to stream
 reply.KeepVisible();
 chat.Busy(false);
+```
+
+## Queueing a message typed mid-reply
+
+An `OmniBox` configured with `AllowSendWhileGenerating = true` (see `omni-box.md`) keeps sending
+while a reply streams instead of stopping it, which lets the host park that message and send it when
+the turn finishes. Show it in its own stack under the transcript, distinct from the messages already
+in it, with an (x) to drop it and a click to bring it back into the composer:
+
+```csharp
+var queued = ChatMessage(TextBlock(text), Avatar(null, "U")).RightAligned().MaxWidth()
+   .OnRemove(() => DropQueued())                     // (x) — the queue is the handler's to update
+   .OnTapped(() => { composer.ChatText = text; DropQueued(); });
+
+queuedStack.Add(queued);                              // a VStack below the ChatArea
 ```
 
 ## Related

--- a/Tesserae/skills/references/omni-box.md
+++ b/Tesserae/skills/references/omni-box.md
@@ -24,11 +24,12 @@ Config (set via object initializer):
 - `IconSearch` / `IconChat` / `IconStop`, `SearchFooter` / `ChatFooter` (`FooterItems`).
 - `ChatHeader` (`IComponent`) — rendered inside the box above the chat input: what the message is being written against, e.g. a compact `ContextCards` group of the attached documents. Swap it later with `.SetChatHeader(component)`, or pass `null` to empty the slot — it takes up no space while empty. For individual cards *below* the input, use `.WithContextToAdd(...)`.
 - `GeneratingText` — label shown in the footer while generating (default `"Generating"`); the live elapsed time is appended, e.g. `"Generating, 1m 25s"`.
+- `AllowSendWhileGenerating` (default `false`) — when set, typing a message while `IsGenerating` is true sends it (`OnChat` fires) instead of the trigger stopping the reply, so the host can queue it for the turn in flight. The trigger still shows the stop icon while the input is empty and turns back into the send icon as soon as there is text.
 
 OmniBox:
 - `.OnSearch((sender, SearchQuery) => ...)` — fires on search; `query.Tokens` hold the parsed tokens.
 - `.OnChat((sender, ChatMessage) => ...)`, `.OnStop(...)`, `.OnModelChanged(...)`.
-- `.IsGenerating` (bool) — toggles the footer spinner + elapsed-time indicator and swaps the send button for a stop button. `.GeneratingText` (string) — read/write the indicator label; setting it updates the footer live.
+- `.IsGenerating` (bool) — toggles the footer spinner + elapsed-time indicator and swaps the send button for a stop button. `.GeneratingText` (string) — read/write the indicator label; setting it updates the footer live. `.AllowSendWhileGenerating` (bool) — read/write the config flag above.
 - `.SearchText` / `.ChatText` / `.SetSearchText(string)` — read/write input text.
 - `.SetChatHeader(IComponent)` — replace (or clear, with `null`) whatever sits above the chat input.
 - `.RegisterSnap(SnapHandler)` / `.RegisterFilterSnap(FilterSnapHandler)` — turn recognized input into inline filter chips (search modes only).

--- a/Tesserae/src/Components/Chat.cs
+++ b/Tesserae/src/Components/Chat.cs
@@ -684,6 +684,11 @@ namespace Tesserae
                 RemoveRequested?.Invoke(this);
             });
 
+            // A gesture recogniser (.OnTapped) reads pointer events, which a stopped click does not cover:
+            // without this, removing the message would also register as a tap on the bubble. The press is
+            // only kept from bubbling - the button's own click still fires.
+            _removeButton.addEventListener("pointerdown", ev => ev.stopImmediatePropagation());
+
             _bubbleContainer.appendChild(_removeButton);
             _innerElement.classList.add("tss-chatmessage-removable");
         }

--- a/Tesserae/src/Components/Chat.cs
+++ b/Tesserae/src/Components/Chat.cs
@@ -519,6 +519,13 @@ namespace Tesserae
         }
     }
 
+    /// <summary>
+    /// One bubble in a <see cref="ChatArea"/>: content (wrapped in a <see cref="DeltaComponent"/>, so it
+    /// can be replaced repeatedly while a reply streams), an optional avatar, and an optional commands
+    /// slot beside it. Passing a remove handler to <see cref="OnRemove(Action{ChatMessage})"/> adds a
+    /// round (x) button hanging just off the bubble's outer top corner, for a message the reader can take
+    /// back — a queued message that hasn't been sent yet, a notice they can clear.
+    /// </summary>
     [Transpose.Name("tss.ChatMessage")]
     public class ChatMessage : IComponentWithID, IComponent
     {
@@ -530,6 +537,9 @@ namespace Tesserae
         private DeltaComponent _deltaComponent;
         private IComponent _currentContent;
         private ChatArea _parent;
+        private HTMLButtonElement _removeButton;
+
+        private event Action<ChatMessage> RemoveRequested;
 
         /// <summary>
         /// Gets or sets the identifier.
@@ -549,6 +559,11 @@ namespace Tesserae
         /// Gets whether this message is a turn boundary that the transcript should settle near the top when a new turn begins.
         /// </summary>
         public bool IsAnchor { get; private set; }
+
+        /// <summary>
+        /// Gets whether the bubble carries a remove (x) button.
+        /// </summary>
+        public bool IsRemovable => _removeButton != null;
 
         /// <summary>
         /// Initializes a new instance of this class.
@@ -608,6 +623,69 @@ namespace Tesserae
         {
             _deltaComponent.Animated();
             return this;
+        }
+
+        /// <summary>
+        /// Registers a callback invoked when the user clicks the bubble's remove button, and adds that
+        /// button to the bubble if it isn't there yet. The message does not remove itself — the handler
+        /// owns whatever list the message came from, so it can drop it there and rebuild the transcript.
+        /// </summary>
+        public ChatMessage OnRemove(Action<ChatMessage> onRemove)
+        {
+            RemoveRequested += onRemove;
+            EnsureRemoveButton();
+
+            return this;
+        }
+
+        /// <summary>
+        /// Registers a callback invoked when the user clicks the bubble's remove button, and adds that
+        /// button to the bubble if it isn't there yet.
+        /// </summary>
+        public ChatMessage OnRemove(Action onRemove) => OnRemove(_ => onRemove?.Invoke());
+
+        /// <summary>
+        /// Configures whether the bubble shows a remove (x) button. Turning it off keeps any handler
+        /// registered with <see cref="OnRemove(Action{ChatMessage})"/>, so turning it back on restores
+        /// the same behaviour.
+        /// </summary>
+        public ChatMessage Removable(bool value = true)
+        {
+            if (value)
+            {
+                EnsureRemoveButton();
+            }
+            else if (_removeButton != null)
+            {
+                _innerElement.classList.remove("tss-chatmessage-removable");
+                _bubbleContainer.removeChild(_removeButton);
+                _removeButton = null;
+            }
+
+            return this;
+        }
+
+        /// <summary>
+        /// Configures the component to show no remove button.
+        /// </summary>
+        public ChatMessage NoRemove() => Removable(false);
+
+        private void EnsureRemoveButton()
+        {
+            if (_removeButton != null) return;
+
+            _removeButton = Button(Att("tss-chatmessage-remove", type: "button", ariaLabel: "Remove"), I(UIcons.CrossSmall));
+
+            _removeButton.addEventListener("click", ev =>
+            {
+                // The bubble itself can be clickable (a queued message tapped to bring it back into the
+                // composer), so removing it must not read as opening it.
+                StopEvent(ev);
+                RemoveRequested?.Invoke(this);
+            });
+
+            _bubbleContainer.appendChild(_removeButton);
+            _innerElement.classList.add("tss-chatmessage-removable");
         }
         internal void SetParent(ChatArea parent)
         {

--- a/Tesserae/src/Components/OmniBox.cs
+++ b/Tesserae/src/Components/OmniBox.cs
@@ -467,6 +467,13 @@ namespace Tesserae
             /// The elapsed time is appended after it, e.g. "Generating, 1m 25s".
             /// </summary>
             public string GeneratingText { get; set; }
+            /// <summary>
+            /// Gets or sets whether a message typed while a reply is generating is sent instead of the
+            /// trigger stopping that reply — for a host that queues it for the turn in flight. The trigger
+            /// keeps offering "stop" while the input is empty, and turns back into "send" as soon as there
+            /// is something to send. Off by default, so the trigger always stops while generating.
+            /// </summary>
+            public bool AllowSendWhileGenerating { get; set; }
 
             /// <summary>
             /// Gets or sets the chat footer.
@@ -618,6 +625,7 @@ namespace Tesserae
         private readonly IconToggle<Mode> _modeToggle;
         private readonly bool _tokenIgnoreCase;
         private bool _isGenerating = false;
+        private bool _allowSendWhileGenerating = false;
         private readonly UIcons _iconChat;
         private readonly UIcons _iconStop;
         private HTMLElement _generatingText;
@@ -671,6 +679,7 @@ namespace Tesserae
             _tokenIgnoreCase = config.TokenIgnoreCase;
             _iconChat = config.IconChat;
             _iconStop = config.IconStop;
+            _allowSendWhileGenerating = config.AllowSendWhileGenerating;
             _generatingLabel = config.GeneratingText ?? "Generating";
             _suggestionsFetcher = config.SuggestionsFetcher;
 
@@ -2609,7 +2618,7 @@ namespace Tesserae
 
         private void TriggerChat()
         {
-            if (_isGenerating)
+            if (_isGenerating && !CanSendWhileGenerating)
             {
                 TriggerStop();
                 return;
@@ -2621,6 +2630,10 @@ namespace Tesserae
             ResizeChatInput();
         }
 
+        // While generating, the trigger sends instead of stopping only when the host asked for it and
+        // there is actually something to send - an empty input still offers "stop".
+        private bool CanSendWhileGenerating => _allowSendWhileGenerating && _chatInput != null && !string.IsNullOrWhiteSpace(_chatInput.value);
+
         private void UpdateChatTriggerActiveState()
         {
             if (_chatTriggerBtn == null || _chatInput == null) return;
@@ -2628,6 +2641,25 @@ namespace Tesserae
             var el = _chatTriggerBtn.Render();
             if (hasText) el.classList.add("tss-omnibox-chat-btn-active");
             else el.classList.remove("tss-omnibox-chat-btn-active");
+
+            // What the trigger does while generating depends on whether there is text, so typing (or
+            // clearing) the input is what flips it between "send" and "stop".
+            UpdateChatTriggerIcon();
+        }
+
+        private void UpdateChatTriggerIcon()
+        {
+            if (_chatTriggerBtn == null) return;
+
+            if (_isGenerating && !CanSendWhileGenerating)
+            {
+                _chatTriggerBtn.SetIcon(_iconStop).Danger();
+            }
+            else
+            {
+                _chatTriggerBtn.SetIcon(_iconChat);
+                _chatTriggerBtn.IsDanger = false;
+            }
         }
 
         // Maximum height (in px) the chat input grows to before it starts scrolling internally.
@@ -2908,19 +2940,13 @@ namespace Tesserae
             {
                 if (_isGenerating == value) return;
                 _isGenerating = value;
+
+                UpdateChatTriggerIcon();
+
                 if (_chatTriggerBtn != null)
                 {
-                    if (value)
-                    {
-                        _chatTriggerBtn.SetIcon(_iconStop).Danger();
-                        _container.classList.add("tss-omnibox-generating");
-                    }
-                    else
-                    {
-                        _chatTriggerBtn.SetIcon(_iconChat);
-                        _chatTriggerBtn.IsDanger = false;
-                        _container.classList.remove("tss-omnibox-generating");
-                    }
+                    if (value) _container.classList.add("tss-omnibox-generating");
+                    else       _container.classList.remove("tss-omnibox-generating");
                 }
 
                 if (value)
@@ -2931,6 +2957,22 @@ namespace Tesserae
                 {
                     StopGeneratingTimer();
                 }
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets whether a message typed while <see cref="IsGenerating"/> is set is sent instead of
+        /// the trigger stopping the reply in flight — for a host that queues it for the turn in progress.
+        /// The trigger still offers "stop" while the input is empty.
+        /// </summary>
+        public bool AllowSendWhileGenerating
+        {
+            get => _allowSendWhileGenerating;
+            set
+            {
+                if (_allowSendWhileGenerating == value) return;
+                _allowSendWhileGenerating = value;
+                UpdateChatTriggerIcon();
             }
         }
 

--- a/Tesserae/tps/assets/css/tss.chat.css
+++ b/Tesserae/tps/assets/css/tss.chat.css
@@ -60,6 +60,7 @@
 }
 
 .tss-chatmessage-bubble {
+    position: relative;
     padding: 2px 0;
     border-radius: 0;
     background-color: transparent;
@@ -95,6 +96,82 @@
 
 .tss-chatmessage-container:hover .tss-chatmessage-commands {
     opacity: 1;
+}
+
+/* content-visibility: auto brings paint containment with it, which clips anything hanging off the
+   container's box - including the remove button below. A removable message opts out: there are few of
+   them in a transcript, so the skipped-rendering win is not worth a clipped button. */
+.tss-chatmessage-removable {
+    content-visibility: visible;
+}
+
+/* The remove button hangs off the bubble's outer top corner, so it costs no layout and never sits over
+   the message. Same solid neutral disc as a ContextCard's, fading in while the message is hovered or
+   focused - and always visible where there is no hover to speak of. */
+.tss-chatmessage-remove {
+    position: absolute;
+    top: -6px;
+    right: -6px;
+    z-index: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 18px;
+    height: 18px;
+    padding: 0;
+    border: none;
+    border-radius: 50%;
+    background: var(--tss-colors-neutral-1000);
+    color: var(--tss-colors-neutral-0);
+    cursor: pointer;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.12s ease-in-out, background 0.12s ease-in-out;
+}
+
+/* On a right-aligned bubble the avatar sits at the outer edge, so the free corner is the other one. */
+.tss-chat-right .tss-chatmessage-remove {
+    right: auto;
+    left: -6px;
+}
+
+/* The neutral scale flips with the theme, so in dark mode it takes a mid grey to stay visible on a
+   dark bubble, and the white glyph comes from the inverted scale (which is light there). */
+.tss-dark-mode .tss-chatmessage-remove {
+    background: var(--tss-colors-neutral-500);
+    color: var(--tss-colors-dark-neutral-0);
+}
+
+.tss-chatmessage-remove i {
+    font-size: 11px;
+    line-height: 1;
+}
+
+.tss-chatmessage-remove:hover,
+.tss-dark-mode .tss-chatmessage-remove:hover {
+    background: var(--tss-danger-background-color);
+    color: var(--tss-danger-foreground-color);
+}
+
+.tss-chatmessage-remove:active,
+.tss-dark-mode .tss-chatmessage-remove:active {
+    background: var(--tss-danger-background-active-color);
+    color: var(--tss-danger-foreground-active-color);
+}
+
+.tss-chatmessage-container:hover > .tss-chatmessage-bubble > .tss-chatmessage-remove,
+.tss-chatmessage-container:focus-within > .tss-chatmessage-bubble > .tss-chatmessage-remove,
+.tss-chatmessage-remove:focus-visible {
+    opacity: 1;
+    pointer-events: auto;
+}
+
+/* Nothing hovers on a touch screen, so there the button is simply always visible. */
+@media (hover: none) {
+    .tss-chatmessage-remove {
+        opacity: 1;
+        pointer-events: auto;
+    }
 }
 
 .tss-chat-left {


### PR DESCRIPTION
Groundwork for "queue a message while the assistant is still replying" in a host app (Curiosity Workspace): the two pieces the toolkit was missing, so the host can park a message typed mid-reply, show it under the transcript, and send it once the turn finishes.

## `ChatMessage.OnRemove(...)`

Adds a round (x) button hanging off the bubble's outer top corner — the same solid neutral disc `ContextCard` already uses, fading in while the message is hovered or focused, and always visible where there is no hover to speak of.

- `.OnRemove(Action)` / `.OnRemove(Action<ChatMessage>)` — register the handler and add the button.
- `.Removable(bool)` — toggle the button without dropping the handler; `.NoRemove()` takes it away; `.IsRemovable` reads the state.
- The bubble does **not** remove itself — the handler owns whatever list the message came from.
- The click is stopped on the button, so a bubble that is itself clickable (`.OnTapped(...)`, e.g. "tap the queued message to edit it again") doesn't also fire.
- On a right-aligned bubble the avatar occupies the outer edge, so the button moves to the other corner.
- A removable message opts out of `content-visibility: auto`: the paint containment it brings would clip a button hanging off the box. There are few such messages in a transcript, so the skipped-rendering win isn't worth a clipped button.

## `OmniBox.Config.AllowSendWhileGenerating`

Off by default, so nothing changes for existing callers. When set, the trigger keeps *sending* while `IsGenerating` is true instead of stopping the reply — which is what lets a host queue that message. With an empty input it still offers stop, so the trigger icon now follows both the generating state and whether there is text (previously only the generating state). Also exposed as a read/write property.

## Sample

`ChatSample` turns the flag on and demonstrates the whole loop: a message sent mid-reply is parked in its own stack below the transcript, with the (x) to drop it and a click to take it back into the composer, and goes out as soon as the reply finishes.

## Verification

- `dotnet build` (Tesserae + Tesserae.Tests) clean.
- Driven in Chromium against the samples site: sending mid-reply queues instead of stopping, the queued bubble renders below the transcript, the (x) appears on hover at the bubble's corner and drops it, clicking the bubble restores the text to the composer, and the queued message is sent when the reply completes.

Docs: `skills/references/chat.md` (the new methods plus a "queueing a message typed mid-reply" section) and `skills/references/omni-box.md` (the new flag). The matching pages in the `documentation` repo aren't in this session's scope and still need the same edit.

---
_Generated by [Claude Code](https://claude.ai/code/session_017ri6tadMDb4qizd1UrR5oa)_