### PR TITLE
Keep webfonts out of the default font stacks

### DIFF
--- a/Tesserae/skills/references/styling.md
+++ b/Tesserae/skills/references/styling.md
@@ -23,11 +23,12 @@ On components implementing `ITextFormating` (`ITextFormatingExtensions`):
 Tesserae draws with exactly two font stacks, and every rule that sets a
 `font-family` names one of them with no inline fallback list:
 
-- `--tss-sansserif-font-family` — everything but code. Defaults to
-  `"Plus Jakarta Sans", "Inter", "Segoe UI", …`; Tesserae does not ship the font
-  files, so an app that wants the first name in that list serves its own
-  `@font-face` for it.
+- `--tss-sansserif-font-family` — everything but code.
 - `--tss-monospace-font-family` — code, paths, identifiers.
+
+Both default to system fonts only. A webfont has to be served by whoever uses
+it, so the toolkit never names one — an app that ships one puts it in front by
+overriding the variable.
 
 Override either one on `:root` (or on any sub-tree) and the whole UI follows,
 form controls included. From C#, reference them as `Theme.Fonts.SansSerif` /

--- a/Tesserae/tps/assets/css/tss.common.css
+++ b/Tesserae/tps/assets/css/tss.common.css
@@ -3,8 +3,11 @@
     /* Families - the only two font stacks Tesserae draws with. Every rule that sets a font-family
        references one of them with no inline fallback list, so an app that overrides either variable
        (on :root, or on a sub-tree) actually replaces the stack everywhere instead of only in the
-       places that happened to name it. */
-    --tss-sansserif-font-family: "Plus Jakarta Sans", "Inter", "Segoe UI", SegoeUI, "Helvetica Neue", Helvetica, Arial, sans-serif;
+       places that happened to name it.
+       Both name system fonts only: a webfont has to be served by whoever uses it, so naming one here
+       would be a promise the toolkit cannot keep. An app that ships one puts it in front by overriding
+       the variable. */
+    --tss-sansserif-font-family: "Segoe UI", SegoeUI, "Helvetica Neue", Helvetica, Arial, sans-serif;
     --tss-monospace-font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
     /* Weights */
     --tss-font-weight-regular: 400;


### PR DESCRIPTION
Follow-up to #300, which had already merged by the time this correction was ready — so it is a new PR rather than another commit on that branch.

#300 left `--tss-sansserif-font-family` defaulting to a stack that led with **Plus Jakarta Sans** and **Inter**. Neither is shipped by the toolkit, so naming them was a promise it cannot keep: a consumer that doesn't serve those `@font-face` rules silently falls through to the next entry, and the declared default describes a font nobody has.

Both stacks name **system fonts only** now. The sans-serif default is the stack it always was:

```css
--tss-sansserif-font-family: "Segoe UI", SegoeUI, "Helvetica Neue", Helvetica, Arial, sans-serif;
```

An app that ships a webfont puts it in front by overriding the variable, which is the whole point of there being one. That is what mosaik does — its `--font-family-sans-serif` (Plus Jakarta Sans, then Inter, then the system stack) is pointed at `--tss-sansserif-font-family`, so the value #300 had hard-coded here now lives on the side that actually serves the font files.

Net effect: #300's change to that line becomes purely "read the variable" rather than "read the variable *and* change the default font".

`styling.md` updated to match.

## A note on scope

You asked to remove Plus Jakarta Sans. I removed Inter as well, since it is a webfont on exactly the same footing — the reason given ("shouldn't mention fonts that are not in the Tesserae project") applies to both, and dropping it restores the pre-existing default exactly. Say the word if you want Inter kept as a fallback and I'll put it back.

## Validation

Rebuilt Tesserae, installed it over the package in the NuGet cache, rebuilt the mosaik front-end and checked in the browser that the app's font is unaffected — mosaik's override supplies it, so nothing regressed from removing it here:

```
--tss-sansserif-font-family -> "Plus Jakarta Sans", "Inter", "Segoe UI", -apple-system, …
body font-family            -> "Plus Jakarta Sans", Inter, "Segoe UI", -apple-system, …
Plus Jakarta Sans loaded    -> true
```

Overriding the variable to an obviously wrong font still re-fonts the body and the kbd chips, so the single-source-of-truth path is intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013REMmHfXfZKcZQHea9Xxk6


---
_Generated by [Claude Code](https://claude.ai/code/session_013REMmHfXfZKcZQHea9Xxk6)_