### PR TITLE
IconToggle: restyle as a segmented control, give it its own sample page

### DIFF
--- a/Tesserae.Tests/src/Samples/Components/IconToggleSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/IconToggleSample.cs
@@ -1,0 +1,266 @@
+using System;
+using static Transpose.Core.dom;
+using static Tesserae.UI;
+using static Tesserae.Tests.Samples.SamplesHelper;
+
+namespace Tesserae.Tests.Samples
+{
+    [SampleDetails(Group = "Components", Order = 0, Icon = UIcons.LayoutFluid)]
+    public class IconToggleSample : IComponent, ISample
+    {
+        public enum ViewMode { List, Grid, Table }
+
+        public enum ComposerMode { Chat, Search }
+
+        public enum Align { Left, Center, Justify }
+
+        public enum Device { Desktop, Tablet, Phone }
+
+        private readonly IComponent _content;
+
+        public IconToggleSample()
+        {
+            _content = SectionStack().Secondary()
+               .SampleTitle(typeof(IconToggleSample), UIcons.LayoutFluid, "A segmented control of icon buttons where exactly one is selected")
+               .FlatSection(Stack().Children(
+                    Card(VStack().WS().Children(
+                        TextBlock("An IconToggle is a segmented control: a small track holding two or more icon buttons, of which exactly one is selected at a time. It's the compact alternative to a ChoiceGroup for switching a mode or a view."),
+                        TextBlock("Each item carries an icon, a tooltip and a data payload of type T, and the current payload is exposed as an observable, so the selection can drive content or be two-way bound."))).SetTitle("Overview")))
+               .FlatSection(Stack().Children(
+                    Card(VStack().WS().Children(
+                        TextBlock("Reach for an IconToggle when the options are few (two to four), mutually exclusive, and each has an icon that reads on its own — view switchers, alignment, a chat/search mode selector. Always give every item a tooltip: an icon alone is rarely self-explanatory, and the tooltip is the only label an icon-only item has."),
+                        VStack().Children(
+                            SampleDo("Keep it to a handful of items that all fit on one row"),
+                            SampleDo("Add a text label when the icon alone is ambiguous"),
+                            SampleDo("Select a sensible default — the first item is selected on render"),
+                            SampleDont("Use it for actions; those are Buttons, not a selection"),
+                            SampleDont("Use it for options that aren't mutually exclusive — use CheckBoxes")))).SetTitle("Best Practices")))
+               .FlatSection(Stack().Children(
+                    Card(VStack().WS().Children(
+                        SampleSubTitle("Basic"),
+                        TextBlock("Icon-only items, the first one selected on render.").Secondary(),
+                        BasicExample(),
+
+                        SampleSubTitle("With labels"),
+                        TextBlock("Passing a text as the last argument of IconToggleItem puts a label next to the icon.").Secondary(),
+                        LabelledExample(),
+
+                        SampleSubTitle("Sizes"),
+                        TextBlock("The default fits inline next to other controls; Compact() is for dense toolbars and Large() for a page-level switch.").Secondary(),
+                        SizesExample(),
+
+                        SampleSubTitle("Rounded"),
+                        TextBlock("Rounded(BorderRadius) reshapes the track, and the items follow along.").Secondary(),
+                        RoundedExample(),
+
+                        SampleSubTitle("Vertical"),
+                        TextBlock("Vertical() stacks the items into a rail, every item as wide as the widest.").Secondary(),
+                        VerticalExample(),
+
+                        SampleSubTitle("Full width"),
+                        TextBlock("FullWidth() stretches the track to its container, with every item taking an equal share.").Secondary(),
+                        FullWidthExample(),
+
+                        SampleSubTitle("Disabled"),
+                        TextBlock("An item can be disabled on its own, or the whole control at once.").Secondary(),
+                        DisabledExample(),
+
+                        SampleSubTitle("Driving content"),
+                        TextBlock("The selection is an observable, so a DeferSync can rebuild a panel whenever it changes.").Secondary(),
+                        DrivingContentExample(),
+
+                        SampleSubTitle("Event handling"),
+                        TextBlock("OnChange fires on every change but not for the initial selection.").Secondary(),
+                        EventExample(),
+
+                        SampleSubTitle("Two-way binding"),
+                        TextBlock("IconToggle is bindable, so it stays in sync with an observable changed from anywhere else.").Secondary(),
+                        BindingExample(),
+
+                        SampleSubTitle("In a toolbar"),
+                        TextBlock("A Compact() toggle lines up with the other buttons of a toolbar row.").Secondary(),
+                        ToolbarExample()
+                    )).SetTitle("Usage")))
+               .SeeAlso(typeof(ToggleSample), typeof(ChoiceGroupSample), typeof(SegmentedPivotSample), typeof(ButtonSample), typeof(OmniBoxSample), typeof(BindingSample));
+        }
+
+        private static IComponent BasicExample()
+        {
+            var toggle = IconToggle(
+                IconToggleItem(UIcons.List,  "List view",  ViewMode.List),
+                IconToggleItem(UIcons.Apps,  "Grid view",  ViewMode.Grid),
+                IconToggleItem(UIcons.Table, "Table view", ViewMode.Table));
+
+            return HStack().AlignItemsCenter().Children(
+                toggle,
+                DeferSync(toggle.AsObservable(), mode => TextBlock($"{mode} view").Secondary().ML(12)));
+        }
+
+        private static IComponent LabelledExample()
+        {
+            return HStack().AlignItemsCenter().Children(
+                IconToggle(
+                    IconToggleItem(UIcons.Comment, "Ask the assistant", ComposerMode.Chat,   "Chat"),
+                    IconToggleItem(UIcons.Search,  "Search everything", ComposerMode.Search, "Search")),
+                IconToggle(
+                    IconToggleItem(UIcons.AlignLeft,    "Align left",    Align.Left,    "Left"),
+                    IconToggleItem(UIcons.AlignCenter,  "Center",        Align.Center,  "Center"),
+                    IconToggleItem(UIcons.AlignJustify, "Justify",       Align.Justify, "Justify")).ML(16));
+        }
+
+        private static IComponent SizesExample()
+        {
+            return VStack().Children(
+                LabelledRow("Compact()", IconToggle(
+                    IconToggleItem(UIcons.List, "List view", ViewMode.List),
+                    IconToggleItem(UIcons.Apps, "Grid view", ViewMode.Grid)).Compact()),
+                LabelledRow("Default", IconToggle(
+                    IconToggleItem(UIcons.List, "List view", ViewMode.List),
+                    IconToggleItem(UIcons.Apps, "Grid view", ViewMode.Grid))),
+                LabelledRow("Large()", IconToggle(
+                    IconToggleItem(UIcons.List, "List view", ViewMode.List),
+                    IconToggleItem(UIcons.Apps, "Grid view", ViewMode.Grid)).Large()));
+        }
+
+        private static IComponent RoundedExample()
+        {
+            return VStack().Children(
+                LabelledRow("BorderRadius.Small",  ModeToggle().Rounded(BorderRadius.Small)),
+                LabelledRow("BorderRadius.Medium", ModeToggle().Rounded(BorderRadius.Medium)),
+                LabelledRow("BorderRadius.Full",   ModeToggle().Rounded(BorderRadius.Full)));
+        }
+
+        private static IComponent VerticalExample()
+        {
+            return HStack().Children(
+                IconToggle(
+                    IconToggleItem(UIcons.List,  "List view",  ViewMode.List),
+                    IconToggleItem(UIcons.Apps,  "Grid view",  ViewMode.Grid),
+                    IconToggleItem(UIcons.Table, "Table view", ViewMode.Table)).Vertical(),
+                IconToggle(
+                    IconToggleItem(UIcons.DesktopWallpaper, "Desktop", Device.Desktop, "Desktop"),
+                    IconToggleItem(UIcons.TabletAndroid,    "Tablet",  Device.Tablet,  "Tablet"),
+                    IconToggleItem(UIcons.MobileNotch,      "Phone",   Device.Phone,   "Phone")).Vertical().ML(24));
+        }
+
+        private static IComponent FullWidthExample()
+        {
+            return VStack().WS().MaxWidth(420.px()).Children(
+                IconToggle(
+                    IconToggleItem(UIcons.Comment, "Ask the assistant", ComposerMode.Chat,   "Chat"),
+                    IconToggleItem(UIcons.Search,  "Search everything", ComposerMode.Search, "Search")).FullWidth());
+        }
+
+        private static IComponent DisabledExample()
+        {
+            var partly = IconToggle(
+                IconToggleItem(UIcons.List,   "List view",                    ViewMode.List),
+                IconToggleItem(UIcons.Apps,   "Grid view",                    ViewMode.Grid),
+                IconToggleItem(UIcons.Marker, "Map view (needs a location)",  ViewMode.Table).Disabled());
+
+            var whole = ModeToggle().Disabled();
+
+            return VStack().Children(
+                LabelledRow("One item disabled", partly),
+                LabelledRow("Whole control disabled", whole));
+        }
+
+        private static IComponent DrivingContentExample()
+        {
+            var toggle = IconToggle(
+                IconToggleItem(UIcons.List,  "List view",  ViewMode.List),
+                IconToggleItem(UIcons.Apps,  "Grid view",  ViewMode.Grid),
+                IconToggleItem(UIcons.Table, "Table view", ViewMode.Table));
+
+            return VStack().WS().Children(
+                toggle,
+                DeferSync(toggle.AsObservable(), mode => Preview(mode)).MT(8));
+        }
+
+        private static IComponent Preview(ViewMode mode)
+        {
+            var items = new[] { "Quarterly report", "Design review notes", "Roadmap draft" };
+
+            if (mode == ViewMode.List)
+            {
+                var list = VStack().WS();
+
+                foreach (var item in items)
+                {
+                    list.Add(HStack().AlignItemsCenter().Children(Icon(UIcons.Document).PR(8), TextBlock(item)).PT(4).PB(4));
+                }
+
+                return Card(list).WS();
+            }
+
+            if (mode == ViewMode.Grid)
+            {
+                var grid = HStack().WS();
+
+                foreach (var item in items)
+                {
+                    grid.Add(Card(VStack().Children(Icon(UIcons.Document), TextBlock(item).PT(8))).W(140).MR(8));
+                }
+
+                return grid;
+            }
+
+            var table = VStack().WS();
+            table.Add(HStack().WS().Children(TextBlock("Name").SemiBold().W(220), TextBlock("Kind").SemiBold()).PT(4).PB(4));
+
+            foreach (var item in items)
+            {
+                table.Add(HStack().WS().Children(TextBlock(item).W(220), TextBlock("Document").Secondary()).PT(4).PB(4));
+            }
+
+            return Card(table).WS();
+        }
+
+        private static IComponent EventExample()
+        {
+            return IconToggle(
+                    IconToggleItem(UIcons.Sun,  "Light appearance", "light"),
+                    IconToggleItem(UIcons.Moon, "Dark appearance",  "dark"))
+               .OnChange((sender, value) => Toast().Information($"Appearance is now {value}"));
+        }
+
+        private static IComponent BindingExample()
+        {
+            var view = new SettableObservable<ViewMode>(ViewMode.Grid);
+
+            return HStack().AlignItemsCenter().Children(
+                IconToggle(
+                    IconToggleItem(UIcons.List,  "List view",  ViewMode.List),
+                    IconToggleItem(UIcons.Apps,  "Grid view",  ViewMode.Grid),
+                    IconToggleItem(UIcons.Table, "Table view", ViewMode.Table)).Bind(view),
+                Button("List").Small().OnClick(() => view.Value  = ViewMode.List).ML(16),
+                Button("Grid").Small().OnClick(() => view.Value  = ViewMode.Grid),
+                Button("Table").Small().OnClick(() => view.Value = ViewMode.Table),
+                DeferSync(view, v => TextBlock($"view = {v}").SemiBold().ML(8)));
+        }
+
+        private static IComponent ToolbarExample()
+        {
+            var toggle = IconToggle(
+                IconToggleItem(UIcons.List,  "List view",  ViewMode.List),
+                IconToggleItem(UIcons.Apps,  "Grid view",  ViewMode.Grid),
+                IconToggleItem(UIcons.Table, "Table view", ViewMode.Table)).Compact();
+
+            return Card(HStack().WS().AlignItemsCenter().Children(
+                TextBlock("Documents").SemiBold(),
+                HStack().Grow(),
+                SearchBox("Filter").W(180).MR(8),
+                toggle,
+                Button().SetIcon(UIcons.Refresh).Tooltip("Refresh").NoBorder().NoBackground().ML(8))).WS();
+        }
+
+        private static IconToggle<ComposerMode> ModeToggle() => IconToggle(
+            IconToggleItem(UIcons.Comment, "Ask the assistant", ComposerMode.Chat),
+            IconToggleItem(UIcons.Search,  "Search everything", ComposerMode.Search));
+
+        private static IComponent LabelledRow(string label, IComponent toggle) =>
+            HStack().AlignItemsCenter().Children(TextBlock(label).Secondary().W(180), toggle).PB(8);
+
+        public HTMLElement Render() => _content.Render();
+    }
+}

--- a/Tesserae.Tests/src/Samples/Components/ToggleSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/ToggleSample.cs
@@ -54,15 +54,9 @@ namespace Tesserae.Tests.Samples
                         Label("Small").SetContent(Toggle().Rounded(BorderRadius.Small)),
                         Label("Medium").SetContent(Toggle().Rounded(BorderRadius.Medium)),
                         Label("Full").SetContent(Toggle().Rounded(BorderRadius.Full))
-                    ),
-                    
-                    SampleSubTitle("Icon Toggle"),
-                    VStack().Children(
-                        IconToggle(IconToggleItem(UIcons.Comment, "Chat", "Chat"), IconToggleItem(UIcons.Search, "Search", "Search")),
-                        IconToggle(IconToggleItem(UIcons.AppleWhole, "Apple", "Apple"), IconToggleItem(UIcons.Banana, "Banana", "Banana"), IconToggleItem(UIcons.OrangeJuice, "Orange Juice", "Orange Juice"), IconToggleItem(UIcons.Bread, "Bread", "Bread"))
                     )
                 )).SetTitle("Usage")))
-               .SeeAlso(typeof(CheckBoxSample), typeof(ChoiceGroupSample), typeof(ButtonSample), typeof(SegmentedPivotSample));
+               .SeeAlso(typeof(CheckBoxSample), typeof(ChoiceGroupSample), typeof(IconToggleSample), typeof(ButtonSample), typeof(SegmentedPivotSample));
         }
 
         public HTMLElement Render() => _content.Render();

--- a/Tesserae/skills/references/icon-toggle.md
+++ b/Tesserae/skills/references/icon-toggle.md
@@ -5,22 +5,41 @@ description: A segmented control of icon buttons where exactly one is selected a
 
 # IconToggle
 
-A row of icon buttons that behaves like a segmented control: exactly one item is
-selected. Each item carries a `UIcons` glyph, a tooltip and an arbitrary data
-payload of type `T`, surfaced through an observable.
+A row of icon buttons that behaves like a segmented control: an inset track with the
+selected item lifted out of it as a raised pill, and exactly one item selected at a
+time. Each item carries a `UIcons` glyph, a tooltip, an optional label and an
+arbitrary data payload of type `T`, surfaced through an observable.
 
 ## Create
 
 `IconToggle<T>(params IconToggle<T>.Item[] items)` — builds the toggle from items.
-Build items with `IconToggleItem<T>(UIcons icon, string tooltip, T data)`.
-Bring the factories into scope with `using static Tesserae.UI;`. The first item
-is selected by default.
+Build items with `IconToggleItem<T>(UIcons icon, string tooltip, T data, string text = null)`.
+Bring the factories into scope with `using static Tesserae.UI;`. The first item that
+isn't disabled is selected on render.
 
 ## Key configuration
 
-- `.Select(T item)` — programmatically select the item carrying that data.
-- `.AsObservable()` — `IObservable<T>` of the currently selected payload; observe it to react to changes.
-- `IconToggleItem(icon, tooltip, data)` — one entry: glyph, hover tooltip, payload.
+- `IconToggleItem(icon, tooltip, data, text)` — one entry: glyph, hover tooltip, payload
+  and an optional label next to the icon. `.SetText(string)` and `.Disabled(bool = true)`
+  configure an item after the fact.
+- `.Select(T item)` — programmatically select the item carrying that data; values that
+  don't match any item are ignored.
+- `.Selected` — the currently selected payload.
+- `.AsObservable()` — `IObservable<T>` of the selected payload; observe it (or hand it to
+  `DeferSync`) to drive content from the selection.
+- `.OnChange((sender, value) => ...)` — fires on every change, but not for the initial
+  selection.
+- `.Bind(SettableObservable<T>)` — two-way binding: the control follows the observable and
+  writes back to it.
+- `.Compact()` / `.Large()` — a denser control for toolbars, or a roomier one for a
+  page-level switch. The default sits comfortably next to other inline controls.
+- `.Vertical()` / `.Horizontal()` — stack the items into a rail instead of a row (every
+  item as wide as the widest); horizontal is the default.
+- `.FullWidth()` — stretch the track to its container, every item taking an equal share.
+- `.Rounded(BorderRadius radius = BorderRadius.Medium)` — reshape the track; the items
+  follow along, so `BorderRadius.Full` gives a pill.
+- `.Disabled(bool value = true)` — disable the whole control. Items disabled on their own
+  stay disabled when it is re-enabled.
 
 ## Example
 
@@ -33,13 +52,27 @@ var toggle = IconToggle<ViewMode>(
     IconToggleItem(UIcons.List, "List view", ViewMode.List),
     IconToggleItem(UIcons.Apps, "Grid view", ViewMode.Grid),
     IconToggleItem(UIcons.Grid, "Card view", ViewMode.Cards)
-);
+).Compact();
 
-toggle.AsObservable().Observe(mode => Console.WriteLine($"Now: {mode}"));
+var panel = VStack().Children(
+    toggle,
+    DeferSync(toggle.AsObservable(), mode => RenderItems(mode))
+);
+```
+
+With labels, as a mode selector:
+
+```csharp
+IconToggle(
+    IconToggleItem(UIcons.Comment, "Ask the assistant", Mode.Chat,   "Chat"),
+    IconToggleItem(UIcons.Search,  "Search everything", Mode.Search, "Search")
+).FullWidth().OnChange((sender, mode) => Switch(mode));
 ```
 
 ## Related
 
 - ChoiceGroup / Option — `option.md`
+- SegmentedPivot (same look, but it owns the content panes) — `segmented-pivot.md`
+- OmniBox (uses one as its Search/Chat mode selector) — `omni-box.md`
 - Icon — `icon.md`
 - Full docs & API: `/tesserae/components/icon-toggle`

--- a/Tesserae/skills/references/omni-box.md
+++ b/Tesserae/skills/references/omni-box.md
@@ -22,6 +22,10 @@ Config (set via object initializer):
 - `PlaceholderSearch` / `PlaceholderChat`, `ExpandOnFocus`, `TokenIgnoreCase`.
 - `SuggestionsFetcher = async input => OmniBoxSuggestionItem[]` — autocomplete source.
 - `IconSearch` / `IconChat` / `IconStop`, `SearchFooter` / `ChatFooter` (`FooterItems`).
+- `IconModeToggleChat` / `IconModeToggleSearch`, `TooltipModeToggleChat` / `TooltipModeToggleSearch`,
+  `TextModeToggleChat` / `TextModeToggleSearch` — the `SearchAndChat` mode selector in the footer (an
+  `IconToggle`, see `icon-toggle.md`). It is icon-only unless a text is set, and it takes the box's
+  roundness, so `.Rounded(BorderRadius.Full)` gives a pill-shaped selector.
 - `ChatHeader` (`IComponent`) — rendered inside the box above the chat input: what the message is being written against, e.g. a compact `ContextCards` group of the attached documents. Swap it later with `.SetChatHeader(component)`, or pass `null` to empty the slot — it takes up no space while empty. For individual cards *below* the input, use `.WithContextToAdd(...)`.
 - `GeneratingText` — label shown in the footer while generating (default `"Generating"`); the live elapsed time is appended, e.g. `"Generating, 1m 25s"`.
 - `AllowSendWhileGenerating` (default `false`) — when set, typing a message while `IsGenerating` is true sends it (`OnChat` fires) instead of the trigger stopping the reply, so the host can queue it for the turn in flight. The trigger still shows the stop icon while the input is empty and turns back into the send icon as soon as there is text.

--- a/Tesserae/skills/references/segmented-pivot.md
+++ b/Tesserae/skills/references/segmented-pivot.md
@@ -43,4 +43,5 @@ var pivot = SegmentedPivot()
 
 - Pivot — `pivot.md`
 - CardPivot — `card-pivot.md`
+- IconToggle (same look, for a plain value instead of content panes) — `icon-toggle.md`
 - Full docs & API: `/tesserae/surfaces/segmented-pivot`

--- a/Tesserae/skills/references/toggle.md
+++ b/Tesserae/skills/references/toggle.md
@@ -43,4 +43,5 @@ var component = Stack().Children(
 
 - ToggleButton — `.toggle-button.md`
 - CheckBox — `.check-box.md`
+- IconToggle (a segmented control of icons, one selected) — `icon-toggle.md`
 - Full docs & API: `/tesserae/components/toggle`

--- a/Tesserae/src/Base/UI.Components.cs
+++ b/Tesserae/src/Base/UI.Components.cs
@@ -692,7 +692,7 @@ namespace Tesserae
         /// <summary>
         /// Creates a <see cref="Tesserae.IconToggle.Item"/> component.
         /// </summary>
-        public static IconToggle<T>.Item IconToggleItem<T>(UIcons icon, string tooltip, T data) => new IconToggle<T>.Item(icon, tooltip, data);
+        public static IconToggle<T>.Item IconToggleItem<T>(UIcons icon, string tooltip, T data, string text = null) => new IconToggle<T>.Item(icon, tooltip, data, text);
 
         /// <summary>
         /// Creates a <see cref="Tesserae.ChoiceGroup.Choice"/> component.

--- a/Tesserae/src/Components/IconToggle.cs
+++ b/Tesserae/src/Components/IconToggle.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using static Transpose.Core.dom;
@@ -9,26 +10,51 @@ namespace Tesserae
     /// A group of icon buttons of which exactly one is selected at a time, like a segmented control.
     /// </summary>
     [Transpose.Name("tss.IconToggle")]
-    public class IconToggle<T> : IComponent, IBindableComponent<T>
+    public class IconToggle<T> : IComponent, IBindableComponent<T>, IRoundedStyle
     {
-        private Stack                    _stack;
-        private Dictionary<Item, Button> _items;
-        private SettableObservable<T>    _itemsObservable;
+        private readonly Stack                    _stack;
+        private readonly Dictionary<Item, Button> _items;
+        private readonly SettableObservable<T>    _itemsObservable;
+
         /// <summary>
         /// Initializes a new instance of this class.
         /// </summary>
         public IconToggle(Item[] items)
         {
-            _stack           = HStack().NoDefaultMargin().Class("tss-icon-toggle").NoWrap();
-            _items           = new Dictionary<Item, Button>();
-            _itemsObservable = new SettableObservable<T>(items.First().Data);
+            if (items == null || items.Length == 0)
+            {
+                throw new ArgumentException("An IconToggle needs at least one item.", nameof(items));
+            }
+
+            _stack = HStack().NoDefaultMargin().Class("tss-icon-toggle").NoWrap();
+            _items = new Dictionary<Item, Button>();
+
+            // A disabled item can't be clicked, so it can't be the one the control starts on either.
+            var initial = items.FirstOrDefault(i => !i.IsDisabled) ?? items[0];
+
+            _itemsObservable = new SettableObservable<T>(initial.Data);
 
             foreach (var item in items)
             {
                 var b = Button().Class("tss-icon-toggle-item").SetIcon(item.Icon).Tooltip(item.Tooltip).OnClick(() => Select(item.Data));
+
+                if (!string.IsNullOrEmpty(item.Text))
+                {
+                    b.SetText(item.Text);
+                }
+
+                if (item.IsDisabled)
+                {
+                    b.Disabled();
+                }
+
                 _items[item] = b;
                 _stack.Add(b);
             }
+
+            // The initial value is already in the observable, so paint it too — otherwise the control
+            // renders with no visible selection until something calls Select.
+            MarkSelected(initial.Data);
         }
 
         /// <summary>
@@ -37,23 +63,25 @@ namespace Tesserae
         public HTMLElement Render() => _stack.Render();
 
         /// <summary>
-        /// Configures the component to select.
+        /// Selects the item carrying the given data. Values that don't match any item are ignored.
         /// </summary>
-        public void Select(T item)
+        public IconToggle<T> Select(T item)
         {
-            foreach (var kv in _items)
+            if (!_items.Keys.Any(k => EqualityComparer<T>.Default.Equals(k.Data, item)))
             {
-                if (EqualityComparer<T>.Default.Equals(kv.Key.Data, item))
-                {
-                    kv.Value.Class("tss-icon-togle-item-selected");
-                    _itemsObservable.Value = item;
-                }
-                else
-                {
-                    kv.Value.RemoveClass("tss-icon-togle-item-selected");
-                }
+                return this;
             }
+
+            MarkSelected(item);
+            _itemsObservable.Value = item;
+
+            return this;
         }
+
+        /// <summary>
+        /// Gets the currently selected data.
+        /// </summary>
+        public T Selected => _itemsObservable.Value;
 
         /// <summary>
         /// Returns the component's state as a(n) observable.
@@ -66,16 +94,114 @@ namespace Tesserae
         /// </summary>
         public void SetBoundValue(T value) => Select(value);
 
+        /// <summary>
+        /// Calls the handler whenever the selection changes, but not for the initial selection.
+        /// </summary>
+        public IconToggle<T> OnChange(Action<IconToggle<T>, T> onChange)
+        {
+            _itemsObservable.ObserveFutureChanges(value => onChange(this, value));
+
+            return this;
+        }
+
+        /// <summary>
+        /// Renders a denser control, for toolbars and other tight spots.
+        /// </summary>
+        public IconToggle<T> Compact()
+        {
+            var element = _stack.Render();
+            element.classList.remove("tss-icon-toggle-large");
+            element.classList.add("tss-icon-toggle-compact");
+
+            return this;
+        }
+
+        /// <summary>
+        /// Renders a roomier control, for use as a primary, page-level switch.
+        /// </summary>
+        public IconToggle<T> Large()
+        {
+            var element = _stack.Render();
+            element.classList.remove("tss-icon-toggle-compact");
+            element.classList.add("tss-icon-toggle-large");
+
+            return this;
+        }
+
+        /// <summary>
+        /// Stacks the items top to bottom instead of left to right.
+        /// </summary>
+        public IconToggle<T> Vertical()
+        {
+            _stack.Vertical();
+            _stack.Render().classList.add("tss-icon-toggle-vertical");
+
+            return this;
+        }
+
+        /// <summary>
+        /// Stacks the items left to right, the default.
+        /// </summary>
+        public IconToggle<T> Horizontal()
+        {
+            _stack.Horizontal();
+            _stack.Render().classList.remove("tss-icon-toggle-vertical");
+
+            return this;
+        }
+
+        /// <summary>
+        /// Stretches the control to the width of its container, with every item taking an equal share.
+        /// </summary>
+        public IconToggle<T> FullWidth()
+        {
+            _stack.Render().classList.add("tss-icon-toggle-full-width");
+
+            return this;
+        }
+
+        /// <summary>
+        /// Configures whether the whole control is disabled.
+        /// </summary>
+        public IconToggle<T> Disabled(bool value = true)
+        {
+            foreach (var kv in _items)
+            {
+                // An item disabled on its own stays disabled when the control is re-enabled.
+                kv.Value.Disabled(value || kv.Key.IsDisabled);
+            }
+
+            _stack.Render().UpdateClassIf(value, "tss-icon-toggle-disabled");
+
+            return this;
+        }
+
+        private void MarkSelected(T item)
+        {
+            foreach (var kv in _items)
+            {
+                if (EqualityComparer<T>.Default.Equals(kv.Key.Data, item))
+                {
+                    kv.Value.Class("tss-icon-toggle-item-selected");
+                }
+                else
+                {
+                    kv.Value.RemoveClass("tss-icon-toggle-item-selected");
+                }
+            }
+        }
+
         public class Item
         {
             /// <summary>
             /// Initializes a new instance of this class.
             /// </summary>
-            public Item(UIcons icon, string tooltip, T data)
+            public Item(UIcons icon, string tooltip, T data, string text = null)
             {
                 Icon    = icon;
                 Tooltip = tooltip;
                 Data    = data;
+                Text    = text;
             }
 
             /// <summary>
@@ -90,6 +216,34 @@ namespace Tesserae
             /// Gets or sets the data.
             /// </summary>
             public T Data { get; }
+            /// <summary>
+            /// Gets the label shown next to the icon, if any.
+            /// </summary>
+            public string Text { get; private set; }
+            /// <summary>
+            /// Gets whether this item can be selected.
+            /// </summary>
+            public bool IsDisabled { get; private set; }
+
+            /// <summary>
+            /// Sets a label to show next to the icon.
+            /// </summary>
+            public Item SetText(string text)
+            {
+                Text = text;
+
+                return this;
+            }
+
+            /// <summary>
+            /// Configures whether this item is disabled.
+            /// </summary>
+            public Item Disabled(bool value = true)
+            {
+                IsDisabled = value;
+
+                return this;
+            }
         }
     }
 }

--- a/Tesserae/src/Components/OmniBox.cs
+++ b/Tesserae/src/Components/OmniBox.cs
@@ -455,6 +455,14 @@ namespace Tesserae
             /// </summary>
             public string TooltipModeToggleChat { get; set; }
             /// <summary>
+            /// Gets or sets a label to show next to the search icon in the mode selector. Icon-only when null.
+            /// </summary>
+            public string TextModeToggleSearch { get; set; }
+            /// <summary>
+            /// Gets or sets a label to show next to the chat icon in the mode selector. Icon-only when null.
+            /// </summary>
+            public string TextModeToggleChat { get; set; }
+            /// <summary>
             /// Gets or sets the expand on focus.
             /// </summary>
             public bool ExpandOnFocus { get; set; }
@@ -693,7 +701,9 @@ namespace Tesserae
 
             if (_mode == Mode.SearchAndChat)
             {
-                _modeToggle = IconToggle(IconToggleItem(config.IconModeToggleChat, config.TooltipModeToggleChat, Mode.Chat), IconToggleItem(config.IconModeToggleSearch, config.TooltipModeToggleSearch, Mode.Search));
+                _modeToggle = IconToggle(
+                    IconToggleItem(config.IconModeToggleChat, config.TooltipModeToggleChat, Mode.Chat, config.TextModeToggleChat),
+                    IconToggleItem(config.IconModeToggleSearch, config.TooltipModeToggleSearch, Mode.Search, config.TextModeToggleSearch)).Class("tss-omnibox-mode-toggle");
                 _modeToggle.Select(_activeMode.Value);
                 _modeToggle.AsObservable().ObserveFutureChanges(v => _activeMode.Value = v);
                 _footer.appendChild(_modeToggle.Render());

--- a/Tesserae/tps.json
+++ b/Tesserae/tps.json
@@ -83,6 +83,7 @@
                 "tps/assets/css/tss.splitview.css",
                 "tps/assets/css/tss.toast.css",
                 "tps/assets/css/tss.toggle.css",
+                "tps/assets/css/tss.icontoggle.css",
                 "tps/assets/css/tss.skeleton.css",
                 "tps/assets/css/tss.stepper.css",
                 "tps/assets/css/tss.carousel.css",

--- a/Tesserae/tps/assets/css/tss.icontoggle.css
+++ b/Tesserae/tps/assets/css/tss.icontoggle.css
@@ -1,0 +1,155 @@
+/* IconToggle — a segmented control where exactly one item is selected.
+
+   Visually it follows the same language as SegmentedPivot: the control itself is an inset track in a
+   shade of the secondary background, out of which the selected item is lifted as a raised pill in the
+   default background. Geometry and icon size come entirely from the custom properties below, so the
+   size and roundness variants only need to re-declare those. */
+.tss-icon-toggle {
+    --tss-icon-toggle-radius: var(--tss-border-radius-lg);
+    --tss-icon-toggle-inset: 3px;
+    --tss-icon-toggle-height: 26px;
+    --tss-icon-toggle-padding: 8px;
+    --tss-icon-toggle-icon-size: 13px;
+    box-sizing: border-box;
+    width: fit-content;
+    padding: var(--tss-icon-toggle-inset);
+    border-radius: var(--tss-icon-toggle-radius);
+    /* The secondary background is only a few levels off the default one, which would leave the
+       selected pill barely visible against its track — a touch of the foreground pulls them apart,
+       in both themes. */
+    background: color-mix(in srgb, var(--tss-default-foreground-color) 7%, var(--tss-secondary-background-color));
+    box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.05);
+}
+
+/* The items are Buttons, so the shared .tss-btn look (min-width, own shadow, hover background) has
+   to be unwound before the segment styling can take over. The selectors go through .tss-stack-item
+   because Stack wraps every child, and they carry enough classes to outrank .tss-btn-default's own
+   states without needing !important. */
+.tss-icon-toggle > .tss-stack-item > .tss-btn.tss-icon-toggle-item {
+    min-width: 0;
+    min-height: var(--tss-icon-toggle-height);
+    height: var(--tss-icon-toggle-height);
+    margin: 0;
+    padding: 0 var(--tss-icon-toggle-padding);
+    border: none;
+    border-radius: calc(var(--tss-icon-toggle-radius) - var(--tss-icon-toggle-inset));
+    background: transparent;
+    box-shadow: none;
+    color: var(--tss-secondary-foreground-color);
+    font-size: var(--tss-font-size-small);
+    font-weight: var(--tss-font-weight-semibold);
+    white-space: nowrap;
+    transition: background-color 0.15s ease-in-out, color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+}
+
+    .tss-icon-toggle > .tss-stack-item > .tss-btn.tss-icon-toggle-item > i {
+        color: inherit;
+        font-size: var(--tss-icon-toggle-icon-size);
+    }
+
+    /* The 10px the shared button style puts between icon and label is too airy at this scale. */
+    .tss-icon-toggle > .tss-stack-item > .tss-btn.tss-icon-toggle-item > i + span:not(:empty) {
+        margin-left: 6px;
+        min-width: 0;
+    }
+
+    .tss-icon-toggle > .tss-stack-item > .tss-btn.tss-icon-toggle-item:not(.tss-icon-toggle-item-selected):not(.tss-disabled):hover {
+        background-color: color-mix(in srgb, var(--tss-default-foreground-color) 8%, transparent);
+        color: var(--tss-default-foreground-color);
+    }
+
+    .tss-icon-toggle > .tss-stack-item > .tss-btn.tss-icon-toggle-item:not(.tss-icon-toggle-item-selected):not(.tss-disabled):active {
+        background-color: color-mix(in srgb, var(--tss-default-foreground-color) 14%, transparent);
+    }
+
+    .tss-icon-toggle > .tss-stack-item > .tss-btn.tss-icon-toggle-item.tss-icon-toggle-item-selected,
+    .tss-icon-toggle > .tss-stack-item > .tss-btn.tss-icon-toggle-item.tss-icon-toggle-item-selected:hover {
+        background: var(--tss-default-background-color);
+        color: var(--tss-default-foreground-color);
+        box-shadow: var(--tss-shadow-sm);
+    }
+
+    /* In the dark theme the default background is darker than the track, and a pill darker than what
+       it sits in reads as recessed rather than raised — so there the selection goes lighter instead. */
+    .tss-dark-mode .tss-icon-toggle > .tss-stack-item > .tss-btn.tss-icon-toggle-item.tss-icon-toggle-item-selected,
+    .tss-dark-mode .tss-icon-toggle > .tss-stack-item > .tss-btn.tss-icon-toggle-item.tss-icon-toggle-item-selected:hover {
+        background: color-mix(in srgb, var(--tss-default-foreground-color) 22%, var(--tss-secondary-background-color));
+    }
+
+    /* The dark theme's secondary foreground is the same colour as the default one, so an unselected
+       item needs dimming of its own to keep the selection readable. */
+    .tss-dark-mode .tss-icon-toggle > .tss-stack-item > .tss-btn.tss-icon-toggle-item:not(.tss-icon-toggle-item-selected):not(.tss-disabled):not(:hover) {
+        color: color-mix(in srgb, var(--tss-default-foreground-color) 70%, var(--tss-secondary-background-color));
+    }
+
+    /* The segment styling above always wins over .tss-btn:focus's ring (it sets box-shadow), so the
+       keyboard affordance is an outline instead. */
+    .tss-icon-toggle > .tss-stack-item > .tss-btn.tss-icon-toggle-item:focus-visible {
+        outline: 2px solid var(--tss-primary-background-color);
+        outline-offset: -1px;
+    }
+
+    .tss-icon-toggle > .tss-stack-item > .tss-btn.tss-icon-toggle-item.tss-disabled {
+        background: transparent;
+        box-shadow: none;
+        color: var(--tss-disabled-foreground-color);
+    }
+
+/* Size variants */
+.tss-icon-toggle.tss-icon-toggle-compact {
+    --tss-icon-toggle-radius: var(--tss-border-radius-md);
+    --tss-icon-toggle-inset: 2px;
+    --tss-icon-toggle-height: 22px;
+    --tss-icon-toggle-padding: 6px;
+    --tss-icon-toggle-icon-size: 11px;
+}
+
+.tss-icon-toggle.tss-icon-toggle-large {
+    --tss-icon-toggle-radius: var(--tss-border-radius-xl);
+    --tss-icon-toggle-inset: 4px;
+    --tss-icon-toggle-height: 32px;
+    --tss-icon-toggle-padding: 12px;
+    --tss-icon-toggle-icon-size: 15px;
+}
+
+/* .Rounded(...) sets the track radius through the shared .tss-rounded-* classes; the segments derive
+   theirs from this variable, so it has to follow along. */
+.tss-icon-toggle.tss-rounded-sm {
+    --tss-icon-toggle-radius: var(--tss-border-radius-sm);
+}
+
+.tss-icon-toggle.tss-rounded-md {
+    --tss-icon-toggle-radius: var(--tss-border-radius-md);
+}
+
+.tss-icon-toggle.tss-rounded-full {
+    --tss-icon-toggle-radius: var(--tss-border-radius-full);
+}
+
+/* Vertical: every segment takes the width of the widest one, so the pills line up as a rail. */
+.tss-icon-toggle.tss-icon-toggle-vertical > .tss-stack-item {
+    align-self: stretch;
+}
+
+.tss-icon-toggle.tss-icon-toggle-vertical > .tss-stack-item > .tss-btn.tss-icon-toggle-item {
+    width: 100%;
+}
+
+/* Full width: the track fills its container and the segments share it equally. */
+.tss-icon-toggle.tss-icon-toggle-full-width {
+    width: 100%;
+}
+
+    .tss-icon-toggle.tss-icon-toggle-full-width > .tss-stack-item {
+        flex: 1 1 0;
+        min-width: 0;
+    }
+
+    .tss-icon-toggle.tss-icon-toggle-full-width > .tss-stack-item > .tss-btn.tss-icon-toggle-item {
+        width: 100%;
+    }
+
+.tss-icon-toggle.tss-icon-toggle-disabled {
+    cursor: not-allowed;
+    opacity: 0.7;
+}

--- a/Tesserae/tps/assets/css/tss.omnibox.css
+++ b/Tesserae/tps/assets/css/tss.omnibox.css
@@ -110,8 +110,23 @@
     display: none !important;
 }
 
-.tss-omnibox-footer .tss-icon-toggle{
-    margin-bottom:0px;
+.tss-omnibox-footer .tss-icon-toggle {
+    margin-bottom: 0px;
+    margin-right: 4px;
+    align-self: center;
+    flex-shrink: 0;
+}
+
+/* The mode selector takes the shape of the box it sits in, so a pill-shaped OmniBox gets a
+   pill-shaped selector rather than a rounded rectangle floating inside the curve. */
+.tss-omnibox-container.tss-omnibox-rounded-full .tss-omnibox-mode-toggle {
+    --tss-icon-toggle-radius: var(--tss-border-radius-full);
+    border-radius: var(--tss-border-radius-full);
+}
+
+.tss-omnibox-container.tss-omnibox-rounded-sm .tss-omnibox-mode-toggle {
+    --tss-icon-toggle-radius: var(--tss-border-radius-sm);
+    border-radius: var(--tss-border-radius-sm);
 }
 
 

--- a/Tesserae/tps/assets/css/tss.toggle.css
+++ b/Tesserae/tps/assets/css/tss.toggle.css
@@ -244,34 +244,4 @@
             padding-left: 34px;
         }
 
-
-.tss-icon-toggle {
-    border: 1px solid var(--tss-default-border-color);
-    width: fit-content;
-    border-radius: 8px;
-    box-shadow: 0 0.3px 0.9px 0 var(--tss-shadow-color-to);
-}
-
-    .tss-icon-toggle .tss-icon-toggle-item {
-        border-radius: 0px;
-    }
-
-        .tss-icon-toggle .tss-icon-toggle-item.tss-icon-togle-item-selected {
-            background: var(--tss-secondary-background-color);
-            box-shadow: inset 2px 2px 4px rgb(0 0 0 / 0.06);
-            border: 0px solid transparent !important;
-        }
-
-
-    .tss-icon-toggle > .tss-stack-item > .tss-icon-toggle-item {
-        border-right: 1px solid rgba(var(--tss-dark-border-color-root), 0.2) !important;
-    }
-
-    .tss-icon-toggle > .tss-stack-item:first-child > .tss-icon-toggle-item {
-        border-radius: 6px 0px 0px 6px;
-    }
-
-    .tss-icon-toggle > .tss-stack-item:last-child > .tss-icon-toggle-item {
-        border-radius: 0px 6px 6px 0px;
-        border-right: 0px solid transparent !important;
-    }
+/* IconToggle lives in tss.icontoggle.css */


### PR DESCRIPTION
## The mode selector

The `SearchAndChat` mode selector in the OmniBox footer was a bordered box with a divider between items and an inset shadow on the selection, which read as separate small buttons rather than one control. It now follows the same visual language as `SegmentedPivot`: an inset track with the selected item lifted out of it as a raised pill, no dividers, animated hover/active states and a focus outline. It is also shorter (32px instead of 38) so it sits properly in the footer, and it takes the box's roundness — `.Rounded(BorderRadius.Full)` gives a pill-shaped selector inside a pill-shaped box.

The dark theme needs its own rules: there the default background is *darker* than the track, so a pill painted with it reads as recessed. Selected goes lighter than the track instead, and unselected items get dimmed (the dark theme's secondary foreground is the same colour as the default one, so colour alone gave no cue).

The styling moved out of the tail of `tss.toggle.css` into a new `tss.icontoggle.css`, with geometry driven by custom properties so the size and roundness variants only re-declare those. The typo'd `tss-icon-togle-item-selected` class is spelled correctly now.

## IconToggle

New surface, all opt-in:

- optional text labels next to the icons — `IconToggleItem(icon, tooltip, data, text)`, plus `Item.SetText(...)` / `Item.Disabled(...)`
- `Compact()` / `Large()` sizes
- `Vertical()` / `Horizontal()`
- `FullWidth()` — equal-share segments across the container
- `Rounded(BorderRadius)` — implements `IRoundedStyle`
- `Disabled(bool)` on the whole control; items disabled on their own stay disabled when it is re-enabled
- `OnChange((sender, value) => ...)` and a `Selected` getter

Two behaviour fixes came with it: the initial selection is now painted (it previously only landed in the observable, so the control rendered with nothing visibly selected), and `Select` of a value that matches no item is ignored rather than clearing the selection — which is what the reference already claimed.

`OmniBox.Config` gains `TextModeToggleChat` / `TextModeToggleSearch` for labelling the mode selector; it stays icon-only by default.

## Sample page

`IconToggleSample` is a new page, moved out of `ToggleSample` (which links to it), with examples for basic icon-only, labelled items, the three sizes, the three roundness options, vertical, full width, disabled item vs. disabled control, driving a panel through `DeferSync`, `OnChange`, two-way binding and a toolbar row.

## Docs

`skills/references/icon-toggle.md` rewritten for the new surface, `omni-box.md` documents the mode-selector config, and `toggle.md` / `segmented-pivot.md` cross-link it.

## Verification

`dotnet build` clean. Checked in the browser in both themes: selection, per-item and whole-control disabling, the `DeferSync` panel swap and the `OnChange` toast all behave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CYhT7x4EiJeEfS617FvKkB