### PR TITLE
PagesStack: let each page open the document at itself

### DIFF
--- a/Tesserae.Tests/src/Samples/Components/OmniResultSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/OmniResultSample.cs
@@ -538,8 +538,10 @@ namespace Tesserae.Tests.Samples
                     PagesLabel("Thumbnails", PagesStack(thumbnails).TotalPages(9)),
                     PagesLabel("Larger pages", PagesStack(4).PageSize(60, 78)),
                     PagesLabel("MaxVisible(3)", PagesStack(12).MaxVisible(3))),
-                TextBlock("Held open with Fanned(), which is how OmniResult makes the stack follow hovering the whole row (PagesFanOnHover, on by default):").Small().MT(8).MB(8),
-                PagesLabel("Fanned()", PagesStack(5).TotalPages(19).Fanned()));
+                TextBlock("Held open with Fanned(), which is how OmniResult makes the stack follow hovering the whole row (PagesFanOnHover, on by default). OnPageClick makes each drawn page open the document at itself — the click is the page's alone, so it never also counts as a click on the row:").Small().MT(8).MB(8),
+                HStack().WS().Wrap().Gap(32.px()).AlignItems(ItemAlign.End).Children(
+                    PagesLabel("Fanned()", PagesStack(5).TotalPages(19).Fanned()),
+                    PagesLabel("OnPageClick", PagesStack(thumbnails).TotalPages(9).OnPageClick(page => Toast().Information($"Opening page {page + 1}")))));
         }
 
         private static IComponent PagesLabel(string label, PagesStack pages)

--- a/Tesserae/skills/references/pages-stack.md
+++ b/Tesserae/skills/references/pages-stack.md
@@ -36,6 +36,10 @@ Also `new PagesStack(...)`. Bring factories into scope with `using static Tesser
 - `.Fanned(bool = true)` — hold the stack open, for a host that wants the fan to follow hovering
   something larger than the stack. `OmniResult` does exactly this for the row it sits in
   (`PagesFanOnHover`, on by default).
+- `.OnPageClick(Action<int>)` — makes each drawn page clickable, handing the handler its 0-based
+  index, so "open the document at the page the user pointed at" is one call. The click is the page's
+  alone — it never also counts as a click on the row the stack sits in — and each page takes a tab
+  stop of its own and answers Enter and Space. Pass null to make the pages plain again.
 - `TotalPageCount` / `VisiblePageCount` / `IsFanned` — what it is showing right now.
 
 Motion is 240ms and honours `prefers-reduced-motion`. Pages read as paper in both themes: a pale fill
@@ -56,7 +60,7 @@ var thumbs = PagesStack(page1Url, page2Url, page3Url).TotalPages(12);
 var row = OmniResult(hit, hit.Name)
     .SetIcon(UIcons.FilePdf, "#ef4444")
     .SetText(hit.Excerpt)
-    .SetPages(PagesStack(5).TotalPages(hit.Pages));
+    .SetPages(PagesStack(thumbnailUrls).TotalPages(hit.Pages).OnPageClick(page => Open(hit, page)));
 ```
 
 Standalone, in a row of its own, remember it is right-aligned inside its rail — put it in an

--- a/Tesserae/src/Components/PagesStack.cs
+++ b/Tesserae/src/Components/PagesStack.cs
@@ -41,6 +41,7 @@ namespace Tesserae
         private int          _maxVisible = DEFAULT_MAX_VISIBLE;
         private int          _pageWidth  = DEFAULT_PAGE_WIDTH;
         private int          _pageHeight = DEFAULT_PAGE_HEIGHT;
+        private Action<int>  _pageClickHandler;
 
         /// <summary>
         /// Initializes a new instance of this class showing the given thumbnails, at most
@@ -177,6 +178,19 @@ namespace Tesserae
             return this;
         }
 
+        /// <summary>
+        /// Makes each drawn page clickable, handing the handler the page's index (0-based) - so opening a
+        /// document at the page the user pointed at is one call. The click is the page's alone: it does not
+        /// also count as a click on the row the stack sits in. Each page takes a tab stop of its own and
+        /// answers Enter and Space. Pass null to make the pages plain again.
+        /// </summary>
+        public PagesStack OnPageClick(Action<int> onPageClick)
+        {
+            _pageClickHandler = onPageClick;
+
+            return Rebuild();
+        }
+
         private PagesStack Rebuild()
         {
             ClearChildren(_stack);
@@ -239,7 +253,35 @@ namespace Tesserae
             page.style.setProperty("--tss-pagesstack-fan-rotation", $"{-FAN_ROTATION + 2 * FAN_ROTATION * t:0.##}deg");
             page.style.setProperty("--tss-pagesstack-fan-lift",     $"{-2 - 4 * Math.Sin(Math.PI * t):0.##}px");
 
+            if (_pageClickHandler is object) MakePageClickable(page, index);
+
             return page;
+        }
+
+        private void MakePageClickable(HTMLElement page, int index)
+        {
+            page.classList.add("tss-pagesstack-page-clickable");
+            page.setAttribute("role",       "button");
+            page.setAttribute("tabindex",   "0");
+            page.setAttribute("aria-label", $"Page {index + 1}");
+
+            page.addEventListener("click", e =>
+            {
+                StopEvent(e);
+
+                _pageClickHandler?.Invoke(index);
+            });
+
+            page.addEventListener("keydown", e =>
+            {
+                var keyboardEvent = e.As<KeyboardEvent>();
+
+                if (keyboardEvent.key != "Enter" && keyboardEvent.key != " ") return;
+
+                StopEvent(keyboardEvent);
+
+                _pageClickHandler?.Invoke(index);
+            });
         }
     }
 }

--- a/Tesserae/tps/assets/css/tss.pagesstack.css
+++ b/Tesserae/tps/assets/css/tss.pagesstack.css
@@ -43,6 +43,17 @@
     border-color: var(--tss-dark-border-color);
 }
 
+/* A page that opens the document at itself says so, and shows where the keyboard is. */
+.tss-pagesstack-page-clickable {
+    cursor: pointer;
+    outline: none;
+}
+
+.tss-pagesstack-page-clickable:focus-visible {
+    border-color: var(--tss-primary-background-color);
+    box-shadow: 0 0 0 2px var(--tss-primary-background-color);
+}
+
 /* Faux text ruling, for a page with no thumbnail to show. */
 .tss-pagesstack-lines {
     display: block;


### PR DESCRIPTION
OnPageClick hands the handler the page's 0-based index, so "open this document at the page the user pointed at" is one call. The click is the page's alone - it never also counts as a click on the row the stack sits in - and each page takes a tab stop of its own and answers Enter and Space.


Claude-Session: https://claude.ai/code/session_012EVgZkbCYK7M4rHoxQX49t