### PR TITLE
InlineLabel: let a glyph mark carry a colour of its own

### DIFF
--- a/Tesserae/skills/references/inline-label.md
+++ b/Tesserae/skills/references/inline-label.md
@@ -28,7 +28,9 @@ into a row of buttons.
 ## Key configuration
 
 - `.SetText(string)` / `Text` — the text. Null or empty leaves the label as its mark alone.
-- `.SetIcon(UIcons icon, UIconsWeight weight = Regular)` — a glyph before the text.
+- `.SetIcon(UIcons icon, UIconsWeight weight = Regular, string color = null)` — a glyph before the text,
+  in a colour of its own when one is given (a node type's accent, a source's brand) and in the label's
+  own colour otherwise.
 - `.SetIcon(IComponent)` — a component of the host's own (an `Avatar`, an emoji, a `Spinner`), drawn in
   the same box as any other mark.
 - `.SetImage(string url)` — an image (a source's logo, a favicon), fitted rather than cropped.

--- a/Tesserae/src/Components/InlineLabel.cs
+++ b/Tesserae/src/Components/InlineLabel.cs
@@ -89,11 +89,16 @@ namespace Tesserae
         }
 
         /// <summary>
-        /// Puts a glyph before the text.
+        /// Puts a glyph before the text, in a colour of its own when one is given - the accent a node type,
+        /// a source or a status is known by - and in the label's own colour otherwise.
         /// </summary>
-        public InlineLabel SetIcon(UIcons icon, UIconsWeight weight = UIconsWeight.Regular)
+        public InlineLabel SetIcon(UIcons icon, UIconsWeight weight = UIconsWeight.Regular, string color = null)
         {
-            return SetMark(I(icon, weight, "tss-inlinelabel-glyph"), "tss-inlinelabel-mark-icon");
+            var glyph = I(icon, weight, "tss-inlinelabel-glyph");
+
+            if (!string.IsNullOrEmpty(color)) glyph.style.color = color;
+
+            return SetMark(glyph, "tss-inlinelabel-mark-icon");
         }
 
         /// <summary>


### PR DESCRIPTION
A node type's accent, a source's brand: the mark is what carries it, and SetIcon had no way to say so. The colour is optional, so a label whose glyph should read in the label's own colour is unchanged.


Claude-Session: https://claude.ai/code/session_012EVgZkbCYK7M4rHoxQX49t