### PR TITLE
Add InlinePagination, and use it for the modal's previous/next

### DIFF
--- a/Tesserae.Tests/src/Samples/Components/OmniResultSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/OmniResultSample.cs
@@ -83,6 +83,7 @@ namespace Tesserae.Tests.Samples
                 .FlatSection(VStack().WS().Children(Selection()))
                 .FlatSection(VStack().WS().Children(Commands()))
                 .FlatSection(VStack().WS().Children(Pages()))
+                .FlatSection(VStack().WS().Children(InlinePaginationSection()))
                 .SeeAlso(typeof(OmniBoxSample), typeof(ContextCardSample), typeof(ResourceCardSample), typeof(CardSample), typeof(DetailsListSample));
         }
 
@@ -542,6 +543,38 @@ namespace Tesserae.Tests.Samples
                 HStack().WS().Wrap().Gap(32.px()).AlignItems(ItemAlign.End).Children(
                     PagesLabel("Fanned()", PagesStack(5).TotalPages(19).Fanned()),
                     PagesLabel("OnPageClick", PagesStack(thumbnails).TotalPages(9).OnPageClick(page => Toast().Information($"Opening page {page + 1}")))));
+        }
+
+        // ---------- Inline pagination ----------
+
+        private IComponent InlinePaginationSection()
+        {
+            var stepped = InlinePagination(3, 7)
+               .OnPrevious(p => Step(p, -1))
+               .OnNext(p => Step(p, +1));
+
+            return FeatureCard("InlinePagination", "Stepping through a set, in one pill",
+                "InlinePagination is the \"3 of 7\" control the modal's header uses for its previous/next arrows, and it stands on its own wherever a toolbar needs to step through something one at a time - a lightbox, an editor, a preview. Each chevron is enabled by having a handler, so leaving one out is how the first and the last of a set say so; the position and the count only write the label.",
+                HStack().WS().Wrap().Gap(24.px()).AlignItemsCenter().PT(8).PB(8).Children(
+                    InlinePagination(3, 7).OnPrevious(_ => { }).OnNext(_ => { }),
+                    InlinePagination(1, 7).OnNext(_ => { }),
+                    InlinePagination(7, 7).OnPrevious(_ => { }),
+                    InlinePagination().OnPrevious(_ => { }).OnNext(_ => { }),
+                    InlinePagination(3, 7).SetFormat((position, count) => $"{position} / {count}").OnPrevious(_ => { }).OnNext(_ => { }),
+                    InlinePagination().SetLabel("March").OnPrevious(_ => { }).OnNext(_ => { })),
+                TextBlock("In order: both ways, the first of a set, the last of it, no count at all, another format, and a label of the host's own. The one below actually steps:").Small().MT(8).MB(8),
+                stepped);
+        }
+
+        private static void Step(InlinePagination pagination, int by)
+        {
+            var next = pagination.Position + by;
+
+            if (next < 1 || next > pagination.Count) return;
+
+            pagination.SetPosition(next, pagination.Count)
+               .OnPrevious(next > 1 ? new Action<InlinePagination>(p => Step(p, -1)) : null)
+               .OnNext(next < pagination.Count ? new Action<InlinePagination>(p => Step(p, +1)) : null);
         }
 
         private static IComponent PagesLabel(string label, PagesStack pages)

--- a/Tesserae/skills/SKILL.md
+++ b/Tesserae/skills/SKILL.md
@@ -149,7 +149,7 @@ color-picker · command-bar · context-card · context-cards · contribution-bar
 cron-editor · date-picker · details-grid ·
 date-range-picker · date-time-picker · delta-component · dropdown ·
 editable-area · editable-label · expander · grid-picker · horizontal-separator ·
-icon · icon-toggle · image · label · link · live-progress · markdown-block ·
+icon · icon-toggle · image · inline-pagination · label · link · live-progress · markdown-block ·
 menu · message ·
 metric · month-picker · navbar · number-picker · omni-box · omni-result · option ·
 pages-stack · pagination ·

--- a/Tesserae/skills/references/inline-pagination.md
+++ b/Tesserae/skills/references/inline-pagination.md
@@ -1,0 +1,59 @@
+---
+name: inline-pagination
+description: The compact "3 of 7" pill with a chevron either side, for stepping through a set one at a time from a toolbar or a modal header. Use when a Tesserae (C#/Transpose) app needs previous/next beside other commands rather than a row of numbered page buttons.
+---
+
+# InlinePagination
+
+`‹ 3 of 7 ›` in one rounded pill: a chevron either side of where you are in a set. It is for stepping
+through things one at a time — the result open in a preview, the photo in a lightbox, the record in an
+editor — beside other commands in a toolbar or a header. For a list that pages, with numbered buttons
+and a page size, use `Pagination` instead.
+
+## Create
+
+`UI.InlinePagination(int position = 0, int count = 0)` — both 1-based; a count of zero leaves the label
+out and the control is the two chevrons alone. Bring factories into scope with `using static Tesserae.UI;`.
+
+## Key configuration
+
+- `.SetPosition(int position, int count)` / `Position` / `Count` — what the label says.
+- `.OnPrevious(Action<InlinePagination>)` / `.OnNext(Action<InlinePagination>)` — what each chevron
+  does. **A chevron is enabled by having a handler**: passing null greys it out, which is how the first
+  and the last of a set say so. The position and count only write the label, so a set that loads more
+  as it goes stays in charge of when there is a next.
+- `CanGoPrevious` / `CanGoNext` — whether each chevron is enabled.
+- `.SetLabel(string)` — arbitrary text between the chevrons ("March", the name of the thing you are
+  on) in place of the counted label. Null goes back to the count.
+- `.SetFormat(Func<int, int, string>)` — how the position and count are written, for another language
+  or for `3 / 7`.
+- `.SetTooltips(string previous, string next)` — what each chevron is called for a screen reader and
+  in its tooltip; "Previous" and "Next" by default.
+
+Figures are tabular, so stepping through a set never shuffles the chevrons sideways.
+
+## Example
+
+```csharp
+using static Tesserae.UI;
+
+var pager = InlinePagination(index + 1, results.Count);
+
+void Step(InlinePagination p, int by)
+{
+    index += by;
+    Show(results[index]);
+
+    p.SetPosition(index + 1, results.Count)
+     .OnPrevious(index > 0                 ? new Action<InlinePagination>(x => Step(x, -1)) : null)
+     .OnNext    (index < results.Count - 1 ? new Action<InlinePagination>(x => Step(x, +1)) : null);
+}
+
+pager.OnPrevious(p => Step(p, -1)).OnNext(p => Step(p, +1)).SetTooltips("Previous result", "Next result");
+```
+
+## Related
+
+- Pagination — numbered page buttons for a list that pages — `pagination.md`
+- OmniResult — its modal header uses this for previous/next through the results — `omni-result.md`
+- Full docs & API: `/tesserae/components/inline-pagination`

--- a/Tesserae/skills/references/omni-result.md
+++ b/Tesserae/skills/references/omni-result.md
@@ -178,8 +178,9 @@ full-screen, so a modal never offers something the host didn't wire up:
   that opens them as a menu. `.NoOpenInSource()` clears them; `OpenActions` / `CanOpenInSource` read
   them; `.Open(bool inNewTab = false)` runs the primary one from code.
 - `.ModalNavigation(Action<OmniResult<T>> onPrevious, Action<OmniResult<T>> onNext, int position = 0, int count = 0)`
-  — the ‹ › arrows, with "2 of 7" between them when a position and count are given (both 1-based). A
-  null handler greys its arrow out, which is how the first and last result say so.
+  — an `InlinePagination` (`inline-pagination.md`): the ‹ › chevrons with "2 of 7" between them when a
+  position and count are given (both 1-based). A null handler greys its chevron out, which is how the
+  first and last result say so.
 - `.ModalCommands(Action<OmniResult<T>>)` — the `[...]` button; read `CommandsEvent` in the handler to
   place a command surface of the host's own where the user clicked. Null leaves the button out.
 - `.ModalFullScreen(Action<OmniResult<T>>)` — what `[⤢]` does; without one it grows the modal to fill
@@ -277,6 +278,7 @@ var pick = OmniResult(file, file.Name)
 ## Related
 
 - ModalStack — the deck a result's modal is usually pushed onto — `modal-stack.md`
+- InlinePagination — the previous/next control in its modal header — `inline-pagination.md`
 - DetailsGrid — the metadata block that usually fills the modal's head — `details-grid.md`
 - PagesStack — the page preview it takes — `pages-stack.md`
 - ContextMenu — the menu the commands open, and its items — `context-menu.md`

--- a/Tesserae/skills/references/pagination.md
+++ b/Tesserae/skills/references/pagination.md
@@ -38,4 +38,6 @@ var view = VStack().Children(
 
 ## Related
 
+- InlinePagination — the compact "3 of 7" pill, for stepping one at a time from a toolbar — `inline-pagination.md`
+
 - Full docs & API: `/tesserae/components/pagination`

--- a/Tesserae/src/Base/UI.Components.cs
+++ b/Tesserae/src/Base/UI.Components.cs
@@ -264,6 +264,12 @@ namespace Tesserae
         public static Pagination Pagination(int totalItems = 0, int pageSize = 10, int currentPage = 1) => new Pagination(totalItems, pageSize, currentPage);
 
         /// <summary>
+        /// Creates a <see cref="Tesserae.InlinePagination"/>: the compact "3 of 7" pill with a chevron
+        /// either side, for stepping through a set one at a time from a toolbar or a modal's header.
+        /// </summary>
+        public static InlinePagination InlinePagination(int position = 0, int count = 0) => new InlinePagination(position, count);
+
+        /// <summary>
         /// Creates a <see cref="Tesserae.CommandBar"/> component.
         /// </summary>
         public static CommandBar CommandBar(params IComponent[] items) => new CommandBar(items);

--- a/Tesserae/src/Components/InlinePagination.cs
+++ b/Tesserae/src/Components/InlinePagination.cs
@@ -1,0 +1,189 @@
+using System;
+using static Transpose.Core.dom;
+using static Tesserae.UI;
+
+namespace Tesserae
+{
+    /// <summary>
+    /// The compact "‹ 3 of 7 ›" control: a chevron either side of where you are in a set, inside one
+    /// rounded pill. It is for stepping through things one at a time - the result open in a preview, the
+    /// photo in a lightbox, the record in an editor - beside other commands in a toolbar or a header,
+    /// where <see cref="Pagination"/>'s row of numbered page buttons would be far too much.
+    /// <para>
+    /// Each chevron is enabled by having a handler: <see cref="OnPrevious(Action{InlinePagination})"/> and
+    /// <see cref="OnNext(Action{InlinePagination})"/>. Leaving one out greys its chevron, which is how the
+    /// first and the last of a set say so - the position and count only write the label, so a set that
+    /// loads more as it goes stays in charge of when there is a next.
+    /// </para>
+    /// </summary>
+    [Transpose.Name("tss.InlinePagination")]
+    public sealed class InlinePagination : ComponentBase<InlinePagination, HTMLElement>
+    {
+        private readonly HTMLButtonElement _previous;
+        private readonly HTMLButtonElement _next;
+        private readonly HTMLElement       _label;
+
+        private int    _position;
+        private int    _count;
+        private string _text;
+
+        private Func<int, int, string> _format = (position, count) => $"{position} of {count}";
+
+        private Action<InlinePagination> _onPrevious;
+        private Action<InlinePagination> _onNext;
+
+        /// <summary>
+        /// Initializes a new instance of this class showing the given position in the given count, both
+        /// 1-based. A count of zero leaves the label out and the control is the two chevrons alone.
+        /// </summary>
+        public InlinePagination(int position = 0, int count = 0)
+        {
+            _previous = Chevron(UIcons.AngleLeft,  "Previous", () => _onPrevious?.Invoke(this));
+            _next     = Chevron(UIcons.AngleRight, "Next",     () => _onNext?.Invoke(this));
+
+            _label = Span(Att("tss-inlinepagination-label"));
+
+            InnerElement = Div(Att("tss-inlinepagination"), _previous, _label, _next);
+
+            SetPosition(position, count);
+            UpdateChevrons();
+        }
+
+        /// <summary>Gets or sets where in the set the control says you are, 1-based.</summary>
+        public int Position
+        {
+            get => _position;
+            set => SetPosition(value, _count);
+        }
+
+        /// <summary>Gets or sets how many there are in the set. Zero leaves the label out.</summary>
+        public int Count
+        {
+            get => _count;
+            set => SetPosition(_position, value);
+        }
+
+        /// <summary>Returns a value indicating whether the previous chevron is enabled.</summary>
+        public bool CanGoPrevious => _onPrevious is object;
+
+        /// <summary>Returns a value indicating whether the next chevron is enabled.</summary>
+        public bool CanGoNext => _onNext is object;
+
+        /// <summary>
+        /// Renders the component's root HTML element.
+        /// </summary>
+        public override HTMLElement Render() => InnerElement;
+
+        /// <summary>
+        /// Sets where in the set the control says you are, and how many there are - both 1-based. A count
+        /// of zero (or a position past it) leaves the label out, so a set whose size isn't known yet shows
+        /// the chevrons alone rather than a label that would have to lie.
+        /// </summary>
+        public InlinePagination SetPosition(int position, int count)
+        {
+            _position = position < 0 ? 0 : position;
+            _count    = count    < 0 ? 0 : count;
+            _text     = null;
+
+            return RenderLabel();
+        }
+
+        /// <summary>
+        /// Puts the given text between the chevrons in place of the position and count - "Page 3",
+        /// "March", the name of the thing you are on. Pass null to go back to the counted label.
+        /// </summary>
+        public InlinePagination SetLabel(string text)
+        {
+            _text = text;
+
+            return RenderLabel();
+        }
+
+        /// <summary>
+        /// Changes how the position and the count are written - for another language, or for "3 / 7".
+        /// </summary>
+        public InlinePagination SetFormat(Func<int, int, string> format)
+        {
+            _format = format ?? ((position, count) => $"{position} of {count}");
+
+            return RenderLabel();
+        }
+
+        /// <summary>
+        /// Registers what the previous chevron does, and enables it. Pass null to grey it out - which is
+        /// how the first of a set says it is the first.
+        /// </summary>
+        public InlinePagination OnPrevious(Action<InlinePagination> onPrevious)
+        {
+            _onPrevious = onPrevious;
+
+            return UpdateChevrons();
+        }
+
+        /// <summary>
+        /// Registers what the next chevron does, and enables it. Pass null to grey it out.
+        /// </summary>
+        public InlinePagination OnNext(Action<InlinePagination> onNext)
+        {
+            _onNext = onNext;
+
+            return UpdateChevrons();
+        }
+
+        /// <summary>
+        /// Sets what each chevron is called for a screen reader and in its tooltip - "Previous result" and
+        /// "Next result" rather than the bare "Previous" and "Next" they carry by default.
+        /// </summary>
+        public InlinePagination SetTooltips(string previous, string next)
+        {
+            Describe(_previous, previous);
+            Describe(_next,     next);
+
+            return this;
+        }
+
+        private InlinePagination RenderLabel()
+        {
+            var text = _text ?? (_count > 0 && _position > 0 ? _format(_position, _count) : null);
+
+            var isEmpty = string.IsNullOrEmpty(text);
+
+            _label.textContent   = isEmpty ? string.Empty : text;
+            _label.style.display = isEmpty ? "none" : "";
+
+            return this;
+        }
+
+        private InlinePagination UpdateChevrons()
+        {
+            _previous.disabled = _onPrevious is null;
+            _next.disabled     = _onNext is null;
+
+            return this;
+        }
+
+        private static HTMLButtonElement Chevron(UIcons icon, string label, Action onClick)
+        {
+            var button = UI.Button(Att("tss-inlinepagination-button", type: "button"), I(icon, UIconsWeight.Regular));
+
+            Describe(button, label);
+
+            button.addEventListener("click", e =>
+            {
+                StopEvent(e);
+
+                onClick();
+            });
+
+            return button;
+        }
+
+        private static void Describe(HTMLElement button, string label)
+        {
+            if (string.IsNullOrEmpty(label)) return;
+
+            button.setAttribute("aria-label", label);
+            button.setAttribute("title",      label);
+        }
+    }
+}

--- a/Tesserae/src/Components/OmniResult.cs
+++ b/Tesserae/src/Components/OmniResult.cs
@@ -1292,22 +1292,11 @@ namespace Tesserae
         {
             if (_modalPrevious is null && _modalNext is null) return null;
 
-            var previous = ModalButton(UIcons.AngleLeft,  "Previous result", _ => _modalPrevious?.Invoke(this));
-            var next     = ModalButton(UIcons.AngleRight, "Next result",     _ => _modalNext?.Invoke(this));
-
-            previous.disabled = _modalPrevious is null;
-            next.disabled     = _modalNext is null;
-
-            var navigation = Div(Att("tss-omniresult-modal-nav"), previous);
-
-            if (_modalCount > 0)
-            {
-                navigation.appendChild(Span(Att("tss-omniresult-modal-nav-label", text: $"{_modalPosition} of {_modalCount}")));
-            }
-
-            navigation.appendChild(next);
-
-            return Raw(navigation);
+            return InlinePagination(_modalPosition, _modalCount)
+               .Class("tss-omniresult-modal-nav")
+               .SetTooltips("Previous result", "Next result")
+               .OnPrevious(_modalPrevious is null ? null : (Action<InlinePagination>)(_ => _modalPrevious(this)))
+               .OnNext(_modalNext is null ? null : (Action<InlinePagination>)(_ => _modalNext(this)));
         }
 
         private static HTMLButtonElement ModalButton(UIcons icon, string label, Action<MouseEvent> onClick)

--- a/Tesserae/tps.json
+++ b/Tesserae/tps.json
@@ -1,4 +1,4 @@
-{
+﻿{
     "output": "$(OutDir)/tps/",
     "outputFormatting": "Both",
     "reflection": {
@@ -63,6 +63,7 @@
                 "tps/assets/css/tss.modal.css",
                 "tps/assets/css/tss.dialog.css",
                 "tps/assets/css/tss.pagination.css",
+                "tps/assets/css/tss.inlinepagination.css",
                 "tps/assets/css/tss.nav.css",
                 "tps/assets/css/tss.searchbox.css",
                 "tps/assets/css/tss.omnibox.css",

--- a/Tesserae/tps/assets/css/tss.inlinepagination.css
+++ b/Tesserae/tps/assets/css/tss.inlinepagination.css
@@ -1,0 +1,63 @@
+/* InlinePagination — the compact "‹ 3 of 7 ›" pill, for stepping through a set from a toolbar. */
+
+.tss-inlinepagination {
+    display: inline-flex;
+    align-items: center;
+    gap: 0;
+    flex-grow: 0;
+    flex-shrink: 0;
+    box-sizing: border-box;
+    height: 28px;
+    padding: 0 2px;
+    border: 1px solid var(--tss-default-border-color);
+    border-radius: var(--tss-border-radius-lg);
+    background: var(--tss-secondary-background-color);
+    color: var(--tss-secondary-foreground-color);
+}
+
+.tss-inlinepagination-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    box-sizing: border-box;
+    flex-grow: 0;
+    flex-shrink: 0;
+    width: 22px;
+    height: 22px;
+    margin: 0;
+    padding: 0;
+    border: none;
+    border-radius: var(--tss-border-radius-sm);
+    background: transparent;
+    color: inherit;
+    font-size: 11px;
+    line-height: 1;
+    cursor: pointer;
+    -webkit-appearance: none;
+    appearance: none;
+}
+
+.tss-inlinepagination-button:hover:not(:disabled) {
+    background: var(--tss-default-background-hover-color);
+    color: var(--tss-default-foreground-color);
+}
+
+.tss-inlinepagination-button:focus-visible {
+    outline: 2px solid var(--tss-primary-background-color);
+    outline-offset: -2px;
+}
+
+.tss-inlinepagination-button:disabled {
+    opacity: .35;
+    cursor: default;
+}
+
+/* Tabular figures, so stepping through a set doesn't shuffle the chevrons sideways. */
+.tss-inlinepagination-label {
+    padding: 0 6px;
+    font-size: 12px;
+    line-height: 18px;
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+    user-select: none;
+}

--- a/Tesserae/tps/assets/css/tss.omniresult.css
+++ b/Tesserae/tps/assets/css/tss.omniresult.css
@@ -593,24 +593,10 @@
     cursor: default;
 }
 
-/* Previous / next, with where in the list this result is between them - one filled group rather than
-   an outline around each arrow. */
+/* Previous / next, with where in the list this result is between them - an InlinePagination, which
+   draws its own pill; the header only says where it sits. */
 .tss-omniresult-modal-nav {
-    display: inline-flex;
-    align-items: center;
-    gap: 2px;
-    flex-grow: 0;
-    flex-shrink: 0;
-    margin: 0 4px;
-}
-
-.tss-omniresult-modal-nav-label {
-    padding: 0 6px;
-    font-size: 12px;
-    line-height: 18px;
-    font-variant-numeric: tabular-nums;
-    white-space: nowrap;
-    color: var(--tss-secondary-foreground-color);
+    margin: 0 6px;
 }
 
 /* "Open in Dropbox", with the other ways to open it behind the arrow beside it. */
@@ -699,10 +685,17 @@
 }
 
 .tss-modalstack-peek .tss-omniresult-modal-icon .tss-omniresult-icon {
-    width: 22px;
-    height: 22px;
+    width: 24px;
+    height: 24px;
     border-radius: 6px;
     font-size: 11px;
+}
+
+/* A tile that spells its file type out has to shrink with the tile, or "DOCX" is cropped rather than
+   scaled. */
+.tss-modalstack-peek .tss-omniresult-modal-icon .tss-omniresult-icon-text {
+    font-size: 6.5px;
+    letter-spacing: 0;
 }
 
 .tss-modalstack-peek .tss-omniresult-modal-title-text,


### PR DESCRIPTION
The "3 of 7" control the modal header was assembling out of two buttons and a span is now a component of its own: a rounded, bordered pill with a chevron either side, a tabular-figure label, and each chevron enabled by having a handler. It stands on its own wherever a toolbar steps through something one at a time, which Pagination's row of numbered page buttons is far too much for.

Also scales the tile's spelled-out file type down with the tile in a peeking sheet, so "DOCX" is scaled rather than cropped.


Claude-Session: https://claude.ai/code/session_012EVgZkbCYK7M4rHoxQX49t