### PR TITLE
Let a SidebarButton show and answer a keyboard shortcut, and fix tooltip text colour

### DIFF
--- a/Tesserae.Tests/src/Samples/Components/SidebarSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/SidebarSample.cs
@@ -17,10 +17,12 @@ namespace Tesserae.Tests.Samples
         {
             var sidebar = Sidebar();
 
-            // A rounded, primary "pill" button (see .Rounded()), matching the rounded search box below.
+            // A rounded, primary "pill" button (see .Rounded()), matching the rounded search box below,
+            // with the shortcut that presses it shown at its far end (see .SetKeyboardShortcut()).
             var newDocument = new SidebarButton("new-doc", UIcons.Plus, "New document")
                 .Primary()
                 .Rounded()
+                .SetKeyboardShortcut("Ctrl", "Shift", "O")
                 .OnClick(() => Toast().Success("New document"));
 
             sidebar.AddHeader(newDocument);
@@ -123,7 +125,7 @@ namespace Tesserae.Tests.Samples
                .SampleTitle(typeof(SidebarSample), UIcons.Apps, "A sidebar navigation component")
                .FlatSection(Stack().Children(
                     Card(VStack().WS().Children(
-                    TextBlock("A fully featured Sidebar with Search, Navigation, Buttons, and Separators. The header shows a rounded (pill) primary button and a rounded search box with a keyboard shortcut (⌘K / Ctrl+K) — enable both with .Rounded()."))).SetTitle("Overview"),
+                    TextBlock("A fully featured Sidebar with Search, Navigation, Buttons, and Separators. The header shows a rounded (pill) primary button and a rounded search box, each with the shortcut that reaches it at its far end — enable the pill with .Rounded() and the shortcut with .SetKeyboardShortcut()."))).SetTitle("Overview"),
                     Card(VStack().WS().Children(
                         SplitView().WS().H(800).LeftIsSmaller(400.px()).Resizable()
                                    .Left(sidebar.S())

--- a/Tesserae.Tests/src/Samples/Utilities/TippySample.cs
+++ b/Tesserae.Tests/src/Samples/Utilities/TippySample.cs
@@ -32,6 +32,9 @@ namespace Tesserae.Tests.Samples
                     VStack().Children(
                         Button("Hover me").W(200).Tooltip("This is a simple text tooltip"),
                         Button("Animated Tooltip").W(200).Tooltip("This is a simple text tooltip with animations", TooltipAnimation.ShiftAway),
+                        //A component tooltip made of text rather than of controls: it has a colour of its
+                        //own, so it is the case that catches the tooltip surface and its text disagreeing.
+                        Button("Text Component Tooltip").W(200).Tooltip(TextBlock("Two lines of text,\nas a component.").BreakSpaces().MaxWidth(350.px())),
                         Button("Interactive Tooltip").W(200).Tooltip(Button("Click me").OnClick(() => Toast().Success("You clicked!")), interactive: true),
                         Button("Defers on Tooltips").W(200).Tooltip(deferedWithChangingSize),
                         Button("Nested Tooltips").W(200).Tooltip(Button("Click me").OnClick((b1, _) => Tippy.ShowFor(b1, Button("Click me").OnClick(() => Toast().Success("You clicked!")), out var _)), interactive: true)

--- a/Tesserae/skills/references/keyboard-shortcut.md
+++ b/Tesserae/skills/references/keyboard-shortcut.md
@@ -14,6 +14,8 @@ Renders one or more keys as styled chips joined by `+`. Modifier labels adapt to
 ## Key points
 
 - Pass raw key names; normalization to OS-correct glyphs is automatic.
+- A key's plate is one fixed grey per theme, so a chip looks the same wherever it is
+  drawn — on a card, inside a search field, or on a filled `.Primary()` button.
 - Recognized special keys: `Ctrl`, `Control`, `Alt`, `Shift`, `Meta`/`Cmd`, `Enter`, `Escape`/`Esc`, `ArrowUp/Down/Left/Right`, `Backspace`, `Delete`, `Tab`. Anything else renders verbatim.
 - It is a regular `IComponent` — place it inline in a `Stack` alongside `TextBlock`.
 

--- a/Tesserae/skills/references/keyboard-shortcut.md
+++ b/Tesserae/skills/references/keyboard-shortcut.md
@@ -5,7 +5,7 @@ description: Renders key names as styled <kbd> chips, auto-adapting modifier lab
 
 # KeyboardShortcut
 
-Renders one or more keys as styled chips joined by `+`. Modifier labels adapt to the OS (⌘/⌃/⌥/⇧ on macOS, Ctrl/Win/Alt/Shift elsewhere) and special keys are normalized (Enter→↵, Escape→Esc, ArrowUp→↑, Backspace→⌫, Tab→⇥, etc.). This is display-only — it does not bind handlers.
+Renders one or more keys as styled chips joined by `+`. Modifier labels adapt to the OS (⌘/⌃/⌥/⇧ on macOS, Ctrl/Win/Alt/Shift elsewhere) and special keys are normalized (Enter→↵, Escape→Esc, ArrowUp→↑, Backspace→⌫, Tab→⇥, etc.). The component itself is display-only; `KeyboardShortcut.Matches` (below) is how a `keydown` is tested against the same key names.
 
 ## Create
 
@@ -14,8 +14,44 @@ Renders one or more keys as styled chips joined by `+`. Modifier labels adapt to
 ## Key points
 
 - Pass raw key names; normalization to OS-correct glyphs is automatic.
-- Recognized special keys: `Ctrl`/`Control`, `Alt`, `Shift`, `Meta`/`Cmd`, `Enter`, `Escape`/`Esc`, `ArrowUp/Down/Left/Right`, `Backspace`, `Delete`, `Tab`. Anything else renders verbatim.
+- Recognized special keys: `Ctrl`, `Control`, `Alt`, `Shift`, `Meta`/`Cmd`, `Enter`, `Escape`/`Esc`, `ArrowUp/Down/Left/Right`, `Backspace`, `Delete`, `Tab`. Anything else renders verbatim.
 - It is a regular `IComponent` — place it inline in a `Stack` alongside `TextBlock`.
+
+## The command modifier
+
+`Ctrl` (and its aliases `Mod` / `CmdOrCtrl`) means *the platform's command modifier*: it
+shows as `Ctrl` on Windows and Linux and as **⌘** on macOS, and `Matches` accepts
+either Cmd or Ctrl there — a keyboard carried over from Windows still reaches the
+shortcut. Declare it once as `("Ctrl", "Shift", "O")` and both platforms are right.
+
+Use the explicit `Control` for the rare shortcut that means the Control key on a Mac
+too; it shows as ⌃ and only matches `ctrlKey`.
+
+## Matching a key press
+
+`KeyboardShortcut.Matches(KeyboardEvent e, params string[] keys)` — `true` when `e` is
+that shortcut. It takes the same key names the chips display, so what is shown and what
+is bound are declared once and cannot drift apart. Modifiers must match exactly (a
+shortcut without `Shift` does not fire on Shift), and the main key is compared
+case-insensitively, so a shifted letter still matches.
+
+Write it **qualified** as `Tesserae.KeyboardShortcut.Matches(...)`: with
+`using static Tesserae.UI;` in scope, the bare name resolves to the `KeyboardShortcut(...)`
+factory method and the compiler reports `CS0119: ... is a method, which is not valid in
+the given context`.
+
+```csharp
+window.addEventListener("keydown", ev =>
+{
+    if (!Tesserae.KeyboardShortcut.Matches(ev.As<KeyboardEvent>(), "Ctrl", "Shift", "O")) return;
+    StopEvent(ev);
+    NewDocument();
+});
+```
+
+Components that show a shortcut and answer it — `SearchBox.SetKeyboardShortcut(...)`,
+`SidebarButton.SetKeyboardShortcut(...)`, `SidebarSearchBox`, `OmniBox` — do exactly
+this internally, so prefer those when one of them is what you are building.
 
 ## Example
 
@@ -33,4 +69,5 @@ var row = HStack().AlignItems(ItemAlign.Center).Gap(4.px()).Children(
 ## Related
 
 - CommandPalette (actual Ctrl/Cmd-K launcher) — `command-palette.md`
+- Sidebar (`.AsSearchBox(...)`, `SidebarButton.SetKeyboardShortcut(...)`) — `sidebar.md`
 - Full docs & API: `/tesserae/utilities/keyboard-shortcut`

--- a/Tesserae/skills/references/sidebar.md
+++ b/Tesserae/skills/references/sidebar.md
@@ -33,7 +33,8 @@ Bring factories into scope with `using static Tesserae.UI;`.
   persist item order.
 
 Common item types: `SidebarButton(id, UIcons icon, text)` (`.Selected()`,
-`.OnClick(...)`, `.Primary()`, `.Danger()`, `.Rounded()`, `.Tooltip(...)`),
+`.OnClick(...)`, `.Primary()`, `.Danger()`, `.Rounded()`,
+`.SetKeyboardShortcut("Ctrl", "Shift", "O")`, `.Tooltip(...)`),
 `SidebarSeparator(id, text)`, `SidebarNav(id, icon, text, initiallyCollapsed)`,
 `SidebarText(id, text)`,
 `SidebarSearchBox(id, placeholder)` (`.OnSearch(...)`, `.OnClick(...)`,
@@ -56,6 +57,32 @@ sidebar.AddHeader(new SidebarButton("search", UIcons.Search, "Search everything"
 It also takes `.OnClick(...)` — which makes it read-only and hands presses, and
 its `.SetKeyboardShortcut(...)` key, to the handler — but a button is the simpler
 thing when nothing is ever typed into it.
+
+## The shortcut that presses a button
+
+`SidebarButton.SetKeyboardShortcut("Ctrl", "Shift", "O")` shows the shortcut as a
+chip at the button's far end *and* answers it for as long as the button is on
+screen, so the chip is a promise rather than a note. The keys are the ones
+`KeyboardShortcut` displays (`keyboard-shortcut.md`), so `Ctrl` is the platform's
+command modifier: the chip above reads Ctrl+Shift+O and triggers on ⌘⇧O on a Mac.
+
+```csharp
+chatBar.AddHeader(new SidebarButton("new-chat", UIcons.Edit, "New chat")
+    .Rounded()
+    .SetKeyboardShortcut("Ctrl", "Shift", "O")
+    .OnClick(StartNewChat));
+```
+
+The key presses the button, so anything hooked to it — the click handler, an
+`href` wrapper — is reached by the keyboard exactly as it is by the pointer. Only
+the open button carries the chip; the closed rail has room for the glyph and
+nothing else. A collapsed button holds no shortcut either, because there is
+nothing on screen for the key to press.
+
+`.AsSearchBox(keys)` shows the same chip *without* binding the key, because the
+palette or page it opens is what owns that key — and answers it from inside a text
+field too, where a button's shortcut steps aside. Pass no keys and call
+`.SetKeyboardShortcut(...)` when the button itself should answer.
 
 A `.Selected()` item is outlined in the theme's primary color and filled with a
 wash of it, rather than with the grey a hover uses — so where you are still

--- a/Tesserae/src/Components/ChartBase.cs
+++ b/Tesserae/src/Components/ChartBase.cs
@@ -221,7 +221,11 @@ namespace Tesserae
 
             if (_showTooltips)
             {
-                Script.Write("tippy({0}, { content: {1}, allowHTML: true, delay: [100, 0], appendTo: document.body });", el, content);
+                //Into the application z-index lane, like every other tippy here: a chart in a Modal would
+                //otherwise hand its tooltips tippy's fixed 9999 and draw them behind the Layer above it.
+                if (!int.TryParse(Layers.AboveCurrent(), out var zIndex)) zIndex = 9999;
+
+                Script.Write("tippy({0}, { content: {1}, allowHTML: true, delay: [100, 0], appendTo: document.body, zIndex: {2} });", el, content, zIndex);
             }
         }
 

--- a/Tesserae/src/Components/KeyboardShortcut.cs
+++ b/Tesserae/src/Components/KeyboardShortcut.cs
@@ -38,6 +38,84 @@ namespace Tesserae
         /// </summary>
         public override HTMLElement Render() => InnerElement;
 
+        /// <summary>
+        /// Whether <paramref name="e"/> is the shortcut described by <paramref name="keys"/> - the same key
+        /// names this component displays, so a shortcut can be declared once and what is shown cannot drift
+        /// from what is bound.
+        /// <para>
+        /// <c>Ctrl</c> (and its aliases <c>Mod</c> / <c>CmdOrCtrl</c>) is the platform's command modifier:
+        /// Ctrl elsewhere, and on Apple either Cmd or Ctrl - which is also why it shows there as ⌘. Use the
+        /// explicit <c>Control</c> for a shortcut that means the Control key on a Mac too.
+        /// </para>
+        /// </summary>
+        public static bool Matches(KeyboardEvent e, params string[] keys)
+        {
+            if (e is null || keys is null) return false;
+
+            bool   needMod   = false;
+            bool   needCtrl  = false;
+            bool   needAlt   = false;
+            bool   needShift = false;
+            bool   needMeta  = false;
+            string mainKey   = null;
+
+            foreach (var raw in keys)
+            {
+                if (raw is null) continue;
+
+                switch (raw.Trim())
+                {
+                    case "Ctrl":
+                    case "ctrl":
+                    case "Mod":
+                    case "mod":
+                    case "CmdOrCtrl":
+                        needMod = true;
+                        break;
+                    case "Control":
+                    case "control":
+                        needCtrl = true;
+                        break;
+                    case "Alt":
+                    case "alt":
+                        needAlt = true;
+                        break;
+                    case "Shift":
+                    case "shift":
+                        needShift = true;
+                        break;
+                    case "Meta":
+                    case "meta":
+                    case "Cmd":
+                    case "cmd":
+                        needMeta = true;
+                        break;
+                    default:
+                        mainKey = raw.Trim();
+                        break;
+                }
+            }
+
+            if (mainKey is null) return false;
+
+            if (needMod && !needMeta && !needCtrl && IsApple())
+            {
+                //Cmd is the command modifier here, but the same shortcut pressed with Ctrl is not a different
+                //shortcut - a keyboard carried over from Windows should still reach it.
+                if (!e.metaKey && !e.ctrlKey) return false;
+            }
+            else
+            {
+                if ((needMod || needCtrl) != e.ctrlKey) return false;
+                if (needMeta != e.metaKey) return false;
+            }
+
+            if (needAlt   != e.altKey)   return false;
+            if (needShift != e.shiftKey) return false;
+
+            return string.Equals(e.key, mainKey, StringComparison.OrdinalIgnoreCase);
+        }
+
         private static string NormalizeKey(string key)
         {
             if (key == null) return "";
@@ -45,9 +123,15 @@ namespace Tesserae
 
             switch (trimmedKey)
             {
+                //The command modifier, which on Apple is Cmd - see Matches, which accepts either there.
                 case "Ctrl":
                 case "ctrl":
+                case "Mod":
+                case "mod":
+                case "CmdOrCtrl":
+                    return IsApple() ? "⌘" : "Ctrl";
                 case "Control":
+                case "control":
                     return IsApple() ? "⌃" : "Ctrl";
                 case "Alt":
                 case "alt":

--- a/Tesserae/src/Components/OmniBox.cs
+++ b/Tesserae/src/Components/OmniBox.cs
@@ -3665,7 +3665,7 @@ namespace Tesserae
                 if (!IsEnabled) return;
 
                 var e = ev.As<KeyboardEvent>();
-                if (!MatchesShortcut(e, _shortcutKeys)) return;
+                if (!KeyboardShortcut.Matches(e, _shortcutKeys)) return;
 
                 StopEvent(e);
                 if (_mode == Mode.SearchAndChat && _activeMode.Value != Mode.Search)
@@ -3678,67 +3678,6 @@ namespace Tesserae
 
             window.addEventListener("keydown", _globalShortcutHandler);
             return this;
-        }
-
-        private static bool MatchesShortcut(KeyboardEvent e, string[] keys)
-        {
-            bool needCtrl  = false;
-            bool needAlt   = false;
-            bool needShift = false;
-            bool needMeta  = false;
-            string mainKey = null;
-
-            foreach (var raw in keys)
-            {
-                if (raw is null) continue;
-                var k = raw.Trim();
-                switch (k)
-                {
-                    case "Ctrl":
-                    case "ctrl":
-                    case "Control":
-                        needCtrl = true;
-                        break;
-                    case "Alt":
-                    case "alt":
-                        needAlt = true;
-                        break;
-                    case "Shift":
-                    case "shift":
-                        needShift = true;
-                        break;
-                    case "Meta":
-                    case "meta":
-                    case "Cmd":
-                    case "cmd":
-                        needMeta = true;
-                        break;
-                    default:
-                        mainKey = k;
-                        break;
-                }
-            }
-
-            // On macOS, treat "Ctrl" in the shortcut as either Ctrl or Cmd so a single
-            // declaration like ("Ctrl", "K") renders ⌘K and triggers on Cmd+K.
-            bool isApple = navigator.userAgent.IndexOf("Mac") >= 0 || navigator.userAgent.IndexOf("iPhone") >= 0 || navigator.userAgent.IndexOf("iPad") >= 0;
-
-            if (needCtrl && !needMeta && isApple)
-            {
-                if (!e.metaKey && !e.ctrlKey) return false;
-            }
-            else
-            {
-                if (needCtrl != e.ctrlKey) return false;
-                if (needMeta != e.metaKey) return false;
-            }
-
-            if (needAlt   != e.altKey)   return false;
-            if (needShift != e.shiftKey) return false;
-
-            if (mainKey is null) return false;
-
-            return string.Equals(e.key, mainKey, StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary>

--- a/Tesserae/src/Components/SearchBox.cs
+++ b/Tesserae/src/Components/SearchBox.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Transpose.Core;
 using static Transpose.Core.dom;
 using static Tesserae.UI;
@@ -359,7 +359,7 @@ namespace Tesserae
                 if (!IsEnabled) return;
 
                 var e = ev.As<KeyboardEvent>();
-                if (!MatchesShortcut(e, _shortcutKeys)) return;
+                if (!KeyboardShortcut.Matches(e, _shortcutKeys)) return;
 
                 StopEvent(e);
 
@@ -390,67 +390,6 @@ namespace Tesserae
             _onShortcut = onShortcut;
 
             return this;
-        }
-
-        private static bool MatchesShortcut(KeyboardEvent e, string[] keys)
-        {
-            bool needCtrl  = false;
-            bool needAlt   = false;
-            bool needShift = false;
-            bool needMeta  = false;
-            string mainKey = null;
-
-            foreach (var raw in keys)
-            {
-                if (raw is null) continue;
-                var k = raw.Trim();
-                switch (k)
-                {
-                    case "Ctrl":
-                    case "ctrl":
-                    case "Control":
-                        needCtrl = true;
-                        break;
-                    case "Alt":
-                    case "alt":
-                        needAlt = true;
-                        break;
-                    case "Shift":
-                    case "shift":
-                        needShift = true;
-                        break;
-                    case "Meta":
-                    case "meta":
-                    case "Cmd":
-                    case "cmd":
-                        needMeta = true;
-                        break;
-                    default:
-                        mainKey = k;
-                        break;
-                }
-            }
-
-            // On macOS, treat "Ctrl" in the shortcut as either Ctrl or Cmd so a single
-            // declaration like ("Ctrl", "K") renders ⌘K and triggers on Cmd+K.
-            bool isApple = navigator.userAgent.IndexOf("Mac") >= 0 || navigator.userAgent.IndexOf("iPhone") >= 0 || navigator.userAgent.IndexOf("iPad") >= 0;
-
-            if (needCtrl && !needMeta && isApple)
-            {
-                if (!e.metaKey && !e.ctrlKey) return false;
-            }
-            else
-            {
-                if (needCtrl != e.ctrlKey) return false;
-                if (needMeta != e.metaKey) return false;
-            }
-
-            if (needAlt   != e.altKey)   return false;
-            if (needShift != e.shiftKey) return false;
-
-            if (mainKey is null) return false;
-
-            return string.Equals(e.key, mainKey, StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary>

--- a/Tesserae/src/Components/Sidebar/SidebarButton.cs
+++ b/Tesserae/src/Components/Sidebar/SidebarButton.cs
@@ -24,6 +24,9 @@ namespace Tesserae
         private          Action<IComponent>       _tooltipOpen;
         private readonly SettableObservable<bool> _selected;
         private readonly string                   _text;
+        private          HTMLElement              _shortcutChip;
+        private          string[]                 _shortcutKeys;
+        private          Action<Event>            _globalShortcutHandler;
 
         private event Action<HTMLElement> _onRendered;
 
@@ -345,6 +348,21 @@ namespace Tesserae
         }
 
         /// <summary>
+        /// Draws the button with a field's chrome - a border and the secondary surface behind it - instead of
+        /// as a bare row. What a rail's own action wants when it stands next to a search box: the same outline,
+        /// so the two read as a pair of controls rather than as a button beside a form field.
+        /// <para>
+        /// Only the open button takes it; around a single glyph on the closed rail an outline is just a box.
+        /// </para>
+        /// </summary>
+        /// <returns>The current instance of the type.</returns>
+        public SidebarButton Outlined()
+        {
+            _openButton.Class("tss-sidebar-btn-outlined");
+            return this;
+        }
+
+        /// <summary>
         /// Dresses the button as a search field: a rounded outline, the label set as a placeholder rather
         /// than as a label, and - when keys are given - the shortcut that reaches it shown at the far end.
         /// <para>
@@ -353,21 +371,94 @@ namespace Tesserae
         /// starts and be pressable. A real input would take a caret it has nothing to do with.
         /// </para>
         /// </summary>
-        /// <param name="shortcutKeys">The keys to show at the end, e.g. <c>("Ctrl", "K")</c>. None hides it.</param>
+        /// <param name="shortcutKeys">
+        /// The keys to show at the end, e.g. <c>("Ctrl", "K")</c>. None hides it. The chip is a label only -
+        /// use <see cref="SetKeyboardShortcut"/> for the key to press the button as well, which a search that
+        /// answers somewhere else usually does not want: the palette or page it opens owns that key, and
+        /// answers it from inside a text field too, where a button's shortcut steps aside.
+        /// </param>
         public SidebarButton AsSearchBox(params string[] shortcutKeys)
         {
             Rounded();
+            Outlined();
 
             _open.Class("tss-sidebar-btn-searchbox");
             _openButton.Class("tss-sidebar-btn-searchbox-button");
             _closedButton.Class("tss-sidebar-btn-searchbox-button");
 
-            if (shortcutKeys is object && shortcutKeys.Length > 0)
-            {
-                _openButton.Render().appendChild(Div(Att("tss-sidebar-btn-searchbox-shortcut"), KeyboardShortcut(shortcutKeys).Render()));
-            }
+            ShowShortcutChip(shortcutKeys);
 
             return this;
+        }
+
+        /// <summary>
+        /// Shows the shortcut that presses this button at its far end, and answers that shortcut for as long
+        /// as the button is on screen - which is what makes the chip a promise rather than a note. The keys
+        /// are the ones <see cref="Tesserae.KeyboardShortcut"/> displays, so <c>("Ctrl", "Shift", "O")</c>
+        /// reads Ctrl+Shift+O and triggers on ⌘⇧O on a Mac.
+        /// <para>
+        /// Only the open button carries the chip: the closed rail has room for the glyph and nothing else.
+        /// A collapsed button holds no shortcut either - there is nothing on screen for the key to press.
+        /// </para>
+        /// </summary>
+        /// <param name="keys">The keys, e.g. <c>("Ctrl", "Shift", "O")</c>. None removes chip and binding.</param>
+        public SidebarButton SetKeyboardShortcut(params string[] keys)
+        {
+            if (_globalShortcutHandler is object)
+            {
+                window.removeEventListener("keydown", _globalShortcutHandler);
+                _globalShortcutHandler = null;
+            }
+
+            ShowShortcutChip(keys);
+
+            _shortcutKeys = (keys is object && keys.Length > 0) ? keys : null;
+
+            if (_shortcutKeys is null) return this;
+
+            _globalShortcutHandler = ev =>
+            {
+                var element = _open.Render();
+
+                //Mounted is not enough: a collapsed button, or one on a sidebar that is not the one showing,
+                //is not something the user can see themselves pressing.
+                if (!element.IsMounted() || element.clientHeight <= 0) return;
+                if (!_openButton.IsEnabled) return;
+
+                var e = ev.As<KeyboardEvent>();
+
+                if (!Tesserae.KeyboardShortcut.Matches(e, _shortcutKeys)) return;
+
+                StopEvent(e);
+
+                //Pressed rather than called: whatever is hooked to the button - the click handler, an href
+                //wrapper - is then reached by the key exactly as it is by the pointer.
+                _openButton.Render().click();
+            };
+
+            window.addEventListener("keydown", _globalShortcutHandler);
+
+            return this;
+        }
+
+        private void ShowShortcutChip(string[] keys)
+        {
+            if (_shortcutChip is object)
+            {
+                _shortcutChip.remove();
+                _shortcutChip = null;
+            }
+
+            if (keys is null || keys.Length == 0)
+            {
+                _openButton.RemoveClass("tss-sidebar-btn-has-shortcut");
+                return;
+            }
+
+            _shortcutChip = Div(Att("tss-sidebar-btn-shortcut"), KeyboardShortcut(keys).Render());
+
+            _openButton.Class("tss-sidebar-btn-has-shortcut");
+            _openButton.Render().appendChild(_shortcutChip);
         }
 
         /// <summary>

--- a/Tesserae/src/Components/Sidebar/SidebarButton.cs
+++ b/Tesserae/src/Components/Sidebar/SidebarButton.cs
@@ -397,8 +397,9 @@ namespace Tesserae
         /// are the ones <see cref="Tesserae.KeyboardShortcut"/> displays, so <c>("Ctrl", "Shift", "O")</c>
         /// reads Ctrl+Shift+O and triggers on ⌘⇧O on a Mac.
         /// <para>
-        /// Only the open button carries the chip: the closed rail has room for the glyph and nothing else.
-        /// A collapsed button holds no shortcut either - there is nothing on screen for the key to press.
+        /// Only the open button carries the chip - the closed rail has room for the glyph and nothing else -
+        /// but the key works on either, because a collapsed rail is a smaller rail and not a different one.
+        /// A button that is nowhere on screen holds no shortcut: there is nothing for the key to press.
         /// </para>
         /// </summary>
         /// <param name="keys">The keys, e.g. <c>("Ctrl", "Shift", "O")</c>. None removes chip and binding.</param>
@@ -418,12 +419,9 @@ namespace Tesserae
 
             _globalShortcutHandler = ev =>
             {
-                var element = _open.Render();
+                var button = ButtonOnScreen();
 
-                //Mounted is not enough: a collapsed button, or one on a sidebar that is not the one showing,
-                //is not something the user can see themselves pressing.
-                if (!element.IsMounted() || element.clientHeight <= 0) return;
-                if (!_openButton.IsEnabled) return;
+                if (button is null || !button.IsEnabled) return;
 
                 var e = ev.As<KeyboardEvent>();
 
@@ -433,13 +431,28 @@ namespace Tesserae
 
                 //Pressed rather than called: whatever is hooked to the button - the click handler, an href
                 //wrapper - is then reached by the key exactly as it is by the pointer.
-                _openButton.Render().click();
+                button.Render().click();
             };
 
             window.addEventListener("keydown", _globalShortcutHandler);
 
             return this;
         }
+
+        /// <summary>
+        /// Whichever of the two renderings the user can actually see, or null when neither is. Mounted is not
+        /// enough on its own: both are mounted at once while the sidebar hides the one it is not showing, and
+        /// a collapsed button is mounted too.
+        /// </summary>
+        private Button ButtonOnScreen()
+        {
+            if (IsOnScreen(_open.Render())) return _openButton;
+            if (IsOnScreen(_closed.Render())) return _closedButton;
+
+            return null;
+        }
+
+        private static bool IsOnScreen(HTMLElement element) => element is object && element.IsMounted() && element.clientHeight > 0;
 
         private void ShowShortcutChip(string[] keys)
         {

--- a/Tesserae/src/Components/Teaching.cs
+++ b/Tesserae/src/Components/Teaching.cs
@@ -218,13 +218,17 @@ namespace Tesserae
 
             //RFO: This has a key difference against .Tooltip() in that it hard-cods appendTo: document.body so it's not stuck in an element that will cut it off, see https://atomiks.github.io/tippyjs/v6/faq/
 
+            //Into the application z-index lane, as .Tooltip() and Tippy.ShowFor do: a teaching bubble points
+            //at something, and tippy's fixed 9999 would put it behind any Layer opened over that thing.
+            if (!int.TryParse(Layers.AboveCurrent(), out var zIndex)) zIndex = 9999;
+
             if (animation == TooltipAnimation.None)
             {
-                Transpose.Script.Write("tippy({0}, { content: {1}, interactive: {2}, placement: {3}, delay: [{4},{5}],  trigger: 'manual', hideOnClick: {6}, appendTo: document.body });", element, renderedTooltip, interactive, placement.ToString(), 0, 0, hideOnClick);
+                Transpose.Script.Write("tippy({0}, { content: {1}, interactive: {2}, placement: {3}, delay: [{4},{5}],  trigger: 'manual', hideOnClick: {6}, appendTo: document.body, zIndex: {7} });", element, renderedTooltip, interactive, placement.ToString(), 0, 0, hideOnClick, zIndex);
             }
             else
             {
-                Transpose.Script.Write("tippy({0}, { content: {1}, interactive: {2}, placement: {3},  animation: {4}, delay: [{5},{6}],  trigger: 'manual', hideOnClick: {7}, appendTo: document.body });", element, renderedTooltip, interactive, placement.ToString(), animation.ToString(), 0, 0, hideOnClick);
+                Transpose.Script.Write("tippy({0}, { content: {1}, interactive: {2}, placement: {3},  animation: {4}, delay: [{5},{6}],  trigger: 'manual', hideOnClick: {7}, appendTo: document.body, zIndex: {8} });", element, renderedTooltip, interactive, placement.ToString(), animation.ToString(), 0, 0, hideOnClick, zIndex);
             }
 
             Transpose.Script.Write("{0}._tippy.show();", element); //Shows it imediatelly

--- a/Tesserae/tps/assets/css/tss.kbd.css
+++ b/Tesserae/tps/assets/css/tss.kbd.css
@@ -18,12 +18,12 @@
     font-weight: 500;
     line-height: 1;
     color: var(--tss-secondary-foreground-color);
-    /* A wash of the opposite tone rather than a named surface colour: the chip is nearly always drawn
-       on top of one of those surfaces (a search field, the sidebar), and painting it the same colour is
-       what made it invisible. dark-neutral-0 is near-black on a light theme and white on a dark one, so
-       the same two rules read as a raised key in both. */
-    background: rgba(var(--tss-colors-dark-neutral-0-root), 0.07);
-    border: 1px solid rgba(var(--tss-colors-dark-neutral-0-root), 0.16);
+    /* A key is a key: one grey plate, whatever it is drawn on. These were washes of the opposite tone,
+       which reads correctly on the surfaces a chip usually sits on (a search field, the sidebar) but takes
+       the colour of anything else - on a filled button the same chip came out blue, red or green. The
+       neutral scale flips with the theme, so the plate is one tone per theme and never the surface's. */
+    background: var(--tss-colors-neutral-200);
+    border: 1px solid var(--tss-colors-neutral-300);
     border-bottom-width: 2px;
     border-radius: 4px;
     user-select: none;

--- a/Tesserae/tps/assets/css/tss.omnibox.css
+++ b/Tesserae/tps/assets/css/tss.omnibox.css
@@ -727,10 +727,9 @@
     margin-left: 8px;
 }
 
-/* The section headers of the popovers below are TextBlocks, so they carry .tss-fontcolor-default, and
-   tss.tooltip.css paints that class with the *background* color for a tooltip whose background is
-   inverted. These popovers sit on the plain default background instead, where that reads as white text
-   on white. Restated here with enough specificity (and late enough in the bundle) to win. */
+/* The section headers of the popovers below are TextBlocks, so they carry .tss-fontcolor-default, which
+   tss.tooltip.css paints with the tooltip's foreground. A header wants the muted one instead, and these
+   popovers draw their own default-background surface, so the secondary foreground is what reads on it. */
 .tippy-content .tss-textblock.tss-omnibox-model-selector-header,
 .tippy-content .tss-textblock.tss-omnibox-help-header {
     color: var(--tss-secondary-foreground-color);

--- a/Tesserae/tps/assets/css/tss.sidebar.css
+++ b/Tesserae/tps/assets/css/tss.sidebar.css
@@ -885,16 +885,8 @@
     pointer-events: none;
 }
 
-/* A chip washes the surface under it (see tss.kbd.css), which only works over one of the neutral tones.
-   On a filled button it takes the label's own colour and a wash of white instead. */
-.tss-sidebar-btn-open .tss-btn-primary .tss-sidebar-btn-shortcut .tss-kbd-key,
-.tss-sidebar-btn-open .tss-btn-danger .tss-sidebar-btn-shortcut .tss-kbd-key,
-.tss-sidebar-btn-open .tss-btn-success .tss-sidebar-btn-shortcut .tss-kbd-key {
-    color: inherit;
-    background: rgba(255, 255, 255, 0.2);
-    border-color: rgba(255, 255, 255, 0.38);
-}
-
+/* The keys keep their own grey plate on a filled button - see tss.kbd.css - but the separator between them
+   is text on the fill, not a key, so it takes the label's colour rather than staying grey on blue. */
 .tss-sidebar-btn-open .tss-btn-primary .tss-sidebar-btn-shortcut .tss-kbd-separator,
 .tss-sidebar-btn-open .tss-btn-danger .tss-sidebar-btn-shortcut .tss-kbd-separator,
 .tss-sidebar-btn-open .tss-btn-success .tss-sidebar-btn-shortcut .tss-kbd-separator {

--- a/Tesserae/tps/assets/css/tss.sidebar.css
+++ b/Tesserae/tps/assets/css/tss.sidebar.css
@@ -829,39 +829,84 @@
     margin-bottom: 0px;
 }
 
-/* A button dressed as a search field ---------------------------------------------------------------- */
+/* A button drawn with a field's outline -------------------------------------------------------------- */
 
-/* What is on the rail is a way in, not an input - see SidebarButton.AsSearchBox. It borrows the field's
-   outline and its muted label so it reads as where a search starts, and keeps the button's behaviour. */
-.tss-sidebar-btn-searchbox > .tss-btn.tss-sidebar-btn-searchbox-button,
-.tss-sidebar-btn-searchbox > a > .tss-btn.tss-sidebar-btn-searchbox-button {
-    position: relative;
-    height: 40px !important;
-    padding-right: 44px;
+/* See SidebarButton.Outlined. The rail's own action borrows the field's border and surface so that it and
+   the search box it stands next to read as a pair of controls, not as a button beside a form field. */
+.tss-sidebar-btn-open > .tss-btn.tss-sidebar-btn-outlined,
+.tss-sidebar-btn-open > a > .tss-btn.tss-sidebar-btn-outlined {
     border-color: var(--tss-default-border-color);
     background: var(--tss-secondary-background-color);
-    color: var(--tss-secondary-foreground-color);
-    font-weight: var(--tss-font-weight-regular);
 }
 
-.tss-sidebar-btn-searchbox > .tss-btn.tss-sidebar-btn-searchbox-button:hover,
-.tss-sidebar-btn-searchbox > a > .tss-btn.tss-sidebar-btn-searchbox-button:hover {
+.tss-sidebar-btn-open > .tss-btn.tss-sidebar-btn-outlined:hover,
+.tss-sidebar-btn-open > a > .tss-btn.tss-sidebar-btn-outlined:hover {
     border-color: var(--tss-dark-border-color);
     background: var(--tss-default-background-hover-color);
 }
 
-/* The shortcut sits at the end of the field, out of the way of a long label. */
-.tss-sidebar-btn-searchbox-shortcut {
+/* Around a single glyph on the closed rail an outline is just a box. */
+.tss-sidebar.tss-sidebar-closed .tss-sidebar-btn-open > .tss-btn.tss-sidebar-btn-outlined,
+.tss-sidebar.tss-sidebar-closed .tss-sidebar-btn-open > a > .tss-btn.tss-sidebar-btn-outlined {
+    border-color: transparent;
+    background: none;
+}
+
+/* A button dressed as a search field ---------------------------------------------------------------- */
+
+/* What is on the rail is a way in, not an input - see SidebarButton.AsSearchBox. On top of the outline
+   above it takes the field's muted label, so it reads as where a search starts rather than as an action,
+   and it keeps the button's behaviour. */
+.tss-sidebar-btn-searchbox > .tss-btn.tss-sidebar-btn-searchbox-button,
+.tss-sidebar-btn-searchbox > a > .tss-btn.tss-sidebar-btn-searchbox-button {
+    height: 40px !important;
+    color: var(--tss-secondary-foreground-color);
+    font-weight: var(--tss-font-weight-regular);
+}
+
+/* The shortcut that presses a button ---------------------------------------------------------------- */
+
+/* See SidebarButton.SetKeyboardShortcut, and AsSearchBox, which shows the chip without binding the key.
+   Room at the end for the chip, and the positioning context the chip below is placed against. */
+.tss-sidebar-btn-open > .tss-btn.tss-sidebar-btn-has-shortcut,
+.tss-sidebar-btn-open > a > .tss-btn.tss-sidebar-btn-has-shortcut {
+    position: relative;
+    padding-right: 44px;
+}
+
+/* The chip is placed rather than laid out, so it is always at the end and always whole - a label longer
+   than the room reserved for it above ends up running under it, which is the better of the two failures.
+   The offset is the rounded search box's own, so a button and a box stacked on a rail line up. */
+.tss-sidebar-btn-shortcut {
     position: absolute;
     top: 50%;
-    right: 10px;
+    right: 6px;
     transform: translateY(-50%);
     pointer-events: none;
 }
 
-/* On the closed rail there is only the glyph, so the field's chrome would be a box around one icon. */
-.tss-sidebar.tss-sidebar-closed .tss-sidebar-btn-searchbox-button {
+/* A chip washes the surface under it (see tss.kbd.css), which only works over one of the neutral tones.
+   On a filled button it takes the label's own colour and a wash of white instead. */
+.tss-sidebar-btn-open .tss-btn-primary .tss-sidebar-btn-shortcut .tss-kbd-key,
+.tss-sidebar-btn-open .tss-btn-danger .tss-sidebar-btn-shortcut .tss-kbd-key,
+.tss-sidebar-btn-open .tss-btn-success .tss-sidebar-btn-shortcut .tss-kbd-key {
+    color: inherit;
+    background: rgba(255, 255, 255, 0.2);
+    border-color: rgba(255, 255, 255, 0.38);
+}
+
+.tss-sidebar-btn-open .tss-btn-primary .tss-sidebar-btn-shortcut .tss-kbd-separator,
+.tss-sidebar-btn-open .tss-btn-danger .tss-sidebar-btn-shortcut .tss-kbd-separator,
+.tss-sidebar-btn-open .tss-btn-success .tss-sidebar-btn-shortcut .tss-kbd-separator {
+    color: inherit;
+}
+
+/* On the closed rail there is only the glyph, and nowhere for the chip to sit beside it. */
+.tss-sidebar.tss-sidebar-closed .tss-sidebar-btn-shortcut {
+    display: none;
+}
+
+.tss-sidebar.tss-sidebar-closed .tss-sidebar-btn-open > .tss-btn.tss-sidebar-btn-has-shortcut,
+.tss-sidebar.tss-sidebar-closed .tss-sidebar-btn-open > a > .tss-btn.tss-sidebar-btn-has-shortcut {
     padding-right: 0;
-    border-color: transparent;
-    background: none;
 }

--- a/Tesserae/tps/assets/css/tss.tooltip.css
+++ b/Tesserae/tps/assets/css/tss.tooltip.css
@@ -207,8 +207,13 @@
 }
 
 
+/* A tooltip is its own surface, so text in it takes the tooltip's foreground - which is what .tippy-box
+   above sets for anything that simply inherits. A component carries a colour of its own (a TextBlock is
+   .tss-fontcolor-default), and that colour is the page's, not this surface's. This used to hand it the
+   page *background* instead, which is white on a near-white bubble in the light theme and near-black on
+   a grey one in the dark: a tooltip built from a component read as empty either way. */
 .tippy-content .tss-fontcolor-default {
-    color: var(--tss-default-background-color);
+    color: var(--tss-tooltip-foreground-color);
 }
 
 

--- a/Tesserae/tps/assets/css/tss.uptime.css
+++ b/Tesserae/tps/assets/css/tss.uptime.css
@@ -144,11 +144,15 @@
   text-align: left;
 }
 
-.tippy-box[data-theme~='uptime'] .tss-text-block {
+/* This box keeps a dark surface of its own in both themes, so the text on it is light in both - the
+   tooltip's own foreground would be dark here in the light theme. The class names below were
+   .tss-text-block / .tss-font-weight-semibold, which nothing renders (they are .tss-textblock and
+   .tss-fontweight-semibold), so this leant on whatever the base tooltip rules happened to give. */
+.tippy-box[data-theme~='uptime'] .tss-textblock {
   color: #fff !important;
 }
 
-.tippy-box[data-theme~='uptime'] .tss-font-weight-semibold {
+.tippy-box[data-theme~='uptime'] .tss-fontweight-semibold {
   color: #fff !important;
   font-weight: 600 !important;
 }


### PR DESCRIPTION
A search box on the rail says which key reaches it; the button next to it had no way to say the same thing. Adding that turned up three further defects in the same neighbourhood, all fixed here.

Curiosity's side of this is curiosity-ai/mosaik#1734, which needs a package build carrying these APIs before it compiles.

## A shortcut on a sidebar button

`SidebarButton.SetKeyboardShortcut("Ctrl", "Shift", "O")` shows the shortcut as a chip at the button's far end **and** answers it while the button is on screen, so the chip is a promise rather than a note. The key presses the button, so click handlers and `href` wrappers are reached exactly as by the pointer. It works on the open button and on the closed rail's glyph — a collapsed rail is a smaller rail, not a different one — and holds no shortcut when the button is nowhere on screen.

`AsSearchBox(keys)` keeps showing its chip *without* binding, because the palette it opens owns that key and answers it from inside text fields too, where a button's shortcut steps aside.

**`SidebarButton.Outlined()`** — the border and secondary surface that were buried inside `AsSearchBox`, pulled out so a rail's own action can wear a field's chrome and read as its pair. `AsSearchBox` is now built from it.

**`KeyboardShortcut.Matches(e, keys)`** — one copy of the matcher `SearchBox` and `OmniBox` each carried privately (both now delegate), so what a chip shows and what a handler binds cannot drift apart. `Ctrl` is documented as the platform's command modifier and now renders as the **⌘** that matching has always accepted on a Mac; `Mod` / `CmdOrCtrl` are aliases, and the explicit `Control` stays ⌃ for a shortcut that means Control on a Mac too. Write it qualified — `Tesserae.KeyboardShortcut.Matches(...)` — since `using static Tesserae.UI;` shadows the type with the factory method.

## One grey plate for a key chip

The plate was a 7%/16% wash of the opposite tone, which reads as a raised key on the surfaces a chip usually sits on and takes the colour of anything else — on a filled button the same chip came out blue, red or green. It is now an opaque pair from the neutral scale, which flips with the theme: **one plate tone per theme, never the surface's** (light `rgb(240,241,242)` on `rgb(221,222,225)`, dark `rgb(36,37,40)` on `rgb(48,49,52)`). The `+` between two keys is text on the fill rather than a key, so on a filled button it still takes the label's colour.

## Text in a tooltip was invisible

`.tippy-content .tss-fontcolor-default` handed text the page **background** as its colour — white on the near-white bubble in the light theme, near-black on the grey one in the dark. A `TextBlock` carries that class, so every component tooltip made of text was unreadable (Curiosity's chat-history names among them); `Tooltip("string")` was fine because raw HTML inherits `.tippy-box`'s correct colour. It now takes `--tss-tooltip-foreground-color`: contrast **12.09:1** light, **5.42:1** dark, measured, up from ~1.05:1.

The idiom had spread — `tss.omnibox.css` restates a colour for two headers with a comment explaining the white-on-white, which is no longer what happens (colour kept, comment corrected).

## Two dead selectors and two missing z-indexes

The `uptime` theme keeps a dark box of its own and forced light text on it through `.tss-text-block` / `.tss-font-weight-semibold` — names nothing renders (`.tss-textblock`, `.tss-fontweight-semibold`). Dead, so it was living off the base rule: white by luck in the light theme and dark-on-dark in the dark one. Corrected — 14.67:1 in both.

Four of the six places that create a tippy stack it into the application z-index lane; `ChartBase` and `Teaching` did not, so a chart tooltip or a teaching bubble could be drawn behind a Layer opened over what it points at. Both now match.

## Testing

Verified in a browser against the samples app and a throwaway app reproducing Curiosity's chat rail — screenshots and scripts not committed, per the repo's testing note.

- Chip reads `Ctrl+Shift+O`, and `⌘⇧O` under a Mac user agent, where Cmd+Shift+O fires it.
- Pill and search box: identical x/width, both 42px, chips right-aligned to the same pixel.
- Shortcut fires from the caret inside the search box; a bare `o` does not; it fires on the collapsed rail and after re-opening; the chip is hidden on the rail.
- Plate colour identical across primary/danger/success/default, in a search field and on a plain card, in both themes.
- Tooltip and uptime-theme contrast measured in both themes.

The sample only ever put `Button`s in a tooltip — and buttons have explicit colours in the rule right below the broken one, which is why this survived; the Tippy sample now carries a text component tooltip as the case that catches it. `sidebar.md` and `keyboard-shortcut.md` updated alongside.

One thing to know: `SetKeyboardShortcut` registers a `window` keydown listener that is not removed when the button is discarded, matching `SearchBox.SetKeyboardShortcut`'s existing lifecycle. Handlers are guarded and return early, but say the word and I'll tie both to removal.

Left alone deliberately: the `uptime` theme hard-codes `#24292e`/`#fff` instead of the tooltip tokens — the only theme that does. It is internally correct now, but making it use the tokens is a visible design change, so that call is yours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0185NCgAxh3KvV9PpSUZ4kU5

---
_Generated by [Claude Code](https://claude.ai/code/session_0185NCgAxh3KvV9PpSUZ4kU5)_