### PR TITLE
ContextCard: right-align the second line and chevron on a card given a width

### DIFF
--- a/Tesserae.Tests/src/Samples/Components/ContextCardSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/ContextCardSample.cs
@@ -85,6 +85,7 @@ namespace Tesserae.Tests.Samples
                 .FlatSection(VStack().WS().Children(Grouped()))
                 .FlatSection(VStack().WS().Children(CompactRow()))
                 .FlatSection(VStack().WS().Children(LongNames()))
+                .FlatSection(VStack().WS().Children(Stretched()))
                 .FlatSection(VStack().WS().Children(InAComposer()))
                 .SeeAlso(typeof(ChatSample), typeof(OmniBoxSample), typeof(ToolCallSample), typeof(ResourceCardSample), typeof(CardSample));
         }
@@ -323,6 +324,21 @@ namespace Tesserae.Tests.Samples
                 narrow,
                 TextBlock("And with KeepExtensionVisible(false):").Small().MT(12).MB(8),
                 whole);
+        }
+
+        // ---------- Given a width ----------
+
+        private IComponent Stretched()
+        {
+            var panel = VStack().W(300.px()).Children(
+                ContextCard("Annual report", UIcons.FilePdf).SetSubLabel("PDF").IconTint("#ef4444").Compact().WithChevron().WS(),
+                ContextCard("customers", UIcons.Database).SetSubLabel("Dataset").IconTint("#f59e0b").Compact().WithChevron().WS().MT(6),
+                ContextCard("A cited page whose title runs past the panel", UIcons.Globe).SetSubLabel("Web page").IconTint("#0ea5e9").Compact().WithChevron().WS().MT(6),
+                ContextCard("Q3-forecast.xlsx", UIcons.FileExcel).SetSubLabel("Spreadsheet").IconTint("#16a34a").SetBadge("3 refs").Compact().WithChevron().WS().MT(6));
+
+            return FeatureCard("Given a width", "A column of sources in a side panel",
+                "A card sizes itself to its content, but give it a width of its own — .WS() in a panel listing the sources behind a conversation — and the label takes the extra space, so the second line, the badge and the chevron line up at the cards' end and the label is what gets ellipsized.",
+                panel);
         }
 
         // ---------- In a composer ----------

--- a/Tesserae/skills/references/context-card.md
+++ b/Tesserae/skills/references/context-card.md
@@ -79,7 +79,9 @@ Bring factories into scope with `using static Tesserae.UI;`.
 - `Label`, `SubLabel`, `IsRemovable` — read state.
 
 Sizing helpers work as usual: `.MaxWidth(260.px())` is the normal way to cap a card whose label may
-be long, since the label ellipsizes to whatever width the card ends up with.
+be long, since the label ellipsizes to whatever width the card ends up with. Give the card a width of
+its own (`.WS()` in a side panel listing sources, say) and the label takes the extra space, so the
+second line, the badge and the chevron sit against the card's end and the label is what gets cut.
 
 ## Example
 

--- a/Tesserae/tps/assets/css/tss.contextcard.css
+++ b/Tesserae/tps/assets/css/tss.contextcard.css
@@ -66,8 +66,12 @@
     display: block;
 }
 
+/* The text block owns whatever width the card was given beyond its content (a card stretched across a
+   citations panel, a list row), so the badge and the chevron end up at the card's end rather than
+   trailing the label. A content-sized card has no slack to hand out, so nothing changes there. */
 .tss-contextcard-text {
     display: flex;
+    flex: 1 1 auto;
     flex-direction: column;
     justify-content: center;
     min-width: 0;
@@ -229,7 +233,10 @@
     gap: 6px;
 }
 
+/* Beside the second line, the label is the part that takes the slack, so the two read as "name … kind"
+   with the kind against the card's end and the name as what gets ellipsized when it doesn't fit. */
 .tss-contextcard-compact .tss-contextcard-label {
+    flex: 1 1 auto;
     font-size: var(--tss-font-size-small, 13px);
 }
 

--- a/Tesserae/tps/assets/css/tss.contextcards.css
+++ b/Tesserae/tps/assets/css/tss.contextcards.css
@@ -99,10 +99,6 @@
     border-top: 1px solid var(--tss-default-border-color);
 }
 
-.tss-contextcards-list > .tss-contextcard .tss-contextcard-text {
-    flex: 1 1 auto;
-}
-
 /* One row's ✕: always there (a list is where context gets managed), quiet until hovered. */
 .tss-contextcards-list > .tss-contextcard .tss-contextcard-remove {
     position: static;
@@ -167,6 +163,7 @@
     font-size: 11px;
 }
 
+/* A pill is sized by its content, so here the text block hugs it instead of taking the card's slack. */
 .tss-contextcards-compact > .tss-contextcards-list > .tss-contextcard .tss-contextcard-text {
     flex: 0 1 auto;
     flex-direction: row;


### PR DESCRIPTION
A `ContextCard` sizes itself to its content, but a host can give it a width of its own — a citations panel listing the sources behind a conversation stretches each card across the pane (`ContextCard(label, icon).SetSubLabel(kind).Compact().WithChevron().WS()`). The card's text block did not claim that extra space, so the label, the second line and the chevron bunched up against the icon with all the slack hanging at the card's end.

## What changed

CSS only — no API change.

- `.tss-contextcard-text` → `flex: 1 1 auto`, so the text block owns whatever width the card was given beyond its content. The badge (`margin-left: auto`) and the chevron already sit at the end, so they land against the card's edge.
- `.tss-contextcard-compact .tss-contextcard-label` → `flex: 1 1 auto`, so in the one-line form the label is the part that takes the slack. It reads "name … kind ›", with the label as what gets ellipsized and the second line (already `flex-shrink: 0` + nowrap/ellipsis) pushed right.
- Dropped `.tss-contextcards-list > .tss-contextcard .tss-contextcard-text { flex: 1 1 auto }` from `tss.contextcards.css` — the base rule now covers list rows — and commented the compact-pill-row rule that deliberately opts back out to content-hugging.

Plus a `Given a width` section in `ContextCardSample.cs` demonstrating the case, and a sizing note in `skills/references/context-card.md`.

## Behaviour

A content-sized card has no slack to hand out, so the usual home for these cards — a wrapping row above a composer — is unchanged. Same for the compact `ContextCards` pill row (its `flex: 0 1 auto` override wins on specificity) and the expanded list rows.

One incidental improvement: in a full-width **compact** card the base `justify-content: center` used to centre the label + second line as a pair, which is why a row in an expanded list could look oddly indented. With the label absorbing the slack that no longer applies.

## Verification

- `dotnet build Tesserae.Tests/Tesserae.Tests.csproj` succeeds; screenshots taken against the built sample app.
- Measured in Chromium before/after: a short-label full-width card went from 124px of dead space after the chevron to the chevron flush at the card's inner edge (11px = padding + border), for every card in the panel.
- Content-sized composer cards, the compact pill row and the expanded list rows measured and screenshotted as unchanged.


---
_Generated by [Claude Code](https://claude.ai/code/session_01V9QPmcbBLTjsJHGbiQA2CH)_