### PR TITLE
Drop the PaletteEntry the merge left behind

### DIFF
--- a/Tesserae/src/Components/CommandPalette.cs
+++ b/Tesserae/src/Components/CommandPalette.cs
@@ -50,12 +50,6 @@ namespace Tesserae
             public CommandPaletteResult Result { get; set; }
         }
 
-        private sealed class PaletteEntry
-        {
-            public CommandPaletteAction Action { get; set; }
-            public CommandPaletteResult Result { get; set; }
-        }
-
         private readonly Action<Event> _globalKeyDownHandler;
         private bool _globalListenerActive;
 


### PR DESCRIPTION
The type came through twice, which is a compile error in the class that declares it and made every use of its two members ambiguous.


Claude-Session: https://claude.ai/code/session_012EVgZkbCYK7M4rHoxQX49t