### PR TITLE
Fix UIcons sample icon grid not being scrollable

### DIFF
--- a/Tesserae.Tests/src/Samples/Utilities/UIconsSample.cs
+++ b/Tesserae.Tests/src/Samples/Utilities/UIconsSample.cs
@@ -27,7 +27,7 @@ namespace Tesserae.Tests.Samples
                .FlatSection(Stack().Children(
                     Card(VStack().WS().Children(
                     SampleSubTitle($"Strongly-typed {nameof(UIcons)} enum"),
-                    SearchableList(GetAllIcons().ToArray(), 25.percent(), 25.percent(), 25.percent(), 25.percent()))).SetTitle("Usage")).S(), grow: true)
+                    SearchableList(GetAllIcons().ToArray(), 25.percent(), 25.percent(), 25.percent(), 25.percent()).Height(55.vh()).MinHeight(320.px()))).SetTitle("Usage")))
                .SeeAlso(typeof(EmojiSample), typeof(ButtonSample), typeof(BadgeSample), typeof(TextBlockSample));
         }
 


### PR DESCRIPTION
The Usage section used `grow: true` with `.S()` on the wrapper Stack, but nothing in between constrained the Card's height: `.tss-card-content` is a flex item with the default `min-height: auto`, so it sized to its content (~44,700px) and the section item, which is `overflow: hidden`, simply clipped it. The result was a grid showing only its first few rows with no way to reach the rest.

Give the SearchableList a definite height (55vh, floored at 320px) so the list gets its own scroll viewport and the page scrolls normally around it. This matches how SearchableListSample sizes its lists, and unlike a grow-based section it does not collapse to zero height on short viewports.


Claude-Session: https://claude.ai/code/session_01Fz2t8CHUUmHR4tRKaLECwu