### PR TITLE
Put PaletteEntry back, and quiet the footer's glyphs

### DIFF
--- a/Tesserae/skills/references/inline-label.md
+++ b/Tesserae/skills/references/inline-label.md
@@ -59,7 +59,9 @@ row.SetFooterEntries(
 - `.SetText(string)` / `Text` — the text. Null or empty leaves the label as its mark alone.
 - `.SetIcon(UIcons icon, UIconsWeight weight = Regular, string color = null)` — a glyph before the text,
   in a colour of its own when one is given (a node type's accent, a source's brand) and in the label's
-  own colour otherwise.
+  own colour otherwise. In an `OmniResult` footer the colour is ignored and the glyph takes the footer's
+  secondary text colour, like the text beside it — the row's accent belongs on its icon tile, not
+  repeated on a line of small facts.
 - `.SetIcon(IComponent)` — a component of the host's own (an `Avatar`, an emoji, a `Spinner`), drawn in
   the same box as any other mark.
 - `.SetImage(string url)` — an image (a source's logo, a favicon), fitted rather than cropped.

--- a/Tesserae/skills/references/omni-result.md
+++ b/Tesserae/skills/references/omni-result.md
@@ -84,7 +84,9 @@ The source leads the line and the metadata follows it, and all of it is `InlineL
   a date. Each entry is an `InlineLabel` (`inline-label.md`), so it can carry a mark (a glyph, an image,
   a square of colour), be pressable, or be a real link, and they are all drawn at one size. Dots between
   entries are drawn by CSS, so nothing has to interleave separators, and a footer with no source never
-  starts with one.
+  starts with one. The whole line — text and glyphs alike — is drawn in the secondary text colour, so a
+  glyph given an accent of its own elsewhere is muted here; the source's colour square keeps its colour,
+  being nothing but a colour.
 - `.SetFooterEntries(params string[])` — the same, as plain text.
 - `.AddFooterEntry(IComponent)` — one more entry at the end of the line, as a component of your own
   rather than a label: a badge, a chip, a small control. Same box, same separating dot.

--- a/Tesserae/src/Components/CommandPalette.cs
+++ b/Tesserae/src/Components/CommandPalette.cs
@@ -47,6 +47,12 @@ namespace Tesserae
         /// <summary>How long <see cref="Layer{T}"/> takes to fade a hidden layer out before removing it.</summary>
         private const int LAYER_FADE_OUT_MS = 150;
 
+        private sealed class PaletteEntry
+        {
+            public CommandPaletteAction Action { get; set; }
+            public CommandPaletteResult Result { get; set; }
+        }
+
         private readonly Action<Event> _globalKeyDownHandler;
         private bool _globalListenerActive;
 

--- a/Tesserae/tps/assets/css/tss.inlinelabel.css
+++ b/Tesserae/tps/assets/css/tss.inlinelabel.css
@@ -138,7 +138,7 @@
     border: none;
     border-radius: var(--tss-border-radius-sm);
     background: none;
-    color: inherit;
+    color: var(--tss-secondary-foreground-color);
     font-size: inherit;
     line-height: inherit;
 }
@@ -150,6 +150,16 @@
 
 .tss-omniresult-footer .tss-inlinelabel-mark-icon {
     font-size: 11px;
+}
+
+/* A glyph in the footer is punctuation for the fact beside it, not an accent of its own: the row already
+   has one thing carrying a node's colour - its icon tile - and repeating that colour on a 11px glyph
+   under the title turns a quiet line of facts into a row of little flags. So the glyph takes the
+   footer's own colour even when the host asked for one, which it does by an inline style, hence the
+   !important. A colour swatch (tss-inlinelabel-mark-color) is exempt - it is nothing but its colour. */
+.tss-omniresult-footer .tss-inlinelabel-mark-icon,
+.tss-omniresult-footer .tss-inlinelabel-mark-icon .tss-inlinelabel-glyph {
+    color: var(--tss-secondary-foreground-color) !important;
 }
 
 /* The footer's labels have no box of their own, so the hover background is drawn just around them
@@ -167,4 +177,13 @@
 .tss-omniresult-footer .tss-inlinelabel-interactive:focus-visible {
     background: var(--tss-colors-neutral-400);
     color: var(--tss-default-foreground-hover-color);
+}
+
+/* The glyph lifts with the text it belongs to - the rule above muted it with !important, so this one
+   has to raise it the same way or a hovered label would brighten from the text leftwards only. */
+.tss-omniresult-footer .tss-inlinelabel-interactive:hover .tss-inlinelabel-mark-icon,
+.tss-omniresult-footer .tss-inlinelabel-interactive:hover .tss-inlinelabel-mark-icon .tss-inlinelabel-glyph,
+.tss-omniresult-footer .tss-inlinelabel-interactive:focus-visible .tss-inlinelabel-mark-icon,
+.tss-omniresult-footer .tss-inlinelabel-interactive:focus-visible .tss-inlinelabel-mark-icon .tss-inlinelabel-glyph {
+    color: var(--tss-default-foreground-hover-color) !important;
 }


### PR DESCRIPTION
Fixes the `master` build.

### `CommandPalette.PaletteEntry` is gone from `master`

```
CommandPalette.cs(34,31):  error CS0246: The type or namespace name 'PaletteEntry' could not be found
CommandPalette.cs(34,65):  error CS0246: ...
CommandPalette.cs(593,34): error CS0246: ...
CommandPalette.cs(604,34): error CS0246: ...
```

Two overlapping squash merges from the same branch took the declaration out. An earlier merge left a
duplicate `PaletteEntry` block in the file; #297 removed the duplicate; #298 was opened against a base
that still had both, so its squash removed the survivor as well. Nothing in the four failing lines ever
changed — they are the original uses of a type that is now undeclared.

The type is private to `CommandPalette` and is what `_entries` is a list of. It goes back exactly where
it was:

```csharp
private sealed class PaletteEntry
{
    public CommandPaletteAction Action { get; set; }
    public CommandPaletteResult Result { get; set; }
}
```

Verified with the configuration CI failed in — `dotnet build Tesserae/Tesserae.csproj -c Release
-t:Rebuild` — 0 errors, Transpose included.

### Riding along: footer labels and their glyphs are secondary

An `InlineLabel` in an `OmniResult` footer now states the secondary text colour rather than inheriting
it, and its glyph mark takes that colour too — even when the host passed one to
`SetIcon(icon, color:)`. A row already has one thing carrying an accent, its icon tile; repeating that
colour on an 11px glyph under the title turns a line of facts into a row of little flags. The host
writes the glyph colour as an inline style, so the footer has to say `!important` to win, and the
`:hover` / `:focus-visible` rule has to raise the glyph the same way — otherwise a hovered label
brightens from the text leftwards only. The source's colour square is exempt: it is nothing but its
colour.

Measured in the samples page, forcing `style.color = red` on a footer glyph from the console and
re-reading the computed value:

| | light | dark |
|---|---|---|
| `--tss-secondary-foreground-color` | `rgb(101,103,107)` | `rgb(138,148,166)` |
| label / text | `rgb(101,103,107)` | `rgb(138,148,166)` |
| glyph forced to red | `rgb(101,103,107)` | `rgb(138,148,166)` |
| source swatch | `rgb(0,97,213)` | `rgb(0,97,213)` |

`references/inline-label.md` and `references/omni-result.md` updated to say the footer mutes a glyph's
accent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012EVgZkbCYK7M4rHoxQX49t

---
_Generated by [Claude Code](https://claude.ai/code/session_012EVgZkbCYK7M4rHoxQX49t)_