### PR TITLE
PixelAvatar: stop an overlapping perch covering 1px of its host, and add three designs

### DIFF
--- a/Tesserae.Tests/src/Samples/Components/PixelAvatarSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/PixelAvatarSample.cs
@@ -1,4 +1,4 @@
-using static Tesserae.UI;
+﻿using static Tesserae.UI;
 using static Tesserae.Tests.Samples.SamplesHelper;
 using static Transpose.Core.dom;
 
@@ -15,7 +15,7 @@ namespace Tesserae.Tests.Samples
                .SampleTitle(typeof(PixelAvatarSample), UIcons.Cat, "An animated pixel-art avatar built out of one div per pixel")
                .FlatSection(Stack().Children(
                     Card(VStack().WS().Children(
-                        TextBlock("PixelAvatar renders a small animated sprite as a grid of absolutely positioned square divs. The artwork is stored once, as a byte grid of palette indices, and each of the twelve designs is nothing more than a palette of colors for those indices - so recoloring an avatar costs eleven CSS variable writes and no repaint of the sprite."),
+                        TextBlock("PixelAvatar renders a small animated sprite as a grid of absolutely positioned square divs. The artwork is stored once, as a byte grid of palette indices, and each of the fifteen designs is nothing more than a palette of colors for those indices - so recoloring an avatar costs eleven CSS variable writes and no repaint of the sprite."),
                         TextBlock("Thirteen animations are available. The four *Idle animations loop forever, while the rest play once and hand over to a follow-up animation: Sit settles into SitIdle, Stretch finishes by sitting down, JumpUp is followed by JumpDown, and so on. Idle, SitIdle and CrouchIdle hold their first frame for a random 5-10 seconds rather than cycling continuously, so a resting cat looks still rather than fidgety - and AutoIdle drifts between those three poses on its own."),
                         TextBlock("Avatars can be attached to any other component, which perches them on one of its edges without affecting its layout."),
                         TextBlock("The extracted palettes are the source artwork's own colors, which means some of them are pure white and others near-black. A hairline halo in the theme's contrasting color is drawn by default so every design stays legible in both light and dark mode; Outline(false) turns it off.")))
@@ -29,8 +29,8 @@ namespace Tesserae.Tests.Samples
                        .SetTitle("Best Practices")))
                .FlatSection(Stack().Children(
                     Card(VStack().WS().Children(
-                        SampleSubTitle("The twelve designs, attached to buttons"),
-                        TextBlock("Every avatar below is attached to the top edge of a button. Click a button to switch the animation its cat is playing. Eight designs come from the source sprite sheets; Grey, Sparkle, Lynx and Sudo are authored against the same palette indices. Sudo also carries an accent - an extra half-size pixel on each ear tip, which is not a palette index but an overlay."),
+                        SampleSubTitle("The fifteen designs, attached to buttons"),
+                        TextBlock("Every avatar below is attached to the top edge of a button. Click a button to switch the animation its cat is playing. Eight designs come from the source sprite sheets; Grey, Sparkle, Lynx, Sudo, Cobalt, Ember and Bubblegum are authored against the same palette indices. Sudo also carries an accent - an extra half-size pixel on each ear tip, which is not a palette index but an overlay."),
                         DesignGallery(),
                         SampleSubTitle("Every animation"),
                         TextBlock("Pick an animation to play it on a larger avatar. Non-looping animations chain into their follow-up, so the label updates on its own once they finish. The three resting poses hold their first frame for 5-10 seconds rather than cycling, and AutoIdle drifts between them."),

--- a/Tesserae/skills/references/pixel-avatar.md
+++ b/Tesserae/skills/references/pixel-avatar.md
@@ -1,13 +1,13 @@
----
+﻿---
 name: pixel-avatar
-description: An animated pixel-art cat avatar drawn as one absolutely-positioned div per pixel, with twelve coat designs and thirteen animations, attachable to any other component. Use when adding a small animated mascot or decorative character to a Tesserae (C#/Transpose) app.
+description: An animated pixel-art cat avatar drawn as one absolutely-positioned div per pixel, with fifteen coat designs and thirteen animations, attachable to any other component. Use when adding a small animated mascot or decorative character to a Tesserae (C#/Transpose) app.
 ---
 
 # PixelAvatar
 
 `PixelAvatar` renders a 10x8 pixel-art sprite as a grid of absolutely positioned square
 divs. The artwork lives in the library as a byte grid of palette indices
-(`PixelAvatarSprites`), so all twelve designs share the same frames and differ only in
+(`PixelAvatarSprites`), so all fifteen designs share the same frames and differ only in
 their `PixelAvatarPalette` — switching design rewrites eleven CSS variables and repaints
 nothing.
 
@@ -54,8 +54,10 @@ tab or a removed subtree costs nothing.
 
 `PixelAvatarDesign`: `Black`, `Orange`, `White`, `Beige`, `Siamese`, `SpottedGrey`,
 `SpottedOrange`, `Tuxedo` (extracted from the source sprite sheets), plus `Grey`, `Sparkle`
-(violet with magenta markings), `Lynx` (tawny with dark ear tufts and spots) and `Sudo`
-(near-black navy with an electric blue accent on the ear tips), which are authored against the
+(violet with magenta markings), `Lynx` (tawny with dark ear tufts and spots), `Sudo`
+(near-black navy with an electric blue accent on the ear tips), `Cobalt` (royal blue under a
+navy head, with a sky-blue chest and silver paws), `Ember` (coral red with amber ears and tail)
+and `Bubblegum` (hot pink with a peach chest and a mint sock), which are authored against the
 same palette indices. `PixelAvatarPalettes.All` enumerates them and
 `PixelAvatarPalettes.Get(design)` returns the palette.
 

--- a/Tesserae/src/Components/PixelAvatar.Palettes.cs
+++ b/Tesserae/src/Components/PixelAvatar.Palettes.cs
@@ -29,7 +29,10 @@ namespace Tesserae
         [Name("Grey")]          Grey,
         [Name("Sparkle")]       Sparkle,
         [Name("Lynx")]          Lynx,
-        [Name("Sudo")]          Sudo
+        [Name("Sudo")]          Sudo,
+        [Name("Cobalt")]        Cobalt,
+        [Name("Ember")]         Ember,
+        [Name("Bubblegum")]     Bubblegum
     }
 
     /// <summary>
@@ -62,6 +65,9 @@ namespace Tesserae
             PixelAvatarDesign.Sparkle,
             PixelAvatarDesign.Lynx,
             PixelAvatarDesign.Sudo,
+            PixelAvatarDesign.Cobalt,
+            PixelAvatarDesign.Ember,
+            PixelAvatarDesign.Bubblegum,
         };
 
         // Shorthand so the palette rows below stay readable.
@@ -89,6 +95,12 @@ namespace Tesserae
             palettes[PixelAvatarDesign.Lynx] = PixelAvatarPalette.FromColors("Lynx", C("#338CCC"), C("#E3CDA8"), C("#F0E2C8"), C("#9A7448"), C("#7A5630"), C("#C4A375"), C("#C4A375"), C("#C4A375"), C("#7A5630"), C("#F5EAD6"), C("#5A3F24"), C("#C7B291"));
             // A near-black navy coat with slate ears and an electric blue accent on the ear tips.
             palettes[PixelAvatarDesign.Sudo] = PixelAvatarPalette.FromColors("Sudo", C("#CC33CC"), C("#47525F"), C("#47525F"), C("#47525F"), C("#1D2531"), C("#1D2531"), C("#1D2531"), C("#1D2531"), C("#1D2531"), C("#1D2531"), C("#12171F"), C("#12171F")).WithAccent(C("#0029E7"));
+            // A royal blue coat under a navy head and haunch, with a pale sky-blue chest and silver on the muzzle and paws.
+            palettes[PixelAvatarDesign.Cobalt] = PixelAvatarPalette.FromColors("Cobalt", C("#CC7333"), C("#2F66CC"), C("#8CC3F7"), C("#4A85E8"), C("#1E3A6E"), C("#2F66CC"), C("#1E3A6E"), C("#BCC4CD"), C("#BCC4CD"), C("#8CC3F7"), C("#1E3A6E"), C("#2F66CC"));
+            // A coral red coat with amber ears, tail and chest, an orange forepaw and a plum flank over a violet hind paw.
+            palettes[PixelAvatarDesign.Ember] = PixelAvatarPalette.FromColors("Ember", C("#33CCB2"), C("#F9BE2C"), C("#F9BE2C"), C("#F9BE2C"), C("#F5464F"), C("#F5464F"), C("#F5464F"), C("#92277F"), C("#F98A34"), C("#F9BE2C"), C("#5B21A8"), C("#F5464F"));
+            // A hot pink coat shading into magenta, with a peach chest and a mint sock.
+            palettes[PixelAvatarDesign.Bubblegum] = PixelAvatarPalette.FromColors("Bubblegum", C("#33CC59"), C("#F5399A"), C("#FBC191"), C("#F5399A"), C("#F5399A"), C("#F5399A"), C("#E5148C"), C("#E5148C"), C("#FBC191"), C("#FBC191"), C("#6FE0D0"), C("#F5399A"));
 
             return palettes;
         }

--- a/Tesserae/tps/assets/css/tss.pixelavatar.css
+++ b/Tesserae/tps/assets/css/tss.pixelavatar.css
@@ -209,7 +209,11 @@
     transition: left var(--tss-pxav-walk, 0ms) linear;
 }
 
-/* Overlap mode: no reserved room, the avatar hangs outside the host's box. */
+/* Overlap mode: no reserved room, the avatar hangs outside the host's box.
+   The 1px gaps are the outline halo, not padding: .tss-pixelavatar-canvas draws it with four hard
+   1px drop-shadows, which paint one pixel outside the avatar's own box on every side. Flush against
+   the host (`bottom: 100%`) that pixel lands on the host and reads as the cat overlapping it, so
+   each edge backs off by exactly the halo. */
 
 .tss-pixelavatar-overlap {
     padding: 0;
@@ -219,14 +223,14 @@
 .tss-pixelavatar-overlap.tss-pixelavatar-anchor-topcenter > .tss-pixelavatar,
 .tss-pixelavatar-overlap.tss-pixelavatar-anchor-topright > .tss-pixelavatar {
     top: auto;
-    bottom: 100%;
+    bottom: calc(100% + 1px);
 }
 
 .tss-pixelavatar-overlap.tss-pixelavatar-anchor-bottomleft > .tss-pixelavatar,
 .tss-pixelavatar-overlap.tss-pixelavatar-anchor-bottomcenter > .tss-pixelavatar,
 .tss-pixelavatar-overlap.tss-pixelavatar-anchor-bottomright > .tss-pixelavatar {
     bottom: auto;
-    top: 100%;
+    top: calc(100% + 1px);
 }
 
 .tss-pixelavatar-overlap.tss-pixelavatar-anchor-leftcenter > .tss-pixelavatar {


### PR DESCRIPTION
Two independent PixelAvatar changes, both found while perching the cat on a node-preview sheet in Curiosity Workspace. One commit each, so either can be dropped on its own.

## 1. An overlapping avatar covered 1px of its host

`tss.pixelavatar.css` — in overlap mode a top-anchored avatar sat flush against the host:

```css
.tss-pixelavatar-overlap.tss-pixelavatar-anchor-topleft > .tss-pixelavatar { bottom: 100%; }
```

which is geometrically right — the element's bottom edge lands exactly on the host's top edge — but the avatar paints **outside** its own box. `.tss-pixelavatar-canvas` draws the outline halo as four hard 1px `drop-shadow`s, one per side, and the `drop-shadow(0 1px 0 …)` puts a row of halo one pixel *below* the box. Flush against the host, that row falls on the host, so the cat read as overlapping the modal rather than perching on it.

Each of the two flush edges now backs off by exactly the halo — `bottom: calc(100% + 1px)` for the three top anchors, `top: calc(100% + 1px)` for the three bottom ones. The side anchors already clear it with their existing `margin-right/left: 4px`, so they're untouched.

Verified in Chromium against the samples app, `deviceScaleFactor: 1`:

| case | `modal.top − avatar.bottom` | `avatar.left − modal.left` | avatar height |
|---|---|---|---|
| `Modal` + TopLeft / TopCenter / TopRight | `1` | 6 / 210 / 414 | 32 |
| `OmniResult` sheet + TopLeft | `1` | 6 | 32 |
| `OmniResult` sheet + TopLeft, second sheet pushed on top | `1` (× the peek scale) | 6 | 32 |

Before the change all of these were `0`. The adopted-modal path was checked too: `padding: 0`, `overflow: visible` and the header's inherited corner radius all still apply, and a peeking sheet behind the front one keeps its own `overflow: hidden`, so nothing hangs out of a sheet the user isn't looking at.

## 2. Three more designs

`Cobalt`, `Ember` and `Bubblegum`, authored against the shared palette indices and placed with the other authored coats:

- **Cobalt** — royal blue under a navy head and haunch, with a pale sky-blue chest and silver on the muzzle and paws.
- **Ember** — coral red with amber ears, tail and chest, an orange forepaw and a plum flank over a violet hind paw.
- **Bubblegum** — hot pink shading into magenta, with a peach chest and a mint sock.

None carries an accent, so `Sudo` stays the only design that uses one. Each palette maps its own colours to the index roles rather than sharing one scheme, the way `Siamese`, `SpottedGrey` and `Sparkle` already do.

Also updated, since they pin the count: the `PixelAvatarDesign` enum and `PixelAvatarPalettes.All`, the "twelve designs" copy in `PixelAvatarSample`, and `skills/references/pixel-avatar.md` (front-matter description, the intro, and the design list).

## Notes

- `dotnet build Tesserae.Tests/Tesserae.Tests.csproj` succeeds, and the three new coats were eyeballed in the rendered design gallery — they show up as `Cobalt` / `Ember` / `Bubblegum` buttons with their cat attached and render as intended.
- The measurements above come from driving the samples app in a real browser, so unlike PR #303 the visual side of this one has been checked rather than reasoned about. The one judgement call left for a designer is whether the three palettes are the right colours; the 1px fix is mechanical.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DBficNVcyNDDXq1zKKbKe4)_