### PR TITLE
OmniResult: identifiers, rich content, icon badges and opening as a modal

### DIFF
--- a/Tesserae.Tests/src/Samples/Components/OmniResultSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/OmniResultSample.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Linq;
 using static Transpose.Core.dom;
@@ -69,6 +70,9 @@ namespace Tesserae.Tests.Samples
                 .FlatSection(VStack().WS().Children(NoPages()))
                 .FlatSection(VStack().WS().Children(TitleOnly()))
                 .FlatSection(VStack().WS().Children(Tiles()))
+                .FlatSection(VStack().WS().Children(Identifiers()))
+                .FlatSection(VStack().WS().Children(Content()))
+                .FlatSection(VStack().WS().Children(Modals()))
                 .FlatSection(VStack().WS().Children(Sources()))
                 .FlatSection(VStack().WS().Children(Contributions()))
                 .FlatSection(VStack().WS().Children(Highlighting()))
@@ -151,6 +155,72 @@ namespace Tesserae.Tests.Samples
                     OmniResult(Hits[0], "brake-sensor-reports").SetIcon(UIcons.Folder).SetSource("#0061d5", "Box").SetFooterEntries("No color: the tile falls back to the theme's own")));
         }
 
+        // ---------- Identifiers ----------
+
+        private IComponent Identifiers()
+        {
+            return FeatureCard("Identifiers", "A number or a key before the title",
+                "SetId puts an identifier before the title - an issue number, a ticket key, a row number - drawn the quiet way an identifier reads, with a chevron pointing at the title. It never shrinks, so a long title ellipsizes before the identifier does, and an empty one drops both the identifier and the chevron.",
+                VStack().WS().Children(
+                    Row(Hits[1], withText: false, withPages: false).SetId("JR-2214"),
+                    Row(Hits[2], withText: false, withPages: false).SetId("4471"),
+                    Row(Hits[3], withText: false, withPages: false).SetId("OPS-88").SetBadge("Blocked"),
+                    Row(Hits[5], withText: false, withPages: false)),
+                TextBlock("The last row has no identifier, so it starts at its title.").Small().MT(8));
+        }
+
+        // ---------- Rich content ----------
+
+        private IComponent Content()
+        {
+            return FeatureCard("Rich content", "When an excerpt isn't enough",
+                "SetContent puts a component of your own under the excerpt, in the text column: a thumbnail, a quoted message, a table of the fields that matched. ContentMaxHeight caps how tall it may grow and fades whatever runs past it out, rather than cutting it off - so a clipped preview reads as \"there is more\" instead of as a rendering fault.",
+                VStack().WS().Children(
+                    Row(Hits[1], withText: true, withPages: false)
+                        .SetContent(HStack().Gap(8.px()).PT(4).Children(
+                            Badge("page 14").Pill(),
+                            Badge("revision C").Pill(),
+                            Badge("BRK-SEN-447").Pill())),
+                    Row(Hits[2], withText: false, withPages: false)
+                        .SetContent(VStack().WS().PT(4).Children(
+                            TextBlock("Column F · drift across 14 units").Small(),
+                            TextBlock("Column G · re-calibration requested").Small(),
+                            TextBlock("Column H · CMMS ticket").Small(),
+                            TextBlock("Column I · signed off by").Small(),
+                            TextBlock("Column J · next due").Small(),
+                            TextBlock("Column K · notes").Small()))
+                        .ContentMaxHeight(56.px())),
+                TextBlock("The second row's content is capped at 56px, so it fades out where it is cut.").Small().MT(8));
+        }
+
+        // ---------- Modals ----------
+
+        private IComponent Modals()
+        {
+            return FeatureCard("Opening as a modal", "The row carries its own full view",
+                "SetModalContent gives the row the full view of the thing it stands for, and ToModal builds a Modal showing it - the same identifier, chevron and title as the row for its header, at the size ModalSize asked for. Everything else is left to the caller to chain on what comes back, so the host still owns the commands, the dismissal and the bounds. The Func overload builds the content on open, so a list of a thousand rows pays for none of them until one is asked for.",
+                VStack().WS().Children(
+                    ModalRow(Hits[1], "A modal built on open"),
+                    ModalRow(Hits[3], "Another one, same header")));
+        }
+
+        private OmniResult<Hit> ModalRow(Hit hit, string title)
+        {
+            var row = Row(hit, withText: true, withPages: false)
+                .SetId("JR-2214")
+                .SetModalContent(r => Task.FromResult<IComponent>(VStack().WS().P(16).Children(
+                    TextBlock($"The full view of \"{r.Result.Title}\", built when the modal opened.").MB(12),
+                    TextBlock(r.Result.Text))))
+                .ModalSize(60.vw(), 50.vh());
+
+            return row.OnClick((r, _) =>
+            {
+                var modal = r.ToModal();
+
+                if (modal is object) modal.LightDismiss().ShowCloseButton().Show();
+            });
+        }
+
         // ---------- Sources ----------
 
         private IComponent Sources()
@@ -175,7 +245,12 @@ namespace Tesserae.Tests.Samples
                         .OnClick((r, _) => Toast().Information($"Opening {r.Result.Title}")),
                     OmniResult(Hits[6], "No source at all — the footer starts with its first entry")
                         .SetIcon("TXT", "#94a3b8")
-                        .SetFooterEntries(Hits[6].Metadata)),
+                        .SetFooterEntries(Hits[6].Metadata),
+                    OmniResult(Hits[0], "A marker of your own, and one on the tile's corner")
+                        .SetIcon(UIcons.Folder, "#6366f1")
+                        .SetIconBadge(Image("./assets/img/box-img.svg"))
+                        .SetSource(Image("./assets/img/box-img.svg"), "Box", r => ReportSource("Box", r))
+                        .SetFooterEntries(Hits[0].Metadata)),
                 _sourceState.MT(8));
         }
 

--- a/Tesserae/skills/references/omni-result.md
+++ b/Tesserae/skills/references/omni-result.md
@@ -1,6 +1,6 @@
 ---
 name: omni-result
-description: A search-result row with an icon tile tinted from one color, a title with a badge, an excerpt whose matched terms are highlighted, a footer naming the source, selectable checkboxes, right-click or button commands, and an optional fanning page preview. Use for search result lists, pickers and file browsers in a Tesserae (C#/Transpose) app.
+description: A search-result row with an icon tile tinted from one color, an optional identifier before the title, a badge, an excerpt whose matched terms are highlighted, a rich content preview, a footer naming the source, selectable checkboxes, right-click or button commands, a fanning page preview, and a modal it can open as. Use for search result lists, pickers and file browsers in a Tesserae (C#/Transpose) app.
 ---
 
 # OmniResult&lt;T&gt;
@@ -10,7 +10,7 @@ description: A search-result row with an icon tile tinted from one color, a titl
 without a closure per row:
 
 ```
-[✓]  [PDF]  BRK-SEN-447 calibration procedure.pdf   3 matches in text                 [pages]  [...]
+[✓]  [PDF]  JR-2214 › BRK-SEN-447 calibration.pdf   3 matches in text                 [pages]  [...]
             Torque the mount to 12 Nm before starting brake sensor work. Full calibration steps …
             ▪ Box · sample-files / pdfs · 2.4 MB · Pius Neuhaus · Apr 12, 2024
 ```
@@ -26,19 +26,30 @@ stands for. Also `new OmniResult<T>(result, title)`. Bring factories into scope 
 
 ## Key configuration
 
-**Title, badge, excerpt**
+**Identifier, title, badge, excerpt, content**
 
+- `.SetId(string)` / `Id` — an identifier before the title (an issue number, a ticket key, a row
+  number), drawn quietly and followed by a chevron pointing at the title. Null or empty drops both.
 - `.SetTitle(string)` / `Title` — one line, ellipsized, with the full text as its tooltip.
+- `.SetTitle(IComponent, string text = null)` — the escape hatch for a title that genuinely isn't
+  text, such as one built from fields an administrator configured. The `text` alongside it stays the
+  row's `Title`, so the tooltip and the modal header still have something to say; `Highlight` does not
+  reach inside a component title.
 - `.SetBadge(string)` — the quiet pill next to the title ("3 matches in text"). Null or empty hides it.
 - `.SetBadge(IComponent)` — a `Badge` with a tone of its own, a `Spinner`, a small button.
 - `.SetText(string)` / `Text` — the excerpt, as **plain text**, ellipsized to two lines.
 - `.TextLines(int)` — how many lines the excerpt gets before it is ellipsized.
-- `.HighlightWords(params string[])` — mark those words in the excerpt, case-insensitively. The marks
-  and the badge share one pair of colors, from the `--tss-highlight-color` token (the same value as
-  `--tss-link-color`, so `Theme.SetPrimary` moves both), and the excerpt itself is a quiet grey.
+- `.SetContent(IComponent)` — a rich preview under the excerpt, in the text column: a thumbnail, a
+  quoted message, a table of the fields that matched. Null takes it away.
+- `.ContentMaxHeight(UnitSize)` — caps how tall that preview may grow, fading the overflow out rather
+  than cutting it off. Null un-caps it.
+- `.HighlightWords(params string[])` — mark those words in the **title and the excerpt**,
+  case-insensitively. The marks and the badge share one pair of colors, from the `--tss-highlight-color`
+  token (the same value as `--tss-link-color`, so `Theme.SetPrimary` moves both), and the excerpt
+  itself is a quiet grey.
 - `.Highlight(Regex)` / `.Highlight(string pattern, bool ignoreCase = true)` — mark every match, e.g.
   the pattern a search backend hands back. Matching runs against the text and each match is wrapped in
-  its own element, so an excerpt containing angle brackets renders them instead of obeying them.
+  its own element, so text containing angle brackets renders them instead of obeying them.
 
 **Icon tile**
 
@@ -48,6 +59,9 @@ stands for. Also `new OmniResult<T>(result, title)`. Bring factories into scope 
   and the computed pair is cached per color (a list drawing one color per file type only pays once).
 - `.SetIcon(string text, string color = null)` — a short type name ("PPTX", "CSV") in place of a glyph.
 - `.SetIcon(IComponent, string color = null)` — an `Image` thumbnail, an `Avatar`, an emoji.
+- `.SetIconBadge(IComponent badge, OmniResultBadgeCorner corner = BottomRight)` — a marker pinned to a
+  corner of the tile, drawn outside its clipping: where the result came from, that it is pinned.
+  Corners: `TopLeft`, `TopRight`, `BottomLeft`, `BottomRight`. Null clears that corner.
 
 Pass a literal color (`"#ef4444"`) rather than a CSS variable when you want the tint to track the
 theme: a `var(--…)` is resolved once, at the time it is set.
@@ -58,6 +72,8 @@ theme: a `var(--…)` is resolved once, at the time it is set.
   in that color plus the text, at the footer's start. Null or empty text drops it. Given a handler the
   source becomes clickable — scoping the search to it is the usual thing to do — with its own tab stop,
   Enter/Space, and an underline on hover; the click never also counts as opening the result.
+- `.SetSource(IComponent marker, string text, Action<OmniResult<T>> onClick = null)` — the same, with a
+  marker of the host's own (the source's logo, an avatar) in place of the colored square.
 - `.OnSourceClick(Action<OmniResult<T>>)` — the same handler on its own (null makes the source plain
   text again). `SetSource` only replaces the handler when it is given one, so the two compose in either
   order.
@@ -90,6 +106,8 @@ theme: a `var(--…)` is resolved once, at the time it is set.
 - `.InlineCommands(params IComponent[])` / `.InlineCommands(OmniResultCommandsVisibility visibility, params IComponent[])`
   — one or two buttons before the `[...]`, `OnHover` (default) or `AlwaysVisible`. The space is
   reserved either way.
+- `CommandsEvent` — the pointer event that last asked for the commands (null when they were asked for
+  from the keyboard), for a host that shows a command surface of its own rather than a `ContextMenu`.
 
 **Contribution bar**
 
@@ -106,6 +124,38 @@ theme: a `var(--…)` is resolved once, at the time it is set.
 - `.PagesFanOnHover(bool = true)` — the stack fans while the whole row is hovered, not only while the
   pointer is over the pages. On by default.
 
+**Opening as a modal**
+
+A row can carry the full view of the thing it stands for and open as a modal showing it, so the list
+and the detail are one object rather than two that have to be kept in step.
+
+- `.SetModalContent(IComponent)` / `.SetModalContent(Func<OmniResult<T>, Task<IComponent>>)` — what the
+  modal shows; the `Func` overload builds it on open, so content nobody asks for is never paid for.
+  Null makes the row modal-less again.
+- `HasModalContent` — whether it has any, so "this result has no preview" is one check.
+- `.ModalSize(UnitSize width, UnitSize height)` — the size it opens at. `Auto` by default.
+- `.SetModalHeader(Func<OmniResult<T>, IComponent>)` — replaces the default header (the same
+  identifier, chevron and title the row shows) with one built from the result — for a header that also
+  carries commands or status beside the title. Null goes back to the default.
+- `.ModalTitle()` — that default header on its own, to build around.
+- `.ToModal()` — a `Modal` with that header and content, at that size, or null when the row has no
+  modal content. Everything else (commands, dismissal, bounds, how it is shown) is left to the caller
+  to chain on what comes back.
+- `.GetModalContentAsync()` — the content on its own, for a host that shows it somewhere other than in
+  a modal: a side panel, a page, a pane.
+
+```csharp
+var modal = row.ToModal();
+
+if (modal is object)
+{
+    modal.MinWidth(60.vw()).MaxHeight(95.vh())
+         .SetHeaderCommands(Button(UIcons.Share).OnClick(() => Share(row.Result)))
+         .LightDismiss()
+         .Show();
+}
+```
+
 ## Example
 
 ```csharp
@@ -118,6 +168,8 @@ foreach (var hit in results)
 {
     var row = OmniResult(hit, hit.Name)                        // T is whatever `hit` is
         .SetIcon(UIcons.FilePdf, "#ef4444")
+        .SetIconBadge(Image(hit.SourceLogo), OmniResultBadgeCorner.BottomRight)
+        .SetId(hit.Reference)                                  // "JR-2214 › the title"
         .SetBadge($"{hit.Matches} matches in text")
         .SetText(hit.Excerpt)
         .HighlightWords(terms)
@@ -142,7 +194,9 @@ foreach (var hit in results)
             ContextMenuItem().Divider(),
             ContextMenuItem("Delete").OnClick(() => Delete(r.Result))
         }, OmniResultCommandsMode.ButtonOnHover)
-        .InlineCommands(Button(UIcons.Download).Tooltip("Download").OnClick(() => Download(hit)));
+        .InlineCommands(Button(UIcons.Download).Tooltip("Download").OnClick(() => Download(hit)))
+        .SetModalContent(async r => await BuildFullViewAsync(r.Result))                  // opens as a modal
+        .ModalSize(80.vw(), 80.vh());
 
     list.Add(row);
 }

--- a/Tesserae/src/Components/OmniResult.cs
+++ b/Tesserae/src/Components/OmniResult.cs
@@ -1,12 +1,28 @@
 using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using static Transpose.Core.dom;
 using Transpose.Core;
 using static Tesserae.UI;
 
 namespace Tesserae
 {
+    /// <summary>
+    /// Which corner of an <see cref="OmniResult{T}"/> icon tile a badge is pinned to.
+    /// </summary>
+    public enum OmniResultBadgeCorner
+    {
+        /// <summary>The top-left corner - where a "pinned" marker usually goes.</summary>
+        TopLeft,
+        /// <summary>The top-right corner.</summary>
+        TopRight,
+        /// <summary>The bottom-left corner.</summary>
+        BottomLeft,
+        /// <summary>The bottom-right corner - where a "where it came from" marker usually goes.</summary>
+        BottomRight
+    }
+
     /// <summary>
     /// Where the selection checkbox of an <see cref="OmniResult{T}"/> lives, and when it shows. A selected
     /// result always shows its checkbox, whatever the mode.
@@ -66,13 +82,17 @@ namespace Tesserae
     public sealed class OmniResult<T> : ComponentBase<OmniResult<T>, HTMLElement>
     {
         private readonly HTMLElement _selectContainer;
+        private readonly HTMLElement _iconHolder;
         private readonly HTMLElement _iconContainer;
+        private readonly HTMLElement _idContainer;
+        private readonly HTMLElement _idText;
         private readonly HTMLElement _titleElement;
         private readonly HTMLElement _badgeContainer;
         private readonly HTMLElement _headerContainer;
         private readonly HTMLElement _bodyContainer;
+        private readonly HTMLElement _contentContainer;
         private readonly HTMLElement _sourceContainer;
-        private readonly HTMLElement _sourceSquare;
+        private readonly HTMLElement _sourceMarker;
         private readonly HTMLElement _sourceText;
         private readonly HTMLElement _footerContainer;
         private readonly HTMLElement _contributionContainer;
@@ -81,12 +101,16 @@ namespace Tesserae
         private readonly HTMLElement _commandsContainer;
         private readonly HTMLElement _inlineCommandsContainer;
 
+        private readonly Dictionary<string, HTMLElement> _iconBadges = new Dictionary<string, HTMLElement>();
+
         private CheckBox          _checkBox;
         private ContributionBar   _contribution;
         private HTMLButtonElement _menuButton;
         private PagesStack        _pages;
 
+        private string                       _id;
         private string                       _title;
+        private IComponent                   _titleComponent;
         private string                       _text;
         private Regex                        _highlighter;
         private OmniResultSelectionMode      _selectionMode = OmniResultSelectionMode.OnHoverBeforeIcon;
@@ -96,6 +120,11 @@ namespace Tesserae
         private Action<OmniResult<T>>        _sourceClickHandler;
         private Func<OmniResult<T>, ContextMenu.Item[]> _menuGenerator;
         private MouseEvent                   _lastPointerEvent;
+
+        private Func<OmniResult<T>, Task<IComponent>> _modalContent;
+        private Func<OmniResult<T>, IComponent>       _modalHeader;
+        private UnitSize                              _modalWidth  = UnitSize.Auto();
+        private UnitSize                              _modalHeight = UnitSize.Auto();
 
         private event Action<OmniResult<T>, bool> SelectionChanged;
         private event Action<OmniResult<T>>       RangeSelectionRequested;
@@ -109,34 +138,41 @@ namespace Tesserae
 
             _selectContainer = Div(Att("tss-omniresult-select"));
             _iconContainer   = Div(Att("tss-omniresult-icon"));
+            _iconHolder      = Div(Att("tss-omniresult-icon-holder"), _iconContainer);
+
+            _idText       = Span(Att("tss-omniresult-id-value"));
+            _idContainer  = Div(Att("tss-omniresult-id"), _idText, I(UIcons.AngleRight, UIconsWeight.Regular, "tss-omniresult-id-chevron"));
 
             _titleElement   = Span(Att("tss-omniresult-title"));
             _badgeContainer = Div(Att("tss-omniresult-badge"));
 
-            _headerContainer = Div(Att("tss-omniresult-header"), _titleElement, _badgeContainer);
+            _headerContainer = Div(Att("tss-omniresult-header"), _idContainer, _titleElement, _badgeContainer);
 
-            _bodyContainer = Div(Att("tss-omniresult-body"));
+            _bodyContainer    = Div(Att("tss-omniresult-body"));
+            _contentContainer = Div(Att("tss-omniresult-content"));
 
-            _sourceSquare    = Span(Att("tss-omniresult-source-square"));
+            _sourceMarker    = Span(Att("tss-omniresult-source-square"));
             _sourceText      = Span(Att("tss-omniresult-source-text"));
-            _sourceContainer = Div(Att("tss-omniresult-source"), _sourceSquare, _sourceText);
+            _sourceContainer = Div(Att("tss-omniresult-source"), _sourceMarker, _sourceText);
 
             _footerContainer = Div(Att("tss-omniresult-footer"));
 
             _contributionContainer = Div(Att("tss-omniresult-contribution"));
 
-            _mainContainer = Div(Att("tss-omniresult-main"), _headerContainer, _bodyContainer, _footerContainer, _contributionContainer);
+            _mainContainer = Div(Att("tss-omniresult-main"), _headerContainer, _bodyContainer, _contentContainer, _footerContainer, _contributionContainer);
 
             _railContainer           = Div(Att("tss-omniresult-rail"));
             _inlineCommandsContainer = Div(Att("tss-omniresult-inline-commands"));
             _commandsContainer       = Div(Att("tss-omniresult-commands"), _inlineCommandsContainer);
 
-            InnerElement = Div(Att("tss-omniresult"), _selectContainer, _iconContainer, _mainContainer, _railContainer, _commandsContainer);
+            InnerElement = Div(Att("tss-omniresult"), _selectContainer, _iconHolder, _mainContainer, _railContainer, _commandsContainer);
 
+            SetId(null);
             SetTitle(title);
             SetText(null);
+            SetContent(null);
             SetBadge((string)null);
-            SetSource(null, null);
+            SetSource((string)null, null);
             SetContributionBar(null);
 
             HookEvents();
@@ -154,6 +190,16 @@ namespace Tesserae
         {
             get => _title;
             set => SetTitle(value);
+        }
+
+        /// <summary>
+        /// Gets or sets the identifier shown before the title - an issue number, a ticket key, a row number -
+        /// followed by a chevron pointing at the title. A null or empty value drops both.
+        /// </summary>
+        public string Id
+        {
+            get => _id;
+            set => SetId(value);
         }
 
         /// <summary>
@@ -224,15 +270,51 @@ namespace Tesserae
         public override HTMLElement Render() => InnerElement;
 
         /// <summary>
-        /// Sets the title of the result. The title is ellipsized to one line, and carries the full text as
-        /// its native tooltip.
+        /// Sets the title of the result. The title is ellipsized to one line, carries the full text as its
+        /// native tooltip, and has the terms of <see cref="Highlight(Regex)"/> marked in it.
         /// </summary>
         public OmniResult<T> SetTitle(string title)
         {
-            _title = title ?? string.Empty;
+            _titleComponent = null;
+            _title          = title ?? string.Empty;
 
-            _titleElement.textContent = _title;
-            _titleElement.setAttribute("title", _title);
+            RenderTitle();
+
+            return this;
+        }
+
+        /// <summary>
+        /// Puts a component in the title slot in place of the plain title - the escape hatch for a result
+        /// whose title genuinely isn't text, such as one built from fields an administrator configured. The
+        /// text passed alongside it stays the row's <see cref="Title"/>, so the tooltip, the modal header and
+        /// anything else reading the title still have something to say. Pass null to go back to plain text.
+        /// <para>
+        /// A component title is drawn as it was given: <see cref="Highlight(Regex)"/> does not reach inside it.
+        /// </para>
+        /// </summary>
+        public OmniResult<T> SetTitle(IComponent title, string text = null)
+        {
+            _titleComponent = title;
+            _title          = text ?? _title ?? string.Empty;
+
+            RenderTitle();
+
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the identifier shown before the title - an issue number, a ticket key, a row number - drawn in
+        /// the quiet way an identifier reads and followed by a chevron pointing at the title. A null or empty
+        /// value drops the identifier and the chevron with it.
+        /// </summary>
+        public OmniResult<T> SetId(string id)
+        {
+            _id = id;
+
+            var isEmpty = string.IsNullOrEmpty(id);
+
+            _idText.textContent      = isEmpty ? string.Empty : id;
+            _idContainer.style.display = isEmpty ? "none" : "";
 
             return this;
         }
@@ -336,14 +418,84 @@ namespace Tesserae
         }
 
         /// <summary>
-        /// Marks every match of the given expression in the excerpt - the same pattern a search backend
-        /// hands back for highlighting. Matching is done against the text itself and the matches are wrapped
-        /// in their own elements, so the excerpt is never treated as markup.
+        /// Puts a component under the excerpt, in the text column: the rich preview a result has of its own -
+        /// a thumbnail, a quoted message, a table of the fields that matched - for everything a plain excerpt
+        /// can't say. Pass null to take it away.
+        /// <para>
+        /// Cap how tall it is allowed to be with <see cref="ContentMaxHeight(UnitSize)"/>, which fades the
+        /// overflow out rather than cutting it off.
+        /// </para>
+        /// </summary>
+        public OmniResult<T> SetContent(IComponent content)
+        {
+            ClearChildren(_contentContainer);
+
+            if (content is object) _contentContainer.appendChild(content.Render());
+
+            _contentContainer.style.display = content is null ? "none" : "";
+
+            return this;
+        }
+
+        /// <summary>
+        /// Caps how tall the <see cref="SetContent(IComponent)"/> preview is allowed to grow, fading whatever
+        /// runs past it out instead of cutting it off. Pass null to un-cap it.
+        /// </summary>
+        public OmniResult<T> ContentMaxHeight(UnitSize maxHeight)
+        {
+            var isCapped = maxHeight is object;
+
+            _contentContainer.style.maxHeight = isCapped ? maxHeight.ToString() : "";
+            _contentContainer.UpdateClassIf(isCapped, "tss-omniresult-content-masked");
+
+            return this;
+        }
+
+        /// <summary>
+        /// Pins a badge to a corner of the icon tile - where a result came from, that it is pinned - drawn
+        /// over the tile's corner and outside its clipping. Pass null to clear that corner.
+        /// </summary>
+        public OmniResult<T> SetIconBadge(IComponent badge, OmniResultBadgeCorner corner = OmniResultBadgeCorner.BottomRight)
+        {
+            var cornerClass = CornerClass(corner);
+
+            if (_iconBadges.TryGetValue(cornerClass, out var stale))
+            {
+                _iconHolder.removeChild(stale);
+                _iconBadges.Remove(cornerClass);
+            }
+
+            if (badge is null) return this;
+
+            var holder = Div(Att("tss-omniresult-icon-badge " + cornerClass), badge.Render());
+
+            _iconHolder.appendChild(holder);
+            _iconBadges[cornerClass] = holder;
+
+            return this;
+        }
+
+        private static string CornerClass(OmniResultBadgeCorner corner)
+        {
+            switch (corner)
+            {
+                case OmniResultBadgeCorner.TopLeft:     return "tss-omniresult-icon-badge-tl";
+                case OmniResultBadgeCorner.TopRight:    return "tss-omniresult-icon-badge-tr";
+                case OmniResultBadgeCorner.BottomLeft:  return "tss-omniresult-icon-badge-bl";
+                default:                                return "tss-omniresult-icon-badge-br";
+            }
+        }
+
+        /// <summary>
+        /// Marks every match of the given expression in the title and the excerpt - the same pattern a search
+        /// backend hands back for highlighting. Matching is done against the text itself and the matches are
+        /// wrapped in their own elements, so neither is ever treated as markup.
         /// </summary>
         public OmniResult<T> Highlight(Regex highlighter)
         {
             _highlighter = highlighter;
 
+            RenderTitle();
             RenderText();
 
             return this;
@@ -391,10 +543,43 @@ namespace Tesserae
         /// </summary>
         public OmniResult<T> SetSource(string color, string text, Action<OmniResult<T>> onClick = null)
         {
+            ClearChildren(_sourceMarker);
+
+            _sourceMarker.classList.remove("tss-omniresult-source-custom");
+            _sourceMarker.style.background = color ?? string.Empty;
+
+            return SetSourceText(text, onClick);
+        }
+
+        /// <summary>
+        /// Names where the result came from with a marker of the host's own - the source's logo, an avatar -
+        /// in place of the plain colored square, followed by the text. Everything else behaves as
+        /// <see cref="SetSource(string, string, Action{OmniResult{T}})"/>: a null or empty text hides it, and
+        /// passing a handler makes the source clickable.
+        /// </summary>
+        public OmniResult<T> SetSource(IComponent marker, string text, Action<OmniResult<T>> onClick = null)
+        {
+            ClearChildren(_sourceMarker);
+
+            _sourceMarker.style.background = string.Empty;
+            _sourceMarker.UpdateClassIf(marker is object, "tss-omniresult-source-custom");
+
+            if (marker is object) _sourceMarker.appendChild(marker.Render());
+
+            return SetSourceText(text, onClick);
+        }
+
+        private OmniResult<T> SetSourceText(string text, Action<OmniResult<T>> onClick)
+        {
             var isEmpty = string.IsNullOrEmpty(text);
 
-            _sourceText.textContent        = isEmpty ? string.Empty : text;
-            _sourceSquare.style.background = color ?? string.Empty;
+            _sourceText.textContent = isEmpty ? string.Empty : text;
+
+            // No color and no marker of its own: the source is its name alone, rather than a name behind a
+            // blank square.
+            var hasMarker = !string.IsNullOrEmpty(_sourceMarker.style.background) || _sourceMarker.childElementCount > 0;
+
+            _sourceMarker.style.display = hasMarker ? "" : "none";
 
             // Only when one is given, so a later SetSource can't silently drop a handler an earlier
             // OnSourceClick registered. OnSourceClick(null) is how a source stops being clickable.
@@ -672,6 +857,117 @@ namespace Tesserae
             if (!value) _pages?.Fanned(false);
 
             return this;
+        }
+
+        /// <summary>
+        /// Gets the pointer event that last asked for this result's commands - the right-click, or the click
+        /// on the [...] button - or null when they were asked for from the keyboard. A host that shows its own
+        /// command surface (rather than a <see cref="ContextMenu"/> through <see cref="ShowMenu"/>) reads this
+        /// to place it where the user asked.
+        /// </summary>
+        public MouseEvent CommandsEvent => _lastPointerEvent;
+
+        /// <summary>
+        /// Gets a value indicating whether the result has content to open as a modal
+        /// (see <see cref="ToModal"/>).
+        /// </summary>
+        public bool HasModalContent => _modalContent is object;
+
+        /// <summary>
+        /// Sets what <see cref="ToModal"/> puts inside the modal for this result - the full view of the thing
+        /// the row stands for. Pass null to make the result modal-less again.
+        /// </summary>
+        public OmniResult<T> SetModalContent(IComponent content)
+        {
+            _modalContent = content is null ? (Func<OmniResult<T>, Task<IComponent>>)null : (_ => Task.FromResult(content));
+
+            return this;
+        }
+
+        /// <summary>
+        /// Sets what <see cref="ToModal"/> puts inside the modal, built on open and given the result - for
+        /// content that shouldn't be paid for until someone asks to see it.
+        /// </summary>
+        public OmniResult<T> SetModalContent(Func<OmniResult<T>, Task<IComponent>> content)
+        {
+            _modalContent = content;
+
+            return this;
+        }
+
+        /// <summary>
+        /// Builds the modal content on its own, for a host that shows it somewhere other than in a modal - a
+        /// side panel, a page, a pane of its own. Returns null when the result has no modal content.
+        /// </summary>
+        public Task<IComponent> GetModalContentAsync() => _modalContent is null ? Task.FromResult((IComponent)null) : _modalContent(this);
+
+        /// <summary>
+        /// Replaces the modal's header - by default the same identifier, title and badge the row shows - with
+        /// one built from the result. Pass null to go back to the default header.
+        /// </summary>
+        public OmniResult<T> SetModalHeader(Func<OmniResult<T>, IComponent> header)
+        {
+            _modalHeader = header;
+
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the size the modal of <see cref="ToModal"/> opens at. Auto by default, which lets the modal
+        /// size itself to its content (and to whatever bounds the caller sets on it afterwards).
+        /// </summary>
+        public OmniResult<T> ModalSize(UnitSize width, UnitSize height)
+        {
+            _modalWidth  = width  ?? UnitSize.Auto();
+            _modalHeight = height ?? UnitSize.Auto();
+
+            return this;
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Tesserae.Modal"/> showing this result: the row's identifier, title and badge as
+        /// the header, and whatever <c>SetModalContent</c> was given as the body, at the size
+        /// <see cref="ModalSize(UnitSize, UnitSize)"/> asked for. Everything else - commands, dismissal,
+        /// bounds, how it is shown - is left to the caller to chain on the returned modal.
+        /// <para>
+        /// Returns null when the result has no modal content, so a caller can treat "this result has no
+        /// preview" as one check.
+        /// </para>
+        /// </summary>
+        public Modal ToModal()
+        {
+            if (_modalContent is null) return null;
+
+            var content = _modalContent;
+
+            var modal = UI.Modal()
+               .Class("tss-omniresult-modal")
+               .SetHeader(_modalHeader is object ? _modalHeader(this) : ModalTitle())
+               .Width(_modalWidth)
+               .Height(_modalHeight);
+
+            modal.Content(Defer(() => content(this)).WS());
+
+            return modal;
+        }
+
+        /// <summary>
+        /// The header <see cref="ToModal"/> uses by default: the identifier, the title and the badge, drawn
+        /// the way the row draws them. Useful to a caller building its own header around it.
+        /// </summary>
+        public IComponent ModalTitle()
+        {
+            var header = Div(Att("tss-omniresult-modal-title"));
+
+            if (!string.IsNullOrEmpty(_id))
+            {
+                header.appendChild(Span(Att("tss-omniresult-id-value", text: _id)));
+                header.appendChild(I(UIcons.AngleRight, UIconsWeight.Regular, "tss-omniresult-id-chevron"));
+            }
+
+            header.appendChild(Span(Att("tss-omniresult-modal-title-text", text: _title, title: _title)));
+
+            return Raw(header);
         }
 
         /// <summary>
@@ -960,26 +1256,47 @@ namespace Tesserae
             return this;
         }
 
-        // The excerpt is built out of text nodes and marker spans, never out of markup, so a result whose
-        // text happens to contain angle brackets renders them rather than obeying them.
+        private void RenderTitle()
+        {
+            _titleElement.setAttribute("title", _title ?? string.Empty);
+            _titleElement.UpdateClassIf(_titleComponent is object, "tss-omniresult-title-custom");
+
+            if (_titleComponent is null)
+            {
+                RenderHighlighted(_titleElement, _title);
+                return;
+            }
+
+            ClearChildren(_titleElement);
+
+            _titleElement.appendChild(_titleComponent.Render());
+        }
+
         private void RenderText()
         {
-            ClearChildren(_bodyContainer);
-
             var isEmpty = string.IsNullOrEmpty(_text);
 
             _bodyContainer.style.display = isEmpty ? "none" : "";
 
-            if (isEmpty) return;
+            RenderHighlighted(_bodyContainer, _text);
+        }
+
+        // Text is built out of text nodes and marker spans, never out of markup, so a title or an excerpt
+        // that happens to contain angle brackets renders them rather than obeying them.
+        private void RenderHighlighted(HTMLElement target, string text)
+        {
+            ClearChildren(target);
+
+            if (string.IsNullOrEmpty(text)) return;
 
             if (_highlighter is null)
             {
-                _bodyContainer.textContent = _text;
+                target.textContent = text;
                 return;
             }
 
             var position = 0;
-            var matches  = _highlighter.Matches(_text);
+            var matches  = _highlighter.Matches(text);
 
             for (int i = 0; i < matches.Count; i++)
             {
@@ -989,17 +1306,17 @@ namespace Tesserae
 
                 if (match.Index > position)
                 {
-                    _bodyContainer.appendChild(document.createTextNode(_text.Substring(position, match.Index - position)));
+                    target.appendChild(document.createTextNode(text.Substring(position, match.Index - position)));
                 }
 
-                _bodyContainer.appendChild(Span(Att("tss-omniresult-highlight", text: match.Value)));
+                target.appendChild(Span(Att("tss-omniresult-highlight", text: match.Value)));
 
                 position = match.Index + match.Length;
             }
 
-            if (position < _text.Length)
+            if (position < text.Length)
             {
-                _bodyContainer.appendChild(document.createTextNode(_text.Substring(position)));
+                target.appendChild(document.createTextNode(text.Substring(position)));
             }
         }
     }

--- a/Tesserae/tps/assets/css/tss.omniresult.css
+++ b/Tesserae/tps/assets/css/tss.omniresult.css
@@ -102,11 +102,42 @@
 }
 
 /* Replacing the icon: no tile at all. */
-.tss-omniresult-select-replacing .tss-omniresult-icon {
+.tss-omniresult-select-replacing .tss-omniresult-icon-holder {
     display: none;
 }
 
 /* Icon tile ------------------------------------------------------------------------------------- */
+
+/* The tile clips its own content, so corner badges hang off this holder instead - which doesn't. */
+.tss-omniresult-icon-holder {
+    position: relative;
+    flex-grow: 0;
+    flex-shrink: 0;
+    line-height: 0;
+}
+
+.tss-omniresult-icon-badge {
+    position: absolute;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1;
+    line-height: 0;
+    pointer-events: none;
+}
+
+.tss-omniresult-icon-badge img,
+.tss-omniresult-icon-badge svg {
+    display: block;
+    width: 14px;
+    height: 14px;
+    border-radius: 3px;
+}
+
+.tss-omniresult-icon-badge-tl { left: -4px;  top: -4px; }
+.tss-omniresult-icon-badge-tr { right: -4px; top: -4px; }
+.tss-omniresult-icon-badge-bl { left: -4px;  bottom: -4px; }
+.tss-omniresult-icon-badge-br { right: -4px; bottom: -4px; }
 
 .tss-omniresult-icon {
     display: flex;
@@ -182,6 +213,46 @@
     color: var(--tss-default-foreground-color);
 }
 
+/* A title built from a component of the host's own lays itself out, so the one-line ellipsis the plain
+   title gets would only fight it. */
+.tss-omniresult-title.tss-omniresult-title-custom {
+    display: flex;
+    align-items: center;
+    min-width: 0;
+    flex-grow: 1;
+    overflow: visible;
+    white-space: normal;
+}
+
+/* The identifier before the title - an issue number, a ticket key - and the chevron pointing at it. It
+   never shrinks, so a long title ellipsizes before the identifier does. */
+.tss-omniresult-id {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    flex-grow: 0;
+    flex-shrink: 0;
+    min-width: 0;
+}
+
+.tss-omniresult-id-value {
+    max-width: 140px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: 14px;
+    font-weight: 600;
+    line-height: 22px;
+    font-variant-numeric: tabular-nums;
+    color: var(--tss-secondary-foreground-color);
+}
+
+.tss-omniresult-id-chevron {
+    font-size: 11px;
+    line-height: 1;
+    color: var(--tss-secondary-foreground-color);
+}
+
 .tss-omniresult-badge {
     display: flex;
     flex-grow: 0;
@@ -224,6 +295,18 @@
 .tss-omniresult-highlight {
     border-radius: 3px;
     padding: 0 2px;
+}
+
+/* The rich preview under the excerpt, capped by ContentMaxHeight - which fades the overflow out rather
+   than cutting it off, so a clipped preview reads as "there is more" instead of as a rendering fault. */
+.tss-omniresult-content {
+    min-width: 0;
+    overflow: hidden;
+}
+
+.tss-omniresult-content-masked {
+    -webkit-mask-image: linear-gradient(to bottom, black calc(100% - 28px), transparent 100%);
+    mask-image: linear-gradient(to bottom, black calc(100% - 28px), transparent 100%);
 }
 
 /* Footer ----------------------------------------------------------------------------------------- */
@@ -281,6 +364,23 @@
     height: 10px;
     border-radius: 2px;
     background: var(--tss-primary-background-color);
+}
+
+/* A marker of the host's own - a source logo, an avatar - in place of the plain colored square. */
+.tss-omniresult-source-square.tss-omniresult-source-custom {
+    width: 14px;
+    height: 14px;
+    border-radius: 3px;
+    background: none;
+    line-height: 0;
+}
+
+.tss-omniresult-source-square.tss-omniresult-source-custom img,
+.tss-omniresult-source-square.tss-omniresult-source-custom svg {
+    display: block;
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
 }
 
 .tss-omniresult-source-text {
@@ -381,6 +481,26 @@
 
 .tss-omniresult-menu-button:hover {
     background: var(--tss-default-background-active-color);
+    color: var(--tss-default-foreground-color);
+}
+
+/* As a modal ------------------------------------------------------------------------------------- */
+
+/* The modal header repeats the row's identifier, chevron and title, so opening a result reads as the
+   same thing enlarged rather than as a different surface. */
+.tss-omniresult-modal-title {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    min-width: 0;
+}
+
+.tss-omniresult-modal-title-text {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: 16px;
+    font-weight: 600;
     color: var(--tss-default-foreground-color);
 }
 


### PR DESCRIPTION
Everything a host needs to draw a real search result out of one row, so a
result list and the detail behind it can be one object rather than two kept
in step by hand.

- SetId puts an identifier before the title (an issue number, a ticket key)
  with a chevron pointing at it; empty drops both.
- SetTitle(IComponent, text) for a title that genuinely isn't text, keeping
  the plain text for the tooltip and the modal header.
- Highlight now marks the title as well as the excerpt.
- SetContent puts a rich preview under the excerpt, capped and faded out by
  ContentMaxHeight rather than cut off.
- SetIconBadge pins a marker to a corner of the tile, outside its clipping.
- SetSource takes a marker component (a source logo) as well as a color.
- SetModalContent / SetModalHeader / ModalSize / ToModal / ModalTitle /
  GetModalContentAsync: the row carries the full view of what it stands for
  and builds the modal showing it, leaving the commands, dismissal and
  bounds to the caller.
- CommandsEvent exposes the pointer event that asked for the commands, for a
  host that places a command surface of its own.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012EVgZkbCYK7M4rHoxQX49t