### PR TITLE
Add sidebar shift feature for nested navigation

### DIFF
--- a/Tesserae.Tests/src/Samples/Components/SidebarShiftSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/SidebarShiftSample.cs
@@ -1,0 +1,138 @@
+using System;
+using Tesserae;
+using static Transpose.Core.dom;
+using static Tesserae.UI;
+using static Tesserae.Tests.Samples.SamplesHelper;
+
+namespace Tesserae.Tests.Samples
+{
+    [SampleDetails(Group = "Components", Order = 101, Icon = UIcons.AngleRight)]
+    public class SidebarShiftSample : IComponent, ISample
+    {
+        private readonly IComponent _content;
+
+        public SidebarShiftSample()
+        {
+            var sidebar    = Sidebar();
+            var chatBar    = Sidebar();
+            var homePane   = HomePane();
+            var chatPane   = ChatPane();
+
+            BuildMainSidebar(sidebar, chatBar);
+            BuildChatSidebar(sidebar, chatBar);
+
+            // The child sidebar always belongs to a new interface, so the content area follows it
+            chatPane.Collapse();
+
+            sidebar.OnShiftChanged(isShifted =>
+            {
+                if (isShifted)
+                {
+                    homePane.Collapse();
+                    chatPane.Show();
+                }
+                else
+                {
+                    chatPane.Collapse();
+                    homePane.Show();
+                }
+            });
+
+            _content = SectionStack().Secondary()
+               .SampleTitle(typeof(SidebarShiftSample), UIcons.AngleRight, "Sliding a sidebar into a nested sidebar")
+               .FlatSection(Stack().Children(
+                    Card(VStack().WS().Children(
+                        TextBlock("Use .ShiftTo(childSidebar) when navigating into an interface that has its own navigation: the child sidebar slides in horizontally from the right and takes over the sidebar. .ShiftBack() slides back to the main sidebar. The panel that ends up out of view is set to display:none once the animation finishes, so it can't be tabbed into. Only one depth level is supported."),
+                        TextBlock("Click \"AI assistant\" below to shift into the chat sidebar, and the back arrow in its header to come back."))).SetTitle("Overview"),
+                    Card(VStack().WS().Children(
+                        SplitView().WS().H(800).LeftIsSmaller(280.px())
+                                   .Left(sidebar.S())
+                                   .Right(Stack().WS().HS().Children(homePane, chatPane))
+                    )).SetTitle("Usage")))
+               .SeeAlso(typeof(SidebarSample), typeof(SidebarSeparatorSample), typeof(SidenavSample), typeof(NavbarSample));
+        }
+
+        private static void BuildMainSidebar(Sidebar sidebar, Sidebar chatBar)
+        {
+            sidebar.AddHeader(new SidebarButton("brand", new ImageIcon("/assets/img/curiosity-logo.svg"), "Curiosity"));
+
+            sidebar.AddHeader(new SidebarSearchBox("search-everything", "Search everything")
+               .Rounded()
+               .SetKeyboardShortcut("Ctrl", "K")
+               .OnSearch(term => sidebar.Search(term)));
+
+            sidebar.AddContent(new SidebarButton("search", UIcons.Search, "Search"));
+
+            // The chevron hints that this entry opens an interface with its own sidebar
+            var assistant = new SidebarButton("assistant", UIcons.Sparkles, "AI assistant", new SidebarCommand(UIcons.AngleRight))
+               .CommandsAlwaysVisible()
+               .OnClick(() => sidebar.ShiftTo(chatBar));
+
+            sidebar.AddContent(assistant);
+
+            sidebar.AddContent(new SidebarButton("favorites", UIcons.Bookmark,    "Favorites"));
+            sidebar.AddContent(new SidebarButton("mail",      UIcons.Envelope,    "Mail"));
+            sidebar.AddContent(new SidebarButton("contacts",  UIcons.User,        "Contacts"));
+            sidebar.AddContent(new SidebarButton("notes",     UIcons.NotebookAlt, "Notes"));
+            sidebar.AddContent(new SidebarButton("spaces",    UIcons.Table,       "Spaces"));
+
+            sidebar.AddContent(new SidebarSeparator("apps", "Apps"));
+
+            sidebar.AddContent(new SidebarButton("outlook", UIcons.Envelope, "Outlook", Count("4.2k")));
+            sidebar.AddContent(new SidebarButton("teams",   UIcons.Users,    "Teams",   Count("1.8k")));
+            sidebar.AddContent(new SidebarButton("box",     UIcons.Cube,     "Box",     Count("9.4k")));
+
+            sidebar.AddFooter(CurrentUser("main"));
+
+            // Collapsing is shared with the shifted sidebar, so both rails stay in sync
+            sidebar.AddFooter(new SidebarButton("collapse", UIcons.AngleLeft, "Collapse").OnClick(() => sidebar.Toggle()));
+        }
+
+        private static void BuildChatSidebar(Sidebar sidebar, Sidebar chatBar)
+        {
+            chatBar.AddHeader(new SidebarButton("back", UIcons.AngleLeft, "AI assistant")
+               .OnClick(() => sidebar.ShiftBack()));
+
+            chatBar.AddHeader(new SidebarButton("new-chat", UIcons.Plus, "New chat")
+               .Primary()
+               .Rounded()
+               .OnClick(() => Toast().Success("New chat")));
+
+            chatBar.AddHeader(new SidebarSearchBox("search-chats", "Search chats")
+               .Rounded()
+               .OnSearch(term => chatBar.Search(term)));
+
+            chatBar.AddContent(new SidebarSeparator("today", "Today"));
+            chatBar.AddContent(new SidebarButton("chat-1", UIcons.Comment, "Brake sensor calibration"));
+            chatBar.AddContent(new SidebarButton("chat-2", UIcons.Comment, "Q2 supplier risk summary"));
+
+            chatBar.AddContent(new SidebarSeparator("yesterday", "Yesterday"));
+            chatBar.AddContent(new SidebarButton("chat-3", UIcons.Comment, "Line 3 handover recap"));
+            chatBar.AddContent(new SidebarButton("chat-4", UIcons.Comment, "Draft: Bismuth response"));
+
+            chatBar.AddContent(new SidebarSeparator("last-7-days", "Last 7 days"));
+            chatBar.AddContent(new SidebarButton("chat-5", UIcons.Comment, "Ingolstadt drift report"));
+            chatBar.AddContent(new SidebarButton("chat-6", UIcons.Comment, "Harness rev C rollout"));
+
+            chatBar.AddFooter(CurrentUser("chat"));
+        }
+
+        private static SidebarBadge Count(string count) => new SidebarBadge(count).Foreground(Theme.Secondary.Foreground).Background(Theme.Secondary.Background);
+
+        // Both sidebars carry the same account row at the bottom, but each needs its own instance
+        // because a sidebar item can only be rendered in one place at a time.
+        private static SidebarButton CurrentUser(string suffix) => new SidebarButton($"user-{suffix}", UIcons.User, "Pius Neuhaus", new SidebarCommand(UIcons.MenuDots));
+
+        private static IComponent HomePane() => Stack().WS().HS().AlignItems(ItemAlign.Center).JustifyContent(ItemJustify.Center).Children(
+            VStack().Children(
+                TextBlock("Hi Pius — what are you working on?").XLarge().SemiBold(),
+                TextBlock("Pick AI assistant on the left to shift the sidebar into the chat interface.").Medium().Secondary().PT(8)));
+
+        private static IComponent ChatPane() => Stack().WS().HS().AlignItems(ItemAlign.Center).JustifyContent(ItemJustify.Center).Children(
+            VStack().Children(
+                TextBlock("AI assistant").XLarge().SemiBold(),
+                TextBlock("The sidebar now shows the chat history. Use the back arrow to shift back.").Medium().Secondary().PT(8)));
+
+        public HTMLElement Render() => _content.Render();
+    }
+}

--- a/Tesserae/skills/references/sidebar.md
+++ b/Tesserae/skills/references/sidebar.md
@@ -23,6 +23,8 @@ Bring factories into scope with `using static Tesserae.UI;`.
 - `.InsertAfterContent(item, addAfter)` — insert relative to an existing item.
 - `.RemoveContent(item)`, `.ClearContent()`, `.Clear()` — remove items.
 - `.Closed(bool = true)` / `.Toggle()` / `.IsClosed` — collapse to icon rail.
+- `.ShiftTo(childSidebar)` / `.ShiftBack()` / `.IsShifted` — slide into a nested
+  sidebar (see below).
 - `.AsNavbar()` — render horizontally as a top bar with a hamburger drawer.
 - `.Secondary()` — use the secondary background colour.
 - `.Sortable(bool)` — enable/disable drag reordering.
@@ -51,6 +53,43 @@ filters searchable items. Configure it fluently:
 `SidebarSearchBox.Rounded(BorderRadius = Full)` render the item with rounded
 corners (a full pill by default; pass `BorderRadius.Small`/`Medium`/`Full`).
 Combine `.Primary().Rounded()` on a button for a prominent call-to-action.
+
+## Shift into a child sidebar
+
+When navigating into an interface that has its own navigation (a chat view, a
+project workspace, ...), shift the sidebar into a second `Sidebar` instead of
+rebuilding the items. The child slides in horizontally from the right, and the
+panel that ends up out of view is set to `display: none` once the animation is
+over, so it can't be tabbed or read into.
+
+- `.ShiftTo(childSidebar)` — mount the child sidebar and slide into it. Calling
+  it with a different sidebar replaces the mounted one.
+- `.ShiftBack()` — slide back into the main sidebar.
+- `.IsShifted` / `.ShiftedSidebar` — current state and mounted child.
+- `.OnShiftChanged(isShifted => ...)` — run when the sidebar shifts, e.g. to swap
+  the content area alongside it.
+
+Only one depth level is supported: a child sidebar can't shift again. The child
+is rendered inside the hosting sidebar and follows its open/closed state, so
+`.Toggle()` on the main sidebar collapses both. Shifting is ignored in
+`.AsNavbar()` mode.
+
+```csharp
+var sidebar = Sidebar();
+var chatBar = Sidebar();
+
+sidebar.AddContent(new SidebarButton("assistant", UIcons.Sparkles, "AI assistant",
+        new SidebarCommand(UIcons.AngleRight))
+    .CommandsAlwaysVisible()
+    .OnClick(() => sidebar.ShiftTo(chatBar)));
+
+chatBar.AddHeader(new SidebarButton("back", UIcons.AngleLeft, "AI assistant")
+    .OnClick(() => sidebar.ShiftBack()));
+chatBar.AddContent(new SidebarSeparator("today", "Today"));
+chatBar.AddContent(new SidebarButton("chat-1", UIcons.Comment, "Brake sensor calibration"));
+
+sidebar.OnShiftChanged(isShifted => Router.Navigate(isShifted ? "#/chat" : "#/home"));
+```
 
 ## Example
 

--- a/Tesserae/src/Components/Sidebar/Sidebar.cs
+++ b/Tesserae/src/Components/Sidebar/Sidebar.cs
@@ -29,6 +29,17 @@ namespace Tesserae
 
         private HTMLDivElement _mobileBackdrop;
 
+        // Shift support: when a child sidebar is mounted, the sections are moved inside a
+        // horizontally sliding track that holds the main panel and the child panel side by side.
+        private Sidebar        _shiftChild;
+        private HTMLDivElement _shiftTrack;
+        private HTMLDivElement _shiftChildPanel;
+        private Stack          _shiftMainPanel;
+        private IComponent     _shiftHost;
+        private bool           _isShifted;
+        private double         _shiftTimeout;
+        private Action<bool>   _onShiftChanged;
+
         /// <summary>
         /// The transition time for sidebar animations in milliseconds.
         /// </summary>
@@ -55,6 +66,12 @@ namespace Tesserae
 
             _closed.Observe(isClosed =>
             {
+                // A shifted child sidebar is rendered inside this one, so it has to follow the same open/closed state
+                if (_shiftChild is object)
+                {
+                    _shiftChild.IsClosed = isClosed;
+                }
+
                 // Show or hide the mobile backdrop (used in navbar/mobile mode)
                 if (_mobileBackdrop is object)
                 {
@@ -239,10 +256,23 @@ namespace Tesserae
             }
             else
             {
-                _sidebar.Children(VStack().Class("tss-sidebar-header").WS().NoShrink().Children(header.Select(si => closed ? si.RenderClosed() : si.RenderOpen())),
+                var sections = new IComponent[]
+                {
+                    VStack().Class("tss-sidebar-header").WS().NoShrink().Children(header.Select(si => closed ? si.RenderClosed() : si.RenderOpen())),
                     stackMiddle.Class("tss-sidebar-middle").WS().H(10).Grow().ScrollY().Children(middle.Select(si => closed ? si.RenderClosed() : si.RenderOpen())),
                     VStack().Class("tss-sidebar-footer").WS().NoShrink().Children(footer.Select(si => closed ? si.RenderClosed() : si.RenderOpen()))
-                );
+                };
+
+                if (_shiftChild is object)
+                {
+                    // The sections live in the main panel of the sliding track instead of directly in the sidebar
+                    _shiftMainPanel.Children(sections);
+                    _sidebar.Children(_shiftHost);
+                }
+                else
+                {
+                    _sidebar.Children(sections);
+                }
             }
         }
 
@@ -277,6 +307,119 @@ namespace Tesserae
         {
             _closed.Toggle();
             return this;
+        }
+
+        /// <summary>
+        /// Gets whether the sidebar is currently showing the shifted (child) sidebar.
+        /// </summary>
+        public bool IsShifted => _isShifted;
+
+        /// <summary>
+        /// Gets the child sidebar that is currently mounted for shifting, if any.
+        /// </summary>
+        public Sidebar ShiftedSidebar => _shiftChild;
+
+        /// <summary>
+        /// Slides horizontally into a child sidebar, used when navigating into an interface that has its own sidebar.
+        /// The child sidebar is rendered inside this one and follows its open/closed state.
+        /// Only one depth level is supported: shifting into another child replaces the current one.
+        /// Call <see cref="ShiftBack"/> to slide back into this sidebar.
+        /// </summary>
+        /// <param name="child">The sidebar to shift into.</param>
+        /// <returns>The current instance of the type.</returns>
+        public Sidebar ShiftTo(Sidebar child)
+        {
+            if (child is null)
+            {
+                return ShiftBack();
+            }
+
+            if (_isNavbar)
+            {
+                return this; //shifting is not supported while rendering as a navbar
+            }
+
+            if (!ReferenceEquals(_shiftChild, child))
+            {
+                EnsureShiftScaffolding();
+
+                _shiftChild = child;
+                child.IsClosed = _closed.Value;
+
+                ClearChildren(_shiftChildPanel);
+                _shiftChildPanel.appendChild(child.Render());
+
+                Refresh(); //moves the sections into the main panel of the track
+            }
+
+            SetShifted(true);
+            return this;
+        }
+
+        /// <summary>
+        /// Slides back from the child sidebar into this sidebar.
+        /// </summary>
+        /// <returns>The current instance of the type.</returns>
+        public Sidebar ShiftBack()
+        {
+            SetShifted(false);
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a handler that is called whenever the sidebar shifts into the child sidebar (true) or back (false).
+        /// </summary>
+        /// <param name="onShiftChanged">The event handler.</param>
+        /// <returns>The current instance of the type.</returns>
+        public Sidebar OnShiftChanged(Action<bool> onShiftChanged)
+        {
+            _onShiftChanged = onShiftChanged;
+            return this;
+        }
+
+        private void EnsureShiftScaffolding()
+        {
+            if (_shiftTrack is object) return;
+
+            _shiftMainPanel  = VStack().Class("tss-sidebar-shift-panel").Class("tss-sidebar-shift-panel-main");
+            _shiftChildPanel = Div(Att("tss-sidebar-shift-panel tss-sidebar-shift-panel-child tss-sidebar-shift-panel-hidden"));
+            _shiftTrack      = Div(Att("tss-sidebar-shift-track"), _shiftMainPanel.Render(), _shiftChildPanel);
+            _shiftHost       = Raw(_shiftTrack).WS().Grow();
+
+            _sidebar.Class("tss-sidebar-has-shift");
+        }
+
+        private void SetShifted(bool shifted)
+        {
+            if (_shiftTrack is null || _isShifted == shifted) return;
+
+            _isShifted = shifted;
+
+            window.clearTimeout(_shiftTimeout);
+
+            var mainPanel  = _shiftMainPanel.Render();
+            var enterPanel = shifted ? _shiftChildPanel : mainPanel;
+            var leavePanel = shifted ? mainPanel : _shiftChildPanel;
+
+            // The panel we're sliding into is display:none, so it has to be laid out before the
+            // transform starts, otherwise the browser has nothing to animate towards.
+            enterPanel.classList.remove("tss-sidebar-shift-panel-hidden");
+            var _flush = _shiftTrack.offsetWidth;
+
+            if (shifted)
+            {
+                _shiftTrack.classList.add("tss-sidebar-shifted");
+            }
+            else
+            {
+                _shiftTrack.classList.remove("tss-sidebar-shifted");
+            }
+
+            // Once the slide is over the panel that moved out of view is hidden, so it stops
+            // taking focus and is no longer reachable by screen readers.
+            _shiftTimeout = window.setTimeout((_) => leavePanel.classList.add("tss-sidebar-shift-panel-hidden"), SIDEBAR_TRANSITION_TIME);
+
+            _onShiftChanged?.Invoke(shifted);
         }
 
         /// <summary>

--- a/Tesserae/tps/assets/css/tss.sidebar.css
+++ b/Tesserae/tps/assets/css/tss.sidebar.css
@@ -620,6 +620,95 @@
     margin-bottom: 16px;
 }
 
+/* Sidebar shift (sliding into a child sidebar)
+
+   When a child sidebar is mounted, the sidebar sections move into a track that holds the main
+   panel and the child panel side by side. The track slides horizontally by one full width, and
+   the panel that ends up out of view is hidden once the transition is over.
+
+   The horizontal padding moves from the sidebar to the panels so that the off-screen panel is
+   fully clipped instead of peeking into the padding area. The child panel doesn't need it: the
+   nested .tss-sidebar brings its own. */
+.tss-sidebar.tss-sidebar-has-shift {
+    overflow: hidden;
+    padding-left: 0px;
+    padding-right: 0px;
+}
+
+    .tss-sidebar.tss-sidebar-has-shift > .tss-stack-item {
+        display: flex;
+        min-height: 0;
+    }
+
+.tss-sidebar-shift-track {
+    position: relative;
+    display: flex;
+    flex: 1 1 auto;
+    width: 100%;
+    min-height: 0;
+    transform: translateX(0);
+    transition: 0.3s transform ease-out;
+}
+
+    .tss-sidebar-shift-track.tss-sidebar-shifted {
+        transform: translateX(-100%);
+    }
+
+/* Panels are absolutely positioned so that hiding one doesn't move the other */
+.tss-sidebar-shift-panel {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+}
+
+    .tss-sidebar-shift-panel.tss-sidebar-shift-panel-child {
+        left: 100%;
+    }
+
+    .tss-sidebar-shift-panel.tss-sidebar-shift-panel-hidden {
+        display: none;
+    }
+
+.tss-sidebar-shift-panel-main {
+    padding-left: 12px;
+    padding-right: 12px;
+}
+
+.tss-sidebar.tss-sidebar-closed .tss-sidebar-shift-panel-main {
+    padding-left: 4px;
+    padding-right: 4px;
+}
+
+/* Same full-bleed middle section as .tss-sidebar > .tss-stack-item:nth-child(2) */
+.tss-sidebar-shift-panel-main > .tss-stack-item:nth-child(2) {
+    margin: 0px -12px !important;
+    width: calc(100% + 24px) !important;
+    padding-left: 12px !important;
+}
+
+.tss-sidebar.tss-sidebar-closed .tss-sidebar-shift-panel-main > .tss-stack-item:nth-child(2) {
+    margin: 0px -4px !important;
+    width: calc(100% + 8px) !important;
+    padding-left: 4px !important;
+}
+
+/* The nested child sidebar fills its panel and lets the hosting sidebar own width and background */
+.tss-sidebar-shift-panel-child > .tss-sidebar {
+    width: 100% !important;
+    max-width: none;
+    flex: 1 1 auto;
+    min-height: 0;
+    padding-top: 0px;
+    padding-bottom: 0px;
+    background: transparent;
+    transition: none;
+}
+
 /* SidebarSegmentedPivot styles */
 .tss-sidebar-segmentedpivot-wrapper-open {
     margin-left: 8px;


### PR DESCRIPTION
## Summary

Adds a horizontal slide transition feature to `Sidebar` that allows navigating into a child sidebar. When `.ShiftTo(childSidebar)` is called, the child sidebar slides in from the right and takes over the navigation, while the main sidebar's sections move into a sliding track. `.ShiftBack()` slides back to the main sidebar. The panel that moves out of view is hidden once the animation completes, preventing it from being tabbed into or read by screen readers.

## Key Changes

- **Sidebar shift scaffolding**: Added private fields to manage the shift state (`_shiftChild`, `_shiftTrack`, `_shiftChildPanel`, `_shiftMainPanel`, `_isShifted`, etc.) and methods to set up and manage the sliding track structure.

- **Public API**: 
  - `.ShiftTo(Sidebar child)` — mount and slide into a child sidebar
  - `.ShiftBack()` — slide back to the main sidebar
  - `.IsShifted` property — query current shift state
  - `.ShiftedSidebar` property — get the mounted child sidebar
  - `.OnShiftChanged(Action<bool>)` — subscribe to shift state changes

- **State synchronization**: The child sidebar automatically follows the parent's open/closed state via the existing `_closed` observable, so toggling the main sidebar collapses both.

- **Rendering integration**: Modified `RenderSidebar()` to conditionally place sections into the main panel of the shift track when a child is mounted, or directly into the sidebar otherwise.

- **CSS styling** (`tss.sidebar.css`): Added comprehensive styles for the shift feature:
  - `.tss-sidebar-shift-track` — the horizontal sliding container with `transform: translateX()` animation
  - `.tss-sidebar-shift-panel` — absolute-positioned panels for main and child sidebars
  - `.tss-sidebar-shifted` — modifier class that triggers the slide animation
  - Padding adjustments to ensure off-screen panels are fully clipped
  - Nested sidebar styling to fill its panel and inherit the host's width/background

- **Sample** (`SidebarShiftSample.cs`): Demonstrates the feature with a main sidebar containing an "AI assistant" button that shifts into a chat sidebar, with a back button to return. Shows how to swap content areas alongside the sidebar shift using `OnShiftChanged()`.

- **Documentation** (`sidebar.md`): Added reference section explaining the shift feature, API, constraints (one depth level only, ignored in navbar mode), and a code example.

## Implementation Details

- Shift is not supported in navbar mode (`.AsNavbar()`); calling `.ShiftTo()` returns early without effect.
- Only one depth level is supported; shifting to a different child replaces the current one.
- The child panel is initially hidden with `display: none` and laid out before the transform animation starts to ensure the browser has a target to animate towards.
- A timeout ensures the panel that slides out of view is hidden after the transition completes (using `SIDEBAR_TRANSITION_TIME`).
- The shift track uses absolute positioning for both panels so hiding one doesn't affect the layout of the other.

https://claude.ai/code/session_01N8bYiesd7fB998rzpsyrnQ