### PR TITLE
Close the form-submission hole in the Sandbox default CSP

### DIFF
--- a/Tesserae/skills/references/sandbox.md
+++ b/Tesserae/skills/references/sandbox.md
@@ -24,6 +24,26 @@ Both return a `Sandbox`. Bring factories into scope with `using static Tesserae.
 - `.ContentSecurityPolicy(string)` / `.NoContentSecurityPolicy()` — override or disable the CSP.
 - `.AllowSameOrigin()` — **weakens isolation**; only for trusted content.
 
+## What the default CSP does and does not stop
+
+`Sandbox.DefaultContentSecurityPolicy` is
+`default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src data: blob:; form-action 'none'; base-uri 'none';`
+
+It stops every way the content can *fetch* something: remote images, stylesheets, fonts,
+`fetch`/`XHR`/`sendBeacon`, WebSockets, nested frames, `prefetch`, and CSS `url()` — including
+`@import` and `@font-face`. `form-action` and `base-uri` are spelled out because neither falls back
+to `default-src`; without `form-action 'none'` a framed document with `allow-forms` can submit a
+form to any host on load and exfiltrate that way.
+
+It does **not** stop the document navigating *itself* — `location = …`, a `meta refresh`, or a click
+on a link — because no fetch directive covers that. Sandbox flags are what govern those: without
+`allow-scripts` the automatic ones (`location`, `meta refresh`, a scripted `.click()`) are blocked
+too, but a **reader's click on a link inside the frame still navigates it**. To close that, strip the
+links out of the content before framing it — e.g. sanitize with
+`MarkdownSanitization.NoLinksOrEmbeddedContent`'s DOMPurify configuration (see
+`markdown-block.md`). `allow-popups` and top-level navigation are already blocked by the default
+flags.
+
 ## Example
 
 ```csharp

--- a/Tesserae/src/Components/Sandbox.cs
+++ b/Tesserae/src/Components/Sandbox.cs
@@ -25,8 +25,20 @@ namespace Tesserae
     [Transpose.Name("tss.Sandbox")]
     public sealed class Sandbox : ComponentBase<Sandbox, HTMLIFrameElement>, ISpecialCaseStyling
     {
-        /// <summary>The fully-locked default CSP: inline scripts and styles only, images limited to data/blob URIs, no network access.</summary>
-        public const string DefaultContentSecurityPolicy = "default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src data: blob:;";
+        /// <summary>
+        /// The fully-locked default CSP: inline scripts and styles only, images limited to data/blob URIs,
+        /// no network access.
+        ///
+        /// <para><c>form-action 'none'</c> is spelled out because it has no fallback to
+        /// <c>default-src</c>: without it a framed document can post a form to any host and reach the
+        /// network that way, and with <c>allow-scripts allow-forms</c> it can do so on load without the
+        /// reader touching anything. <c>base-uri 'none'</c> keeps a <c>base</c> tag from repointing the
+        /// document's relative URLs. Note that a document navigating *itself* - <c>location=</c>, a
+        /// <c>meta refresh</c>, a click on a link - is governed by neither, only by the sandbox flags:
+        /// drop <see cref="AllowScripts"/> to stop the automatic ones, and strip the links out of the
+        /// content to stop the clicked ones.</para>
+        /// </summary>
+        public const string DefaultContentSecurityPolicy = "default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src data: blob:; form-action 'none'; base-uri 'none';";
 
         // Injected into the sandboxed document. Captures errors / CSP violations / unhandled rejections
         // and (when the host asks for it) reports the document height, posting everything back over the


### PR DESCRIPTION
## What

`Sandbox.DefaultContentSecurityPolicy` gains `form-action 'none'; base-uri 'none';`.

Neither directive falls back to `default-src`, so `default-src 'none'` did not cover them: a framed document could post a form to any host and reach the network that way, and with the default `allow-scripts allow-forms` flags it could do so **on load**, without the reader touching anything. `base-uri 'none'` stops a `base` tag repointing the document's relative URLs.

## Why it went unnoticed

Measured against a real HTTP server counting what actually arrives (a CSP-blocked request still shows up in devtools/Playwright as a request, which is what makes this easy to miss). Every channel the default CSP is meant to close never reached the server — remote images, stylesheets, fonts, CSS `url()` including `@import` and `@font-face`, `fetch`/`XHR`/`sendBeacon`, WebSockets, nested frames, `prefetch`, `window.open`, top navigation. A GET form submission arrived with its query string (`/formjs?leak=secret`), and so did a POST. With `form-action 'none'` neither does.

## What this still does not cover, and why

A document navigating **itself** — `location = …`, a `meta refresh`, a click on a link — is governed by the sandbox flags, not by fetch directives (`navigate-to` never shipped). Measured across configurations:

| | form submit | `location=` | meta refresh | scripted `a.click()` | reader clicks a link |
|---|---|---|---|---|---|
| `allow-scripts allow-forms`, old CSP | reaches network | reaches | reaches | reaches | reaches |
| `allow-scripts allow-forms`, new CSP | blocked | reaches | reaches | reaches | reaches |
| no `allow-scripts`, new CSP | blocked | blocked | blocked | blocked | reaches |

So: `form-action` closes the no-interaction form channel for everyone; dropping `AllowScripts` closes the automatic navigations; and a reader's click on a link inside the frame navigates it in *every* configuration — only stripping the links out of the content closes that, which is what `MarkdownSanitization.NoLinksOrEmbeddedContent` is for. `references/sandbox.md` now says all of this so the next caller does not have to re-derive it.

## Note on history

This is the second commit of #307, which was merged before it landed. Rebased onto current master, unchanged; the first commit is already in.

## Verification

`dotnet build` clean on `Tesserae.csproj` and `Tesserae.Tests.csproj`; the shipped `tss.js` carries the new policy, and the 22-payload sweep above was re-run against that build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NYDoVLYC5QtnzRZNz6bbx

---
_Generated by [Claude Code](https://claude.ai/code/session_018NYDoVLYC5QtnzRZNz6bbx)_