### PR TITLE
Add OmniResult and PagesStack components for search results

### DIFF
--- a/Tesserae.Tests/src/Samples/Components/OmniResultSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/OmniResultSample.cs
@@ -1,0 +1,411 @@
+using System.Collections.Generic;
+using System.Linq;
+using static Transpose.Core.dom;
+using static Tesserae.UI;
+using static Tesserae.Tests.Samples.SamplesHelper;
+
+namespace Tesserae.Tests.Samples
+{
+    [SampleDetails(Group = "Components", Order = 105, Icon = UIcons.LayoutFluid)]
+    public class OmniResultSample : IComponent, ISample
+    {
+        // What the sample searched for, and so what the excerpts highlight.
+        private static readonly string[] QueryTerms = { "brake sensor", "calibration" };
+
+        private readonly IComponent _content;
+
+        // "Selection" section: the rows own the selection, the sample only reports on it.
+        private readonly List<OmniResult<Hit>> _selectable = new List<OmniResult<Hit>>();
+        private readonly TextBlock             _selectionState;
+
+        // "Commands" section.
+        private readonly TextBlock _lastCommand;
+
+        private static readonly Hit[] Hits =
+        {
+            new Hit("brake-sensor-reports", null, UIcons.Folder, "#6366f1", "Name match",
+                "Contains inspection sheets and calibration runs for the BRK-447 brake sensor family, 2022 onward.",
+                new[] { "All Files / sample-files", "24 files", "Pius Neuhaus", "2 days ago" }, 0),
+
+            new Hit("BRK-SEN-447 calibration procedure.pdf", "PDF", UIcons.FilePdf, "#ef4444", "3 matches in text",
+                "Torque the mount to 12 Nm before starting brake sensor work. Full calibration steps and the BRK-SEN-447 harness diagram sit on page 14 — connector keying changed in revision C.",
+                new[] { "sample-files / pdfs / procedures", "2.4 MB", "Pius Neuhaus", "Apr 12, 2024" }, 24),
+
+            new Hit("Sensor drift analysis.xlsx", "XLSX", UIcons.FileExcel, "#16a34a", "2 matches in text",
+                "Column F tracks brake sensor drift across 14 units. Values above 0.8 mV trigger a re-calibration request in the CMMS.",
+                new[] { "sample-files / analysis", "480 KB", "Marie Lang", "Apr 11, 2024" }, 3),
+
+            new Hit("Line 3 shift handover — Mar 28.docx", "DOCX", UIcons.FileWord, "#3b82f6", "1 match in text",
+                "Night shift replaced two brake sensor modules on cell 4. Calibration deferred to day shift; ticket JR-2214 stays open.",
+                new[] { "sample-files / handover", "1.1 MB", "Tomas Rieger", "Mar 28, 2024" }, 4),
+
+            new Hit("field-failures / 2024", null, UIcons.Folder, "#6366f1", "Content match in 4 files",
+                "Failure reports filed against the brake sensor housing, including three units returned after calibration drift at the Ingolstadt line.",
+                new[] { "All Files / field-failures", "112 files", "Quality team", "6 hours ago" }, 0),
+
+            new Hit("Supplier notice — Bismuth BRK-447.pdf", "PDF", UIcons.FilePdf, "#ef4444", "Title match",
+                "Bismuth is discontinuing the BRK-447 brake sensor connector; the replacement needs a calibration pass on every line.",
+                new[] { "sample-files / suppliers", "320 KB", "Anja Vogt", "Mar 19, 2024" }, 2),
+
+            new Hit("brake-calibration-log.txt", "TXT", UIcons.File, "#94a3b8", "Name + content match",
+                "2024-03-28T21:14Z cell-4 brake sensor #7741 calibration OK (0.42 mV). 2024-03-28T21:19Z cell-4 sensor #7742 calibration FAILED.",
+                new[] { "sample-files / logs", "88 KB", "System", "Mar 28, 2024" }, 0)
+        };
+
+        public OmniResultSample()
+        {
+            _selectionState = TextBlock("Nothing selected.").Small().Foreground(Theme.Secondary.Foreground);
+            _lastCommand    = TextBlock("No command run yet.").Small().Foreground(Theme.Secondary.Foreground);
+
+            _content = SectionStack().Secondary()
+                .SampleTitle(typeof(OmniResultSample), UIcons.LayoutFluid, "Search-result rows with highlighted excerpts, a source footer, selection, commands and a page preview")
+                .FlatSection(VStack().WS().Children(Overview()))
+                .FlatSection(VStack().WS().Children(Everything()))
+                .FlatSection(VStack().WS().Children(NoText()))
+                .FlatSection(VStack().WS().Children(NoPages()))
+                .FlatSection(VStack().WS().Children(TitleOnly()))
+                .FlatSection(VStack().WS().Children(Tiles()))
+                .FlatSection(VStack().WS().Children(Highlighting()))
+                .FlatSection(VStack().WS().Children(Selection()))
+                .FlatSection(VStack().WS().Children(Commands()))
+                .FlatSection(VStack().WS().Children(Pages()))
+                .SeeAlso(typeof(OmniBoxSample), typeof(ContextCardSample), typeof(ResourceCardSample), typeof(CardSample), typeof(DetailsListSample));
+        }
+
+        // One feature per card: a subtitle, a line or two saying what to try, then the rows themselves.
+        private static Card FeatureCard(string title, string subTitle, string description, params IComponent[] content)
+        {
+            var stack = VStack().WS().Children(SampleSubTitle(subTitle), TextBlock(description).MB(8));
+
+            foreach (var c in content)
+            {
+                stack.Add(c);
+            }
+
+            return Card(stack).SetTitle(title);
+        }
+
+        // ---------- Overview ----------
+
+        private IComponent Overview()
+        {
+            return FeatureCard("Overview", "One row per hit",
+                "OmniResult<T> is the row a search result is drawn as: an icon tile whose background is a wash of the color the glyph is in, a title with a badge saying what matched, an excerpt with the query terms marked in it, and a footer naming the source and whatever metadata belongs beside it. The result it stands for rides along as Result, so one handler shared by a whole list of rows can act on the right hit without a closure per row.",
+                TextBlock("Everything past the title is optional: drop the excerpt, the page preview, the footer, or all of them, and the row tightens up accordingly — the four sections below are the same seven hits with progressively less on them. Rows are selectable, with the checkbox beside or over the tile; commands are reached by right-click and, optionally, a [...] button at the row's top-right, with room for a couple of inline commands before it.").Small());
+        }
+
+        // ---------- Everything ----------
+
+        private IComponent Everything()
+        {
+            return FeatureCard("The full row", "Icon, badge, excerpt, footer and a page preview",
+                "Hover a row: it lifts onto the hover background, the pages fan out like a macOS Downloads stack, and the [...] button appears at the top-right, level with the title. The fan opens inside a rail wide enough for it, so nothing in the row moves.",
+                Results(Hits, withText: true, withPages: true));
+        }
+
+        // ---------- Without the excerpt ----------
+
+        private IComponent NoText()
+        {
+            return FeatureCard("Without the excerpt", "Title, footer and preview only",
+                "A result with nothing worth quoting — or a denser list — simply never gets SetText. The row becomes two lines and the page preview keeps its size, so a mixed list stays on one rhythm.",
+                Results(Hits.Take(4).ToArray(), withText: false, withPages: true));
+        }
+
+        // ---------- Without the preview ----------
+
+        private IComponent NoPages()
+        {
+            return FeatureCard("Without the page preview", "The excerpt takes the full width",
+                "Leave the PagesStack out and the rail goes with it, so the title and the excerpt run to the row's end.",
+                Results(Hits.Take(3).ToArray(), withText: true, withPages: false));
+        }
+
+        // ---------- Title, badge and footer only ----------
+
+        private IComponent TitleOnly()
+        {
+            return FeatureCard("Title and footer only", "The compact list",
+                "Neither excerpt nor preview: one two-line row per hit, which is what a long result list or a picker wants.",
+                Results(Hits, withText: false, withPages: false));
+        }
+
+        // ---------- Tiles ----------
+
+        private IComponent Tiles()
+        {
+            return FeatureCard("Icon tiles", "A glyph, or the file type spelled out",
+                "SetIcon(icon, color) puts a UIcons glyph on the tile in that color, over a wash of the same color computed from it — a pale tint under a light theme, a deep one under a dark theme, cached so a list drawing the same handful of file-type colors only computes each once. SetIcon(text, color) spells the type out instead, for a format no glyph says plainly. Any component works too, for a thumbnail or an avatar.",
+                VStack().WS().Children(
+                    OmniResult(Hits[1], "BRK-SEN-447 calibration procedure.pdf").SetIcon(UIcons.FilePdf, "#ef4444").SetSource("#0061d5", "Box").SetFooterEntries("SetIcon(UIcons.FilePdf, \"#ef4444\")"),
+                    OmniResult(Hits[1], "Q3 line review.pptx").SetIcon("PPTX", "#f97316").SetSource("#0061d5", "Box").SetFooterEntries("SetIcon(\"PPTX\", \"#f97316\")"),
+                    OmniResult(Hits[2], "Sensor drift analysis.xlsx").SetIcon("XLSX", "#16a34a").SetSource("#0061d5", "Box").SetFooterEntries("SetIcon(\"XLSX\", \"#16a34a\")"),
+                    OmniResult(Hits[6], "brake-calibration-log.txt").SetIcon("TXT", "#94a3b8").SetSource("#0061d5", "Box").SetFooterEntries("A grey color stays grey in both themes"),
+                    OmniResult(Hits[0], "curiosity-logo.svg").SetIcon(Image("./assets/img/curiosity-logo.svg")).SetSource("#0061d5", "Box").SetFooterEntries("SetIcon(IComponent) — a thumbnail covers the tile"),
+                    OmniResult(Hits[0], "brake-sensor-reports").SetIcon(UIcons.Folder).SetSource("#0061d5", "Box").SetFooterEntries("No color: the tile falls back to the theme's own")));
+        }
+
+        // ---------- Highlighting ----------
+
+        private IComponent Highlighting()
+        {
+            var hit = Hits[1];
+
+            return FeatureCard("Highlighting", "Marking the query in the excerpt",
+                "The excerpt is plain text, not a component: HighlightWords marks every occurrence of the terms the user searched for, and Highlight takes the Regex a search backend hands back for the job. Matching runs against the text itself and each match is wrapped in its own element, so an excerpt containing angle brackets renders them instead of obeying them.",
+                VStack().WS().Children(
+                    OmniResult(hit, "HighlightWords(\"brake sensor\", \"calibration\")")
+                        .SetIcon(UIcons.FilePdf, "#ef4444")
+                        .SetText(hit.Text)
+                        .HighlightWords(QueryTerms)
+                        .SetSource("#0061d5", "Box"),
+                    OmniResult(hit, "Highlight(\"BRK-[A-Z]+-\\\\d+\")")
+                        .SetIcon(UIcons.FilePdf, "#ef4444")
+                        .SetText(hit.Text)
+                        .Highlight("(BRK-[A-Z]+-\\d+)")
+                        .SetSource("#0061d5", "Box"),
+                    OmniResult(hit, "No highlighter, and markup in the text")
+                        .SetIcon(UIcons.FilePdf, "#ef4444")
+                        .SetText("A passage that contains <script>alert('hi')</script> and <b>bold</b> markup is shown as the text it is.")
+                        .SetSource("#0061d5", "Box"),
+                    OmniResult(hit, "TextLines(4) — a longer excerpt")
+                        .SetIcon(UIcons.FilePdf, "#ef4444")
+                        .SetText(hit.Text + " " + hit.Text)
+                        .HighlightWords(QueryTerms)
+                        .TextLines(4)
+                        .SetSource("#0061d5", "Box")));
+        }
+
+        // ---------- Selection ----------
+
+        private IComponent Selection()
+        {
+            _selectable.Clear();
+
+            var modes = new[]
+            {
+                OmniResultSelectionMode.OnHoverBeforeIcon,
+                OmniResultSelectionMode.OnHoverOverIcon,
+                OmniResultSelectionMode.AlwaysBeforeIcon,
+                OmniResultSelectionMode.ReplacingIcon
+            };
+
+            var sections = VStack().WS();
+
+            for (int m = 0; m < modes.Length; m++)
+            {
+                var mode = modes[m];
+                var list = VStack().WS();
+
+                for (int i = 0; i < 2; i++)
+                {
+                    var hit = Hits[(m * 2 + i) % Hits.Length];
+                    var row = Row(hit, withText: false, withPages: false)
+                        .Selectable(mode)
+                        .OnSelectionChanged((r, isSelected) => ReportSelection())
+                        .OnRangeSelectionRequested(r => SelectRangeTo(r));
+
+                    _selectable.Add(row);
+                    list.Add(row);
+                }
+
+                sections.Add(TextBlock($"OmniResultSelectionMode.{mode}").Small().SemiBold().MT(m == 0 ? 0 : 12).MB(4));
+                sections.Add(list);
+            }
+
+            return FeatureCard("Selection", "Four places for the checkbox",
+                "Selectable(mode) makes a row selectable. The checkbox sits before the tile or over it, revealed on hover or always visible, or takes the tile's place entirely — and a selected row always shows its checkbox, whatever the mode. Ctrl-clicking a row toggles it too, and shift-clicking one asks for the range from the last row selected: a single card knows nothing about its siblings, so OnRangeSelectionRequested hands that to the host list, which selects them itself (that is what the rows below do, across all four groups).",
+                sections,
+                _selectionState.MT(8),
+                HStack().Gap(8.px()).MT(8).Children(
+                    Button("Select all").SetIcon(UIcons.ListCheck).OnClick(() => { foreach (var r in _selectable) r.Selected(); }),
+                    Button("Clear selection").SetIcon(UIcons.Broom).OnClick(() => { foreach (var r in _selectable) r.Selected(false); })));
+        }
+
+        private void SelectRangeTo(OmniResult<Hit> target)
+        {
+            var last = _selectable.FindIndex(r => r.IsSelected);
+
+            if (last < 0)
+            {
+                target.Selected();
+                return;
+            }
+
+            var to   = _selectable.IndexOf(target);
+            var from = last;
+
+            if (to < from)
+            {
+                var swap = from;
+                from = to;
+                to   = swap;
+            }
+
+            for (int i = from; i <= to; i++)
+            {
+                _selectable[i].Selected();
+            }
+        }
+
+        private void ReportSelection()
+        {
+            var selected = _selectable.Where(r => r.IsSelected).ToArray();
+
+            _selectionState.Text = selected.Length == 0
+                ? "Nothing selected."
+                : $"{selected.Length} selected: {string.Join(", ", selected.Select(r => r.Result.Title))}";
+        }
+
+        // ---------- Commands ----------
+
+        private IComponent Commands()
+        {
+            return FeatureCard("Commands", "Right-click, a [...] button, and inline commands",
+                "OnContextMenu registers what opens the row's commands and says how they are reached: by right-click alone, or also by a [...] button at the top-right — always visible, or revealed on hover. The Func overload builds a ContextMenu the row shows itself, at the pointer or under the button; the Action<OmniResult<T>> overload hands the row to a plain handler, which can still place a menu with ShowMenu. InlineCommands puts a couple of buttons before the [...]; the space they take is reserved either way, so revealing them never shifts the row.",
+                VStack().WS().Children(
+                    WithMenu(Row(Hits[1], withText: false, withPages: false), OmniResultCommandsMode.RightClickOnly)
+                        .SetFooterEntries("RightClickOnly — no button is drawn"),
+                    WithMenu(Row(Hits[2], withText: false, withPages: false), OmniResultCommandsMode.ButtonOnHover)
+                        .SetFooterEntries("ButtonOnHover — hover the row"),
+                    WithMenu(Row(Hits[3], withText: false, withPages: false), OmniResultCommandsMode.ButtonAlwaysVisible)
+                        .SetFooterEntries("ButtonAlwaysVisible"),
+                    WithMenu(Row(Hits[5], withText: false, withPages: false), OmniResultCommandsMode.ButtonOnHover)
+                        .InlineCommands(
+                            Button(UIcons.Download).Tooltip("Download").OnClick(() => Report("Download")),
+                            Button(UIcons.Share).Tooltip("Share").OnClick(() => Report("Share")))
+                        .SetFooterEntries("InlineCommands — shown on hover, before the [...]"),
+                    WithMenu(Row(Hits[6], withText: false, withPages: false), OmniResultCommandsMode.ButtonAlwaysVisible)
+                        .InlineCommands(OmniResultCommandsVisibility.AlwaysVisible,
+                            Button(UIcons.Star).Tooltip("Pin").OnClick(() => Report("Pin")))
+                        .SetFooterEntries("InlineCommands(AlwaysVisible)"),
+                    Row(Hits[4], withText: false, withPages: false)
+                        .OnContextMenu(r => Report($"Right-clicked \"{r.Result.Title}\" (plain handler)"))
+                        .SetFooterEntries("The Action<OmniResult<T>> overload — no menu, just a handler")),
+                _lastCommand.MT(8));
+        }
+
+        // The menu is built on every open, so its items can describe the row as it stands right now.
+        private OmniResult<Hit> WithMenu(OmniResult<Hit> row, OmniResultCommandsMode mode)
+        {
+            return row.OnContextMenu(r => new[]
+            {
+                ContextMenuItem(r.Result.Title).Header(),
+                ContextMenuItem(MenuLine(UIcons.FolderOpen, "Open")).OnClick(() => Report($"Opening {r.Result.Title}")),
+                ContextMenuItem(MenuLine(UIcons.Copy, "Copy link")).OnClick(() => Report($"Copied a link to {r.Result.Title}")),
+                ContextMenuItem().Divider(),
+                ContextMenuItem(MenuLine(UIcons.Trash, "Delete", Theme.Danger.Background)).OnClick(() => Report($"Deleted {r.Result.Title}"))
+            }, mode);
+        }
+
+        private static IComponent MenuLine(UIcons icon, string text, string color = null)
+            => HStack().Children(Icon(icon, color: color), TextBlock(text).ML(8));
+
+        private void Report(string what)
+        {
+            _lastCommand.Text = what;
+            Toast().Information(what);
+        }
+
+        // ---------- PagesStack ----------
+
+        private IComponent Pages()
+        {
+            var thumbnails = new[]
+            {
+                "./assets/img/box-img.svg",
+                "./assets/img/curiosity-logo.svg",
+                "./assets/img/box-img.svg",
+                "./assets/img/curiosity-logo.svg"
+            };
+
+            return FeatureCard("PagesStack", "The page preview on its own",
+                "PagesStack is the preview rail: up to five overlapping, slightly rotated pages that fan out on a shallow arc when hovered, with a +N badge over the stack counting the pages it doesn't draw. Given thumbnail urls it draws them (all cropped to one page size); given only a count it draws blank ruled pages. The holder is sized to the width the fan needs and pinned to its right edge, so opening the fan never widens the row — which is why a row can sit right beside it.",
+                HStack().WS().Wrap().Gap(32.px()).PT(8).PB(8).AlignItems(ItemAlign.End).Children(
+                    PagesLabel("1 page", PagesStack(1)),
+                    PagesLabel("3 pages", PagesStack(3)),
+                    PagesLabel("5 pages", PagesStack(5)),
+                    PagesLabel("24 pages", PagesStack(5).TotalPages(24)),
+                    PagesLabel("Thumbnails", PagesStack(thumbnails).TotalPages(9)),
+                    PagesLabel("Larger pages", PagesStack(4).PageSize(60, 78)),
+                    PagesLabel("MaxVisible(3)", PagesStack(12).MaxVisible(3))),
+                TextBlock("Held open with Fanned(), which is how OmniResult makes the stack follow hovering the whole row (PagesFanOnHover, on by default):").Small().MT(8).MB(8),
+                PagesLabel("Fanned()", PagesStack(5).TotalPages(19).Fanned()));
+        }
+
+        private static IComponent PagesLabel(string label, PagesStack pages)
+            => VStack().Children(pages, TextBlock(label).XSmall().Foreground(Theme.Secondary.Foreground).MT(8));
+
+        // ---------- Row helpers ----------
+
+        private IComponent Results(Hit[] hits, bool withText, bool withPages)
+        {
+            var list = VStack().WS();
+
+            foreach (var hit in hits)
+            {
+                list.Add(WithMenu(Row(hit, withText, withPages), OmniResultCommandsMode.ButtonOnHover));
+            }
+
+            return list;
+        }
+
+        private OmniResult<Hit> Row(Hit hit, bool withText, bool withPages)
+        {
+            var row = OmniResult(hit, hit.Title)
+                .SetBadge(hit.Badge)
+                .SetSource("#0061d5", "Box")
+                .SetFooterEntries(hit.Metadata)
+                .OnClick((r, _) => Toast().Information($"Opening {r.Result.Title}"));
+
+            if (hit.IconText is null)
+            {
+                row.SetIcon(hit.Icon, hit.Color);
+            }
+            else
+            {
+                row.SetIcon(hit.IconText, hit.Color);
+            }
+
+            if (withText)
+            {
+                row.SetText(hit.Text).HighlightWords(QueryTerms);
+            }
+
+            // A folder has no pages of its own, so it gets no preview even in the sections that show them.
+            if (withPages && hit.Pages > 0)
+            {
+                row.SetPages(PagesStack(hit.Pages > 5 ? 5 : hit.Pages).TotalPages(hit.Pages));
+            }
+
+            return row;
+        }
+
+        public HTMLElement Render() => _content.Render();
+
+        // The result each row stands for — what a real app would hand the row instead.
+        private class Hit
+        {
+            public string   Title    { get; }
+            public string   IconText { get; }
+            public UIcons   Icon     { get; }
+            public string   Color    { get; }
+            public string   Badge    { get; }
+            public string   Text     { get; }
+            public string[] Metadata { get; }
+            public int      Pages    { get; }
+
+            public Hit(string title, string iconText, UIcons icon, string color, string badge, string text, string[] metadata, int pages)
+            {
+                Title    = title;
+                IconText = iconText;
+                Icon     = icon;
+                Color    = color;
+                Badge    = badge;
+                Text     = text;
+                Metadata = metadata;
+                Pages    = pages;
+            }
+        }
+    }
+}

--- a/Tesserae/skills/SKILL.md
+++ b/Tesserae/skills/SKILL.md
@@ -151,7 +151,8 @@ date-range-picker · date-time-picker · delta-component · dropdown ·
 editable-area · editable-label · expander · grid-picker · horizontal-separator ·
 icon · icon-toggle · image · label · link · live-progress · markdown-block ·
 menu · message ·
-metric · month-picker · navbar · number-picker · omni-box · option · pagination ·
+metric · month-picker · navbar · number-picker · omni-box · omni-result · option ·
+pages-stack · pagination ·
 picker · pixel-avatar · plan · popover · progress-indicator · progress-ring ·
 property-grid · rating · resource-card · sandbox · save-button · saving-toast ·
 search-box · section-title · sidebar · sidebar-separator · sidenav · skeleton ·

--- a/Tesserae/skills/references/context-card.md
+++ b/Tesserae/skills/references/context-card.md
@@ -144,4 +144,5 @@ list of rows, or a compact row of pills with a "+N more". See `context-cards.md`
 - ResourceCard (the larger, full resource summary) — `resource-card.md`
 - Badge / Tag / Chip (removable inline tokens) — `badge.md`
 - Icon and UIcons — `icon.md`, `uicons.md`
+- OmniResult (the search-result row a hit is drawn as) — `omni-result.md`
 - Full docs & API: `/tesserae/components/context-card`

--- a/Tesserae/skills/references/omni-box.md
+++ b/Tesserae/skills/references/omni-box.md
@@ -112,4 +112,5 @@ omni.AddContext(ContextCard("Q3-forecast.xlsx", UIcons.FileExcel).SetSubLabel("S
 - ToolAgentSelector — the tool/agent picker `EnableChatMentions` is commonly wired to — `tool-agent-selector.md`
 - ContextCards — a compact row of pills naming the attached context, mounted in the box's `ChatHeader` slot — `context-cards.md`
 - ContextCard — the cards `WithContextToAdd` renders below the input — `context-card.md`
+- OmniResult — the search-result rows a query typed here is answered with — `omni-result.md`
 - Full docs & API: `/tesserae/components/omni-box`

--- a/Tesserae/skills/references/omni-result.md
+++ b/Tesserae/skills/references/omni-result.md
@@ -33,7 +33,9 @@ stands for. Also `new OmniResult<T>(result, title)`. Bring factories into scope 
 - `.SetBadge(IComponent)` — a `Badge` with a tone of its own, a `Spinner`, a small button.
 - `.SetText(string)` / `Text` — the excerpt, as **plain text**, ellipsized to two lines.
 - `.TextLines(int)` — how many lines the excerpt gets before it is ellipsized.
-- `.HighlightWords(params string[])` — mark those words in the excerpt, case-insensitively.
+- `.HighlightWords(params string[])` — mark those words in the excerpt, case-insensitively. The marks
+  and the badge share one pair of colors, from the `--tss-highlight-color` token (the same value as
+  `--tss-link-color`, so `Theme.SetPrimary` moves both), and the excerpt itself is a quiet grey.
 - `.Highlight(Regex)` / `.Highlight(string pattern, bool ignoreCase = true)` — mark every match, e.g.
   the pattern a search backend hands back. Matching runs against the text and each match is wrapped in
   its own element, so an excerpt containing angle brackets renders them instead of obeying them.

--- a/Tesserae/skills/references/omni-result.md
+++ b/Tesserae/skills/references/omni-result.md
@@ -1,0 +1,149 @@
+---
+name: omni-result
+description: A search-result row with an icon tile tinted from one color, a title with a badge, an excerpt whose matched terms are highlighted, a footer naming the source, selectable checkboxes, right-click or button commands, and an optional fanning page preview. Use for search result lists, pickers and file browsers in a Tesserae (C#/Transpose) app.
+---
+
+# OmniResult&lt;T&gt;
+
+`OmniResult<T>` is the row one search hit is drawn as. It carries the result it stands for as
+`Result`, so a click, selection or command handler shared by a whole list acts on the right hit
+without a closure per row:
+
+```
+[✓]  [PDF]  BRK-SEN-447 calibration procedure.pdf   3 matches in text                 [pages]  [...]
+            Torque the mount to 12 Nm before starting brake sensor work. Full calibration steps …
+            ▪ Box · sample-files / pdfs · 2.4 MB · Pius Neuhaus · Apr 12, 2024
+```
+
+Everything past the title is optional. Drop the excerpt, the preview, the footer, or all three, and
+the row tightens up — the same component covers a two-line picker row and a full result card.
+
+## Create
+
+`UI.OmniResult(result, title = null)` — returns an `OmniResult<T>`, where `T` is whatever the row
+stands for. Also `new OmniResult<T>(result, title)`. Bring factories into scope with
+`using static Tesserae.UI;`.
+
+## Key configuration
+
+**Title, badge, excerpt**
+
+- `.SetTitle(string)` / `Title` — one line, ellipsized, with the full text as its tooltip.
+- `.SetBadge(string)` — the quiet pill next to the title ("3 matches in text"). Null or empty hides it.
+- `.SetBadge(IComponent)` — a `Badge` with a tone of its own, a `Spinner`, a small button.
+- `.SetText(string)` / `Text` — the excerpt, as **plain text**, ellipsized to two lines.
+- `.TextLines(int)` — how many lines the excerpt gets before it is ellipsized.
+- `.HighlightWords(params string[])` — mark those words in the excerpt, case-insensitively.
+- `.Highlight(Regex)` / `.Highlight(string pattern, bool ignoreCase = true)` — mark every match, e.g.
+  the pattern a search backend hands back. Matching runs against the text and each match is wrapped in
+  its own element, so an excerpt containing angle brackets renders them instead of obeying them.
+
+**Icon tile**
+
+- `.SetIcon(UIcons icon, string color = null, UIconsWeight weight = Regular)` — the glyph in `color`,
+  over a wash computed from that same color: a pale tint under a light theme, a deep one under a dark
+  theme. Both variants are written to the element, so flipping the theme at runtime needs no redraw,
+  and the computed pair is cached per color (a list drawing one color per file type only pays once).
+- `.SetIcon(string text, string color = null)` — a short type name ("PPTX", "CSV") in place of a glyph.
+- `.SetIcon(IComponent, string color = null)` — an `Image` thumbnail, an `Avatar`, an emoji.
+
+Pass a literal color (`"#ef4444"`) rather than a CSS variable when you want the tint to track the
+theme: a `var(--…)` is resolved once, at the time it is set.
+
+**Footer**
+
+- `.SetSource(string color, string text)` — a small rounded square in that color plus the text, at the
+  footer's start. Null or empty text drops it.
+- `.SetFooterEntries(params string[])` / `.SetFooterEntries(params IComponent[])` — the metadata after
+  the source: a path, a size, an owner, a date. Dots between entries are drawn by CSS, so nothing has
+  to interleave separators, and a footer with no source never starts with one.
+
+**Selection**
+
+- `.Selectable(OmniResultSelectionMode mode = OnHoverBeforeIcon)` / `.NotSelectable()`.
+  Modes: `OnHoverBeforeIcon`, `OnHoverOverIcon` (on the tile, which fades out under it),
+  `AlwaysBeforeIcon`, `ReplacingIcon` (no tile at all). A selected row always shows its checkbox,
+  whatever the mode, and the column is reserved either way so revealing it never shifts the row.
+- `IsSelected` / `.Selected(bool = true)` / `IsSelectionEnabled`.
+- `.OnSelectionChanged(Action<OmniResult<T>, bool>)` — every change, from the user or from code.
+- `.OnRangeSelectionRequested(Action<OmniResult<T>>)` — shift-click. A row knows nothing about its
+  siblings, so the host list decides what "between" means and selects them itself.
+- Ctrl-click toggles the row; Space toggles the focused row; Enter activates it (`OnClick`).
+- `IsActive` — styles the row like a hovered one, for a keyboard-driven list.
+
+**Commands**
+
+- `.OnContextMenu(Func<OmniResult<T>, ContextMenu.Item[]> menu, OmniResultCommandsMode mode = RightClickOnly)`
+  — the row builds and places the menu itself, at the pointer or under the button.
+- `.OnContextMenu(Action<OmniResult<T>> handler, OmniResultCommandsMode mode = RightClickOnly)` — a
+  plain handler; it can still place a menu with `.ShowMenu(ContextMenu)`, which uses the pointer
+  position when the row was right-clicked and the button when it was pressed.
+- `OmniResultCommandsMode`: `RightClickOnly` (no button drawn), `ButtonOnHover`, `ButtonAlwaysVisible`.
+  `.CommandsMode(mode)` changes it later without touching the handler.
+- `.InlineCommands(params IComponent[])` / `.InlineCommands(OmniResultCommandsVisibility visibility, params IComponent[])`
+  — one or two buttons before the `[...]`, `OnHover` (default) or `AlwaysVisible`. The space is
+  reserved either way.
+
+**Page preview**
+
+- `.SetPages(PagesStack)` — pinned to the row's end, inside a rail wide enough for the fan (see
+  `pages-stack.md`).
+- `.PagesFanOnHover(bool = true)` — the stack fans while the whole row is hovered, not only while the
+  pointer is over the pages. On by default.
+
+## Example
+
+```csharp
+using static Tesserae.UI;
+
+var list  = VStack().WS();
+var terms = new[] { "brake sensor", "calibration" };
+
+foreach (var hit in results)
+{
+    var row = OmniResult(hit, hit.Name)                        // T is whatever `hit` is
+        .SetIcon(UIcons.FilePdf, "#ef4444")
+        .SetBadge($"{hit.Matches} matches in text")
+        .SetText(hit.Excerpt)
+        .HighlightWords(terms)
+        .SetSource("#0061d5", hit.Source)
+        .SetFooterEntries(hit.Path, hit.Size, hit.Owner, hit.Modified)
+        .SetPages(PagesStack(5).TotalPages(hit.Pages))
+        .Selectable(OmniResultSelectionMode.OnHoverBeforeIcon)
+        .OnSelectionChanged((r, isSelected) => RefreshActionBar())
+        .OnRangeSelectionRequested(r => SelectRangeTo(r))       // the host owns the range
+        .OnClick((r, _) => Open(r.Result))
+        .OnContextMenu(r => new[]
+        {
+            ContextMenuItem(r.Result.Name).Header(),
+            ContextMenuItem("Open").OnClick(() => Open(r.Result)),
+            ContextMenuItem().Divider(),
+            ContextMenuItem("Delete").OnClick(() => Delete(r.Result))
+        }, OmniResultCommandsMode.ButtonOnHover)
+        .InlineCommands(Button(UIcons.Download).Tooltip("Download").OnClick(() => Download(hit)));
+
+    list.Add(row);
+}
+```
+
+A picker row — no excerpt, no preview, the checkbox always in place:
+
+```csharp
+var pick = OmniResult(file, file.Name)
+    .SetIcon("XLSX", "#16a34a")
+    .SetSource("#0061d5", "Box")
+    .SetFooterEntries(file.Path, file.Size)
+    .Selectable(OmniResultSelectionMode.AlwaysBeforeIcon);
+```
+
+## Related
+
+- PagesStack — the page preview it takes — `pages-stack.md`
+- ContextMenu — the menu the commands open, and its items — `context-menu.md`
+- OmniBox — the search input these rows usually answer — `omni-box.md`
+- ResourceCard (the larger, tile-shaped resource summary) — `resource-card.md`
+- ContextCard (the compact chat-attachment card) — `context-card.md`
+- Badge — what `SetBadge(IComponent)` takes — `badge.md`
+- CheckBox — the selection control — `check-box.md`
+- DetailsList / SearchableList (when the results are really a table or a grid) — `details-list.md`, `searchable-list.md`
+- Full docs & API: `/tesserae/components/omni-result`

--- a/Tesserae/skills/references/pages-stack.md
+++ b/Tesserae/skills/references/pages-stack.md
@@ -1,0 +1,70 @@
+---
+name: pages-stack
+description: A macOS-Downloads-style stack of page thumbnails that fans out on hover, with a plus-N badge for the pages it does not draw, inside a rail sized so opening the fan never widens the row. Use as the document preview beside a search result or file row in a Tesserae (C#/Transpose) app.
+---
+
+# PagesStack
+
+`PagesStack` is the little pile of pages a document preview is drawn as: up to five overlapping,
+slightly rotated pages that fan out along a shallow arc when the pointer is over them, with a `+N`
+badge over the top-right counting whatever the stack doesn't draw.
+
+The important part is the geometry. The stack lives in a **holder sized to the width the fan needs**
+and is pinned to that holder's right edge, so the fan opens into reserved space: it draws on top of
+whatever is beside it instead of pushing the row around. That is what lets it sit right next to a
+result's title and metadata.
+
+Pages are either image thumbnails or blank ruled placeholders, for a document whose thumbnails
+haven't been generated — or aren't worth generating — yet.
+
+## Create
+
+- `UI.PagesStack(params string[] imageUrls)` — one page per url, all cropped to the same page size.
+- `UI.PagesStack(int pages)` — that many blank ruled pages.
+
+Also `new PagesStack(...)`. Bring factories into scope with `using static Tesserae.UI;`.
+
+## Key configuration
+
+- `.SetPages(params string[])` / `.SetPages(int)` — replace the pages.
+- `.TotalPages(int)` — how many pages the document has: the ones past those drawn are counted by the
+  `+N` badge. A stack given thumbnails draws only those, so `PagesStack(4 urls).TotalPages(9)` is four
+  thumbnails and a `+5`.
+- `.MaxVisible(int)` — how many pages are drawn before the rest collapse into the badge (5 by default).
+- `.PageSize(int width, int height)` — the size every page is drawn at (48×62 by default). The rail
+  width follows from it, so a larger page reserves more room for the fan.
+- `.Fanned(bool = true)` — hold the stack open, for a host that wants the fan to follow hovering
+  something larger than the stack. `OmniResult` does exactly this for the row it sits in
+  (`PagesFanOnHover`, on by default).
+- `TotalPageCount` / `VisiblePageCount` / `IsFanned` — what it is showing right now.
+
+Motion is 240ms and honours `prefers-reduced-motion`. Pages read as paper in both themes: a pale fill
+with hairline rules under a light theme, lifted off the background under a dark one.
+
+## Example
+
+```csharp
+using static Tesserae.UI;
+
+// A 24-page PDF: five pages drawn, "+19" over the corner.
+var preview = PagesStack(5).TotalPages(24);
+
+// Real thumbnails, and more pages than there are thumbnails for.
+var thumbs = PagesStack(page1Url, page2Url, page3Url).TotalPages(12);
+
+// Where it usually goes: the preview rail of a search result.
+var row = OmniResult(hit, hit.Name)
+    .SetIcon(UIcons.FilePdf, "#ef4444")
+    .SetText(hit.Excerpt)
+    .SetPages(PagesStack(5).TotalPages(hit.Pages));
+```
+
+Standalone, in a row of its own, remember it is right-aligned inside its rail — put it in an
+`HStack().AlignItems(ItemAlign.End)` if you are lining several up next to their labels.
+
+## Related
+
+- OmniResult — the search-result row this is the preview for — `omni-result.md`
+- Image — what a thumbnail page is drawn with — `image.md`
+- Carousel (when the pages should be paged through rather than previewed) — `carousel.md`
+- Full docs & API: `/tesserae/components/pages-stack`

--- a/Tesserae/skills/references/resource-card.md
+++ b/Tesserae/skills/references/resource-card.md
@@ -44,4 +44,5 @@ var card = ResourceCard()
 
 - Card — `.card.md`
 - ContextCard (the compact chat-attachment variant) — `.context-card.md`
+- OmniResult (the search-result row, with highlighting and a page preview) — `omni-result.md`
 - Full docs & API: `/tesserae/components/resource-card`

--- a/Tesserae/skills/references/theme-colors.md
+++ b/Tesserae/skills/references/theme-colors.md
@@ -11,7 +11,9 @@ description: The static `Theme` class for switching light/dark mode and overridi
 
 - `Theme.Light()` — switch to light mode.
 - `Theme.Dark()` — switch to dark mode (toggles the `tss-dark-mode` body class).
-- `Theme.SetPrimary(Color light, Color dark)` — set primary color for both modes.
+- `Theme.SetPrimary(Color light, Color dark)` — set primary color for both modes. It also drives the
+  colors derived from it: `--tss-link-color` (links, `Badge().Info()`) and `--tss-highlight-color`
+  (marked search terms, see `omni-result.md`).
 - `Theme.SetBackground(Color light, Color dark)` — set background for both modes.
 
 ## Properties

--- a/Tesserae/src/Base/UI.Components.cs
+++ b/Tesserae/src/Base/UI.Components.cs
@@ -1120,6 +1120,25 @@ namespace Tesserae
         public static ContextCard ContextCard(string label, IComponent iconOrImage) => new ContextCard(label, iconOrImage);
 
         /// <summary>
+        /// Creates a <see cref="Tesserae.OmniResult{T}"/> search-result row for the given result: an icon
+        /// tile, a title with an optional badge, an optional highlighted excerpt, an optional footer naming
+        /// the source, and an optional <see cref="Tesserae.PagesStack"/> preview.
+        /// </summary>
+        public static OmniResult<T> OmniResult<T>(T result, string title = null) => new OmniResult<T>(result, title);
+
+        /// <summary>
+        /// Creates a <see cref="Tesserae.PagesStack"/> showing the given page thumbnails: a stack of
+        /// overlapping pages that fans out when hovered, inside a rail wide enough for the fan.
+        /// </summary>
+        public static PagesStack PagesStack(params string[] imageUrls) => new PagesStack(imageUrls);
+
+        /// <summary>
+        /// Creates a <see cref="Tesserae.PagesStack"/> showing the given number of blank ruled pages, for a
+        /// document with no thumbnails to show.
+        /// </summary>
+        public static PagesStack PagesStack(int pages) => new PagesStack(pages);
+
+        /// <summary>
         /// Creates a <see cref="Tesserae.ContextCards"/> group: the given <see cref="Tesserae.ContextCard"/>s
         /// behind one summary pill that expands to list them, or - with <see cref="Tesserae.ContextCards.Compact()"/>
         /// - a compact row of pills that collapses everything past the fifth into a "+N more" pill.

--- a/Tesserae/src/Base/UI.Theme.cs
+++ b/Tesserae/src/Base/UI.Theme.cs
@@ -299,6 +299,7 @@ namespace Tesserae
                 sb.AppendLine(":root {");
                 sb.Append("  --tss-primary-background-color-root: ").Append(primaryLightColor.ToRGBvar()).AppendLine(";");
                 sb.Append("  --tss-link-color-root: ").Append(primaryLightColor.ToRGBvar()).AppendLine(";");
+                sb.Append("  --tss-highlight-color-root: ").Append(primaryLightColor.ToRGBvar()).AppendLine(";");
                 sb.Append("  --tss-primary-border-color-root: ").Append(borderColorLight.ToRGBvar()).AppendLine(";");
                 sb.Append("  --tss-primary-background-hover-color-root: ").Append(borderColorLight.ToRGBvar()).AppendLine(";");
                 sb.Append("  --tss-primary-background-active-color-root: ").Append(backgroundActiveLight.ToRGBvar()).AppendLine(";");
@@ -308,6 +309,7 @@ namespace Tesserae
                 sb.Append(@"
     --tss-primary-background-color: rgb(var(--tss-primary-background-color-root ));
     --tss-link-color: rgb(var(--tss-link-color-root ));
+    --tss-highlight-color: rgb(var(--tss-highlight-color-root ));
     --tss-primary-border-color: rgb(var(--tss-primary-border-color-root ));
     --tss-primary-background-hover-color: rgb(var(--tss-primary-background-hover-color-root ));
     --tss-primary-background-active-color: rgb(var(--tss-primary-background-active-color-root ));
@@ -319,6 +321,7 @@ namespace Tesserae
                 sb.AppendLine(".tss-dark-mode {");
                 sb.Append("  --tss-primary-background-color-root: ").Append(primaryDarkColor.ToRGBvar()).AppendLine(";");
                 sb.Append("  --tss-link-color-root: ").Append(primaryDarkColor.ToRGBvar()).AppendLine(";");
+                sb.Append("  --tss-highlight-color-root: ").Append(primaryDarkColor.ToRGBvar()).AppendLine(";");
                 sb.Append("  --tss-primary-border-color-root: ").Append(borderColorDark.ToRGBvar()).AppendLine(";");
                 sb.Append("  --tss-primary-background-hover-color-root: ").Append(borderColorDark.ToRGBvar()).AppendLine(";");
                 sb.Append("  --tss-primary-background-active-color-root: ").Append(backgroundActiveDark.ToRGBvar()).AppendLine(";");
@@ -328,6 +331,7 @@ namespace Tesserae
                 sb.Append(@"
     --tss-primary-background-color: rgb(var(--tss-primary-background-color-root ));
     --tss-link-color: rgb(var(--tss-link-color-root ));
+    --tss-highlight-color: rgb(var(--tss-highlight-color-root ));
     --tss-primary-border-color: rgb(var(--tss-primary-border-color-root ));
     --tss-primary-background-hover-color: rgb(var(--tss-primary-background-hover-color-root ));
     --tss-primary-background-active-color: rgb(var(--tss-primary-background-active-color-root ));

--- a/Tesserae/src/Components/OmniResult.cs
+++ b/Tesserae/src/Components/OmniResult.cs
@@ -1,0 +1,972 @@
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using static Transpose.Core.dom;
+using Transpose.Core;
+using static Tesserae.UI;
+
+namespace Tesserae
+{
+    /// <summary>
+    /// Where the selection checkbox of an <see cref="OmniResult{T}"/> lives, and when it shows. A selected
+    /// result always shows its checkbox, whatever the mode.
+    /// </summary>
+    public enum OmniResultSelectionMode
+    {
+        /// <summary>A checkbox in its own column before the icon, revealed while the result is hovered.</summary>
+        OnHoverBeforeIcon,
+        /// <summary>A checkbox over the icon tile, revealed - and covering the icon - while the result is hovered.</summary>
+        OnHoverOverIcon,
+        /// <summary>A checkbox in its own column before the icon, always visible.</summary>
+        AlwaysBeforeIcon,
+        /// <summary>A checkbox in place of the icon tile, which is not drawn at all.</summary>
+        ReplacingIcon
+    }
+
+    /// <summary>
+    /// How the commands of an <see cref="OmniResult{T}"/> are reached.
+    /// </summary>
+    public enum OmniResultCommandsMode
+    {
+        /// <summary>Right-clicking the result, and nothing else - no button is drawn.</summary>
+        RightClickOnly,
+        /// <summary>Right-clicking the result, or a [...] button revealed while it is hovered.</summary>
+        ButtonOnHover,
+        /// <summary>Right-clicking the result, or a [...] button that is always visible.</summary>
+        ButtonAlwaysVisible
+    }
+
+    /// <summary>
+    /// When the inline commands of an <see cref="OmniResult{T}"/> show.
+    /// </summary>
+    public enum OmniResultCommandsVisibility
+    {
+        /// <summary>Revealed while the result is hovered (or focused).</summary>
+        OnHover,
+        /// <summary>Always visible.</summary>
+        AlwaysVisible
+    }
+
+    /// <summary>
+    /// A search-result card: an icon tile, a title with an optional badge, an optional excerpt with the
+    /// matched terms highlighted, an optional footer naming the source and whatever metadata the host wants
+    /// beside it, and an optional <see cref="PagesStack"/> preview pinned to its right.
+    /// <para>
+    /// The result it stands for is carried as <see cref="Result"/>, so a click, selection or command handler
+    /// shared by a whole list of results can act on the right one without a closure per card.
+    /// </para>
+    /// <para>
+    /// Rows are selectable (<see cref="Selectable(OmniResultSelectionMode)"/>) with a checkbox that can sit
+    /// beside or over the icon; commands are reached by right-click and, optionally, a [...] button
+    /// (<see cref="OnContextMenu(Action{OmniResult{T}}, OmniResultCommandsMode)"/>), with room for a few
+    /// inline commands before it (<see cref="InlineCommands(OmniResultCommandsVisibility, IComponent[])"/>).
+    /// </para>
+    /// </summary>
+    [Transpose.Name("tss.OmniResult")]
+    public sealed class OmniResult<T> : ComponentBase<OmniResult<T>, HTMLElement>
+    {
+        private readonly HTMLElement _selectContainer;
+        private readonly HTMLElement _iconContainer;
+        private readonly HTMLElement _titleElement;
+        private readonly HTMLElement _badgeContainer;
+        private readonly HTMLElement _headerContainer;
+        private readonly HTMLElement _bodyContainer;
+        private readonly HTMLElement _sourceContainer;
+        private readonly HTMLElement _sourceSquare;
+        private readonly HTMLElement _sourceText;
+        private readonly HTMLElement _footerContainer;
+        private readonly HTMLElement _mainContainer;
+        private readonly HTMLElement _railContainer;
+        private readonly HTMLElement _commandsContainer;
+        private readonly HTMLElement _inlineCommandsContainer;
+
+        private CheckBox          _checkBox;
+        private HTMLButtonElement _menuButton;
+        private PagesStack        _pages;
+
+        private string                       _title;
+        private string                       _text;
+        private Regex                        _highlighter;
+        private OmniResultSelectionMode      _selectionMode = OmniResultSelectionMode.OnHoverBeforeIcon;
+        private bool                         _selectionEnabled;
+        private bool                         _pagesFanOnHover = true;
+        private Action<OmniResult<T>>        _commandsHandler;
+        private Func<OmniResult<T>, ContextMenu.Item[]> _menuGenerator;
+        private MouseEvent                   _lastPointerEvent;
+
+        private event Action<OmniResult<T>, bool> SelectionChanged;
+        private event Action<OmniResult<T>>       RangeSelectionRequested;
+
+        /// <summary>
+        /// Initializes a new instance of this class standing for the given result.
+        /// </summary>
+        public OmniResult(T result, string title = null)
+        {
+            Result = result;
+
+            _selectContainer = Div(Att("tss-omniresult-select"));
+            _iconContainer   = Div(Att("tss-omniresult-icon"));
+
+            _titleElement   = Span(Att("tss-omniresult-title"));
+            _badgeContainer = Div(Att("tss-omniresult-badge"));
+
+            _headerContainer = Div(Att("tss-omniresult-header"), _titleElement, _badgeContainer);
+
+            _bodyContainer = Div(Att("tss-omniresult-body"));
+
+            _sourceSquare    = Span(Att("tss-omniresult-source-square"));
+            _sourceText      = Span(Att("tss-omniresult-source-text"));
+            _sourceContainer = Div(Att("tss-omniresult-source"), _sourceSquare, _sourceText);
+
+            _footerContainer = Div(Att("tss-omniresult-footer"));
+
+            _mainContainer = Div(Att("tss-omniresult-main"), _headerContainer, _bodyContainer, _footerContainer);
+
+            _railContainer           = Div(Att("tss-omniresult-rail"));
+            _inlineCommandsContainer = Div(Att("tss-omniresult-inline-commands"));
+            _commandsContainer       = Div(Att("tss-omniresult-commands"), _inlineCommandsContainer);
+
+            InnerElement = Div(Att("tss-omniresult"), _selectContainer, _iconContainer, _mainContainer, _railContainer, _commandsContainer);
+
+            SetTitle(title);
+            SetText(null);
+            SetBadge((string)null);
+            SetSource(null, null);
+
+            HookEvents();
+        }
+
+        /// <summary>
+        /// Gets the result this card stands for - the search hit, document, record or row it was built from.
+        /// </summary>
+        public T Result { get; }
+
+        /// <summary>
+        /// Gets or sets the title of the result.
+        /// </summary>
+        public string Title
+        {
+            get => _title;
+            set => SetTitle(value);
+        }
+
+        /// <summary>
+        /// Gets or sets the excerpt shown under the title, or null when the result has none. Plain text: the
+        /// only markup it gets is the highlighting of <see cref="Highlight(Regex)"/>.
+        /// </summary>
+        public string Text
+        {
+            get => _text;
+            set => SetText(value);
+        }
+
+        /// <summary>
+        /// Returns a value indicating whether the result can be selected.
+        /// </summary>
+        public bool IsSelectionEnabled => _selectionEnabled;
+
+        /// <summary>
+        /// Gets or sets whether the result is selected. Setting it runs the
+        /// <see cref="OnSelectionChanged(Action{OmniResult{T}, bool})"/> handlers, so a host list can keep its
+        /// own selection in step whether the change came from the user or from code.
+        /// </summary>
+        public bool IsSelected
+        {
+            get => _selectionEnabled && InnerElement.classList.contains("tss-omniresult-selected");
+            set
+            {
+                if (!_selectionEnabled)
+                {
+                    InnerElement.classList.remove("tss-omniresult-selected");
+                    return;
+                }
+
+                if (IsSelected == value) return;
+
+                InnerElement.UpdateClassIf(value, "tss-omniresult-selected");
+                InnerElement.setAttribute("aria-selected", value ? "true" : "false");
+
+                if (_checkBox is object) _checkBox.IsChecked = value;
+
+                SelectionChanged?.Invoke(this, value);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets whether the result is the active one - the row a keyboard-driven list has moved to.
+        /// It is styled like a hovered row, and reveals whatever the row reveals on hover.
+        /// </summary>
+        public bool IsActive
+        {
+            get => InnerElement.classList.contains("tss-omniresult-active");
+            set => InnerElement.UpdateClassIf(value, "tss-omniresult-active");
+        }
+
+        /// <summary>
+        /// Gets the <see cref="PagesStack"/> preview shown at the end of the row, or null when it has none.
+        /// </summary>
+        public PagesStack Pages => _pages;
+
+        /// <summary>
+        /// Renders the component's root HTML element.
+        /// </summary>
+        public override HTMLElement Render() => InnerElement;
+
+        /// <summary>
+        /// Sets the title of the result. The title is ellipsized to one line, and carries the full text as
+        /// its native tooltip.
+        /// </summary>
+        public OmniResult<T> SetTitle(string title)
+        {
+            _title = title ?? string.Empty;
+
+            _titleElement.textContent = _title;
+            _titleElement.setAttribute("title", _title);
+
+            return this;
+        }
+
+        /// <summary>
+        /// Puts the given icon on the tile, in the given color, over a paler wash of that same color. Pass
+        /// the full-strength color the glyph should be - the background is computed from it (and cached), a
+        /// light tint of it under a light theme and a deep one under a dark theme.
+        /// </summary>
+        public OmniResult<T> SetIcon(UIcons icon, string color = null, UIconsWeight weight = UIconsWeight.Regular)
+        {
+            ClearChildren(_iconContainer);
+
+            _iconContainer.appendChild(I(icon, weight, "tss-omniresult-icon-glyph"));
+
+            return TintIcon(color);
+        }
+
+        /// <summary>
+        /// Puts the given short text on the tile in place of an icon - a file type, "PPTX" or "CSV", where
+        /// no glyph says it as plainly - in the given color, over a paler wash of that same color.
+        /// </summary>
+        public OmniResult<T> SetIcon(string text, string color = null)
+        {
+            ClearChildren(_iconContainer);
+
+            _iconContainer.appendChild(Span(Att("tss-omniresult-icon-text", text: text ?? string.Empty)));
+
+            return TintIcon(color);
+        }
+
+        /// <summary>
+        /// Puts the given component on the tile - an <see cref="Image"/> thumbnail, an <see cref="Avatar"/>,
+        /// an emoji - optionally tinting the tile with the given color.
+        /// </summary>
+        public OmniResult<T> SetIcon(IComponent iconOrImage, string color = null)
+        {
+            ClearChildren(_iconContainer);
+
+            if (iconOrImage != null) _iconContainer.appendChild(iconOrImage.Render());
+
+            return TintIcon(color);
+        }
+
+        /// <summary>
+        /// Puts a badge next to the title - what matched, how many times, how the result was found.
+        /// A null or empty value hides it.
+        /// </summary>
+        public OmniResult<T> SetBadge(string text)
+        {
+            ClearChildren(_badgeContainer);
+
+            var isEmpty = string.IsNullOrEmpty(text);
+
+            // A Badge, tinted the quiet way a "what matched" label wants to read - a host that needs a tone
+            // of its own passes its own Badge to the IComponent overload instead.
+            if (!isEmpty) _badgeContainer.appendChild(Badge(text).Pill().Class("tss-omniresult-badge-pill").Render());
+
+            _badgeContainer.style.display = isEmpty ? "none" : "";
+
+            return this;
+        }
+
+        /// <summary>
+        /// Puts the given component next to the title in place of the plain badge - a <see cref="Badge"/>
+        /// with a tone of its own, a <see cref="Spinner"/>, a small button. A null value empties the slot.
+        /// </summary>
+        public OmniResult<T> SetBadge(IComponent badge)
+        {
+            ClearChildren(_badgeContainer);
+
+            if (badge != null) _badgeContainer.appendChild(badge.Render());
+
+            _badgeContainer.style.display = badge is null ? "none" : "";
+
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the excerpt shown under the title. It is plain text, not a component: whatever the search
+        /// returned as the matching passage, ellipsized to the two lines the row gives it, with the terms of
+        /// <see cref="Highlight(Regex)"/> marked in it. A null or empty value drops the line entirely.
+        /// </summary>
+        public OmniResult<T> SetText(string text)
+        {
+            _text = text;
+
+            RenderText();
+
+            return this;
+        }
+
+        /// <summary>
+        /// Caps how many lines of the excerpt are shown before it is ellipsized. Two by default.
+        /// </summary>
+        public OmniResult<T> TextLines(int lines)
+        {
+            _bodyContainer.style.setProperty("-webkit-line-clamp", $"{(lines < 1 ? 1 : lines)}");
+
+            return this;
+        }
+
+        /// <summary>
+        /// Marks every match of the given expression in the excerpt - the same pattern a search backend
+        /// hands back for highlighting. Matching is done against the text itself and the matches are wrapped
+        /// in their own elements, so the excerpt is never treated as markup.
+        /// </summary>
+        public OmniResult<T> Highlight(Regex highlighter)
+        {
+            _highlighter = highlighter;
+
+            RenderText();
+
+            return this;
+        }
+
+        /// <summary>
+        /// Marks every match of the given regular expression in the excerpt, case-insensitively by default.
+        /// </summary>
+        public OmniResult<T> Highlight(string pattern, bool ignoreCase = true)
+        {
+            return Highlight(string.IsNullOrEmpty(pattern)
+                ? null
+                : new Regex(pattern, ignoreCase ? RegexOptions.IgnoreCase : RegexOptions.None));
+        }
+
+        /// <summary>
+        /// Marks every occurrence of the given words in the excerpt, case-insensitively - the convenience
+        /// form of <see cref="Highlight(Regex)"/> for a host that has the query terms rather than a pattern.
+        /// </summary>
+        public OmniResult<T> HighlightWords(params string[] words)
+        {
+            if (words is null || words.Length == 0) return Highlight((Regex)null);
+
+            var escaped = new List<string>();
+
+            foreach (var word in words)
+            {
+                if (!string.IsNullOrWhiteSpace(word)) escaped.Add(Regex.Escape(word));
+            }
+
+            if (escaped.Count == 0) return Highlight((Regex)null);
+
+            return Highlight(new Regex(string.Join("|", escaped), RegexOptions.IgnoreCase));
+        }
+
+        /// <summary>
+        /// Names where the result came from: a small rounded square in the given color, followed by the
+        /// text, at the start of the footer. A null or empty text hides it.
+        /// </summary>
+        public OmniResult<T> SetSource(string color, string text)
+        {
+            var isEmpty = string.IsNullOrEmpty(text);
+
+            _sourceText.textContent        = isEmpty ? string.Empty : text;
+            _sourceSquare.style.background = color ?? string.Empty;
+
+            // Detached rather than hidden when empty, so the dot separators - which are drawn by CSS off
+            // :first-child - don't leave a leading dot in a footer that has no source.
+            if (isEmpty)
+            {
+                if (_sourceContainer.parentElement is object) _footerContainer.removeChild(_sourceContainer);
+            }
+            else if (_sourceContainer.parentElement is null)
+            {
+                _footerContainer.insertBefore(_sourceContainer, _footerContainer.firstChild);
+            }
+
+            return UpdateFooterVisibility();
+        }
+
+        /// <summary>
+        /// Sets the metadata shown after the source in the footer - a path, a size, an owner, a date - each
+        /// entry separated from the next by a dot. Replaces whatever entries were there.
+        /// </summary>
+        public OmniResult<T> SetFooterEntries(params IComponent[] entries)
+        {
+            foreach (var stale in _footerContainer.querySelectorAll(".tss-omniresult-footer-entry"))
+            {
+                _footerContainer.removeChild(stale.As<HTMLElement>());
+            }
+
+            if (entries != null)
+            {
+                foreach (var entry in entries)
+                {
+                    if (entry is null) continue;
+
+                    _footerContainer.appendChild(Div(Att("tss-omniresult-footer-entry"), entry.Render()));
+                }
+            }
+
+            return UpdateFooterVisibility();
+        }
+
+        /// <summary>
+        /// Sets the metadata shown after the source in the footer, as plain text entries.
+        /// </summary>
+        public OmniResult<T> SetFooterEntries(params string[] entries)
+        {
+            if (entries is null) return SetFooterEntries((IComponent[])null);
+
+            var components = new List<IComponent>();
+
+            foreach (var entry in entries)
+            {
+                if (!string.IsNullOrEmpty(entry)) components.Add(TextBlock(entry).XSmall());
+            }
+
+            return SetFooterEntries(components.ToArray());
+        }
+
+        /// <summary>
+        /// Makes the result selectable, with its checkbox shown as the given mode says. The checkbox toggles
+        /// the selection on click; ctrl-clicking the row does the same, and shift-clicking it asks for a
+        /// range (see <see cref="OnRangeSelectionRequested(Action{OmniResult{T}})"/>).
+        /// </summary>
+        public OmniResult<T> Selectable(OmniResultSelectionMode mode = OmniResultSelectionMode.OnHoverBeforeIcon)
+        {
+            _selectionEnabled = true;
+            _selectionMode    = mode;
+
+            EnsureCheckBox();
+            ApplySelectionMode();
+
+            return this;
+        }
+
+        /// <summary>
+        /// Takes the checkbox away again, unselecting the result if it was selected.
+        /// </summary>
+        public OmniResult<T> NotSelectable()
+        {
+            IsSelected        = false;
+            _selectionEnabled = false;
+
+            ApplySelectionMode();
+
+            return this;
+        }
+
+        /// <summary>
+        /// Selects (or unselects) the result. Does nothing on a result that isn't selectable.
+        /// </summary>
+        public OmniResult<T> Selected(bool value = true)
+        {
+            IsSelected = value;
+
+            return this;
+        }
+
+        /// <summary>
+        /// Registers a callback invoked whenever the result is selected or unselected, by the user or by
+        /// code, with the new state.
+        /// </summary>
+        public OmniResult<T> OnSelectionChanged(Action<OmniResult<T>, bool> onSelectionChanged)
+        {
+            SelectionChanged += onSelectionChanged;
+
+            return this;
+        }
+
+        /// <summary>
+        /// Registers a callback invoked when the user shift-clicks the result, i.e. asks for everything
+        /// between the last result they selected and this one. A single card knows nothing about its
+        /// siblings, so the host list owns what "between" means - and selects them itself.
+        /// </summary>
+        public OmniResult<T> OnRangeSelectionRequested(Action<OmniResult<T>> onRangeSelectionRequested)
+        {
+            RangeSelectionRequested += onRangeSelectionRequested;
+
+            return this;
+        }
+
+        /// <summary>
+        /// Registers the handler that opens the commands of this result, and says how it is reached: by
+        /// right-click alone, or also by a [...] button at the top-right of the row - shown always, or only
+        /// while the row is hovered. The handler is given the result, so it can build a menu from
+        /// <see cref="Result"/> and show it with <see cref="ShowMenu(ContextMenu)"/>.
+        /// </summary>
+        public OmniResult<T> OnContextMenu(Action<OmniResult<T>> handler, OmniResultCommandsMode mode = OmniResultCommandsMode.RightClickOnly)
+        {
+            _commandsHandler = handler;
+            _menuGenerator   = null;
+
+            return CommandsMode(mode);
+        }
+
+        /// <summary>
+        /// Attaches a <see cref="ContextMenu"/> of actions to the result: the generator runs on every open
+        /// and is given the result, and the items it returns are shown at the pointer (or under the [...]
+        /// button). Returning null or an empty array opens nothing.
+        /// </summary>
+        public OmniResult<T> OnContextMenu(Func<OmniResult<T>, ContextMenu.Item[]> menu, OmniResultCommandsMode mode = OmniResultCommandsMode.RightClickOnly)
+        {
+            _menuGenerator   = menu;
+            _commandsHandler = null;
+
+            return CommandsMode(mode);
+        }
+
+        /// <summary>
+        /// Changes how the commands registered with <c>OnContextMenu</c> are reached, without touching the
+        /// handler itself.
+        /// </summary>
+        public OmniResult<T> CommandsMode(OmniResultCommandsMode mode)
+        {
+            if (mode == OmniResultCommandsMode.RightClickOnly)
+            {
+                if (_menuButton is object)
+                {
+                    _commandsContainer.removeChild(_menuButton);
+                    _menuButton = null;
+                }
+            }
+            else
+            {
+                EnsureMenuButton();
+            }
+
+            _commandsContainer.UpdateClassIf(mode == OmniResultCommandsMode.ButtonAlwaysVisible, "tss-omniresult-commands-visible");
+
+            return UpdateCommandsVisibility();
+        }
+
+        /// <summary>
+        /// Puts the given components in the row's command area, before the [...] button - the one or two
+        /// actions worth reaching without opening a menu. They show only while the row is hovered by
+        /// default; the space they take is reserved either way, so revealing them never shifts the row.
+        /// </summary>
+        public OmniResult<T> InlineCommands(OmniResultCommandsVisibility visibility, params IComponent[] commands)
+        {
+            ClearChildren(_inlineCommandsContainer);
+
+            if (commands != null)
+            {
+                foreach (var command in commands)
+                {
+                    if (command != null) _inlineCommandsContainer.appendChild(command.Render());
+                }
+            }
+
+            _inlineCommandsContainer.UpdateClassIf(visibility == OmniResultCommandsVisibility.AlwaysVisible, "tss-omniresult-commands-visible");
+
+            return UpdateCommandsVisibility();
+        }
+
+        /// <summary>
+        /// Puts the given components in the row's command area, revealed while the row is hovered.
+        /// </summary>
+        public OmniResult<T> InlineCommands(params IComponent[] commands) => InlineCommands(OmniResultCommandsVisibility.OnHover, commands);
+
+        /// <summary>
+        /// Pins the given <see cref="PagesStack"/> preview to the end of the row, in a rail wide enough for
+        /// it to fan into. Pass null to take it away.
+        /// </summary>
+        public OmniResult<T> SetPages(PagesStack pages)
+        {
+            ClearChildren(_railContainer);
+
+            _pages = pages;
+
+            if (pages is object) _railContainer.appendChild(pages.Render());
+
+            _railContainer.style.display = pages is null ? "none" : "";
+
+            return this;
+        }
+
+        /// <summary>
+        /// Configures whether the <see cref="PagesStack"/> fans while the row is hovered, rather than only
+        /// while the pointer is over the pages themselves. On by default.
+        /// </summary>
+        public OmniResult<T> PagesFanOnHover(bool value = true)
+        {
+            _pagesFanOnHover = value;
+
+            if (!value) _pages?.Fanned(false);
+
+            return this;
+        }
+
+        /// <summary>
+        /// Shows the given menu where the commands were asked for: at the pointer when the row was
+        /// right-clicked, and under the [...] button when it was pressed. This is what a
+        /// <see cref="OnContextMenu(Action{OmniResult{T}}, OmniResultCommandsMode)"/> handler uses to put its
+        /// menu in the right place without tracking the event itself.
+        /// </summary>
+        public OmniResult<T> ShowMenu(ContextMenu menu)
+        {
+            if (menu is null) return this;
+
+            InnerElement.classList.add("tss-omniresult-menu-open");
+
+            menu.OnHide(() => InnerElement.classList.remove("tss-omniresult-menu-open"));
+
+            if (_lastPointerEvent is object)
+            {
+                menu.ShowAt((int)_lastPointerEvent.clientX, (int)_lastPointerEvent.clientY, 0);
+            }
+            else if (_menuButton is object)
+            {
+                menu.ShowFor(_menuButton);
+            }
+            else
+            {
+                menu.ShowFor(InnerElement);
+            }
+
+            return this;
+        }
+
+        private void HookEvents()
+        {
+            InnerElement.setAttribute("tabindex", "0");
+            InnerElement.setAttribute("role", "option");
+
+            InnerElement.addEventListener("click", e =>
+            {
+                var mouseEvent = e.As<MouseEvent>();
+
+                // A click on the checkbox, or on a command, is that control's business - not the row's.
+                if (IsWithinControl(mouseEvent)) return;
+
+                if (_selectionEnabled && mouseEvent.ctrlKey)
+                {
+                    StopEvent(mouseEvent);
+                    ClearTextSelection();
+                    IsSelected = !IsSelected;
+                    return;
+                }
+
+                if (_selectionEnabled && mouseEvent.shiftKey)
+                {
+                    StopEvent(mouseEvent);
+                    ClearTextSelection();
+                    RangeSelectionRequested?.Invoke(this);
+                    return;
+                }
+
+                RaiseOnClick(mouseEvent);
+            });
+
+            InnerElement.addEventListener("mousedown", e => _lastPointerEvent = e.As<MouseEvent>());
+
+            InnerElement.addEventListener("contextmenu", e =>
+            {
+                var mouseEvent = e.As<MouseEvent>();
+
+                _lastPointerEvent = mouseEvent;
+
+                if (HasCommands())
+                {
+                    StopEvent(mouseEvent);
+                    OpenCommands();
+                    return;
+                }
+
+                RaiseOnContextMenu(mouseEvent);
+            });
+
+            InnerElement.addEventListener("mouseenter", e =>
+            {
+                if (_pagesFanOnHover) _pages?.Fanned();
+
+                RaiseOnMouseOver(e.As<MouseEvent>());
+            });
+
+            InnerElement.addEventListener("mouseleave", e =>
+            {
+                if (_pagesFanOnHover) _pages?.Fanned(false);
+
+                RaiseOnMouseOut(e.As<MouseEvent>());
+            });
+
+            InnerElement.addEventListener("keydown", e =>
+            {
+                var keyboardEvent = e.As<KeyboardEvent>();
+
+                if (keyboardEvent.key == "Enter")
+                {
+                    StopEvent(keyboardEvent);
+                    InnerElement.click();
+                }
+                else if (keyboardEvent.key == " " && _selectionEnabled)
+                {
+                    StopEvent(keyboardEvent);
+                    IsSelected = !IsSelected;
+                }
+                else if ((keyboardEvent.key == "ContextMenu" || (keyboardEvent.key == "F10" && keyboardEvent.shiftKey)) && HasCommands())
+                {
+                    StopEvent(keyboardEvent);
+                    _lastPointerEvent = null;
+                    OpenCommands();
+                }
+            });
+        }
+
+        private bool HasCommands() => _commandsHandler is object || _menuGenerator is object;
+
+        private void OpenCommands()
+        {
+            if (_menuGenerator is object)
+            {
+                var items = _menuGenerator(this);
+
+                if (items is null || items.Length == 0) return;
+
+                ShowMenu(UI.ContextMenu().Items(items));
+
+                return;
+            }
+
+            _commandsHandler?.Invoke(this);
+        }
+
+        // Clicks inside the checkbox or a command are handled by that control, and must not also count as a
+        // click on (or a selection of) the row itself.
+        private bool IsWithinControl(MouseEvent e)
+        {
+            var target = e.target.As<HTMLElement>();
+
+            while (target is object && target != InnerElement)
+            {
+                if (target.classList.contains("tss-omniresult-select")
+                 || target.classList.contains("tss-omniresult-commands"))
+                {
+                    return true;
+                }
+
+                target = target.parentElement;
+            }
+
+            return false;
+        }
+
+        private static void ClearTextSelection() => window.getSelection()?.removeAllRanges();
+
+        private void EnsureCheckBox()
+        {
+            if (_checkBox is object) return;
+
+            _checkBox = CheckBox().Class("tss-omniresult-checkbox");
+
+            _checkBox.OnChange((cb, _) => IsSelected = cb.IsChecked);
+
+            _selectContainer.appendChild(_checkBox.Render());
+        }
+
+        private void ApplySelectionMode()
+        {
+            InnerElement.UpdateClassIf(_selectionEnabled, "tss-omniresult-selectable");
+
+            if (_selectionEnabled)
+            {
+                InnerElement.setAttribute("aria-selected", IsSelected ? "true" : "false");
+            }
+            else
+            {
+                InnerElement.removeAttribute("aria-selected");
+            }
+
+            InnerElement.classList.remove("tss-omniresult-select-hover-before",
+                "tss-omniresult-select-hover-over",
+                "tss-omniresult-select-always-before",
+                "tss-omniresult-select-replacing");
+
+            if (!_selectionEnabled) return;
+
+            switch (_selectionMode)
+            {
+                case OmniResultSelectionMode.OnHoverBeforeIcon:  InnerElement.classList.add("tss-omniresult-select-hover-before"); break;
+                case OmniResultSelectionMode.OnHoverOverIcon:    InnerElement.classList.add("tss-omniresult-select-hover-over"); break;
+                case OmniResultSelectionMode.AlwaysBeforeIcon:   InnerElement.classList.add("tss-omniresult-select-always-before"); break;
+                case OmniResultSelectionMode.ReplacingIcon:      InnerElement.classList.add("tss-omniresult-select-replacing"); break;
+            }
+        }
+
+        private void EnsureMenuButton()
+        {
+            if (_menuButton is object) return;
+
+            _menuButton = UI.Button(Att("tss-omniresult-menu-button", type: "button", ariaLabel: "More commands"), I(UIcons.MenuDots, UIconsWeight.Solid));
+
+            _menuButton.addEventListener("click", e =>
+            {
+                StopEvent(e);
+
+                _lastPointerEvent = e.As<MouseEvent>();
+
+                OpenCommands();
+            });
+
+            _commandsContainer.appendChild(_menuButton);
+        }
+
+        private OmniResult<T> UpdateCommandsVisibility()
+        {
+            var isEmpty = _menuButton is null && _inlineCommandsContainer.childElementCount == 0;
+
+            _commandsContainer.style.display = isEmpty ? "none" : "";
+
+            return this;
+        }
+
+        private OmniResult<T> UpdateFooterVisibility()
+        {
+            _footerContainer.style.display = _footerContainer.childElementCount == 0 ? "none" : "";
+
+            return this;
+        }
+
+        private OmniResult<T> TintIcon(string color)
+        {
+            _iconContainer.classList.remove("tss-omniresult-icon-plain");
+
+            if (string.IsNullOrEmpty(color))
+            {
+                _iconContainer.classList.add("tss-omniresult-icon-plain");
+                return this;
+            }
+
+            var tint = OmniResultTints.For(color);
+
+            _iconContainer.style.setProperty("--tss-omniresult-icon-background",      tint.Background);
+            _iconContainer.style.setProperty("--tss-omniresult-icon-foreground",      tint.Foreground);
+            _iconContainer.style.setProperty("--tss-omniresult-icon-background-dark", tint.BackgroundDark);
+            _iconContainer.style.setProperty("--tss-omniresult-icon-foreground-dark", tint.ForegroundDark);
+
+            return this;
+        }
+
+        // The excerpt is built out of text nodes and marker spans, never out of markup, so a result whose
+        // text happens to contain angle brackets renders them rather than obeying them.
+        private void RenderText()
+        {
+            ClearChildren(_bodyContainer);
+
+            var isEmpty = string.IsNullOrEmpty(_text);
+
+            _bodyContainer.style.display = isEmpty ? "none" : "";
+
+            if (isEmpty) return;
+
+            if (_highlighter is null)
+            {
+                _bodyContainer.textContent = _text;
+                return;
+            }
+
+            var position = 0;
+            var matches  = _highlighter.Matches(_text);
+
+            for (int i = 0; i < matches.Count; i++)
+            {
+                var match = matches[i];
+
+                if (match.Length == 0) continue;
+
+                if (match.Index > position)
+                {
+                    _bodyContainer.appendChild(document.createTextNode(_text.Substring(position, match.Index - position)));
+                }
+
+                _bodyContainer.appendChild(Span(Att("tss-omniresult-highlight", text: match.Value)));
+
+                position = match.Index + match.Length;
+            }
+
+            if (position < _text.Length)
+            {
+                _bodyContainer.appendChild(document.createTextNode(_text.Substring(position)));
+            }
+        }
+    }
+
+    /// <summary>
+    /// The colors an <see cref="OmniResult{T}"/> icon tile is drawn with, derived from the one color the
+    /// host passed: the glyph in that color and the tile in a wash of it, in a light and a dark variant.
+    /// </summary>
+    internal sealed class OmniResultTint
+    {
+        internal OmniResultTint(string background, string foreground, string backgroundDark, string foregroundDark)
+        {
+            Background     = background;
+            Foreground     = foreground;
+            BackgroundDark = backgroundDark;
+            ForegroundDark = foregroundDark;
+        }
+
+        internal string Background     { get; }
+        internal string Foreground     { get; }
+        internal string BackgroundDark { get; }
+        internal string ForegroundDark { get; }
+    }
+
+    /// <summary>
+    /// Computes - and remembers - the tile colors derived from a given icon color. A list of results
+    /// usually draws the same handful of colors over and over (one per file type), and every one of them
+    /// costs a parse and two HSL round-trips, so the results are cached by the color they came from.
+    /// </summary>
+    internal static class OmniResultTints
+    {
+        private static readonly Dictionary<string, OmniResultTint> _cache = new Dictionary<string, OmniResultTint>();
+
+        internal static OmniResultTint For(string color)
+        {
+            if (_cache.TryGetValue(color, out var cached)) return cached;
+
+            var tint = Compute(color);
+
+            _cache[color] = tint;
+
+            return tint;
+        }
+
+        private static OmniResultTint Compute(string color)
+        {
+            try
+            {
+                var parsed     = Color.FromString(color);
+                var hue        = parsed.GetHue();
+                var saturation = parsed.GetSaturation();
+                var lightness  = parsed.GetBrightness();
+
+                // Light theme: a pale wash of the color under the glyph, which keeps the color it was given.
+                var background = Color.FromHsl(hue, Math.Min(saturation, 0.85f), 0.925f).ToHex();
+
+                // Dark theme: the wash goes deep instead of pale, and the glyph is lifted until it reads
+                // against it. A grey (unsaturated) color stays grey through both.
+                var backgroundDark = Color.FromHsl(hue, Math.Min(saturation, 0.5f),  0.19f).ToHex();
+                var foregroundDark = Color.FromHsl(hue, Math.Min(saturation, 0.85f), Math.Max(lightness, 0.68f)).ToHex();
+
+                return new OmniResultTint(background, color, backgroundDark, foregroundDark);
+            }
+            catch (Exception)
+            {
+                // Not a color this can take apart (a gradient, a color function, an unknown keyword): mix it
+                // down for the wash instead of computing one, and let the glyph keep it as it was given.
+                return new OmniResultTint(
+                    $"color-mix(in srgb, {color} 14%, transparent)",
+                    color,
+                    $"color-mix(in srgb, {color} 24%, transparent)",
+                    color);
+            }
+        }
+    }
+}

--- a/Tesserae/src/Components/PagesStack.cs
+++ b/Tesserae/src/Components/PagesStack.cs
@@ -1,0 +1,245 @@
+using System;
+using System.Collections.Generic;
+using static Transpose.Core.dom;
+using static Tesserae.UI;
+
+namespace Tesserae
+{
+    /// <summary>
+    /// A macOS-Downloads-style stack of page thumbnails: a few overlapping, slightly rotated pages that
+    /// fan out when the pointer is over them, with a "+N" badge covering whatever the stack doesn't show.
+    /// <para>
+    /// It is meant as the preview rail of a search result (see <see cref="OmniResult{T}"/>), so it sizes
+    /// itself to the width it needs when <em>fanned</em> and pins the stack to the right edge of that
+    /// reserved rail: opening the fan never widens the row it lives in, and the lifted pages draw on top of
+    /// whatever is beside them instead of pushing it around.
+    /// </para>
+    /// <para>
+    /// Pages are either image thumbnails (<see cref="PagesStack(string[])"/>) or blank ruled placeholders
+    /// (<see cref="PagesStack(int)"/>), for a document whose thumbnails haven't been generated - or aren't
+    /// worth generating - yet.
+    /// </para>
+    /// </summary>
+    [Transpose.Name("tss.PagesStack")]
+    public sealed class PagesStack : ComponentBase<PagesStack, HTMLElement>
+    {
+        // A stack reads as "several pages" well before this; past it the pages are only pixels of each other.
+        private const int DEFAULT_MAX_VISIBLE = 5;
+
+        private const int   DEFAULT_PAGE_WIDTH  = 48;
+        private const int   DEFAULT_PAGE_HEIGHT = 62;
+        private const int   REST_STEP           = 14;  // visible sliver of each page at rest
+        private const int   FAN_STEP            = 25;  // visible sliver of each page when fanned
+        private const float REST_ROTATION       = 1.2f; // degrees added per page at rest
+        private const float FAN_ROTATION        = 7f;   // degrees the outermost pages reach when fanned
+
+        private readonly HTMLElement _stack;
+        private readonly HTMLElement _more;
+
+        private List<string> _urls;
+        private int          _pageCount;
+        private int          _maxVisible = DEFAULT_MAX_VISIBLE;
+        private int          _pageWidth  = DEFAULT_PAGE_WIDTH;
+        private int          _pageHeight = DEFAULT_PAGE_HEIGHT;
+
+        /// <summary>
+        /// Initializes a new instance of this class showing the given thumbnails, at most
+        /// <see cref="MaxVisible(int)"/> of them, each scaled to the same page size.
+        /// </summary>
+        public PagesStack(params string[] imageUrls) : this()
+        {
+            SetPages(imageUrls);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of this class showing the given number of blank ruled pages, for a
+        /// document with no thumbnails to show. Pass <see cref="TotalPages(int)"/> as well when the document
+        /// has more pages than the stack should draw.
+        /// </summary>
+        public PagesStack(int pages) : this()
+        {
+            SetPages(pages);
+        }
+
+        private PagesStack()
+        {
+            _more  = Span(Att("tss-pagesstack-more"));
+            _stack = Div(Att("tss-pagesstack"), _more);
+
+            // The holder is the reserved rail; the stack inside it is absolutely positioned, so fanning
+            // draws outside the rail's flow instead of resizing it.
+            InnerElement = Div(Att("tss-pagesstack-holder"), _stack);
+
+            _urls      = new List<string>();
+            _pageCount = 0;
+
+            _more.style.display = "none";
+        }
+
+        /// <summary>
+        /// Gets the number of pages the document has, which is what the "+N" badge counts from - the same
+        /// as the number of thumbnails unless <see cref="TotalPages(int)"/> said otherwise.
+        /// </summary>
+        public int TotalPageCount => _pageCount;
+
+        /// <summary>
+        /// Gets the number of pages actually drawn in the stack. A stack given thumbnails draws only those
+        /// (the pages past them are counted by the badge rather than faked as blank ones).
+        /// </summary>
+        public int VisiblePageCount => Math.Min(_urls.Count > 0 ? _urls.Count : _pageCount, _maxVisible);
+
+        /// <summary>
+        /// Returns a value indicating whether the stack is held open, i.e. fanned without the pointer
+        /// being over it.
+        /// </summary>
+        public bool IsFanned => InnerElement.classList.contains("tss-pagesstack-fanned");
+
+        /// <summary>
+        /// Renders the component's root HTML element.
+        /// </summary>
+        public override HTMLElement Render() => InnerElement;
+
+        /// <summary>
+        /// Replaces the pages with the given thumbnails. The page count - and so the "+N" badge - follows
+        /// the number of urls unless <see cref="TotalPages(int)"/> is called afterwards.
+        /// </summary>
+        public PagesStack SetPages(params string[] imageUrls)
+        {
+            _urls = new List<string>();
+
+            if (imageUrls != null)
+            {
+                foreach (var url in imageUrls)
+                {
+                    if (!string.IsNullOrEmpty(url)) _urls.Add(url);
+                }
+            }
+
+            _pageCount = _urls.Count;
+
+            return Rebuild();
+        }
+
+        /// <summary>
+        /// Replaces the pages with the given number of blank ruled pages.
+        /// </summary>
+        public PagesStack SetPages(int pages)
+        {
+            _urls      = new List<string>();
+            _pageCount = pages < 0 ? 0 : pages;
+
+            return Rebuild();
+        }
+
+        /// <summary>
+        /// Sets how many pages the document has in total, for a stack given fewer thumbnails than that: the
+        /// pages past the ones drawn are counted by the "+N" badge over the top-right of the stack.
+        /// </summary>
+        public PagesStack TotalPages(int pages)
+        {
+            _pageCount = pages < 0 ? 0 : pages;
+
+            return Rebuild();
+        }
+
+        /// <summary>
+        /// Sets how many pages are drawn before the rest collapse into the "+N" badge. Five by default -
+        /// enough for the stack to read as a stack, few enough that the fan stays narrow.
+        /// </summary>
+        public PagesStack MaxVisible(int count)
+        {
+            _maxVisible = count < 1 ? 1 : count;
+
+            return Rebuild();
+        }
+
+        /// <summary>
+        /// Sets the size every page is drawn at. All pages share one size, whatever their thumbnails'
+        /// aspect ratios are (a thumbnail is cropped to fill), so the stack reads as one document.
+        /// </summary>
+        public PagesStack PageSize(int width, int height)
+        {
+            _pageWidth  = width  < 1 ? 1 : width;
+            _pageHeight = height < 1 ? 1 : height;
+
+            return Rebuild();
+        }
+
+        /// <summary>
+        /// Holds the stack open (or lets it close again), for a host that wants the fan to follow hovering
+        /// something larger than the stack itself - the result row it sits in, say, which is what
+        /// <see cref="OmniResult{T}"/> does by default.
+        /// </summary>
+        public PagesStack Fanned(bool value = true)
+        {
+            InnerElement.UpdateClassIf(value, "tss-pagesstack-fanned");
+
+            return this;
+        }
+
+        private PagesStack Rebuild()
+        {
+            ClearChildren(_stack);
+
+            var shown = VisiblePageCount;
+
+            // The rail is as wide as the fan gets, so the pages have room to open into without the row
+            // they sit in reflowing. The few extra pixels are for the rotation of the outermost pages.
+            var railWidth = shown < 1 ? 0 : _pageWidth + (shown - 1) * FAN_STEP + 4;
+
+            InnerElement.style.width     = $"{railWidth}px";
+            InnerElement.style.flexBasis = $"{railWidth}px";
+            InnerElement.style.height    = $"{_pageHeight + 12}px";
+
+            for (int i = 0; i < shown; i++)
+            {
+                _stack.appendChild(BuildPage(i, shown));
+            }
+
+            var hidden = _pageCount - shown;
+
+            _more.innerText      = $"+{hidden}";
+            _more.style.display  = hidden > 0 ? "" : "none";
+
+            _stack.appendChild(_more);
+
+            InnerElement.UpdateClassIf(shown < 1, "tss-pagesstack-empty");
+
+            return this;
+        }
+
+        private HTMLElement BuildPage(int index, int shown)
+        {
+            var page = Div(Att("tss-pagesstack-page"));
+
+            page.style.width  = $"{_pageWidth}px";
+            page.style.height = $"{_pageHeight}px";
+
+            if (index < _urls.Count)
+            {
+                page.appendChild(Image(Att("tss-pagesstack-image", src: _urls[index])));
+            }
+            else
+            {
+                page.appendChild(Div(Att("tss-pagesstack-lines")));
+            }
+
+            // Page 1 stays on top, so the stack is read from the front - and the sliver of each page
+            // behind it shows on the right, the way a pile of paper nudged sideways looks.
+            page.style.zIndex = $"{shown - index}";
+
+            // At rest: the first page in place, every other one pulled back over it with a growing tilt.
+            page.style.setProperty("--tss-pagesstack-rest-offset",   index == 0 ? "0px" : $"-{_pageWidth - REST_STEP}px");
+            page.style.setProperty("--tss-pagesstack-rest-rotation", $"{REST_ROTATION * index}deg");
+
+            // Fanned: wider gaps, and the pages lifted along a shallow arc, tilting out from the middle.
+            var t = shown == 1 ? 0.5f : (float)index / (shown - 1);
+
+            page.style.setProperty("--tss-pagesstack-fan-offset",   index == 0 ? "0px" : $"-{_pageWidth - FAN_STEP}px");
+            page.style.setProperty("--tss-pagesstack-fan-rotation", $"{-FAN_ROTATION + 2 * FAN_ROTATION * t:0.##}deg");
+            page.style.setProperty("--tss-pagesstack-fan-lift",     $"{-2 - 4 * Math.Sin(Math.PI * t):0.##}px");
+
+            return page;
+        }
+    }
+}

--- a/Tesserae/tps.json
+++ b/Tesserae/tps.json
@@ -114,6 +114,8 @@
                 "tps/assets/css/tss.notificationcenter.css",
                 "tps/assets/css/tss.markdown.css",
                 "tps/assets/css/tss.plan.css",
+                "tps/assets/css/tss.pagesstack.css",
+                "tps/assets/css/tss.omniresult.css",
                 "tps/assets/css/diff2html.min.css",
                 "tps/assets/css/tss.codediff.css"
             ],

--- a/Tesserae/tps/assets/css/tss.common.css
+++ b/Tesserae/tps/assets/css/tss.common.css
@@ -34,6 +34,7 @@
     --tss-default-foreground-active-color-root: 32, 31, 30;
     --tss-progress-background-color-root: 237, 235, 233;
     --tss-link-color-root: 36, 142, 250;
+    --tss-highlight-color-root: 36, 142, 250;
     --tss-tooltip-background-color-root: 249, 250, 251;
     --tss-tooltip-foreground-color-root: 51, 51, 51;
     --tss-primary-background-color-root: 36, 142, 250;
@@ -80,6 +81,7 @@
     --tss-default-foreground-active-color: rgb(var(--tss-default-foreground-active-color-root));
     --tss-progress-background-color: rgb(var(--tss-progress-background-color-root));
     --tss-link-color: rgb(var(--tss-link-color-root));
+    --tss-highlight-color: rgb(var(--tss-highlight-color-root));
     --tss-tooltip-background-color: rgb(var(--tss-tooltip-background-color-root));
     --tss-tooltip-foreground-color: rgb(var(--tss-tooltip-foreground-color-root));
     --tss-primary-background-color: rgb(var(--tss-primary-background-color-root));
@@ -167,6 +169,7 @@
     --tss-default-foreground-active-color-root: 255, 255, 255;
     --tss-progress-background-color-root: 68, 68, 68;
     --tss-link-color-root: 85, 179, 251;
+    --tss-highlight-color-root: 85, 179, 251;
     --tss-tooltip-background-color-root: 101, 103, 107;
     --tss-tooltip-foreground-color-root: 249, 250, 251;
     --tss-primary-background-color-root: 85, 179, 251;
@@ -212,6 +215,7 @@
     --tss-default-foreground-active-color: rgb(var(--tss-default-foreground-active-color-root));
     --tss-progress-background-color: rgb(var(--tss-progress-background-color-root));
     --tss-link-color: rgb(var(--tss-link-color-root));
+    --tss-highlight-color: rgb(var(--tss-highlight-color-root));
     --tss-tooltip-background-color: rgb(var(--tss-tooltip-background-color-root));
     --tss-tooltip-foreground-color: rgb(var(--tss-tooltip-foreground-color-root));
     --tss-primary-background-color: rgb(var(--tss-primary-background-color-root));

--- a/Tesserae/tps/assets/css/tss.omniresult.css
+++ b/Tesserae/tps/assets/css/tss.omniresult.css
@@ -196,13 +196,6 @@
 .tss-omniresult-badge-pill {
     padding: 2px 8px;
     font-weight: 600;
-    background: color-mix(in srgb, var(--tss-link-color) 12%, transparent);
-    color: var(--tss-link-color);
-}
-
-.tss-dark-mode .tss-omniresult-badge-pill {
-    background: color-mix(in srgb, var(--tss-link-color) 26%, transparent);
-    color: color-mix(in srgb, var(--tss-link-color) 70%, white);
 }
 
 .tss-omniresult-body {
@@ -212,18 +205,25 @@
     overflow: hidden;
     font-size: 14px;
     line-height: 20px;
-    color: var(--tss-default-foreground-color);
+    color: var(--tss-colors-dark-neutral-600);
+}
+
+/* What matched reads the same wherever it is said: the badge naming the match and the marks on the
+   terms inside the excerpt share one pair of colors. */
+.tss-omniresult-badge-pill,
+.tss-omniresult-highlight {
+    background: color-mix(in srgb, var(--tss-highlight-color) 12%, transparent);
+    color: var(--tss-highlight-color);
+}
+
+.tss-dark-mode .tss-omniresult-badge-pill,
+.tss-dark-mode .tss-omniresult-highlight {
+    background: color-mix(in srgb, var(--tss-highlight-color) 26%, transparent);
 }
 
 .tss-omniresult-highlight {
     border-radius: 3px;
     padding: 0 2px;
-    background: color-mix(in srgb, var(--tss-primary-background-color) 18%, transparent);
-    color: inherit;
-}
-
-.tss-dark-mode .tss-omniresult-highlight {
-    background: color-mix(in srgb, var(--tss-primary-background-color) 35%, transparent);
 }
 
 /* Footer ----------------------------------------------------------------------------------------- */

--- a/Tesserae/tps/assets/css/tss.omniresult.css
+++ b/Tesserae/tps/assets/css/tss.omniresult.css
@@ -1,0 +1,365 @@
+/* OmniResult — a search-result row: icon tile, title + badge, excerpt, footer, pages rail, commands. */
+
+.tss-omniresult {
+    position: relative;
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+    box-sizing: border-box;
+    width: 100%;
+    padding: 12px 12px 12px 14px;
+    border-radius: var(--tss-border-radius-lg);
+    border-bottom: 1px solid var(--tss-default-border-color);
+    background: transparent;
+    color: var(--tss-default-foreground-color);
+    cursor: pointer;
+    outline: none;
+    transition: background-color 120ms ease-in-out;
+}
+
+.tss-omniresult:hover,
+.tss-omniresult.tss-omniresult-active,
+.tss-omniresult.tss-omniresult-menu-open {
+    background: var(--tss-default-background-hover-color);
+}
+
+.tss-omniresult:focus-visible {
+    box-shadow: inset 0 0 0 2px var(--tss-primary-background-color);
+}
+
+.tss-omniresult.tss-omniresult-selected {
+    background: color-mix(in srgb, var(--tss-primary-background-color) 10%, transparent);
+}
+
+/* Selection ------------------------------------------------------------------------------------- */
+
+.tss-omniresult-select {
+    display: none;
+    flex-grow: 0;
+    flex-shrink: 0;
+    align-items: center;
+    height: 34px;
+}
+
+.tss-omniresult-select .tss-checkbox-container {
+    margin: 0;
+    padding-left: 20px;
+    width: 20px;
+    height: 20px;
+}
+
+/* Beside the icon: the column is there either way, so revealing the checkbox never shifts the row. */
+.tss-omniresult-select-hover-before .tss-omniresult-select,
+.tss-omniresult-select-always-before .tss-omniresult-select,
+.tss-omniresult-select-replacing .tss-omniresult-select {
+    display: flex;
+}
+
+.tss-omniresult-select-hover-before .tss-omniresult-select {
+    opacity: 0;
+    transition: opacity 120ms ease-in-out;
+}
+
+.tss-omniresult-select-hover-before:hover .tss-omniresult-select,
+.tss-omniresult-select-hover-before.tss-omniresult-active .tss-omniresult-select,
+.tss-omniresult-select-hover-before:focus-within .tss-omniresult-select,
+.tss-omniresult-select-hover-before.tss-omniresult-selected .tss-omniresult-select {
+    opacity: 1;
+}
+
+/* Over the icon: the checkbox sits on the tile, which fades out under it rather than being covered by a
+   backplate - so it blends whatever background the row happens to have (hovered, selected, plain). */
+.tss-omniresult-select-hover-over .tss-omniresult-select {
+    display: flex;
+    position: absolute;
+    left: 14px;
+    top: 12px;
+    z-index: 2;
+    align-items: center;
+    justify-content: center;
+    width: 34px;
+    height: 34px;
+    opacity: 0;
+    transition: opacity 120ms ease-in-out;
+}
+
+.tss-omniresult-select-hover-over .tss-omniresult-icon {
+    transition: opacity 120ms ease-in-out;
+}
+
+.tss-omniresult-select-hover-over:hover .tss-omniresult-select,
+.tss-omniresult-select-hover-over.tss-omniresult-active .tss-omniresult-select,
+.tss-omniresult-select-hover-over:focus-within .tss-omniresult-select,
+.tss-omniresult-select-hover-over.tss-omniresult-selected .tss-omniresult-select {
+    opacity: 1;
+}
+
+.tss-omniresult-select-hover-over:hover .tss-omniresult-icon,
+.tss-omniresult-select-hover-over.tss-omniresult-active .tss-omniresult-icon,
+.tss-omniresult-select-hover-over:focus-within .tss-omniresult-icon,
+.tss-omniresult-select-hover-over.tss-omniresult-selected .tss-omniresult-icon {
+    opacity: 0;
+}
+
+/* Replacing the icon: no tile at all. */
+.tss-omniresult-select-replacing .tss-omniresult-icon {
+    display: none;
+}
+
+/* Icon tile ------------------------------------------------------------------------------------- */
+
+.tss-omniresult-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-grow: 0;
+    flex-shrink: 0;
+    box-sizing: border-box;
+    width: 34px;
+    height: 34px;
+    border-radius: 8px;
+    overflow: hidden;
+    font-size: 15px;
+    background: var(--tss-omniresult-icon-background, var(--tss-secondary-background-color));
+    color: var(--tss-omniresult-icon-foreground, var(--tss-default-foreground-color));
+}
+
+.tss-dark-mode .tss-omniresult-icon {
+    background: var(--tss-omniresult-icon-background-dark, var(--tss-secondary-background-color));
+    color: var(--tss-omniresult-icon-foreground-dark, var(--tss-default-foreground-color));
+}
+
+.tss-omniresult-icon.tss-omniresult-icon-plain,
+.tss-dark-mode .tss-omniresult-icon.tss-omniresult-icon-plain {
+    background: var(--tss-secondary-background-color);
+    color: var(--tss-default-foreground-color);
+}
+
+.tss-omniresult-icon-glyph {
+    line-height: 1;
+}
+
+/* A file type spelled out ("PPTX", "XLSX") in place of a glyph. */
+.tss-omniresult-icon-text {
+    font-size: 9px;
+    font-weight: 700;
+    letter-spacing: .02em;
+    text-transform: uppercase;
+    line-height: 1;
+}
+
+.tss-omniresult-icon img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+}
+
+/* Title, badge, excerpt --------------------------------------------------------------------------- */
+
+.tss-omniresult-main {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    flex-grow: 1;
+    min-width: 0;
+}
+
+.tss-omniresult-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+}
+
+.tss-omniresult-title {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: 16px;
+    font-weight: 600;
+    line-height: 22px;
+    color: var(--tss-default-foreground-color);
+}
+
+.tss-omniresult-badge {
+    display: flex;
+    flex-grow: 0;
+    flex-shrink: 0;
+    align-items: center;
+}
+
+.tss-omniresult-badge .tss-token {
+    margin: 0;
+}
+
+.tss-omniresult-badge-pill {
+    padding: 2px 8px;
+    font-weight: 600;
+    background: color-mix(in srgb, var(--tss-link-color) 12%, transparent);
+    color: var(--tss-link-color);
+}
+
+.tss-dark-mode .tss-omniresult-badge-pill {
+    background: color-mix(in srgb, var(--tss-link-color) 26%, transparent);
+    color: color-mix(in srgb, var(--tss-link-color) 70%, white);
+}
+
+.tss-omniresult-body {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    overflow: hidden;
+    font-size: 14px;
+    line-height: 20px;
+    color: var(--tss-default-foreground-color);
+}
+
+.tss-omniresult-highlight {
+    border-radius: 3px;
+    padding: 0 2px;
+    background: color-mix(in srgb, var(--tss-primary-background-color) 18%, transparent);
+    color: inherit;
+}
+
+.tss-dark-mode .tss-omniresult-highlight {
+    background: color-mix(in srgb, var(--tss-primary-background-color) 35%, transparent);
+}
+
+/* Footer ----------------------------------------------------------------------------------------- */
+
+.tss-omniresult-footer {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    row-gap: 2px;
+    min-width: 0;
+    font-size: 12px;
+    line-height: 18px;
+    color: var(--tss-secondary-foreground-color);
+}
+
+/* One dot between entries, drawn by CSS so no host has to interleave separators. */
+.tss-omniresult-footer > .tss-omniresult-footer-entry::before {
+    content: "·";
+    margin: 0 7px;
+    color: var(--tss-secondary-foreground-color);
+}
+
+.tss-omniresult-footer > .tss-omniresult-footer-entry:first-child::before {
+    content: none;
+    margin: 0;
+}
+
+.tss-omniresult-footer-entry {
+    display: flex;
+    align-items: center;
+    min-width: 0;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.tss-omniresult-footer-entry .tss-textblock {
+    margin: 0;
+    color: var(--tss-secondary-foreground-color);
+    white-space: nowrap;
+}
+
+.tss-omniresult-source {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex-grow: 0;
+    flex-shrink: 0;
+}
+
+.tss-omniresult-source-square {
+    display: block;
+    width: 10px;
+    height: 10px;
+    border-radius: 2px;
+    background: var(--tss-primary-background-color);
+}
+
+.tss-omniresult-source-text {
+    color: var(--tss-secondary-foreground-color);
+}
+
+/* Pages rail and commands ------------------------------------------------------------------------ */
+
+.tss-omniresult-rail {
+    display: flex;
+    align-items: flex-start;
+    justify-content: flex-end;
+    flex-grow: 0;
+    flex-shrink: 0;
+}
+
+.tss-omniresult-commands {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    align-self: flex-start;
+    flex-grow: 0;
+    flex-shrink: 0;
+    /* Aligned with the title's line box, so the [...] sits level with the title however tall the row is. */
+    height: 22px;
+    z-index: 3;
+}
+
+.tss-omniresult-inline-commands {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+}
+
+/* Hidden rather than absent, so the row keeps its width whether the commands show or not. */
+.tss-omniresult-commands > .tss-omniresult-menu-button,
+.tss-omniresult-inline-commands {
+    opacity: 0;
+    transition: opacity 120ms ease-in-out;
+}
+
+.tss-omniresult:hover .tss-omniresult-menu-button,
+.tss-omniresult.tss-omniresult-active .tss-omniresult-menu-button,
+.tss-omniresult:focus-within .tss-omniresult-menu-button,
+.tss-omniresult.tss-omniresult-menu-open .tss-omniresult-menu-button,
+.tss-omniresult-commands.tss-omniresult-commands-visible > .tss-omniresult-menu-button,
+.tss-omniresult:hover .tss-omniresult-inline-commands,
+.tss-omniresult.tss-omniresult-active .tss-omniresult-inline-commands,
+.tss-omniresult:focus-within .tss-omniresult-inline-commands,
+.tss-omniresult-inline-commands.tss-omniresult-commands-visible {
+    opacity: 1;
+}
+
+.tss-omniresult-menu-button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-sizing: border-box;
+    width: 26px;
+    height: 26px;
+    padding: 0;
+    border: none;
+    border-radius: var(--tss-border-radius-sm);
+    background: transparent;
+    color: var(--tss-secondary-foreground-color);
+    font-size: 14px;
+    cursor: pointer;
+}
+
+.tss-omniresult-menu-button:hover {
+    background: var(--tss-default-background-active-color);
+    color: var(--tss-default-foreground-color);
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .tss-omniresult,
+    .tss-omniresult-select,
+    .tss-omniresult-inline-commands,
+    .tss-omniresult-menu-button {
+        transition: none;
+    }
+}

--- a/Tesserae/tps/assets/css/tss.pagesstack.css
+++ b/Tesserae/tps/assets/css/tss.pagesstack.css
@@ -1,0 +1,106 @@
+/* PagesStack — a fanning stack of page thumbnails, sized to the width the fan needs. */
+
+.tss-pagesstack-holder {
+    position: relative;
+    display: block;
+    flex-grow: 0;
+    flex-shrink: 0;
+    margin: 2px 0 0 auto;
+    pointer-events: none; /* only the pages themselves are hoverable, not the reserved rail */
+}
+
+.tss-pagesstack-holder.tss-pagesstack-empty {
+    display: none;
+}
+
+.tss-pagesstack {
+    position: absolute;
+    right: 0;
+    bottom: 0;
+    display: flex;
+    align-items: flex-end;
+    width: max-content;
+    pointer-events: auto;
+}
+
+.tss-pagesstack-page {
+    position: relative;
+    flex-grow: 0;
+    flex-shrink: 0;
+    overflow: hidden;
+    box-sizing: border-box;
+    border: 1px solid var(--tss-default-border-color);
+    border-radius: 4px;
+    background: var(--tss-secondary-background-color);
+    box-shadow: -2px 0 6px rgba(31, 31, 31, .10);
+    margin-left: var(--tss-pagesstack-rest-offset, 0px);
+    transform: rotate(var(--tss-pagesstack-rest-rotation, 0deg));
+    transition: margin-left 240ms cubic-bezier(.22, 1, .36, 1),
+                transform 240ms cubic-bezier(.22, 1, .36, 1);
+}
+
+.tss-pagesstack-page:hover {
+    border-color: var(--tss-dark-border-color);
+}
+
+/* Faux text ruling, for a page with no thumbnail to show. */
+.tss-pagesstack-lines {
+    display: block;
+    height: 100%;
+    margin: 5px 5px 0;
+    background: repeating-linear-gradient(to bottom,
+        var(--tss-default-border-color) 0 2px,
+        transparent 2px 7px);
+}
+
+.tss-pagesstack-image {
+    display: block;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+/* Fanned — wider gaps and an arc lift. Driven by :hover on the stack, or by the class a host sets when
+   it wants the fan to follow hovering something larger (a whole result row). */
+.tss-pagesstack:hover > .tss-pagesstack-page,
+.tss-pagesstack-fanned .tss-pagesstack-page {
+    margin-left: var(--tss-pagesstack-fan-offset, 0px);
+    transform: translateY(var(--tss-pagesstack-fan-lift, 0px)) rotate(var(--tss-pagesstack-fan-rotation, 0deg));
+}
+
+/* The overflow count is absolute, so it never widens the rail. */
+.tss-pagesstack-more {
+    position: absolute;
+    right: 0;
+    top: -2px;
+    z-index: 20;
+    padding: 2px 4px;
+    border-radius: 4px;
+    font-size: 11px;
+    font-weight: 500;
+    line-height: 1;
+    white-space: nowrap;
+    color: var(--tss-default-foreground-color);
+    background: var(--tss-default-background-color);
+    pointer-events: none;
+}
+
+/* A page has to read as paper against the row it sits on, which under a dark theme means lifting it off
+   the background rather than tinting it down. */
+.tss-dark-mode .tss-pagesstack-page {
+    background: color-mix(in srgb, var(--tss-default-foreground-color) 14%, var(--tss-secondary-background-color));
+    border-color: var(--tss-dark-border-color);
+    box-shadow: -2px 0 6px rgba(0, 0, 0, .35);
+}
+
+.tss-dark-mode .tss-pagesstack-lines {
+    background: repeating-linear-gradient(to bottom,
+        color-mix(in srgb, var(--tss-default-foreground-color) 20%, transparent) 0 2px,
+        transparent 2px 7px);
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .tss-pagesstack-page {
+        transition: none;
+    }
+}


### PR DESCRIPTION
## Summary

Introduces two new components for building search result interfaces:

- **`OmniResult<T>`**: A comprehensive search-result row component featuring an icon tile, title with optional badge, excerpt with highlighted matched terms, footer with source and metadata, optional selection checkbox, context menu commands, and inline commands.
- **`PagesStack`**: A macOS-Downloads-style fanning stack of page thumbnails with a "+N" badge, designed as a document preview rail for search results.

Both components are fully styled, documented, and include comprehensive samples.

## Key Changes

### New Components

- **`OmniResult<T>` (`Tesserae/src/Components/OmniResult.cs`)**: 
  - Carries the result object as a generic parameter (`Result` property) so shared handlers don't need closures
  - Configurable selection modes: `OnHoverBeforeIcon`, `OnHoverOverIcon`, `AlwaysBeforeIcon`, `ReplacingIcon`
  - Configurable command access: `RightClickOnly`, `ButtonOnHover`, `ButtonAlwaysVisible`
  - Excerpt highlighting via regex or word list with `Highlight()` / `HighlightWords()`
  - Icon support: UIcons glyphs, text labels, or custom components, all with color tinting
  - Footer with source indicator and metadata entries
  - Optional inline commands and context menu
  - Active/focused state styling for keyboard navigation
  - ~970 lines of implementation with full event handling and state management

- **`PagesStack` (`Tesserae/src/Components/PagesStack.cs`)**:
  - Displays up to 5 overlapping, slightly rotated pages by default
  - Fans out on hover with smooth animations
  - Supports image thumbnails or blank ruled placeholders
  - Sized to reserved rail space so fanning never widens the parent row
  - Configurable page dimensions and max visible count
  - "+N" badge for pages beyond the visible stack

### Styling

- **`tss.omniresult.css`**: Complete styling for all OmniResult states and selection modes
  - Hover, active, and selected states with smooth transitions
  - Selection checkbox positioning (before icon, over icon, replacing icon)
  - Commands button and inline commands layout
  - Highlight styling for matched terms (uses `--tss-highlight-color` token)
  - Footer with CSS-generated dot separators

- **`tss.pagesstack.css`**: Styling for the fanning page stack
  - Rest and fanned states with CSS custom properties for animation
  - Page rotation and lift effects
  - Responsive sizing and positioning

### Documentation & Samples

- **`omni-result.md`**: Complete reference with factory signatures, configuration methods, and usage examples
- **`pages-stack.md`**: Reference for the PagesStack component
- **`OmniResultSample.cs`**: Comprehensive sample demonstrating all features:
  - Overview of the full row
  - Variations without excerpt, preview, or both
  - Icon tinting and badge customization
  - Highlighting and excerpt rendering
  - Selection modes and behavior
  - Command handling (right-click and button)
  - Page preview integration

### Integration

- Added `OmniResult<T>` and `PagesStack` factory methods to `UI.Components.cs`
- Added `--tss-highlight-color` CSS custom property to `tss.common.css` (defaults to link color)
- Updated `tps.json` to include new stylesheet assets
- Updated `SKILL.md` to index the new components
- Updated related component references (ContextCard, OmniBox, ResourceCard) with cross-links

## Notable Implementation Details

- **Generic result carrier**: `OmniResult<T>` uses a generic type parameter to carry the underlying result object, enabling shared event handlers across lists without per-row closures
- **Highlight rendering**: Matched terms in excerpts are wrapped in dedicated elements rather than treated as markup, so excerpts containing angle brackets render safely
- **Icon tinting**: Color-to-background computation is cached per color to avoid redundant calculations in large lists
- **Selection state sync**: The `IsSelected` property runs registered handlers, allowing

https://claude.ai/code/session_01KYMqT85foDn2rmFk2Xz5rv