### PR TITLE
Add Illustration support to Message component

### DIFF
--- a/Tesserae.Tests/src/Samples/Components/MessageSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/MessageSample.cs
@@ -90,6 +90,14 @@ namespace Tesserae.Tests.Samples
                )).SetTitle("Horizontal layout")))
                .FlatSection(Stack().Children(
                     Card(VStack().WS().Children(
+                    TextBlock("Use Illustration(...) to place a picture below the content - a drawing, a mascot or an animation. It suits empty states, where the message is the whole screen and the leading icon alone reads a bit thin."),
+
+                    SampleSubTitle("Illustrated empty state"),
+                    Message().Text("Sessions you start will show up here")
+                        .Illustration(PixelAvatar(42, PixelAvatarDesign.Grey, PixelAvatarAnimation.SitIdle).PixelSize(8))
+               )).SetTitle("Illustration")))
+               .FlatSection(Stack().Children(
+                    Card(VStack().WS().Children(
                     TextBlock("Use Action(...) to attach an action component. On the default layout it renders below the content; on a horizontal message it renders on the right side, beside the content."),
 
                     SampleSubTitle("Action (vertical)"),

--- a/Tesserae/skills/references/message.md
+++ b/Tesserae/skills/references/message.md
@@ -5,8 +5,9 @@ description: An inline informational message strip with an icon, title, body, op
 
 # Message
 
-A static message block with an icon, title, text body and optional note area.
-Comes with tone variants for standard, success, warning and error states.
+A static message block with an icon, title, text body, and optional note and
+illustration areas. Comes with tone variants for standard, success, warning and
+error states.
 
 ## Create
 
@@ -20,6 +21,7 @@ optional and can also be set fluently. Bring the factory into scope with
 - `.Title(string)` / `.Title(IComponent)` — title.
 - `.Text(string)` / `.Text(IComponent)` — body text.
 - `.Note(string)` / `.Note(IComponent)` — extra note area below the body.
+- `.Illustration(IComponent)` — a picture below the content (drawing, mascot, animation), for empty states.
 - `.Variant(MessageVariant)` — tone: `Default`, `Success`, `Warning`, `Error`.
 
 ## Example
@@ -38,6 +40,10 @@ var empty = Message("No results found", "We couldn't find any items matching you
 var error = Message("Something went wrong", "We couldn't save your changes.")
     .Icon(UIcons.CrossCircle)
     .Variant(MessageVariant.Error);
+
+// An empty state whose picture sits below the text
+var emptyList = Message().Text("Sessions you start will show up here")
+    .Illustration(PixelAvatar(key, PixelAvatarDesign.Grey, PixelAvatarAnimation.SitIdle).PixelSize(8));
 ```
 
 ## Related

--- a/Tesserae/src/Components/Message.cs
+++ b/Tesserae/src/Components/Message.cs
@@ -16,6 +16,7 @@ namespace Tesserae
         private readonly HTMLDivElement _titleContainer;
         private readonly HTMLDivElement _textContainer;
         private readonly HTMLDivElement _noteContainer;
+        private readonly HTMLDivElement _illustrationContainer;
 
         private IComponent  _action;
         private HTMLElement _actionContainer;
@@ -33,6 +34,8 @@ namespace Tesserae
             _textContainer    = Div(Att("tss-message-text"));
             _noteContainer    = Div(Att("tss-message-note"));
             _actionContainer  = Div(Att("tss-message-action"));
+
+            _illustrationContainer = Div(Att("tss-message-illustration"));
 
             if (!string.IsNullOrEmpty(title)) Title(title);
             if (!string.IsNullOrEmpty(message)) Text(message);
@@ -123,6 +126,20 @@ namespace Tesserae
             _noteContainer.innerHTML = "";
             _noteContainer.appendChild(note.Render());
             if(!_contentContainer.contains(_noteContainer)) _contentContainer.appendChild(_noteContainer);
+            return this;
+        }
+
+        /// <summary>
+        /// Adds an illustration below the message content, for empty states that want a picture
+        /// (a drawing, a mascot, an animation) instead of - or on top of - the leading icon.
+        /// </summary>
+        public Message Illustration(IComponent illustration)
+        {
+            ClearChildren(_illustrationContainer);
+            _illustrationContainer.appendChild(illustration.Render());
+
+            if (!InnerElement.contains(_illustrationContainer)) InnerElement.insertBefore(_illustrationContainer, _actionContainer);
+
             return this;
         }
 

--- a/Tesserae/tps/assets/css/tss.message.css
+++ b/Tesserae/tps/assets/css/tss.message.css
@@ -29,6 +29,15 @@
         margin-top: 4px;
     }
 
+/* No icon, no title: an empty slot would still draw its circle / claim its margin. */
+.tss-message-icon:empty {
+    display: none;
+}
+
+.tss-message-title:empty {
+    margin-bottom: 0;
+}
+
 .tss-message-content {
     display: flex;
     flex-direction: column;
@@ -71,6 +80,15 @@
     font-size: 16px;
 }
 
+.tss-message-illustration {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    max-width: 100%;
+    margin-top: 8px;
+    opacity: 0.5;
+}
+
 /* Horizontal layout: icon sits beside the content instead of stacked above it */
 .tss-message-horizontal {
     flex-direction: row;
@@ -110,6 +128,10 @@
 
     .tss-message-horizontal .tss-message-note {
         margin-top: 12px;
+    }
+
+    .tss-message-horizontal .tss-message-illustration {
+        margin-top: 0;
     }
 
 /* Variants: soft tinted background with a rounded border */


### PR DESCRIPTION
## Summary

Adds an optional illustration area to the Message component, allowing developers to place decorative content (drawings, mascots, animations) below the message text. This is particularly useful for empty states where the message occupies the full screen and a leading icon alone feels insufficient.

## Changes

- **Message.cs**: Added `_illustrationContainer` field and new `Illustration(IComponent)` fluent method to configure the illustration area. The illustration is inserted before the action container to maintain proper DOM ordering.

- **tss.message.css**: 
  - Added `.tss-message-illustration` styles with flexbox centering, max-width constraint, top margin, and 50% opacity for a subtle appearance.
  - Added responsive rule for horizontal layout to remove top margin on illustrations.
  - Added rules to hide empty icon and title elements and remove title margin when empty, preventing unused layout space.

- **message.md**: Updated component documentation to describe the new illustration feature and added it to the fluent methods list with a usage example showing an empty state with a pixel avatar illustration.

- **MessageSample.cs**: Added a new sample section demonstrating the illustration feature with an empty state message and pixel avatar.

## Implementation Details

The illustration container is created during component initialization but only inserted into the DOM when `Illustration()` is called, following the lazy-insertion pattern used by other optional areas (note, action). The 50% opacity and centered layout make the illustration visually subordinate to the primary message content while still providing visual interest for empty states.

https://claude.ai/code/session_01MMR95kqyd6eJztp97oLaWY