### PR TITLE
Add a no-links-or-embedded-content mode to Markdown rendering

### DIFF
--- a/Tesserae.Tests/src/Samples/Components/MarkdownBlockSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/MarkdownBlockSample.cs
@@ -41,6 +41,13 @@ Type some markdown below to see it rendered live.
 | Sanitize | yes       |
 ";
 
+            const string paranoidSample =
+@"A [link to somewhere](https://example.com/phishing) reads as its label only, an autolink like
+https://example.com/tracker is plain text, and this image never loads:
+
+![a pixel that would call home](https://example.com/pixel.png)
+";
+
             var live   = MarkdownBlock(startingMarkdown);
             var editor = TextArea(startingMarkdown).WS().H(220).OnInput((ta, _) => live.Text = ta.Text);
 
@@ -65,7 +72,10 @@ Type some markdown below to see it rendered live.
                         ),
                         SampleSubTitle("Sanitization"),
                         TextBlock("MarkdownBlock will strip dangerous HTML even when it is embedded inside Markdown:"),
-                        MarkdownBlock("This `<script>alert('xss')</script>` will not run, and this <img src=x onerror=alert(1)> attribute is stripped too.")
+                        MarkdownBlock("This `<script>alert('xss')</script>` will not run, and this <img src=x onerror=alert(1)> attribute is stripped too."),
+                        SampleSubTitle("No links or embedded content"),
+                        TextBlock("For Markdown you don't trust to link or to load a remote URL - an LLM reply, say - pass MarkdownSanitization.NoLinksOrEmbeddedContent. Anchors keep their label as plain text and images are dropped:"),
+                        MarkdownBlock(paranoidSample, MarkdownSanitization.NoLinksOrEmbeddedContent)
                     )).SetTitle("Usage")))
                .SeeAlso(typeof(TextBlockSample), typeof(ChatSample), typeof(CodeDiffSample), typeof(SanitizeHTMLSample), typeof(AnnotatedTextEditorSample));
         }

--- a/Tesserae/skills/references/markdown-block.md
+++ b/Tesserae/skills/references/markdown-block.md
@@ -10,14 +10,43 @@ display. Setting `Text` re-renders.
 
 ## Create
 
-`MarkdownBlock(string text = "")` — renders the given Markdown. Bring the factory
-into scope with `using static Tesserae.UI;`.
+`MarkdownBlock(string text = "", MarkdownSanitization sanitization = MarkdownSanitization.Default)`
+— renders the given Markdown. Bring the factory into scope with `using static Tesserae.UI;`.
 
 ## Key configuration
 
 - `.Text` — get/set the Markdown source; assigning re-renders the sanitized HTML.
 - `.HTML` — read the rendered, sanitized HTML.
 - `.CanWrap` — whether the rendered text may wrap (false adds `tss-text-nowrap`).
+- `.Sanitization(MarkdownSanitization)` — change how strictly the HTML is sanitized
+  and re-render the current source with it.
+- `.OnAfterRender(Action<HTMLElement>)` — called with the inner element every time
+  the source is re-parsed, for post-processing the rendered tree (wrapping code
+  blocks, attaching copy buttons, …).
+
+## Sanitization
+
+Both modes run the parsed HTML through DOMPurify; the mode picks its configuration.
+
+- `MarkdownSanitization.Default` — DOMPurify's default profile: scripts and event
+  handlers go, links and images stay.
+- `MarkdownSanitization.NoLinksOrEmbeddedContent` — also removes every link and
+  every piece of embedded content (anchors, images, SVG, media) and the attributes
+  that fetch a remote URL. A link keeps its label as plain text and is not
+  clickable; an image is dropped entirely. Use it for Markdown from a source you
+  don't trust to link or to load a remote URL — an LLM reply, for instance, where a
+  rendered image is a call out to a third-party server and a rendered link is a way
+  to phish the reader.
+
+```csharp
+// An assistant reply: rendered, but with nothing clickable and nothing fetched.
+var reply = MarkdownBlock(assistantText, MarkdownSanitization.NoLinksOrEmbeddedContent);
+```
+
+The same option exists on the static helpers behind the component:
+`Markdown.ConvertMarkdownSanitized(text, sanitization)` returns the sanitized HTML
+string and `Markdown.RenderMarkdownSanitized(text, sanitization)` returns a rendered
+element.
 
 ## Example
 

--- a/Tesserae/src/Base/UI.Components.cs
+++ b/Tesserae/src/Base/UI.Components.cs
@@ -742,7 +742,7 @@ namespace Tesserae
         /// <summary>
         /// Creates a <see cref="Tesserae.MarkdownBlock"/> component that renders Markdown source as sanitized HTML.
         /// </summary>
-        public static MarkdownBlock MarkdownBlock(string text = "") => new MarkdownBlock(text);
+        public static MarkdownBlock MarkdownBlock(string text = "", MarkdownSanitization sanitization = MarkdownSanitization.Default) => new MarkdownBlock(text, sanitization);
 
         /// <summary>
         /// Creates a <see cref="Tesserae.CodeDiff"/> component that renders a unified diff using diff2html.

--- a/Tesserae/src/Components/MarkdownBlock.cs
+++ b/Tesserae/src/Components/MarkdownBlock.cs
@@ -13,15 +13,22 @@ namespace Tesserae
     {
         private string                _text;
         private Action<HTMLElement>   _onAfterRender;
+        private MarkdownSanitization  _sanitization;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MarkdownBlock"/> class.
         /// </summary>
         /// <param name="text">The Markdown source text to render.</param>
-        public MarkdownBlock(string text = "")
+        /// <param name="sanitization">
+        /// How strictly to sanitize the rendered HTML. Pass
+        /// <see cref="MarkdownSanitization.NoLinksOrEmbeddedContent"/> for Markdown from a source you
+        /// don't trust to link or to load a remote URL.
+        /// </param>
+        public MarkdownBlock(string text = "", MarkdownSanitization sanitization = MarkdownSanitization.Default)
         {
             InnerElement                  = Div(Att("tss-markdown"));
             InnerElement.style.whiteSpace = "break-spaces";
+            _sanitization                 = sanitization;
             Text                          = text ?? string.Empty;
         }
 
@@ -32,9 +39,19 @@ namespace Tesserae
             set
             {
                 _text                  = value ?? string.Empty;
-                InnerElement.innerHTML = Tesserae.Markdown.ConvertMarkdownSanitized(_text);
+                InnerElement.innerHTML = Tesserae.Markdown.ConvertMarkdownSanitized(_text, _sanitization);
                 _onAfterRender?.Invoke(InnerElement);
             }
+        }
+
+        /// <summary>
+        /// Sets how strictly the rendered HTML is sanitized and re-renders the current source with it.
+        /// </summary>
+        public MarkdownBlock Sanitization(MarkdownSanitization sanitization)
+        {
+            _sanitization = sanitization;
+            Text          = _text;
+            return this;
         }
 
         /// <summary>Gets the rendered sanitized HTML (derived from <see cref="Text"/>).</summary>

--- a/Tesserae/src/Helpers/Markdown.cs
+++ b/Tesserae/src/Helpers/Markdown.cs
@@ -14,6 +14,7 @@ namespace Tesserae
     public static class Markdown
     {
         private static object _shared;
+        private static object _noLinksOrEmbeddedContentConfig;
 
         private static object GetShared()
         {
@@ -25,13 +26,40 @@ namespace Tesserae
         }
 
         /// <summary>
+        /// The DOMPurify configuration behind <see cref="MarkdownSanitization.NoLinksOrEmbeddedContent"/>:
+        /// every element that navigates or fetches a URL, plus the attributes that carry one (a style
+        /// attribute included - <c>background-image: url(...)</c> loads a remote image as surely as an
+        /// <c>img</c> does). DOMPurify keeps a forbidden element's children by default, so an anchor
+        /// leaves its label behind as plain text while an image, having no children, disappears with
+        /// its tag.
+        /// </summary>
+        private static object GetNoLinksOrEmbeddedContentConfig()
+        {
+            if (_noLinksOrEmbeddedContentConfig == null)
+            {
+                _noLinksOrEmbeddedContentConfig = Script.Write<object>(
+                    "{ FORBID_TAGS: ['a','area','map','img','image','picture','source','track','svg','use','video','audio','iframe','frame','frameset','embed','object','portal','link','base','style','form','input','button','textarea'],"
+                  + "  FORBID_ATTR: ['href','xlink:href','src','srcset','sizes','poster','background','data','action','formaction','ping','usemap','longdesc','style'] }");
+            }
+            return _noLinksOrEmbeddedContentConfig;
+        }
+
+        /// <summary>
         /// Parses the given markdown <paramref name="text"/> and runs the resulting HTML through DOMPurify.
         /// </summary>
-        public static string ConvertMarkdownSanitized(string text)
+        /// <param name="text">The Markdown source.</param>
+        /// <param name="sanitization">How strictly to sanitize the parsed HTML. See <see cref="MarkdownSanitization"/>.</param>
+        public static string ConvertMarkdownSanitized(string text, MarkdownSanitization sanitization = MarkdownSanitization.Default)
         {
             var marked = GetShared();
             var parsedAsMarkdown = Script.Write<string>("{0}.parse({1})", marked, text);
             var cleaned = RemoveExcessiveNewLines(parsedAsMarkdown);
+
+            if (sanitization == MarkdownSanitization.NoLinksOrEmbeddedContent)
+            {
+                return Script.Write<string>("DOMPurify.sanitize({0}, {1})", cleaned, GetNoLinksOrEmbeddedContentConfig());
+            }
+
             var sanitized = Script.Write<string>("DOMPurify.sanitize({0})", cleaned);
             return sanitized;
         }
@@ -45,9 +73,9 @@ namespace Tesserae
         /// Parses and sanitizes the markdown, then wraps the resulting HTML in a span with the
         /// <c>tss-markdown</c> class so it picks up the default Tesserae markdown styling.
         /// </summary>
-        public static HTMLElement RenderMarkdownSanitized(string text)
+        public static HTMLElement RenderMarkdownSanitized(string text, MarkdownSanitization sanitization = MarkdownSanitization.Default)
         {
-            var convertedText = ConvertMarkdownSanitized(text);
+            var convertedText = ConvertMarkdownSanitized(text, sanitization);
             var el            = Raw(convertedText, forceParseAsHTML: true);
             el.classList.add("tss-markdown");
             el.style.whiteSpace = "break-spaces";

--- a/Tesserae/src/Helpers/MarkdownSanitization.cs
+++ b/Tesserae/src/Helpers/MarkdownSanitization.cs
@@ -1,0 +1,28 @@
+namespace Tesserae
+{
+    /// <summary>
+    /// How strictly the HTML produced from a Markdown source is sanitized before it is inserted
+    /// into the page. Both modes go through DOMPurify - the mode only picks the configuration.
+    /// </summary>
+    [Transpose.Name("tss.mds")]
+    public enum MarkdownSanitization
+    {
+        /// <summary>
+        /// DOMPurify's default profile: scripts and event handlers are removed, but links,
+        /// images and other embedded media survive.
+        /// </summary>
+        Default,
+
+        /// <summary>
+        /// Everything <see cref="Default"/> removes, plus every link and every piece of embedded
+        /// content: anchors, images, SVG, media elements and the attributes that fetch a remote
+        /// URL. Link text is kept as plain text, so a Markdown link reads as its label and is not
+        /// clickable, and an image is dropped entirely.
+        ///
+        /// Use it for Markdown written by something you don't trust to link or to load a remote
+        /// URL - an LLM reply, for instance, where a rendered image is a way to call out to a
+        /// third-party server and a rendered link is a way to phish the reader.
+        /// </summary>
+        NoLinksOrEmbeddedContent
+    }
+}


### PR DESCRIPTION
## What

`MarkdownBlock` and the `Markdown` helpers now take a `MarkdownSanitization`, which picks the DOMPurify configuration applied to the parsed HTML:

- `MarkdownSanitization.Default` — DOMPurify's default profile, exactly what every caller gets today.
- `MarkdownSanitization.NoLinksOrEmbeddedContent` — also forbids every element that navigates or fetches a URL (`a`, `img`, SVG, `picture`/`source`/`track`, media, frames, `form`/`input`, `style`) and the attributes that carry one (`href`, `src`, `srcset`, `poster`, `background`, `formaction`, … including `style`, since `background-image: url(...)` loads a remote image as surely as an `img` does).

DOMPurify keeps a forbidden element's children, so a link renders as its label in plain text while an image — having no children — disappears with its tag.

Surface added:

- `Markdown.ConvertMarkdownSanitized(text, sanitization)` / `Markdown.RenderMarkdownSanitized(text, sanitization)`
- `MarkdownBlock(text, sanitization)` (constructor + `UI` factory) and a `.Sanitization(...)` fluent method that re-renders the current source

## Why

For Markdown from a source you don't trust to link or to load a remote URL — an LLM reply, typically — a rendered image is a call out to a third-party server the moment the message appears, and a rendered link is a way to phish the reader. Doing it in the sanitizer config rather than as a pass over the rendered DOM means there is no window where the markup exists in the document.

Consumed by the Curiosity Workspace front-end as the `ParanoidMessageRendering` chat setting (curiosity-ai/mosaik#, same branch name), which needs a Tesserae package bump carrying this to build.

## Verification

`dotnet build` clean on `Tesserae.csproj` and `Tesserae.Tests.csproj`. The samples app was then driven in headless Chromium against the bundled marked 18 / DOMPurify 3.4.9 — on the new sample block: 0 anchors, 0 images, link labels and autolinks rendered as plain text, and zero network requests to the image host. The default-mode blocks on the same page still render their links and images unchanged.

## Also in this change

- `Tesserae/skills/references/markdown-block.md` documents the modes, the new factory signature, `.Sanitization(...)` and `.OnAfterRender(...)`.
- `MarkdownBlockSample` gets a "No links or embedded content" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NYDoVLYC5QtnzRZNz6bbx

---
_Generated by [Claude Code](https://claude.ai/code/session_018NYDoVLYC5QtnzRZNz6bbx)_