### PR TITLE
Add Rounded() and WithAskAI() to OmniBox

### DIFF
--- a/Tesserae.Tests/src/Samples/Components/OmniBoxSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/OmniBoxSample.cs
@@ -31,6 +31,7 @@ namespace Tesserae.Tests.Samples
                .FlatSection(VStack().WS().Children(InlineChips()))
                .FlatSection(VStack().WS().Children(FooterItems()))
                .FlatSection(VStack().WS().Children(KeyboardShortcut()))
+               .FlatSection(VStack().WS().Children(RoundedAndAskAI()))
                .FlatSection(VStack().WS().Children(FileDrop()))
                .FlatSection(VStack().WS().Children(Models()))
                .FlatSection(VStack().WS().Children(Generating()))
@@ -404,6 +405,47 @@ namespace Tesserae.Tests.Samples
                 "SetKeyboardShortcut(\"Ctrl\", \"K\") registers a document-level shortcut that focuses the input, and shows the keys as a hint at the end of the search input. The hint is there to be discovered, so it steps out of the way while the input has focus and comes back on blur — and it is hidden in chat mode. Focus() does the same thing programmatically.",
                 box,
                 Button("Focus() it").SetIcon(UIcons.Cursor).MT(8).OnClick(() => box.Focus()));
+        }
+
+        // ---------- Rounded shape and the Ask AI button ----------
+
+        private IComponent RoundedAndAskAI()
+        {
+            var pill = Track(OmniBox(new OmniBox.Config(OmniBox.Mode.Search)
+            {
+                PlaceholderSearch = "brake sensor calibration"
+            })
+            .WS()
+            .H(48)
+            .Rounded()
+            .SetSearchRightText("18 results · 0.21s")
+            .WithAskAI("Ask AI", UIcons.Beacon, box => Toast().Information($"Asking AI about: {box.SearchText}"))
+            .OnSearch((s, q) => Toast().Information($"Searched for: {q.RawQuery}")));
+
+            var square = Track(OmniBox(new OmniBox.Config(OmniBox.Mode.Search)
+            {
+                PlaceholderSearch = "The default box, with the same Ask AI button"
+            })
+            .WS()
+            .WithAskAI(onClick: box => Toast().Information($"Asking AI about: {box.SearchText}"))
+            .OnSearch((s, q) => Toast().Information($"Searched for: {q.RawQuery}")));
+
+            var both = Track(OmniBox(new OmniBox.Config(OmniBox.Mode.SearchAndChat)
+            {
+                PlaceholderSearch = "Ask AI sits in the footer here — switch to chat and it steps aside",
+                PlaceholderChat   = "Switch back to search to see the Ask AI button again"
+            })
+            .WS()
+            .Rounded()
+            .WithAskAI("Ask AI", UIcons.Beacon, box => Toast().Information($"Asking AI about: {box.SearchText}"))
+            .OnSearch((s, q) => Toast().Information($"Searched for: {q.RawQuery}"))
+            .OnChat((s, q) => Toast().Information(q.Text)));
+
+            return FeatureCard("Rounded and Ask AI", "A pill-shaped box with a primary action",
+                "Rounded(BorderRadius radius = BorderRadius.Full) rounds the box, and everything meeting its outline follows: the search container, the buttons at its ends, and the Ask AI button. WithAskAI(text, icon, onClick) adds that primary button at the end of the search input (search modes only) and hands the OmniBox to the click handler, so it can read SearchText. In SearchAndChat the button sits at the end of the footer and hides itself in chat mode.",
+                Label("Rounded() with Ask AI").SetContent(pill),
+                Label("The default roundness, same button").SetContent(square).MT(6),
+                Label("Mode.SearchAndChat").SetContent(both).MT(6));
         }
 
         // ---------- File drop ----------

--- a/Tesserae/skills/references/omni-box.md
+++ b/Tesserae/skills/references/omni-box.md
@@ -41,6 +41,16 @@ OmniBox:
   input, for filters the app owns rather than ones the user typed. A chip takes a text (with optional
   background/foreground colors and an `onClick`) or an arbitrary `IComponent`.
 - `.SetSearchRightText(string)` — a label at the far end of the search input, e.g. a result count.
+- `.Rounded(BorderRadius radius = BorderRadius.Full)` — rounds the box, and everything meeting its
+  outline follows: the search container, the buttons at its ends and the "Ask AI" button. `Full` makes
+  the single-row search box a pill (and drops the vertical dividers between its buttons); on the
+  multi-row chat layouts, where a stadium shape would curve through the input, it settles for a
+  generously rounded rectangle instead.
+- `.WithAskAI(string text = "Ask AI", UIcons icon = UIcons.Beacon, Action<OmniBox> onClick = null)` — a
+  primary-styled button at the end of the search input (search modes only), following the box's
+  roundness. The handler gets the OmniBox, so it can read `.SearchText`. In `SearchAndChat` the button
+  sits at the end of the footer and hides itself while the box is in chat mode. Calling it again updates
+  the button that is there; a null or empty `text` hides it.
 - `.SetModels(params ModelOption[])` / `.LockModel(ModelOption)` / `.SetThinkingEffort(ThinkingEffort)`
   — the chat footer's model selector; a locked model shows with a lock and stops opening the popover.
 - `.SetKeyboardShortcut(params string[] keys)` — e.g. `("Ctrl", "K")`: a document-level shortcut that
@@ -85,6 +95,16 @@ var config = new OmniBox.Config(OmniBox.Mode.SearchAndChat)
 var omni = new OmniBox(config)
     .OnSearch((s, q) => Console.WriteLine($"Search: {q.Tokens.Count} tokens"))
     .OnChat((s, m) => Console.WriteLine("Chat sent"));
+```
+
+A pill-shaped search box with a result count and an "Ask AI" action:
+
+```csharp
+var omni = new OmniBox(new OmniBox.Config(OmniBox.Mode.Search) { PlaceholderSearch = "Search…" })
+    .Rounded()                                   // BorderRadius.Full — a pill
+    .SetSearchRightText("18 results · 0.21s")
+    .WithAskAI("Ask AI", UIcons.Beacon, box => AskAI(box.SearchText))
+    .OnSearch((s, q) => Search(q.RawQuery));
 ```
 
 Context attached to the next message, shown inside the box below the input:

--- a/Tesserae/src/Components/OmniBox.cs
+++ b/Tesserae/src/Components/OmniBox.cs
@@ -575,6 +575,8 @@ namespace Tesserae
         private readonly Button      _searchHelpBtn;
         private readonly Button      _searchClearBtn;
         private readonly Button      _searchTriggerBtn;
+        private Button          _askAIBtn;
+        private Action<OmniBox> _onAskAI;
         private bool _helpShowSyntax;
 
         private string[]      _shortcutKeys;
@@ -1245,6 +1247,10 @@ namespace Tesserae
                     _activeInput = _chatInput;
                     _container.classList.add("tss-omnibox-mode-chat");
                     _container.classList.remove("tss-omnibox-mode-search");
+                    // A textarea measured while it was display:none reports no content height at all, so a
+                    // box that started in search mode arrives here with a zero-height input: size it now
+                    // that it is the visible one.
+                    ResizeChatInput();
                     break;
                 }
                 case Mode.SearchAndChat:
@@ -3123,6 +3129,55 @@ namespace Tesserae
             return this;
         }
 
+        /// <summary>
+        /// Adds a primary-styled action button at the end of the search input — the way out of a search
+        /// that isn't finding it, over to whatever answers the question instead. The button follows the
+        /// box's roundness, so a box made round with <see cref="Rounded(BorderRadius)"/> gets a pill.
+        /// Search modes only: in <see cref="Mode.SearchAndChat"/> the button sits at the end of the
+        /// footer and hides itself while the box is in chat mode. Calling this again updates the button
+        /// that is already there; passing a null or empty <paramref name="text"/> hides it.
+        /// </summary>
+        /// <param name="text">The button label, e.g. "Ask AI".</param>
+        /// <param name="icon">The icon shown before the label.</param>
+        /// <param name="onClick">Called with this OmniBox when the button is clicked — read
+        /// <see cref="SearchText"/> from it to know what was typed.</param>
+        public OmniBox WithAskAI(string text = "Ask AI", UIcons icon = UIcons.Beacon, Action<OmniBox> onClick = null)
+        {
+            if (_mode != Mode.Search && _mode != Mode.SearchAndChat)
+            {
+                throw new InvalidOperationException("WithAskAI can only be called when OmniBox is in Search or SearchAndChat mode.");
+            }
+
+            _onAskAI = onClick;
+
+            if (_askAIBtn is null)
+            {
+                _askAIBtn = Button().Primary().Class("tss-omnibox-ask-ai-btn").OnClick(() =>
+                {
+                    if (!IsEnabled) return;
+                    _onAskAI?.Invoke(this);
+                });
+
+                if (_mode == Mode.Search)
+                {
+                    _searchContainer.appendChild(_askAIBtn.Render());
+                }
+                else
+                {
+                    _footer.appendChild(_askAIBtn.Render());
+                }
+            }
+
+            if (string.IsNullOrEmpty(text))
+            {
+                _askAIBtn.Collapse();
+                return this;
+            }
+
+            _askAIBtn.SetText(text).SetIcon(icon).Show();
+            return this;
+        }
+
         private void ShowSearchHelp()
         {
             var content = VStack().NoDefaultMargin().W(520).MaxHeight(500.px()).ScrollY().Class("tss-omnibox-help-panel");
@@ -3741,6 +3796,34 @@ namespace Tesserae
             _chatHeader.innerHTML = string.Empty;
 
             if (component is object) _chatHeader.appendChild(component.Render());
+
+            return this;
+        }
+
+        /// <summary>
+        /// Renders the box with rounded corners (defaults to a fully rounded "pill" shape). The radius
+        /// carries over to everything that meets the box's outline — the search container, the buttons at
+        /// its ends and the "Ask AI" button added with
+        /// <see cref="WithAskAI(string, UIcons, Action{OmniBox})"/> — and the pill shape also drops the
+        /// vertical dividers between them, so the contents sit inside the curve.
+        /// </summary>
+        /// <param name="radius">The border radius to apply. Defaults to <see cref="BorderRadius.Full"/>.</param>
+        public OmniBox Rounded(BorderRadius radius = BorderRadius.Full)
+        {
+            _container.classList.remove("tss-omnibox-rounded-sm", "tss-omnibox-rounded-md", "tss-omnibox-rounded-full");
+
+            switch (radius)
+            {
+                case BorderRadius.Small:
+                    _container.classList.add("tss-omnibox-rounded-sm");
+                    break;
+                case BorderRadius.Medium:
+                    _container.classList.add("tss-omnibox-rounded-md");
+                    break;
+                case BorderRadius.Full:
+                    _container.classList.add("tss-omnibox-rounded-full");
+                    break;
+            }
 
             return this;
         }

--- a/Tesserae/tps/assets/css/tss.omnibox.css
+++ b/Tesserae/tps/assets/css/tss.omnibox.css
@@ -1,4 +1,7 @@
 .tss-omnibox-container {
+    /* The box's own roundness, picked by .Rounded(BorderRadius) and followed by everything that meets
+       its outline: the search container, the buttons at its ends and the "Ask AI" button. */
+    --tss-omnibox-radius: var(--tss-border-radius-md);
     display: inline-flex;
     flex-direction: row;
     position: relative;
@@ -6,7 +9,7 @@
     margin: 0px;
     padding: 0px;
     border: 1px solid var(--tss-default-border-color);
-    border-radius: var(--tss-border-radius-md);
+    border-radius: var(--tss-omnibox-radius);
     background: var(--tss-default-background-color) none repeat scroll 0% 0%;
     color: var(--tss-default-foreground-color);
     align-items: stretch;
@@ -34,8 +37,8 @@
             background: var(--tss-secondary-background-color);
             color: var(--tss-secondary-foreground-color);
             flex-shrink: 0;
-            border-top-left-radius: var(--tss-border-radius-md);
-            border-bottom-left-radius: var(--tss-border-radius-md);
+            border-top-left-radius: var(--tss-omnibox-radius);
+            border-bottom-left-radius: var(--tss-omnibox-radius);
             border-top-right-radius: 0;
             border-bottom-right-radius: 0;
         }
@@ -61,8 +64,8 @@
             background: transparent;
             border-left: 1px solid var(--tss-default-border-color);
             flex-shrink: 0;
-            border-top-right-radius: var(--tss-border-radius-md);
-            border-bottom-right-radius: var(--tss-border-radius-md);
+            border-top-right-radius: var(--tss-omnibox-radius);
+            border-bottom-right-radius: var(--tss-omnibox-radius);
             border-top-left-radius: 0;
             border-bottom-left-radius: 0;
         }
@@ -116,7 +119,64 @@
     align-items: stretch;
     width: 100%;
     height: 36px;
-    border-radius: var(--tss-border-radius-md);
+    border-radius: var(--tss-omnibox-radius);
+}
+
+/* Roundness, picked with .Rounded(BorderRadius) */
+.tss-omnibox-container.tss-omnibox-rounded-sm {
+    --tss-omnibox-radius: var(--tss-border-radius-sm);
+}
+
+.tss-omnibox-container.tss-omnibox-rounded-md {
+    --tss-omnibox-radius: var(--tss-border-radius-md);
+}
+
+.tss-omnibox-container.tss-omnibox-rounded-full {
+    --tss-omnibox-radius: var(--tss-border-radius-full);
+}
+
+/* A stadium shape only reads well on the single-row search box: on the multi-row chat layouts a
+   9999px radius curves in through the input and the footer, so BorderRadius.Full settles for a
+   generously rounded rectangle there instead. */
+.tss-omnibox-container.tss-omnibox-rounded-full.tss-omnibox-chat-and-search,
+.tss-omnibox-container.tss-omnibox-rounded-full.tss-omnibox-mode-chat {
+    --tss-omnibox-radius: 24px;
+}
+
+/* A pill has no straight edge to hang a divider off, and its corners curve away from anything sitting
+   flush against them: so in the fully rounded box the dividers go, the buttons at the ends become
+   circles, and the row is inset far enough to stay inside the curve. */
+.tss-omnibox-container.tss-omnibox-rounded-full:not(.tss-omnibox-chat-and-search) .tss-omnibox-search-container {
+    box-sizing: border-box;
+    padding: 0 6px;
+}
+
+.tss-omnibox-container.tss-omnibox-rounded-full:not(.tss-omnibox-chat-and-search) .tss-omnibox-search-container .tss-btn {
+    border-radius: var(--tss-border-radius-full);
+    border-left-color: transparent;
+    border-right-color: transparent;
+}
+
+/* The icon buttons become discs, kept a little short of the row so they clear the pill's own curve
+   (the icon-only buttons hold their 1:1 aspect ratio, so the width follows). */
+.tss-omnibox-container.tss-omnibox-rounded-full:not(.tss-omnibox-chat-and-search) .tss-omnibox-search-container .tss-btn:not(.tss-omnibox-ask-ai-btn) {
+    align-self: center;
+    height: calc(100% - 8px);
+    min-height: 0;
+    max-height: 44px;
+    padding: 0;
+}
+
+/* Chips lose the grey strip and its divider in a pill — there is no straight edge for either — and go
+   fully round themselves, so their corners don't cut across the box's curve. */
+.tss-omnibox-container.tss-omnibox-rounded-full .tss-omnibox-inline-chips {
+    background: transparent;
+    border-right: none;
+    padding-left: 6px;
+}
+
+.tss-omnibox-container.tss-omnibox-rounded-full .tss-omnibox-inline-chip {
+    border-radius: var(--tss-border-radius-full);
 }
 
 /* Slot above the chat input, inside the box: what the message is being written against (a
@@ -325,6 +385,7 @@
 .tss-omnibox-container.tss-omnibox-mode-chat .tss-omnibox-search-history-btn,
 .tss-omnibox-container.tss-omnibox-mode-chat .tss-omnibox-search-clear-btn,
 .tss-omnibox-container.tss-omnibox-mode-chat .tss-omnibox-search-btn,
+.tss-omnibox-container.tss-omnibox-mode-chat .tss-omnibox-ask-ai-btn,
 .tss-omnibox-container.tss-omnibox-mode-chat .tss-omnibox-search-footer-item {
     display: none;
 }
@@ -503,6 +564,49 @@
 .tss-dark-mode .tss-btn.tss-omnibox-chat-btn.tss-omnibox-chat-btn-active:not(.tss-disabled):not(.tss-btn-danger):hover {
     background: #e6e6e6;
     color: #000;
+}
+
+/* "Ask AI" button (WithAskAI): a primary action at the end of the search input that follows the box's
+   roundness, so a pill box gets a pill button. It sizes itself to the box with room left around it,
+   whatever height the box is given. */
+.tss-omnibox-container .tss-omnibox-search-container .tss-btn.tss-omnibox-ask-ai-btn,
+.tss-omnibox-container .tss-omnibox-footer .tss-btn.tss-omnibox-ask-ai-btn {
+    border-radius: var(--tss-omnibox-radius);
+    align-self: center;
+    flex-shrink: 0;
+    min-width: 0;
+    min-height: 28px;
+    margin: 0 4px;
+    padding: 0 14px;
+    font-size: 13px;
+    font-weight: 600;
+    white-space: nowrap;
+}
+
+.tss-omnibox-container .tss-omnibox-search-container .tss-btn.tss-omnibox-ask-ai-btn {
+    height: calc(100% - 8px);
+    max-height: 44px;
+}
+
+.tss-omnibox-container .tss-omnibox-footer .tss-btn.tss-omnibox-ask-ai-btn {
+    height: 32px;
+}
+
+/* The label is a plain span, so it takes the button's foreground; the icon needs telling. */
+.tss-btn.tss-omnibox-ask-ai-btn:not(.tss-disabled) > i {
+    color: inherit;
+}
+
+/* A disabled box ignores the click, so the button says as much. */
+.tss-omnibox-container.tss-disabled .tss-btn.tss-omnibox-ask-ai-btn {
+    opacity: 0.5;
+    cursor: default;
+}
+
+/* Tighter than the 10px a .tss-btn puts between an icon and its label: this button is compact. */
+.tss-btn.tss-omnibox-ask-ai-btn > i + span:not(:empty) {
+    margin-left: 6px;
+    min-width: 0;
 }
 
 /* Model selector button (chat footer) */


### PR DESCRIPTION
Adds two new fluent methods to OmniBox: `Rounded()` for pill-shaped styling and `WithAskAI()` for a primary action button at the end of the search input.

## Summary

This change extends OmniBox with rounded corner styling and a dedicated "Ask AI" button, enabling search interfaces to offer a primary action for escalating to AI when search results aren't sufficient. The rounded styling applies consistently to the entire box outline (search container, end buttons, and the Ask AI button), with special handling for pill shapes that removes dividers and adjusts button geometry.

## Key Changes

**OmniBox.cs:**
- Added `_askAIBtn` field and `_onAskAI` callback to track the Ask AI button and its click handler
- Implemented `WithAskAI(string text, UIcons icon, Action<OmniBox> onClick)` method that:
  - Creates a primary-styled button at the end of the search input (search modes only)
  - In `SearchAndChat` mode, places the button in the footer and hides it during chat
  - Allows updating or hiding the button by calling the method again with null/empty text
  - Passes the OmniBox instance to the click handler so it can read `SearchText`
- Implemented `Rounded(BorderRadius radius = BorderRadius.Full)` method that:
  - Applies rounded corners to the entire box outline
  - Defaults to `BorderRadius.Full` for a pill shape
  - Supports `Small`, `Medium`, and `Full` radius options
- Fixed `UpdateMode()` to call `ResizeChatInput()` when switching to chat mode, since textareas measured while hidden report zero height

**tss.omnibox.css:**
- Introduced `--tss-omnibox-radius` CSS variable to centralize radius control across all box elements
- Added `.tss-omnibox-rounded-*` classes for `sm`, `md`, and `full` radius variants
- Special handling for `BorderRadius.Full` in chat layouts: uses `24px` instead of `9999px` to avoid curves cutting through multi-row content
- Pill shape styling (when `rounded-full` and not chat-and-search):
  - Removes dividers between buttons (transparent borders)
  - Makes icon buttons circular with inset padding to clear the pill curve
  - Makes chips fully rounded to align with the box curve
- Added `.tss-omnibox-ask-ai-btn` styling:
  - Primary button that follows the box's roundness
  - Sizes itself to the box with 4px margins and 8px vertical padding
  - Compact icon-to-label spacing (6px instead of 10px)
  - Disabled state with reduced opacity
  - Hides in chat mode via existing `.tss-omnibox-mode-chat` rules
- Updated `.tss-omnibox-mode-chat` to hide the Ask AI button

**omni-box.md (skill reference):**
- Documented `Rounded()` with explanation of pill shape behavior and multi-row layout handling
- Documented `WithAskAI()` with parameter descriptions and mode-specific behavior
- Added example code showing a pill-shaped search box with result count and Ask AI button

**OmniBoxSample.cs:**
- Added `RoundedAndAskAI()` sample demonstrating:
  - A pill-shaped search box with result count and Ask AI button
  - A default-roundness box with the same Ask AI button
  - SearchAndChat mode showing button placement in footer and mode switching behavior

## Notable Implementation Details

- The `--tss-omnibox-radius` CSS variable ensures all box elements (container, search container, end buttons, Ask AI button, chips) stay visually consistent when the radius changes
- Pill shape special cases: chat layouts use `24px` instead of `9999px` to avoid visual artifacts in multi-row layouts; icon buttons become circles with adjusted sizing; dividers are removed
- The Ask AI button is created lazily on first `WithAskAI()` call and appended to either the search container (Search mode) or footer (SearchAndChat mode)
- Chat mode hides the Ask AI button via CSS class rules

https://claude.ai/code/session_01Mr8uytaexBdHBFeMvdDH9w