### PR TITLE
Make a pixel avatar answer clicks when nothing else does

### DIFF
--- a/Tesserae.Tests/src/Samples/Components/PixelAvatarSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/PixelAvatarSample.cs
@@ -44,6 +44,9 @@ namespace Tesserae.Tests.Samples
                         SampleSubTitle("Pixel size and facing"),
                         TextBlock("The sprite is 10x8 pixels; PixelSize sets how many CSS pixels each of them takes. Facing mirrors the artwork, which is drawn facing right."),
                         SizeGallery(),
+                        SampleSubTitle("Clicking the cat"),
+                        TextBlock("An avatar with no click of its own to do answers when you click it: once plays Interact, twice in quick succession plays Startle, and either one wakes a sleeping cat. The reaction hands the avatar back to what it was doing, so an auto-idling cat carries on drifting afterwards. Registering an OnClick handler - or wrapping the cat in a button with AsButton - hands the click to your code and turns the reaction off; ReactToClicks() overrides either way."),
+                        ClickGallery(),
                         SampleSubTitle("As a button"),
                         TextBlock("AsButton() wraps the avatar in a Button with no background, border, padding or minimum size, so the button hugs the cat exactly instead of the usual button chrome - the avatar becomes the clickable surface via ReplaceContent. Click a cat to play an animation."),
                         AsButtonGallery(),
@@ -224,6 +227,34 @@ namespace Tesserae.Tests.Samples
                     TextBlock("Speed 3").Tiny().Secondary().PT(8)));
 
             return VStack().WS().Children(sizes, facing.PT(24));
+        }
+
+        private static IComponent ClickGallery()
+        {
+            var reacting = PixelAvatar(42, PixelAvatarDesign.Beige, PixelAvatarAnimation.AutoIdle).PixelSize(8);
+            var sleepy   = PixelAvatar(42, PixelAvatarDesign.Grey, PixelAvatarAnimation.AutoIdle).PixelSize(8).SleepAfter(2000);
+            var handled  = PixelAvatar(42, PixelAvatarDesign.Cobalt, PixelAvatarAnimation.AutoIdle).PixelSize(8);
+            var counter  = TextBlock("Clicked 0 times").Tiny().Secondary();
+            var clicks   = 0;
+
+            // A handler of its own means the cat does what the application says instead of reacting.
+            handled.OnClick((_, __) =>
+            {
+                clicks++;
+                counter.Text = $"Clicked {clicks} time{(clicks == 1 ? "" : "s")}";
+            });
+
+            return HStack().AlignItems(ItemAlign.End).Children(
+                VStack().AlignItemsCenter().PR(32).Children(
+                    reacting,
+                    TextBlock("Click, or double click").Tiny().Secondary().PT(8)),
+                VStack().AlignItemsCenter().PR(32).Children(
+                    sleepy,
+                    TextBlock("Nods off quickly: click to wake").Tiny().Secondary().PT(8)),
+                VStack().AlignItemsCenter().PR(32).Children(
+                    handled,
+                    TextBlock("Has its own OnClick").Tiny().Secondary().PT(8),
+                    counter));
         }
 
         private static IComponent AsButtonGallery()

--- a/Tesserae/skills/references/pixel-avatar.md
+++ b/Tesserae/skills/references/pixel-avatar.md
@@ -51,6 +51,7 @@ tab or a removed subtree costs nothing.
 - `.SetDesign(PixelAvatarDesign)` — swap the coat. See **Custom palettes** below for the ways to supply your own colors.
 - `.Outline(bool = true)` — a hairline halo in the theme's contrasting color, **on by default**. Several palettes contain pure white (`White`, `SpottedGrey`, `SpottedOrange`) and several near-black (`Black`, `Tuxedo`, `Siamese`), so without it those designs disappear against one theme or the other. `.OutlineColor(string)` overrides the color, which defaults to translucent black in light mode and translucent white in dark mode.
 - `.OnAnimationStarted((avatar, animation) => ...)` / `.OnAnimationFinished((avatar, animation) => ...)` — the second fires when a non-looping animation reaches its last frame, just before its follow-up takes over; calling `Play` from the handler suppresses that hand-over.
+- `.ReactToClicks(bool = true)` — the built-in click reaction; see **Clicking the cat** below.
 
 `PixelAvatarDesign`: `Black`, `Orange`, `White`, `Beige`, `Siamese`, `SpottedGrey`,
 `SpottedOrange`, `Tuxedo` (extracted from the source sprite sheets), plus `Grey`, `Sparkle`
@@ -100,6 +101,36 @@ jittered by ±20% on use, so nothing the cat does lands on a stopwatch:
 - `.SleepAfter(ms)` — resting time before it sleeps, jittered on use. `PixelAvatar.DefaultSleepAfterMs` is 60000; pass zero to keep it awake indefinitely.
 - `.Wake()` — restarts the sleep countdown, and plays the wake-up performance if the cat was actually out.
 - `.Speed(x)` — scales every frame duration and rest hold together.
+
+## Clicking the cat
+
+A cat that ignores you is furniture, so an avatar with no click of its own to do answers when
+you click it:
+
+- One click plays `Interact`.
+- A second click within `PixelAvatar.DoubleClickWindowMs` (400ms) plays `Startle` instead. The first click's reaction starts immediately rather than waiting the window out, so the cat answers at once and the second click simply overrides it.
+- Either one on a sleeping cat calls `Wake()`, which is its own `Stretch` and `Startle` performance, and any click restarts the sleep countdown.
+
+The reaction hands the avatar back to whatever it was doing when it ends, so an auto-idling cat
+goes on drifting between resting poses afterwards rather than being left standing wherever the
+reaction chained into.
+
+It is **on by default and turns itself off as soon as the click belongs to the application**:
+registering an `OnClick` handler on the avatar, or wrapping the cat in a button with
+`AsButton()`, hands the click over. A **paused** avatar never reacts either, which is what keeps
+a `PixelAvatarBadge` still.
+
+`.ReactToClicks(bool = true)` overrides all of that — call it after `AsButton()` to have the cat
+answer as well as act, or `.ReactToClicks(false)` to have a decorative avatar ignore clicks
+entirely.
+
+```csharp
+// Reacts on its own: click for Interact, double click for Startle.
+var cat = PixelAvatar(SpriteKey.Value, PixelAvatarDesign.Beige, PixelAvatarAnimation.AutoIdle);
+
+// Its own handler, so no built-in reaction - unless you ask for it back.
+cat.OnClick((_, __) => OpenProfile()).ReactToClicks();
+```
 
 ## Custom palettes
 
@@ -188,6 +219,7 @@ the target is an `OmniBox` and the anchor is one of the `Top*` ones, and wires u
 - Typing settles it back to `Idle` — a one-shot animation is allowed to play out first, only the looping poses are cut short.
 - About 10s after your **last** keystroke the cat walks over to the text caret and watches you type; each keystroke pushes that back, and it takes priority over the spontaneous animations. Arriving, it plays `Startle` or `Interact` — picked at random, so it reads as having noticed what you are typing rather than quietly sitting down — and then the ordinary random flow resumes.
 - Focusing or typing wakes a sleeping cat with `Stretch` then `Startle` rather than snapping it back to `Idle`.
+- Clicking the cat works here too — see **Clicking the cat**; the reaction plays and the companion picks the roaming back up when it ends.
 
 ```csharp
 var perched = PixelAvatar(SpriteKey.Value, PixelAvatarDesign.Orange).AttachTo(omniBox, PixelAvatarAnchor.TopLeft);
@@ -249,6 +281,10 @@ if `PixelSize` changes later.
 var avatar = PixelAvatar(SpriteKey.Value, PixelAvatarDesign.Orange, PixelAvatarAnimation.SitIdle).PixelSize(8);
 var button = avatar.AsButton().OnClick(() => avatar.Play(PixelAvatarAnimation.Stretch));
 ```
+
+The button owns the click from there, so `AsButton()` turns the built-in click reaction off —
+see **Clicking the cat**. `avatar.ReactToClicks()` after it puts the reaction back on top of the
+button's own handler.
 
 This claims the same pixel-size tracking slot `AttachTo` uses, so don't call both on the same
 avatar — perch it on a button with `AttachTo` for a mascot next to the click target, or make the

--- a/Tesserae/src/Components/PixelAvatar.cs
+++ b/Tesserae/src/Components/PixelAvatar.cs
@@ -29,6 +29,12 @@ namespace Tesserae
         /// </summary>
         public const int DefaultSleepAfterMs = 16000;
 
+        /// <summary>
+        /// How long after a click a second one still counts as a double click, in milliseconds.
+        /// See <see cref="ReactToClicks"/>.
+        /// </summary>
+        public const int DoubleClickWindowMs = 400;
+
         // How far the viewer sits from the sprite, as a multiple of its rendered width. Low enough
         // that the near edge visibly swings toward you mid-turn, high enough that the sprite does
         // not distort at rest.
@@ -55,6 +61,12 @@ namespace Tesserae
             PixelAvatarAnimation.Stretch,
             PixelAvatarAnimation.Startle
         };
+
+        // The two click reactions. They are sequences of one rather than a plain Play so that the
+        // avatar hands back to whatever it was doing once the reaction is over - an auto-idling cat
+        // goes on drifting instead of being left standing in whatever the reaction chained into.
+        private static readonly PixelAvatarAnimation[] PokeSequence    = { PixelAvatarAnimation.Interact };
+        private static readonly PixelAvatarAnimation[] StartleSequence = { PixelAvatarAnimation.Startle };
 
         // The accent is not a palette index - it is an extra half-size pixel laid over each ear
         // tip, so a design can carry a spot of color the shared artwork has no cell for.
@@ -90,6 +102,9 @@ namespace Tesserae
         private int                          _lastHoldMs;
         private PixelAvatarAnimation[]       _sequence;
         private int                          _sequenceIndex;
+        private bool                         _reactsToClicks = true;
+        private bool                         _hasClickHandler;
+        private double                       _clickTimer;
 
         private event Action<PixelAvatar, PixelAvatarAnimation> AnimationFinished;
         private event Action<PixelAvatar, PixelAvatarAnimation> AnimationStarted;
@@ -138,6 +153,12 @@ namespace Tesserae
             SetDesign(design);
             RenderFrame();
             UpdateAriaLabel();
+
+            AttachClick();
+
+            // Registered after AttachClick so an application's own handler runs first. It only ever
+            // does something when there is no such handler - see ReactToClicks.
+            InnerElement.addEventListener("click", _ => ReactToClick());
 
             TrackMounting();
         }
@@ -207,9 +228,42 @@ namespace Tesserae
 
             if (!IsAsleep) return this;
 
-            _sequence      = WakeSequence;
-            _sequenceIndex = 1;
-            return PlayCore(WakeSequence[0]);
+            return PlaySequence(WakeSequence);
+        }
+
+        /// <summary>
+        /// Sets whether the avatar reacts to being clicked on its own: a click plays
+        /// <see cref="PixelAvatarAnimation.Interact"/>, a second one inside
+        /// <see cref="DoubleClickWindowMs"/> plays <see cref="PixelAvatarAnimation.Startle"/>
+        /// instead, and either one on a sleeping cat wakes it with <see cref="Wake"/>. The reaction
+        /// hands the avatar back to what it was doing, so an auto-idling cat goes on drifting
+        /// between resting poses afterwards.
+        ///
+        /// It is on by default and turns itself off as soon as the avatar has a click of its own to
+        /// do: registering an <see cref="OnClick"/> handler or wrapping the cat in a button with
+        /// <see cref="AsButton"/> hands the click to the application. Call this to get the reaction
+        /// back on top of that, or to turn it off entirely. A paused avatar never reacts, which is
+        /// what keeps a <see cref="PixelAvatarBadge"/> still.
+        /// </summary>
+        public PixelAvatar ReactToClicks(bool value = true)
+        {
+            _reactsToClicks = value;
+
+            if (!value) ClearClickTimer();
+            return this;
+        }
+
+        /// <summary>
+        /// Registers a callback invoked when the avatar is clicked. Doing so turns off the built-in
+        /// click reaction described in <see cref="ReactToClicks"/>, since the click now belongs to
+        /// the application.
+        /// </summary>
+        public override PixelAvatar OnClick(ComponentEventHandler<PixelAvatar, MouseEvent> onClick, bool clearPrevious = true)
+        {
+            if (onClick != null) _hasClickHandler = true;
+            else if (clearPrevious) _hasClickHandler = false;
+
+            return base.OnClick(onClick, clearPrevious);
         }
 
         /// <summary>Gets the index of the frame currently shown.</summary>
@@ -401,6 +455,56 @@ namespace Tesserae
             return PlayCore(animation);
         }
 
+        // Plays a scripted run of animations in place of the usual hand-over chain. Tick hands the
+        // avatar back to whatever it was doing when the last step finishes, which is what lets a
+        // wake-up or a click reaction happen without cancelling auto-idling.
+        private PixelAvatar PlaySequence(PixelAvatarAnimation[] sequence)
+        {
+            _sequence      = sequence;
+            _sequenceIndex = 1;
+            return PlayCore(sequence[0]);
+        }
+
+        // A cat that ignores you is furniture. One click and it looks up; click again while it is
+        // still looking and you have startled it.
+        private void ReactToClick()
+        {
+            if (!_reactsToClicks || _hasClickHandler || _paused) return;
+
+            var wasAsleep = IsAsleep;
+
+            // Pushes the sleep countdown back either way, and when the cat was actually out this
+            // plays the wake-up performance - which already ends in a startle, so there is no
+            // reaction to add on top of it.
+            Wake();
+
+            if (wasAsleep)
+            {
+                ClearClickTimer();
+                return;
+            }
+
+            if (_clickTimer != 0)
+            {
+                ClearClickTimer();
+                PlaySequence(StartleSequence);
+                return;
+            }
+
+            // The reaction plays on the first click rather than waiting out the double-click window,
+            // so the cat answers immediately; a second click within the window simply overrides it.
+            _clickTimer = window.setTimeout(_ => _clickTimer = 0, DoubleClickWindowMs);
+            PlaySequence(PokeSequence);
+        }
+
+        private void ClearClickTimer()
+        {
+            if (_clickTimer == 0) return;
+
+            window.clearTimeout(_clickTimer);
+            _clickTimer = 0;
+        }
+
         private PixelAvatar PlayCore(PixelAvatarAnimation animation)
         {
             _animation = PixelAvatarSprites.Get(animation);
@@ -494,9 +598,15 @@ namespace Tesserae
         ///
         /// This claims the same pixel-size tracking slot <see cref="AttachTo"/> uses, so an avatar
         /// already attached to another component should not also be turned into a button.
+        ///
+        /// The button owns the click from here on, so the built-in click reaction is turned off -
+        /// see <see cref="ReactToClicks"/>, which turns it back on if you want the cat to answer as
+        /// well as act.
         /// </summary>
         public Button AsButton()
         {
+            ReactToClicks(false);
+
             var button = UI.Button()
                .ReplaceContent(this)
                .NoBackground()


### PR DESCRIPTION
An avatar with no click of its own to do now reacts to being clicked: one
click plays Interact, a second inside 400ms plays Startle instead, and
either one on a sleeping cat wakes it with the usual stretch-and-startle
performance.

The reaction runs as a one-step scripted sequence rather than a plain
Play, so the avatar hands back to whatever it was doing when it ends and
an auto-idling cat carries on drifting between resting poses.

It stays out of the way of anything that owns the click already:
registering an OnClick handler on the avatar turns it off, AsButton()
turns it off (the button is the click owner), and a paused avatar never
reacts, which is what keeps a PixelAvatarBadge still. ReactToClicks()
overrides all three ways.

Also wires AttachClick(), without which an OnClick handler on an avatar
never fired at all.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Y6pr4T7nBBQoxoLCUtzJyT