### PR TITLE
CSS corrections: ToolAgentSelector rows, IconToggle's selected pill, OmniResult footer separators

### DIFF
--- a/Tesserae/tps/assets/css/tss.icontoggle.css
+++ b/Tesserae/tps/assets/css/tss.icontoggle.css
@@ -66,7 +66,11 @@
     .tss-icon-toggle > .tss-stack-item > .tss-btn.tss-icon-toggle-item.tss-icon-toggle-item-selected:hover {
         background: var(--tss-default-background-color);
         color: var(--tss-default-foreground-color);
-        box-shadow: var(--tss-shadow-sm);
+        /* --tss-shadow-sm on its own is a 5%-opacity drop in the light theme, which against a track only
+           a few percent off the pill's own colour left the selection reading as barely more than a hover.
+           A hairline in the foreground colour gives the pill an edge in either theme; the drop stays for
+           the lift. */
+        box-shadow: var(--tss-shadow-sm), 0 0 0 1px color-mix(in srgb, var(--tss-default-foreground-color) 14%, transparent);
     }
 
     /* In the dark theme the default background is darker than the track, and a pill darker than what

--- a/Tesserae/tps/assets/css/tss.omniresult.css
+++ b/Tesserae/tps/assets/css/tss.omniresult.css
@@ -358,6 +358,14 @@
     display: none;
 }
 
+/* And for one holding nothing but a component that collapsed itself, which is how anything that is not
+   an InlineLabel says it has nothing to show - AddFooterEntry takes any component, and one that looks
+   something up (a list of neighbours, say) only finds out there is nothing after the entry already
+   exists. So this has to be a rule the collapsing satisfies later, not a check when the entry is added. */
+.tss-omniresult-footer > .tss-omniresult-footer-entry:has(> .tss-collapse:only-child) {
+    display: none;
+}
+
 /* An entry is a box around one InlineLabel, and the label does its own ellipsizing - so the entry must
    NOT clip: a hovered label's background reaches 4px past its text on each side, and hiding the
    overflow cut the right end of it (the left survived by eating into the separator's gap). */

--- a/Tesserae/tps/assets/css/tss.toolagentselector.css
+++ b/Tesserae/tps/assets/css/tss.toolagentselector.css
@@ -123,7 +123,11 @@
 .tss-toolagent-item {
     position: relative;
     display: flex;
-    align-items: flex-start;
+    /* The box, the icon tile and the text block are all different heights, so they have to be centred
+       against each other rather than hung from the top of the row: compact rows have one line of text
+       and looked plainly misaligned, and a row with a description centres the way any list row with a
+       subtitle does. */
+    align-items: center;
     gap: 10px;
     padding: 8px;
     border-radius: 8px;
@@ -149,7 +153,6 @@
         flex-shrink: 0;
         width: 18px;
         height: 18px;
-        margin-top: 1px;
         border-radius: 4px;
         border: 1px solid var(--tss-default-foreground-color);
         background: var(--tss-default-background-color);
@@ -165,13 +168,15 @@
             content: "";
             position: absolute;
             display: block;
-            left: 5px;
-            top: 1px;
+            /* The tick's ink is the element's right and bottom borders, which span its whole box, so
+               centring the element is what centres the tick. Fixed offsets left it high and right. */
+            left: 50%;
+            top: 50%;
             width: 5px;
             height: 10px;
             border: solid var(--tss-primary-foreground-color);
             border-width: 0 2px 2px 0;
-            transform: rotate(45deg);
+            transform: translate(-50%, -50%) rotate(45deg);
         }
 
     .tss-toolagent-item-icon {


### PR DESCRIPTION
Four CSS corrections, found while building against Tesserae in Curiosity Workspace. All four were being worked around app-side; they belong here because none of them is app-specific — they are wrong for any consumer.

## `tss.toolagentselector.css`

**A row's three parts weren't aligned to each other.** `.tss-toolagent-item` used `align-items: flex-start`, hanging the checkbox (18px), the icon tile (26px) and the text block (one or two lines) from the top of the row. A **compact** row — where the description is `display: none` and the text is a single line — read as plainly misaligned: the box sits high against the icon tile, and neither lines up with the label.

Now `align-items: center`, which is also how any list row with a subtitle centres its leading elements, so the non-compact case still reads correctly. That in turn made the `margin-top: 1px` on `.tss-toolagent-item-checkmark` redundant — it existed only to lift the box against the title's ascender under `flex-start` — so it's gone.

**The tick inside a checked box was off-centre.** It was positioned with fixed offsets:

```css
left: 5px;
top: 1px;
transform: rotate(45deg);
```

which left it above and to the right of the box's centre. The tick's ink is the element's right and bottom borders, so it spans the element's whole 5×10 box — meaning centring the *element* is what centres the tick:

```css
left: 50%;
top: 50%;
transform: translate(-50%, -50%) rotate(45deg);
```

## `tss.icontoggle.css`

**Which segment is selected read as barely more than a hover, in the light theme.** The selected pill is drawn in `--tss-default-background-color` on a track only a few percent off it, separated by `--tss-shadow-sm` — which in the light theme is `0 1px 2px 0 rgba(0, 0, 0, 0.05)`. A 5%-opacity drop between a white pill and a 7%-dark track is close to invisible.

The pill now also gets a hairline in the foreground colour, which gives it an edge in either theme, and keeps the drop for the lift:

```css
box-shadow: var(--tss-shadow-sm), 0 0 0 1px color-mix(in srgb, var(--tss-default-foreground-color) 14%, transparent);
```

The dark theme already has a rule for this problem in the other direction ("a pill darker than what it sits in reads as recessed rather than raised"); it replaces only `background`, so it picks the hairline up too. I deliberately did **not** touch the track's `7%` foreground mix or the unselected label colour — both are shared by the two themes, and retuning them to fix the light theme would have narrowed the dark theme's own contrast.

## `tss.omniresult.css`

**A footer entry holding only a collapsed component still drew its separating dot.** The footer already covers two of the three ways an entry can turn out to have nothing in it — `:empty`, and `:has(> .tss-inlinelabel-empty:only-child)` — so the dot goes with the entry. The third way is a component that collapsed itself.

`AddFooterEntry` takes any component, and `Collapse()` (`display: none`) is how anything that is not an `InlineLabel` says it has nothing to show. A component that looks something up — a list of a node's neighbours, say — only discovers there is nothing *after* the entry exists, leaving:

```html
<div class="tss-omniresult-footer-entry"><div class="tss-collapse"><div></div></div></div>
```

laying out and drawing its `::before` dot against no content, so a file's footer showed a stray `·` between two real facts. Hence a third rule that the later collapse satisfies, rather than a check when the entry is added:

```css
.tss-omniresult-footer > .tss-omniresult-footer-entry:has(> .tss-collapse:only-child) {
    display: none;
}
```

## Notes

- CSS only — no C# changed. Worth saying for the ToolAgentSelector one, because the alignment looks like a missing `AlignItemsCenter`: the rows are built as a raw `Label(Att("tss-toolagent-item"), …)` with plain divs inside (`ToolAgentSelector.cs:504`), not a `Stack`, so the alignment lives only in the stylesheet.
- Every file touched was already listed in `Tesserae/tps.json`, so nothing to register.
- `dotnet build Tesserae/Tesserae.csproj` succeeds.
- Each fix is its own commit, so any one can be dropped on its own.
- I have not been able to eyeball the rendered result — these were reasoned from the geometry, the theme variables and the emitted DOM, so the two changes with a visual judgement in them (the pill's hairline weight, and centring a row that *does* have a description) are worth a designer's glance before merging. The tick centring and the footer rule are mechanical.