### PR TITLE
Font variables, a real search box in the CommandPalette, and sidebar fixes

### DIFF
--- a/Tesserae/skills/references/command-palette.md
+++ b/Tesserae/skills/references/command-palette.md
@@ -22,6 +22,27 @@ CommandPalette:
 - `.ActionExecuted` event — fires after an action runs.
 - `.SetResults(...)` / `.OnSearch(...)` / `.ResultActivated` — rows of your own, below.
 - `.CurrentQuery` — what is typed in the search box right now, trimmed.
+- `.LightDismiss()` / `.NoLightDismiss()` / `.CanLightDismiss` — whether clicking beside the palette closes
+  it, the way it does on a `Modal`. On by default. Escape closes it too, wherever the focus ended up.
+- `.SearchBox` / `.ConfigureSearchBox(Action&lt;OmniBox&gt;)` — the box itself, below.
+
+## The search box is an OmniBox
+
+The palette is typed into a full `OmniBox` (`omni-box.md`) in `Search` mode, not a bare input, so it can
+offer whatever the app's own search box offers — snaps (`@file`), value filters (`kind:pdf`), history,
+suggestions. Reach it with `.SearchBox`, or configure it in a chain with `.ConfigureSearchBox(...)`:
+
+```csharp
+palette.ConfigureSearchBox(box =>
+{
+    box.RegisterSnaps(mySnaps);
+    box.RegisterFilterSnaps(myFilters);
+    box.SetSearchPlaceholder("Type a filter or search...");
+});
+```
+
+Give a palette that stands in for a search page the *same* configuration that page's box has — otherwise
+the preview answers a different question than the page it hands over to.
 
 `CommandPaletteAction(string id, string name)` properties:
 - `Perform` (`Action`), `Subtitle`, `Keywords`, `Section`, `Icon` (`UIcons?`).
@@ -38,9 +59,13 @@ result looks the same wherever it is shown.
 - `.SetResults(IEnumerable<CommandPaletteResult>)` (also `params`) — replace the rows. They are shown as
   given: the palette does not filter them, because whoever produced them for a query already knows which
   ones answer it. The actions beneath them are still filtered as usual.
-- `.OnSearch(Func<string, Task<IEnumerable<CommandPaletteResult>>> search, int debounceMs = 200)` — have
-  the rows refreshed as the query changes. Debounced, and an answer that arrives after a newer query was
-  typed is dropped, so a slow search never overwrites a faster one behind it.
+- `.OnSearch(Func<OmniBox.SearchQuery, Task<IEnumerable<CommandPaletteResult>>> search, int debounceMs = 200)`
+  — have the rows refreshed as the query changes. Debounced, and an answer that arrives after a newer query
+  was typed is dropped, so a slow search never overwrites a faster one behind it. The `SearchQuery` carries
+  the parsed text (`RawQuery`, `Tokens`) plus whatever snaps and value filters the box picked out of it, so
+  a filter typed on its own (`kind:pdf`) is a search like any other.
+- `.OnSearch(Func<string, Task<IEnumerable<CommandPaletteResult>>> search, int debounceMs = 200)` — the same,
+  for a palette that only needs the text that was typed.
 - `new CommandPaletteResult(IComponent component, Action activate = null)` — the row and what Enter does
   with it, plus a `Section` heading like an action's. With no `activate` the row is only clickable, which
   is what a component that already answers its own click wants.
@@ -50,9 +75,10 @@ Rows join the arrow-key walk like any other item, and the palette closes after o
 what the palette only had room to preview.
 
 ```csharp
-palette.OnSearch(async query =>
+palette.OnSearch(async searchQuery =>
 {
-    var hits = await SearchAsync(query);
+    var query = searchQuery.RawQuery?.Trim() ?? "";
+    var hits  = await SearchAsync(query, searchQuery.FilterSnaps);
 
     var rows = hits.Take(5).Select(hit => new CommandPaletteResult(
         OmniResult(hit, hit.Title).SetIcon(hit.Extension, hit.Color).Highlight(query),

--- a/Tesserae/skills/references/inline-label.md
+++ b/Tesserae/skills/references/inline-label.md
@@ -67,11 +67,18 @@ row.SetFooterEntries(
 - `.SetImage(string url)` — an image (a source's logo, a favicon), fitted rather than cropped.
 - `.SetColor(string color)` — a small rounded square of that colour.
 - `.NoMark()` — text alone.
+- `.IsEmpty` — whether there is nothing to show (no text and no mark). A label that ends up empty also
+  carries the `tss-inlinelabel-empty` class, which is how a container leaves out what stands for it — the
+  dot an `OmniResult` footer puts before every entry — without looking inside it. A label that is still
+  loading is not empty: it is showing a skeleton in place of what it is about to say.
 - `.OnClick(Action<InlineLabel>)` — makes it pressable: it takes a tab stop, answers Enter and Space,
   and the click stops at the label so pressing it never also counts as a click on the row it sits in.
   The usual `OnClick(ComponentEventHandler<InlineLabel, MouseEvent>)` works too.
 - `.SetHref(string href, bool openInNewTab = false)` — makes it a real link. The label is an anchor
   either way, so a link is middle-clickable and shows its address in the status bar.
+- `.IsEmpty` — whether there is neither text nor mark in it. A label that is empty and not still loading
+  also carries the `tss-inlinelabel-empty` class, which is how a container leaves out what stands for it —
+  an `OmniResult` footer hides the entry, and its separating dot with it — without looking inside.
 
 Whatever the mark is it takes one box — 14px on the compact button, 12px in a footer — and the text
 ellipsizes rather than wrapping, so a long path gives way to whatever it shares the line with. What a

--- a/Tesserae/skills/references/omni-box.md
+++ b/Tesserae/skills/references/omni-box.md
@@ -84,6 +84,9 @@ OmniBox:
 - `.Focus()`.
 - `.CaretClientX()` — the viewport x of the text caret in whichever input is focused, clamped to that input's bounds, or `double.NaN` when there is nothing to measure. Used to point something at where the user is typing, e.g. the `PixelAvatar` companion walking over to the caret.
 - `OmniBox.ParseQuery(string, bool tokenIgnoreCase = false)` — static parser returning a `SearchQuery`.
+- `.CurrentSearchQuery` — what the box says right now, parsed: the same `SearchQuery` pressing Enter would
+  raise, chips included. For a host that answers as the query is typed rather than on Enter (a
+  `CommandPalette`, a search-as-you-type page).
 
 ## Example
 

--- a/Tesserae/skills/references/sidebar.md
+++ b/Tesserae/skills/references/sidebar.md
@@ -91,6 +91,14 @@ filters searchable items. Configure it fluently:
 - `.SetKeyboardShortcut("Ctrl", "K")` — show a shortcut chip (renders ⌘K on
   macOS, Ctrl+K elsewhere) and focus the box when the shortcut is pressed.
 - `.Rounded(BorderRadius = Full)` — render as a full bordered, rounded "pill".
+- `.Text` / `.SetText(text)` — read or replace what is in the box. Setting it
+  does not raise `.OnSearch(...)`, so a caller that clears the box decides for
+  itself what to do about the results.
+- `.Focus()` — put the caret in the box.
+
+It is an `ISidebarItem`, so it is normally added to a `Sidebar`; `.RenderOpen()`
+gives you the box as an `IComponent` when the list it filters is drawn by a
+component of your own rather than by the sidebar itself.
 
 ## Rounded (pill) style
 

--- a/Tesserae/skills/references/styling.md
+++ b/Tesserae/skills/references/styling.md
@@ -18,6 +18,32 @@ On components implementing `ITextFormating` (`ITextFormatingExtensions`):
 - Alignment: `.TextCenter()`.
 - Explicit: `.SetTextSize(TextSize.Small)`, `.SetTextWeight(TextWeight.SemiBold)`.
 
+## Fonts
+
+Tesserae draws with exactly two font stacks, and every rule that sets a
+`font-family` names one of them with no inline fallback list:
+
+- `--tss-sansserif-font-family` — everything but code. Defaults to
+  `"Plus Jakarta Sans", "Inter", "Segoe UI", …`; Tesserae does not ship the font
+  files, so an app that wants the first name in that list serves its own
+  `@font-face` for it.
+- `--tss-monospace-font-family` — code, paths, identifiers.
+
+Override either one on `:root` (or on any sub-tree) and the whole UI follows,
+form controls included. From C#, reference them as `Theme.Fonts.SansSerif` /
+`Theme.Fonts.Monospace` rather than repeating the `var(...)` literal:
+
+```css
+:root {
+    --tss-sansserif-font-family: "Plus Jakarta Sans", "Inter", sans-serif;
+    --tss-monospace-font-family: "Monaspace Neon", ui-monospace, monospace;
+}
+```
+
+```csharp
+TextBlock(path).Style(s => s.fontFamily = Theme.Fonts.Monospace);
+```
+
 ## Spacing & sizing (IComponentExtensions)
 
 - Padding/margin: `.Padding(...)`, `.MarginBottom(...)`, etc.

--- a/Tesserae/skills/references/theme-colors.md
+++ b/Tesserae/skills/references/theme-colors.md
@@ -20,6 +20,7 @@ description: The static `Theme` class for switching light/dark mode and overridi
 
 - `Theme.IsLight` / `Theme.IsDark` — current mode (bool).
 - `Theme.Default`, `Theme.Primary`, `Theme.Secondary`, `Theme.Danger`, `Theme.Success` — color accessors exposing `.Background`, `.Foreground`, `.Border`, etc.
+- `Theme.Fonts.SansSerif` / `Theme.Fonts.Monospace` — the two font stacks the toolkit draws with, as CSS variable references. See `styling.md`.
 - `Theme.OnThemeChanged` — event raised on mode change.
 
 ## Example

--- a/Tesserae/src/Base/UI.Theme.cs
+++ b/Tesserae/src/Base/UI.Theme.cs
@@ -427,6 +427,25 @@ namespace Tesserae
                 public const string Foreground = "var(--tss-sidebar-foreground-color)";
             }
 
+            /// <summary>
+            /// The two font stacks Tesserae draws with. Override the variables these point at - on
+            /// <c>:root</c>, or on any sub-tree - to change the font everywhere, rather than setting a
+            /// font-family per component.
+            /// </summary>
+            public static class Fonts
+            {
+                /// <summary>
+                /// CSS variable reference for the app's sans-serif font stack, which everything but code
+                /// is drawn in.
+                /// </summary>
+                public const string SansSerif = "var(--tss-sansserif-font-family)";
+                /// <summary>
+                /// CSS variable reference for the monospace font stack code, paths and identifiers are
+                /// drawn in.
+                /// </summary>
+                public const string Monospace = "var(--tss-monospace-font-family)";
+            }
+
             public static class Secondary
             {
                 /// <summary>

--- a/Tesserae/src/Components/CommandPalette.cs
+++ b/Tesserae/src/Components/CommandPalette.cs
@@ -19,7 +19,7 @@ namespace Tesserae
         private readonly HTMLDivElement _positioner;
         private readonly HTMLDivElement _animator;
         private readonly HTMLDivElement _searchContainer;
-        private readonly HTMLInputElement _searchInput;
+        private readonly OmniBox _searchBox;
         private readonly HTMLDivElement _breadcrumbs;
         private readonly HTMLButtonElement _backButton;
         private readonly HTMLSpanElement _pathText;
@@ -35,7 +35,7 @@ namespace Tesserae
         private readonly List<HTMLElement> _entryElements = new List<HTMLElement>();
 
         private readonly List<CommandPaletteResult> _hostResults = new List<CommandPaletteResult>();
-        private Func<string, Task<IEnumerable<CommandPaletteResult>>> _search;
+        private Func<OmniBox.SearchQuery, Task<IEnumerable<CommandPaletteResult>>> _search;
         private int _searchDebounceMs = 200;
         private double _searchTimer = -1;
         private int _searchGeneration;
@@ -55,6 +55,9 @@ namespace Tesserae
 
         private readonly Action<Event> _globalKeyDownHandler;
         private bool _globalListenerActive;
+
+        private readonly Action<Event> _lightDismissHandler;
+        private bool _canLightDismiss;
 
         /// <summary>
         /// Raised when action executed occurs.
@@ -85,6 +88,63 @@ namespace Tesserae
         public string GlobalShortcutKey { get; set; } = "k";
 
         /// <summary>
+        /// Whether clicking beside the palette closes it, the way it does on a <see cref="Modal"/>. On by
+        /// default.
+        /// </summary>
+        public bool CanLightDismiss
+        {
+            get => _canLightDismiss;
+            set
+            {
+                if (_canLightDismiss == value) return;
+
+                _canLightDismiss = value;
+
+                if (value)
+                {
+                    _overlay.addEventListener("click",    _lightDismissHandler);
+                    _positioner.addEventListener("click", _lightDismissHandler);
+                }
+                else
+                {
+                    _overlay.removeEventListener("click",    _lightDismissHandler);
+                    _positioner.removeEventListener("click", _lightDismissHandler);
+                }
+            }
+        }
+
+        /// <summary>Enables light-dismiss behaviour (clicking outside the palette closes it).</summary>
+        public CommandPalette LightDismiss()
+        {
+            CanLightDismiss = true;
+            return this;
+        }
+
+        /// <summary>Removes / disables the light dismiss on the component.</summary>
+        public CommandPalette NoLightDismiss()
+        {
+            CanLightDismiss = false;
+            return this;
+        }
+
+        /// <summary>
+        /// The box the palette is typed into. It is a full <see cref="OmniBox"/>, so a host can give the
+        /// palette the same snaps, value filters, history and suggestions its own search box has instead of
+        /// the palette being a lesser search than the page it stands in for.
+        /// </summary>
+        public OmniBox SearchBox => _searchBox;
+
+        /// <summary>
+        /// Configures <see cref="SearchBox"/> - the place to hand the palette the search box configuration
+        /// the rest of the app shares.
+        /// </summary>
+        public CommandPalette ConfigureSearchBox(Action<OmniBox> configure)
+        {
+            configure?.Invoke(_searchBox);
+            return this;
+        }
+
+        /// <summary>
         /// Creates a CommandPalette whose global Ctrl/Cmd keyboard listener is bound
         /// to the lifetime of <paramref name="host"/>: the listener is attached when
         /// <paramref name="host"/> first mounts to the DOM and detached when it is
@@ -95,18 +155,22 @@ namespace Tesserae
         {
             if (host is null) throw new ArgumentNullException(nameof(host));
 
-            _searchInput = UI.TextBox(Att("tss-commandpalette-search", type: "search", placeholder: "Type a command"));
-            _searchInput.setAttribute("aria-label", "Command palette search");
-            _searchInput.addEventListener("input", _ => RefreshResults());
-            _searchInput.addEventListener("keydown", e => HandleSearchKeyDown(e.As<KeyboardEvent>()));
-            _searchInput.addEventListener("blur", e =>
-            {
-                if(_searchInput.IsMounted())
-                {
-                    StopEvent(e);
-                    _searchInput.focus();
-                }
-            });
+            //The palette searches with the same box the rest of the app searches with, so a host can give it
+            //the snaps, filters, history and suggestions its own search box has - see ConfigureSearchBox.
+            _searchBox = UI.OmniBox(new OmniBox.Config(OmniBox.Mode.Search) { PlaceholderSearch = "Type a command" })
+               .Class("tss-commandpalette-search");
+
+            _searchBox.OnInput((_, __) => RefreshResults());
+            _searchBox.OnKeyDown((_, e) => HandleSearchKeyDown(e));
+
+            //A chip is part of the query - picking "kind:pdf" out of a suggestion narrows the search the
+            //same way typing does - and it arrives without an input event, so it has to be watched for.
+            _searchBox.InlineFilterChips?.ObserveFutureChanges(_ => RefreshResults());
+
+            //Enter is the OmniBox's own - it commits a snap suggestion or raises a search - so what the
+            //palette does with it hangs off the search rather than off the key.
+            _searchBox.OnSearch((_, __) => ActivateSelected());
+
             _backButton = UI.Button(Att("tss-commandpalette-back tss-fontweight-semibold", type: "button", title: "Go Back"),
                                     Div(Att("tss-commandpalette-icon"), I(Att($"tss-commandpalette-icon-item {UIcons.AngleLeft}"))));
 
@@ -119,18 +183,25 @@ namespace Tesserae
             _pathText = Span(Att("tss-commandpalette-path tss-fontweight-semibold"));
             _breadcrumbs = Div(Att("tss-commandpalette-breadcrumbs"), _backButton, _pathText);
 
-            _searchContainer = Div(Att("tss-commandpalette-search-container"), _breadcrumbs, _searchInput);
+            _searchContainer = Div(Att("tss-commandpalette-search-container"), _breadcrumbs, _searchBox.Render());
             _results = Div(Att("tss-commandpalette-results", role: "listbox"));
             _emptyState = Div(Att("tss-commandpalette-empty", text: "No results"));
 
             _animator = Div(Att("tss-commandpalette-animator"), _searchContainer, _results, _emptyState);
             _positioner = Div(Att("tss-commandpalette-positioner"), _animator);
             _overlay = Div(Att("tss-commandpalette-overlay"));
-            _overlay.addEventListener("click", e =>
+
+            //The positioner covers the overlay, so a click beside the palette lands on it rather than on the
+            //backdrop - both have to answer, or light dismiss only works on the strip the positioner misses.
+            _lightDismissHandler = e =>
             {
+                if (e.target is object && e.target != _overlay && e.target != _positioner) return;
+
                 StopEvent(e);
                 Hide();
-            });
+            };
+
+            CanLightDismiss = true;
 
             _contentHtml = Div(Att("tss-commandpalette-container"), _overlay, _positioner);
 
@@ -160,8 +231,8 @@ namespace Tesserae
         /// </summary>
         public string Placeholder
         {
-            get => _searchInput.placeholder;
-            set => _searchInput.placeholder = value ?? string.Empty;
+            get => _searchBox.SearchPlaceholder;
+            set => _searchBox.SetSearchPlaceholder(value ?? string.Empty);
         }
 
         /// <summary>
@@ -238,9 +309,12 @@ namespace Tesserae
         /// The call is debounced, and an answer that arrives after a newer query was typed is dropped, so a
         /// slow search can never overwrite a faster one behind it.
         /// </summary>
-        /// <param name="search">Given the current query, the rows to show. Null clears the search.</param>
+        /// <param name="search">
+        /// Given what the box says - parsed, with whatever snaps and value filters the host registered on
+        /// <see cref="SearchBox"/> already picked out of it - the rows to show. Null clears the search.
+        /// </param>
         /// <param name="debounceMs">How long typing has to stop before the search runs.</param>
-        public CommandPalette OnSearch(Func<string, Task<IEnumerable<CommandPaletteResult>>> search, int debounceMs = 200)
+        public CommandPalette OnSearch(Func<OmniBox.SearchQuery, Task<IEnumerable<CommandPaletteResult>>> search, int debounceMs = 200)
         {
             _search           = search;
             _searchDebounceMs = debounceMs < 0 ? 0 : debounceMs;
@@ -252,14 +326,24 @@ namespace Tesserae
             }
             else if (IsVisible)
             {
-                RunSearch(CurrentQuery);
+                RunSearch(_searchBox.CurrentSearchQuery);
             }
 
             return this;
         }
 
+        /// <summary>
+        /// Asks the host for the rows to show, for a palette that only needs the text that was typed. See
+        /// <see cref="OnSearch(Func{OmniBox.SearchQuery, Task{IEnumerable{CommandPaletteResult}}}, int)"/>
+        /// for the overload that also hands over the box's filters.
+        /// </summary>
+        public CommandPalette OnSearch(Func<string, Task<IEnumerable<CommandPaletteResult>>> search, int debounceMs = 200)
+        {
+            return OnSearch(search is null ? null : (Func<OmniBox.SearchQuery, Task<IEnumerable<CommandPaletteResult>>>)(query => search(query?.RawQuery?.Trim() ?? string.Empty)), debounceMs);
+        }
+
         /// <summary>What is typed in the palette's search box right now, trimmed.</summary>
-        public string CurrentQuery => _searchInput.value?.Trim() ?? string.Empty;
+        public string CurrentQuery => _searchBox.SearchText?.Trim() ?? string.Empty;
 
         /// <summary>
         /// Opens the component.
@@ -299,7 +383,7 @@ namespace Tesserae
 
             base.Show();
             ResetState();
-            window.setTimeout(_ => _searchInput.focus(), 0);
+            window.setTimeout(_ => _searchBox.Focus(), 0);
             return this;
         }
 
@@ -350,7 +434,7 @@ namespace Tesserae
 
         private void ResetState()
         {
-            _searchInput.value = string.Empty;
+            _searchBox.SetSearchText(string.Empty);
             _currentParentId = null;
             RefreshResults();
         }
@@ -370,11 +454,26 @@ namespace Tesserae
 
         private void HandleGlobalKeyDown(Event ev)
         {
+            var e = ev.As<KeyboardEvent>();
+
+            //Escape closes the palette wherever the focus ended up - activating a row takes it out of the
+            //search box, and a palette that can only be closed with the mouse after that is a trap.
+            if (IsVisible && e.key == "Escape")
+            {
+                var focused = document.activeElement.As<HTMLElement>();
+
+                if (focused is null || !_searchContainer.contains(focused))
+                {
+                    StopEvent(e);
+                    Hide();
+                    return;
+                }
+            }
+
             if (!EnableGlobalShortcut && !EnableGlobalActionShortcuts)
             {
                 return;
             }
-            var e = ev.As<KeyboardEvent>();
 
             var target = (e.target is object ? e.target : e.srcElement).As<HTMLElement>();
             if (target != null && (target.isContentEditable || target.tagName == "INPUT" || target.tagName == "TEXTAREA" || target.tagName == "SELECT"))
@@ -420,7 +519,9 @@ namespace Tesserae
                 return;
             }
 
-            if (e.key == "Enter" | e.key == "Tab")
+            //Enter never reaches here - the OmniBox stops it and raises its search instead, which is what
+            //the palette listens to (see the constructor).
+            if (e.key == "Tab")
             {
                 StopEvent(e);
                 ActivateSelected();
@@ -442,7 +543,7 @@ namespace Tesserae
                 return;
             }
 
-            if (e.key == "Backspace" && string.IsNullOrEmpty(_searchInput.value) && !string.IsNullOrEmpty(_currentParentId))
+            if (e.key == "Backspace" && string.IsNullOrEmpty(_searchBox.SearchText) && !string.IsNullOrEmpty(_currentParentId))
             {
                 StopEvent(e);
                 NavigateBack();
@@ -459,9 +560,9 @@ namespace Tesserae
 
             var current = _actionLookup.ContainsKey(_currentParentId) ? _actionLookup[_currentParentId] : null;
             _currentParentId = current?.ParentId;
-            _searchInput.value = string.Empty;
+            _searchBox.SetSearchText(string.Empty);
             RefreshResults();
-            window.setTimeout(_ => _searchInput.focus(), 0);
+            window.setTimeout(_ => _searchBox.Focus(), 0);
         }
 
         private void ActivateSelected()
@@ -497,7 +598,7 @@ namespace Tesserae
             if (HasChildren(action))
             {
                 _currentParentId = action.Id;
-                _searchInput.value = string.Empty;
+                _searchBox.SetSearchText(string.Empty);
                 RefreshResults();
                 return;
             }
@@ -631,7 +732,7 @@ namespace Tesserae
 
             CancelPendingSearch();
 
-            var query = CurrentQuery;
+            var query = _searchBox.CurrentSearchQuery;
 
             if (_searchDebounceMs == 0)
             {
@@ -654,7 +755,7 @@ namespace Tesserae
             _searchTimer = -1;
         }
 
-        private void RunSearch(string query)
+        private void RunSearch(OmniBox.SearchQuery query)
         {
             var search = _search;
 
@@ -667,7 +768,7 @@ namespace Tesserae
             RunSearchAsync(search, query, generation).FireAndForget();
         }
 
-        private async Task RunSearchAsync(Func<string, Task<IEnumerable<CommandPaletteResult>>> search, string query, int generation)
+        private async Task RunSearchAsync(Func<OmniBox.SearchQuery, Task<IEnumerable<CommandPaletteResult>>> search, OmniBox.SearchQuery query, int generation)
         {
             var results = await search(query);
 

--- a/Tesserae/src/Components/InlineLabel.cs
+++ b/Tesserae/src/Components/InlineLabel.cs
@@ -92,7 +92,18 @@ namespace Tesserae
         public string Text { get; private set; }
 
         /// <summary>Whether the label has nothing to show - no text, and no mark.</summary>
-        private bool IsEmpty => string.IsNullOrEmpty(Text) && _mark.style.display == "none";
+        public bool IsEmpty => string.IsNullOrEmpty(Text) && _mark.style.display == "none";
+
+        /// <summary>
+        /// Says on the element itself whether there is anything in it, so a container can leave out what
+        /// stands for an empty label - the dot an <see cref="OmniResult{T}"/> footer puts before every
+        /// entry - without having to look inside it. A label that is still loading is not empty: it is
+        /// showing a skeleton in place of what it is about to say.
+        /// </summary>
+        private void UpdateEmptyClass()
+        {
+            InnerElement.UpdateClassIf(IsEmpty && !InnerElement.classList.contains("tss-inlinelabel-loading"), "tss-inlinelabel-empty");
+        }
 
         /// <summary>
         /// Renders the component's root HTML element.
@@ -110,6 +121,8 @@ namespace Tesserae
 
             _text.textContent   = isEmpty ? string.Empty : text;
             _text.style.display = isEmpty ? "none" : "";
+
+            UpdateEmptyClass();
 
             return this;
         }
@@ -170,6 +183,8 @@ namespace Tesserae
             _mark.className        = "tss-inlinelabel-mark";
             _mark.style.background = string.Empty;
             _mark.style.display    = "none";
+
+            UpdateEmptyClass();
 
             return this;
         }
@@ -233,6 +248,8 @@ namespace Tesserae
 
             if (content is object) _mark.appendChild(content);
 
+            UpdateEmptyClass();
+
             return this;
         }
 
@@ -250,6 +267,8 @@ namespace Tesserae
                 {
                     skeleton.As<HTMLElement>().remove();
                 }
+
+                UpdateEmptyClass();
 
                 //Nothing to say: the label takes its slot with it rather than leaving a gap in the line.
                 if (IsEmpty) this.WhenMounted(RemoveWithItsSlot);

--- a/Tesserae/src/Components/OmniBox.cs
+++ b/Tesserae/src/Components/OmniBox.cs
@@ -1685,13 +1685,25 @@ namespace Tesserae
             }
         }
 
+        /// <summary>
+        /// What the box says right now, parsed - the same <see cref="SearchQuery"/> pressing Enter would
+        /// raise, chips included. For a host that answers as the query is typed rather than on Enter.
+        /// </summary>
+        public SearchQuery CurrentSearchQuery => BuildSearchQuery();
+
+        private SearchQuery BuildSearchQuery()
+        {
+            var query = ParseQuery(_searchInput is object ? _searchInput.value : string.Empty, _tokenIgnoreCase);
+
+            query.Snaps       = GetActiveSnaps();
+            query.FilterSnaps = GetActiveFilterSnaps();
+
+            return query;
+        }
+
         private void TriggerSearch()
         {
-            var val = _searchInput.value;
-            var query = ParseQuery(val, _tokenIgnoreCase);
-            query.Snaps = GetActiveSnaps();
-            query.FilterSnaps = GetActiveFilterSnaps();
-            Searched?.Invoke(this, query);
+            Searched?.Invoke(this, BuildSearchQuery());
         }
 
         private SnapHandler[] GetActiveSnaps()

--- a/Tesserae/src/Components/Sidebar/SidebarSearchBox.cs
+++ b/Tesserae/src/Components/Sidebar/SidebarSearchBox.cs
@@ -68,6 +68,30 @@ namespace Tesserae
         }
 
         /// <summary>
+        /// The text in the box. Setting it does not raise <see cref="OnSearch"/> - a caller that clears the
+        /// box usually has its own idea of what to do about the results.
+        /// </summary>
+        public string Text
+        {
+            get => _searchBox.Text;
+            set => _searchBox.SetText(value);
+        }
+
+        /// <summary>Sets the text in the box, without raising <see cref="OnSearch"/>.</summary>
+        public SidebarSearchBox SetText(string text)
+        {
+            _searchBox.SetText(text);
+            return this;
+        }
+
+        /// <summary>Puts the caret in the box.</summary>
+        public SidebarSearchBox Focus()
+        {
+            _searchBox.Focus();
+            return this;
+        }
+
+        /// <summary>
         /// Makes the box a way in rather than a place to type: clicking it - open, or as the icon on the
         /// closed rail - runs the handler, and so does focusing it, which is what
         /// <see cref="SetKeyboardShortcut"/> does. Nothing can be typed into it, because what is typed

--- a/Tesserae/tps/assets/css/tss.body.css
+++ b/Tesserae/tps/assets/css/tss.body.css
@@ -13,5 +13,15 @@ body {
     color: var(--tss-default-foreground-color);
     background-color: var(--tss-default-background-color);
     font-size: var(--tss-font-size-small);
-    font-family: Segoe UI, SegoeUI, "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-family: var(--tss-sansserif-font-family);
+}
+
+/* Form controls do not inherit the document font, so an app that overrides
+   --tss-sansserif-font-family would otherwise keep the browser's own font inside every input. */
+input,
+textarea,
+select,
+button,
+optgroup {
+    font-family: inherit;
 }

--- a/Tesserae/tps/assets/css/tss.commandpalette.css
+++ b/Tesserae/tps/assets/css/tss.commandpalette.css
@@ -38,22 +38,24 @@
     gap: 8px;
     padding: 12px 16px;
     border-bottom: 1px solid var(--tss-default-border-color);
-    display: inline-flex;
+    display: flex;
     flex-direction: row;
-    min-height:60px;
+    align-items: center;
+    min-height: 60px;
 }
 
-.tss-commandpalette-search {
-    width: 100%;
-    border: none;
-    outline: none;
+/* The palette is typed into an OmniBox, which brings its own outline - inside the palette's own box that
+   would be a border around a border, so it gives its chrome up and keeps only its behaviour. */
+.tss-omnibox-container.tss-commandpalette-search {
+    flex: 1 1 auto;
+    min-width: 0;
+    border-color: transparent;
     background: transparent;
-    color: var(--tss-default-foreground-color);
-    font-size: 16px;
+    box-shadow: none;
 }
 
-.tss-commandpalette-search::placeholder {
-    color: var(--tss-secondary-foreground-color);
+.tss-omnibox-container.tss-commandpalette-search .tss-omnibox-search-input {
+    font-size: 16px;
 }
 
 .tss-commandpalette-breadcrumbs {
@@ -122,14 +124,20 @@
    so the palette gives it the full width and only keeps the part of an item that says "this is the one":
    the rounded highlight behind it. */
 .tss-commandpalette-result {
-    display: block;
+    display: inline-flex;
+    align-items: stretch;
+    width: 100%;
+    box-sizing: border-box;
     padding: 0;
     gap: 0;
     overflow: hidden;
 }
 
+/* The row is the only thing in the item, so it takes all of it - and may shrink below its content's
+   intrinsic width, which is what lets a long title ellipsize instead of widening the palette. */
 .tss-commandpalette-result > * {
-    width: 100%;
+    flex: 1 1 auto;
+    min-width: 0;
 }
 
 /* The active row is filled with the primary colour, which a result's own hover background would fight -

--- a/Tesserae/tps/assets/css/tss.common.css
+++ b/Tesserae/tps/assets/css/tss.common.css
@@ -1,5 +1,11 @@
 ﻿/* Variables - Colors should reflect in the Theme.cs file*/
 :root {
+    /* Families - the only two font stacks Tesserae draws with. Every rule that sets a font-family
+       references one of them with no inline fallback list, so an app that overrides either variable
+       (on :root, or on a sub-tree) actually replaces the stack everywhere instead of only in the
+       places that happened to name it. */
+    --tss-sansserif-font-family: "Plus Jakarta Sans", "Inter", "Segoe UI", SegoeUI, "Helvetica Neue", Helvetica, Arial, sans-serif;
+    --tss-monospace-font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
     /* Weights */
     --tss-font-weight-regular: 400;
     --tss-font-weight-semibold: 600;

--- a/Tesserae/tps/assets/css/tss.contextcard.css
+++ b/Tesserae/tps/assets/css/tss.contextcard.css
@@ -112,7 +112,7 @@
 
 /* A path, a table name or a size, given the same monospace treatment ToolCall gives its command. */
 .tss-contextcard-mono .tss-contextcard-sublabel {
-    font-family: var(--tss-monospace-font-family, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+    font-family: var(--tss-monospace-font-family);
 }
 
 /* Whatever the host wants at the end of the card - a count, a status, a source. Quiet, never shrinks. */

--- a/Tesserae/tps/assets/css/tss.cron.css
+++ b/Tesserae/tps/assets/css/tss.cron.css
@@ -83,7 +83,7 @@
 }
 
 .tss-cron-custom-input .tss-textbox {
-    font-family: monospace;
+    font-family: var(--tss-monospace-font-family);
 }
 
 .tss-cron-actions {

--- a/Tesserae/tps/assets/css/tss.kbd.css
+++ b/Tesserae/tps/assets/css/tss.kbd.css
@@ -13,16 +13,19 @@
     min-width: 22px;
     height: 22px;
     padding: 0 5px;
-    font-family: var(--tss-font-family, system-ui, sans-serif);
+    font-family: var(--tss-sansserif-font-family);
     font-size: 11px;
     font-weight: 500;
     line-height: 1;
-    color: var(--tss-default-foreground-color);
-    background: var(--tss-secondary-background-color, #f3f3f3);
-    border: 1px solid var(--tss-default-border-color);
+    color: var(--tss-secondary-foreground-color);
+    /* A wash of the opposite tone rather than a named surface colour: the chip is nearly always drawn
+       on top of one of those surfaces (a search field, the sidebar), and painting it the same colour is
+       what made it invisible. dark-neutral-0 is near-black on a light theme and white on a dark one, so
+       the same two rules read as a raised key in both. */
+    background: rgba(var(--tss-colors-dark-neutral-0-root), 0.07);
+    border: 1px solid rgba(var(--tss-colors-dark-neutral-0-root), 0.16);
     border-bottom-width: 2px;
     border-radius: 4px;
-    box-shadow: 0 1px 0 rgba(0,0,0,0.08);
     user-select: none;
     white-space: nowrap;
 }

--- a/Tesserae/tps/assets/css/tss.markdown.css
+++ b/Tesserae/tps/assets/css/tss.markdown.css
@@ -7,7 +7,7 @@
     -ms-text-size-adjust: 100%;
     -webkit-text-size-adjust: 100%;
     color: var(--tss-default-foreground-color);
-    font-family: var(--tss-font-family, "Segoe UI", SegoeUI, "Helvetica Neue", Helvetica, Arial, sans-serif);
+    font-family: var(--tss-sansserif-font-family);
     font-size: var(--tss-font-size-small);
     line-height: 1.6;
     word-wrap: break-word;
@@ -239,7 +239,7 @@
 .tss-markdown code,
 .tss-markdown kbd,
 .tss-markdown pre {
-    font-family: var(--tss-monospace-font-family, ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace);
+    font-family: var(--tss-monospace-font-family);
 }
 
     .tss-markdown code {

--- a/Tesserae/tps/assets/css/tss.omnibox.css
+++ b/Tesserae/tps/assets/css/tss.omnibox.css
@@ -571,7 +571,7 @@
 
 .tss-omnibox-help-trigger {
     color: var(--tss-primary-foreground-color);
-    font-family: var(--tss-font-mono, monospace);
+    font-family: var(--tss-monospace-font-family);
     font-weight: 600;
 }
 

--- a/Tesserae/tps/assets/css/tss.omniresult.css
+++ b/Tesserae/tps/assets/css/tss.omniresult.css
@@ -340,6 +340,19 @@
     margin: 0;
 }
 
+/* An entry that emptied itself - a label that looked something up and found nothing to say, and took
+   itself out of the document - must take its separator with it, or the line keeps a dot with nothing on
+   one side of it. The dot belongs to the entry, so hiding the entry is all it takes. */
+.tss-omniresult-footer > .tss-omniresult-footer-entry:empty {
+    display: none;
+}
+
+/* Same for one holding nothing but a label with neither text nor mark in it - a label says so about
+   itself (see InlineLabel), so the footer does not have to look inside it. */
+.tss-omniresult-footer > .tss-omniresult-footer-entry:has(> .tss-inlinelabel-empty:only-child) {
+    display: none;
+}
+
 /* An entry is a box around one InlineLabel, and the label does its own ellipsizing - so the entry must
    NOT clip: a hovered label's background reaches 4px past its text on each side, and hiding the
    overflow cut the right end of it (the left survived by eating into the separator's gap). */

--- a/Tesserae/tps/assets/css/tss.plan.css
+++ b/Tesserae/tps/assets/css/tss.plan.css
@@ -365,7 +365,7 @@
 .tss-plan-substep-message {
     font-size: var(--tss-font-size-xsmall);
     color: var(--tss-secondary-foreground-color);
-    font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+    font-family: var(--tss-monospace-font-family);
     margin-top: 1px;
 }
 

--- a/Tesserae/tps/assets/css/tss.sidebar.css
+++ b/Tesserae/tps/assets/css/tss.sidebar.css
@@ -95,11 +95,7 @@
    it on shifts nothing. :not(.tss-disabled) is what carries this past .tss-btn-default's own colours. */
 .tss-sidebar-btn.tss-sidebar-selected:not(.tss-disabled),
 .tss-sidebar-btn-open.tss-sidebar-selected > .tss-sidebar-btn:not(.tss-disabled),
-.tss-sidebar-btn-open.tss-sidebar-selected > a > .tss-sidebar-btn:not(.tss-disabled),
-.tss-sidebar-nav.tss-sidebar-selected > .tss-sidebar-nav-header.tss-sidebar-btn-open > .tss-btn:not(.tss-disabled),
-.tss-sidebar-nav.tss-sidebar-selected > .tss-sidebar-nav-header.tss-sidebar-btn-open > a > .tss-btn:not(.tss-disabled),
-.tss-sidebar-nav.tss-sidebar-selected > .tss-btn:not(.tss-disabled),
-.tss-sidebar-nav.tss-sidebar-selected > a > .tss-btn:not(.tss-disabled) {
+.tss-sidebar-btn-open.tss-sidebar-selected > a > .tss-sidebar-btn:not(.tss-disabled) {
     color: var(--tss-primary-background-color);
     border-color: var(--tss-primary-background-color);
     background: rgba(var(--tss-primary-background-color-root), 0.1);
@@ -111,11 +107,7 @@
 .tss-sidebar-btn-open.tss-sidebar-selected > .tss-sidebar-btn:not(.tss-disabled):hover,
 .tss-sidebar-btn-open.tss-sidebar-selected > a > .tss-sidebar-btn:not(.tss-disabled):hover,
 .tss-sidebar-btn-open.tss-sidebar-selected:hover > .tss-sidebar-btn:not(.tss-disabled),
-.tss-sidebar-btn-open.tss-sidebar-selected:hover > a > .tss-sidebar-btn:not(.tss-disabled),
-.tss-sidebar-nav.tss-sidebar-selected > .tss-sidebar-nav-header.tss-sidebar-btn-open > .tss-btn:not(.tss-disabled):hover,
-.tss-sidebar-nav.tss-sidebar-selected > .tss-sidebar-nav-header.tss-sidebar-btn-open > a > .tss-btn:not(.tss-disabled):hover,
-.tss-sidebar-nav.tss-sidebar-selected > .tss-btn:not(.tss-disabled):hover,
-.tss-sidebar-nav.tss-sidebar-selected > a > .tss-btn:not(.tss-disabled):hover {
+.tss-sidebar-btn-open.tss-sidebar-selected:hover > a > .tss-sidebar-btn:not(.tss-disabled) {
     color: var(--tss-primary-background-color);
     border-color: var(--tss-primary-background-color);
     background: rgba(var(--tss-primary-background-color-root), 0.18);
@@ -127,11 +119,7 @@
    on a dark surface itself. The border stays the primary - it is a line on the background, not type. */
 .tss-dark-mode .tss-sidebar-btn.tss-sidebar-selected:not(.tss-disabled),
 .tss-dark-mode .tss-sidebar-btn-open.tss-sidebar-selected > .tss-sidebar-btn:not(.tss-disabled),
-.tss-dark-mode .tss-sidebar-btn-open.tss-sidebar-selected > a > .tss-sidebar-btn:not(.tss-disabled),
-.tss-dark-mode .tss-sidebar-nav.tss-sidebar-selected > .tss-sidebar-nav-header.tss-sidebar-btn-open > .tss-btn:not(.tss-disabled),
-.tss-dark-mode .tss-sidebar-nav.tss-sidebar-selected > .tss-sidebar-nav-header.tss-sidebar-btn-open > a > .tss-btn:not(.tss-disabled),
-.tss-dark-mode .tss-sidebar-nav.tss-sidebar-selected > .tss-btn:not(.tss-disabled),
-.tss-dark-mode .tss-sidebar-nav.tss-sidebar-selected > a > .tss-btn:not(.tss-disabled) {
+.tss-dark-mode .tss-sidebar-btn-open.tss-sidebar-selected > a > .tss-sidebar-btn:not(.tss-disabled) {
     color: color-mix(in srgb, var(--tss-primary-background-color) 55%, white);
     background: rgba(var(--tss-primary-background-color-root), 0.22);
 }
@@ -140,13 +128,22 @@
 .tss-dark-mode .tss-sidebar-btn-open.tss-sidebar-selected > .tss-sidebar-btn:not(.tss-disabled):hover,
 .tss-dark-mode .tss-sidebar-btn-open.tss-sidebar-selected > a > .tss-sidebar-btn:not(.tss-disabled):hover,
 .tss-dark-mode .tss-sidebar-btn-open.tss-sidebar-selected:hover > .tss-sidebar-btn:not(.tss-disabled),
-.tss-dark-mode .tss-sidebar-btn-open.tss-sidebar-selected:hover > a > .tss-sidebar-btn:not(.tss-disabled),
-.tss-dark-mode .tss-sidebar-nav.tss-sidebar-selected > .tss-sidebar-nav-header.tss-sidebar-btn-open > .tss-btn:not(.tss-disabled):hover,
-.tss-dark-mode .tss-sidebar-nav.tss-sidebar-selected > .tss-sidebar-nav-header.tss-sidebar-btn-open > a > .tss-btn:not(.tss-disabled):hover,
-.tss-dark-mode .tss-sidebar-nav.tss-sidebar-selected > .tss-btn:not(.tss-disabled):hover,
-.tss-dark-mode .tss-sidebar-nav.tss-sidebar-selected > a > .tss-btn:not(.tss-disabled):hover {
+.tss-dark-mode .tss-sidebar-btn-open.tss-sidebar-selected:hover > a > .tss-sidebar-btn:not(.tss-disabled) {
     color: color-mix(in srgb, var(--tss-primary-background-color) 55%, white);
     background: rgba(var(--tss-primary-background-color-root), 0.32);
+}
+
+/* A nav is a group, not a destination - it reads as selected while something inside it is open - so it
+   gets the plain hover the rest of the rail uses rather than the primary wash a selected button gets.
+   The wash also recoloured everything inside the header, which on a dark surface left the glyph the same
+   colour as the fill it sat on; the hover colours are the ones the buttons are drawn for. */
+.tss-sidebar-nav.tss-sidebar-selected > .tss-sidebar-nav-header.tss-sidebar-btn-open > .tss-btn:not(.tss-disabled),
+.tss-sidebar-nav.tss-sidebar-selected > .tss-sidebar-nav-header.tss-sidebar-btn-open > a > .tss-btn:not(.tss-disabled),
+.tss-sidebar-nav.tss-sidebar-selected > .tss-btn:not(.tss-disabled),
+.tss-sidebar-nav.tss-sidebar-selected > a > .tss-btn:not(.tss-disabled) {
+    color: var(--tss-default-foreground-hover-color);
+    border-color: var(--tss-default-background-hover-color);
+    background: var(--tss-default-background-hover-color);
 }
 
 

--- a/Tesserae/tps/assets/css/tss.toolcall.css
+++ b/Tesserae/tps/assets/css/tss.toolcall.css
@@ -53,7 +53,7 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    font-family: var(--tss-monospace-font-family, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+    font-family: var(--tss-monospace-font-family);
     font-size: 12px;
 }
 
@@ -268,7 +268,7 @@
 }
 
 .tss-toolsused-modal-detail-title {
-    font-family: var(--tss-monospace-font-family, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+    font-family: var(--tss-monospace-font-family);
     font-weight: var(--tss-font-weight-medium, 500);
 }
 
@@ -342,7 +342,7 @@
 
 .tss-toolsused-list-text {
     flex: 1;
-    font-family: var(--tss-monospace-font-family, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+    font-family: var(--tss-monospace-font-family);
     font-size: 13px;
     color: var(--tss-colors-neutral-800, #1f2937);
     overflow: hidden;
@@ -447,7 +447,7 @@
     border: 1px solid var(--tss-default-border-color);
     border-radius: 6px;
     background: var(--tss-secondary-background-color);
-    font-family: var(--tss-monospace-font-family, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+    font-family: var(--tss-monospace-font-family);
     font-size: 12px;
     white-space: pre-wrap;
     word-break: break-word;


### PR DESCRIPTION
Part of a pair with `curiosity-ai/mosaik#claude/mosaik-tesserae-ui-fixes-3r16qd`, which is what these changes were validated against (built locally and dropped over the package in the NuGet cache).

## Fonts

The toolkit now draws from exactly two stacks, and every rule that sets a `font-family` names one of them with **no inline fallback list of its own**:

- `--tss-sansserif-font-family` — everything but code
- `--tss-monospace-font-family` — code, paths, identifiers

That repetition was the bug: `--tss-font-family`, `--tss-font-mono`, a bare `monospace` and a hard-coded `Segoe UI` stack were all in play, each carrying its own fallbacks, so overriding a variable only changed the font where a rule happened to name it. Both are declared once in `tss.common.css` and reachable from C# as `Theme.Fonts.SansSerif` / `Theme.Fonts.Monospace`.

Also added `font-family: inherit` for `input` / `textarea` / `select` / `button` / `optgroup` — form controls don't inherit the document font, so an override otherwise left the browser's own font inside every input.

The sans-serif default leads with **Plus Jakarta Sans**, then Inter. The toolkit ships neither font file; an app that wants them serves its own `@font-face` (mosaik does).

## CommandPalette

**The search box is an `OmniBox`** in `Search` mode rather than a bare `<input>`, so a palette can offer the snaps, value filters, history and suggestions the app's own search box offers instead of being a lesser search than the page it stands in for:

```csharp
palette.ConfigureSearchBox(box =>
{
    box.RegisterFilterSnaps(myFilters);
    box.SetSearchPlaceholder("Type a filter or search...");
});
```

- `.SearchBox` / `.ConfigureSearchBox(Action<OmniBox>)` reach it.
- `OnSearch` now hands over the parsed `OmniBox.SearchQuery` — raw text plus whatever chips the box picked out of it, so a filter typed on its own (`kind:pdf`) is a search like any other. The `string` overload is kept for source compatibility.
- A chip being added or removed re-runs the search the way typing does. This was a genuine gap found while testing: committing a `kind:` suggestion left the palette showing results for the query it had before the chip.
- Enter comes from the box's own search event, because the OmniBox stops that key itself (`StopEvent` uses `stopImmediatePropagation`).

New on OmniBox: `.CurrentSearchQuery`, the same `SearchQuery` pressing Enter would raise, for a host that answers as the query is typed.

**Light dismiss.** Clicking beside the palette did nothing. The cause is structural rather than a missing handler: `.tss-commandpalette-positioner` is a full-size element stacked *above* `.tss-commandpalette-overlay`, so a click in the margin landed on the positioner and the overlay's handler never fired. Both answer now, behind `CanLightDismiss` / `LightDismiss()` / `NoLightDismiss()` mirroring `Modal`, and Escape closes the palette wherever the focus ended up after a row was activated.

**Result rows** are `inline-flex` again rather than `block`, taking the item's full width and free to shrink (`flex: 1 1 auto; min-width: 0`) so a long title ellipsizes instead of widening the palette.

## Sidebar

A `SidebarNav` marked selected was given the primary wash a selected *button* gets, which recoloured everything inside the header — on a dark surface that left the glyph the same colour as the fill behind it, so the icons disappeared. A nav is a group rather than a destination, so it gets the plain hover instead, in both themes.

`SidebarSearchBox` grows `.Text` / `.SetText(...)` / `.Focus()` for a host that drives the box itself.

## Keyboard shortcut chip

`.tss-kbd-key` was painted with `--tss-secondary-background-color`, which is the colour of the search field *and* of the sidebar it sits on — so the chip was invisible in exactly the two places it is used. It is a wash of the opposite tone now (`--tss-colors-dark-neutral-0-root` at low alpha), which reads as a raised key on a light theme and on a dark one:

| | chip background | on |
|---|---|---|
| light | `rgba(24, 25, 26, 0.07)` | `rgb(249, 250, 251)` |
| dark | `rgba(255, 255, 255, 0.07)` | `rgb(23, 24, 33)` |

## OmniResult footer

A footer entry hides itself — separating dot included — when the label inside it has nothing left to say. `InlineLabel` says so about itself with a `tss-inlinelabel-empty` class (and `IsEmpty` is public now) rather than the footer reaching inside it to find out.

## Validation

Driven with Playwright against the mosaik front-end and a local Curiosity Workspace, in light and dark mode:

- Plus Jakarta Sans loads and applies; overriding either variable to an obviously wrong font (Comic Sans) re-fonted the body **and** the kbd chips, confirming the single-source-of-truth path.
- Palette opens with an OmniBox, `kind:` offers its 17 filter suggestions, `kind:PDFs` becomes a chip and re-triggers the search, result rows are full-width flex, and a click in the margin closes it.
- Selected nav header keeps a visible icon in both themes (`rgb(32,31,30)` on light, `rgb(255,255,255)` on dark).
- An emptied footer entry computes `display: none`, so its dot is not painted.

Skill references updated alongside the code (`command-palette`, `omni-box`, `sidebar`, `inline-label`, `styling`, `theme-colors`), per the repo's "keep skills in sync" rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013REMmHfXfZKcZQHea9Xxk6


---
_Generated by [Claude Code](https://claude.ai/code/session_013REMmHfXfZKcZQHea9Xxk6)_