### PR TITLE
OmniResult: allow overriding the size of a text icon tile

### DIFF
--- a/Tesserae.Tests/src/Samples/Components/OmniResultSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/OmniResultSample.cs
@@ -151,11 +151,12 @@ namespace Tesserae.Tests.Samples
         private IComponent Tiles()
         {
             return FeatureCard("Icon tiles", "A glyph, or the file type spelled out",
-                "SetIcon(icon, color) puts a UIcons glyph on the tile in that color, over a wash of the same color computed from it — a pale tint under a light theme, a deep one under a dark theme, cached so a list drawing the same handful of file-type colors only computes each once. SetIcon(text, color) spells the type out instead, for a format no glyph says plainly. Any component works too, for a thumbnail or an avatar.",
+                "SetIcon(icon, color) puts a UIcons glyph on the tile in that color, over a wash of the same color computed from it — a pale tint under a light theme, a deep one under a dark theme, cached so a list drawing the same handful of file-type colors only computes each once. SetIcon(text, color) spells the type out instead, for a format no glyph says plainly, at any of the standard TextSize sizes. Any component works too, for a thumbnail or an avatar.",
                 VStack().WS().Children(
                     OmniResult(Hits[1], "BRK-SEN-447 calibration procedure.pdf").SetIcon(UIcons.FilePdf, "#ef4444").SetSource("#0061d5", "Box").SetFooterEntries("SetIcon(UIcons.FilePdf, \"#ef4444\")"),
                     OmniResult(Hits[1], "Q3 line review.pptx").SetIcon("PPTX", "#f97316").SetSource("#0061d5", "Box").SetFooterEntries("SetIcon(\"PPTX\", \"#f97316\")"),
                     OmniResult(Hits[2], "Sensor drift analysis.xlsx").SetIcon("XLSX", "#16a34a").SetSource("#0061d5", "Box").SetFooterEntries("SetIcon(\"XLSX\", \"#16a34a\")"),
+                    OmniResult(Hits[2], "Line 4 sensor events.jsonl").SetIcon("JSONL", "#0ea5e9", TextSize.Tiny).SetSource("#0061d5", "Box").SetFooterEntries("SetIcon(\"JSONL\", \"#0ea5e9\", TextSize.Tiny) — a longer type at a smaller size"),
                     OmniResult(Hits[6], "brake-calibration-log.txt").SetIcon("TXT", "#94a3b8").SetSource("#0061d5", "Box").SetFooterEntries("A grey color stays grey in both themes"),
                     OmniResult(Hits[0], "curiosity-logo.svg").SetIcon(Image("./assets/img/curiosity-logo.svg")).SetSource("#0061d5", "Box").SetFooterEntries("SetIcon(IComponent) — a thumbnail covers the tile"),
                     OmniResult(Hits[0], "brake-sensor-reports").SetIcon(UIcons.Folder).SetSource("#0061d5", "Box").SetFooterEntries("No color: the tile falls back to the theme's own")));

--- a/Tesserae/skills/references/omni-result.md
+++ b/Tesserae/skills/references/omni-result.md
@@ -57,7 +57,10 @@ stands for. Also `new OmniResult<T>(result, title)`. Bring factories into scope 
   over a wash computed from that same color: a pale tint under a light theme, a deep one under a dark
   theme. Both variants are written to the element, so flipping the theme at runtime needs no redraw,
   and the computed pair is cached per color (a list drawing one color per file type only pays once).
-- `.SetIcon(string text, string color = null)` — a short type name ("PPTX", "CSV") in place of a glyph.
+- `.SetIcon(string text, string color = null, TextSize? size = null)` — a short type name ("PPTX",
+  "CSV") in place of a glyph. It is drawn at the size the tile is sized for; pass a `TextSize`
+  (`Tiny`, `XSmall`, `Small`, …) to override that — `Tiny` for text longer than the three or four
+  letters a type name usually is.
 - `.SetIcon(IComponent, string color = null)` — an `Image` thumbnail, an `Avatar`, an emoji.
 - `.SetIconBadge(IComponent badge, OmniResultBadgeCorner corner = BottomRight)` — a marker pinned to a
   corner of the tile, drawn outside its clipping: where the result came from, that it is pinned.

--- a/Tesserae/src/Components/OmniResult.cs
+++ b/Tesserae/src/Components/OmniResult.cs
@@ -346,13 +346,17 @@ namespace Tesserae
 
         /// <summary>
         /// Puts the given short text on the tile in place of an icon - a file type, "PPTX" or "CSV", where
-        /// no glyph says it as plainly - in the given color, over a paler wash of that same color.
+        /// no glyph says it as plainly - in the given color, over a paler wash of that same color. It is drawn
+        /// at the size the tile is sized for unless <paramref name="size"/> asks for another one - text longer
+        /// than the three or four letters a type name usually is wants <see cref="TextSize.Tiny"/>.
         /// </summary>
-        public OmniResult<T> SetIcon(string text, string color = null)
+        public OmniResult<T> SetIcon(string text, string color = null, TextSize? size = null)
         {
             ClearChildren(_iconContainer);
 
-            _iconContainer.appendChild(Span(Att("tss-omniresult-icon-text", text: text ?? string.Empty)));
+            var className = size.HasValue ? $"tss-omniresult-icon-text {size.Value}" : "tss-omniresult-icon-text";
+
+            _iconContainer.appendChild(Span(Att(className, text: text ?? string.Empty)));
 
             return TintIcon(color);
         }

--- a/Tesserae/tps/assets/css/tss.omniresult.css
+++ b/Tesserae/tps/assets/css/tss.omniresult.css
@@ -177,11 +177,16 @@
 
 /* A file type spelled out ("PPTX", "XLSX") in place of a glyph. */
 .tss-omniresult-icon-text {
-    font-size: 12px;
     font-weight: 700;
     letter-spacing: .02em;
     text-transform: uppercase;
     line-height: 1;
+}
+
+/* The size the tile is sized for, declared through :where() so it costs no specificity - a tss-fontsize-*
+   class from the TextSize passed to SetIcon then wins over it without needing !important. */
+:where(.tss-omniresult-icon-text) {
+    font-size: 12px;
 }
 
 .tss-omniresult-icon img {


### PR DESCRIPTION
`OmniResult<T>.SetIcon(string text, …)` drew the spelled-out file type at a fixed 12px, which crops a type name longer than the three or four letters the 34px tile is sized for. It now takes an optional `TextSize`:

```csharp
OmniResult(hit, "Line 4 sensor events.jsonl").SetIcon("JSONL", "#0ea5e9", TextSize.Tiny)
```

The size is applied as the standard `tss-fontsize-*` class, the same way `Icon` and `Button.SetIcon` take a `TextSize`.

### The CSS bit worth a look

`.tss-omniresult-icon-text` hard-coded `font-size: 12px` — the same specificity as `.tss-fontsize-*`, so adding the class alone would not have won. The first attempt was to default the parameter to `TextSize.Small` and drop the declaration, but `--tss-font-size-small` resolves to **13px** in the current theme, not 12px, so that silently resized every existing tile (browser-verified: `XLSX` / `PPTX` started overflowing the tile).

Instead the default now lives in a zero-specificity `:where(.tss-omniresult-icon-text)` rule, so existing calls still render at exactly 12px and any `TextSize` class overrides it without `!important`. The `.tss-modalstack-peek` shrink rule (0,3,0) still wins over both.

### Verification

Built the samples site and measured in headless Chromium: tiles with no size compute 12px as before, the new `TextSize.Tiny` tile computes 10px and no longer overflows.

### Also updated

- `Tesserae/skills/references/omni-result.md` — the signature and when to reach for a smaller size.
- `Tesserae.Tests` — a `JSONL` row in the "Icon tiles" section demonstrating it.

Not touched: the matching page in the `documentation` repo wants the same signature update, but it is outside this session's repo scope.

---
_Generated by [Claude Code](https://claude.ai/code/session_0117PCXnHLYMB8azWDEXxeKU)_