### PR TITLE
Add ShortcutOnlyOnHover to hide keyboard shortcut chips until hover

### DIFF
--- a/Tesserae.Tests/src/Samples/Components/SidebarSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/SidebarSample.cs
@@ -35,8 +35,17 @@ namespace Tesserae.Tests.Samples
 
             sidebar.AddHeader(searchBox);
 
-            sidebar.AddContent(new SidebarButton("home", UIcons.Home, "Home"));
-            sidebar.AddContent(new SidebarButton("profile", UIcons.User, "Profile"));
+            // Rows that each carry a key: every chip at once would be a column of noise beside the labels, so
+            // they wait for the pointer (or for keyboard focus) — see .ShortcutOnlyOnHover().
+            sidebar.AddContent(new SidebarButton("home", UIcons.Home, "Home")
+                .SetKeyboardShortcut("Ctrl", "Shift", "H")
+                .ShortcutOnlyOnHover()
+                .OnClick(() => Toast().Success("Home")));
+
+            sidebar.AddContent(new SidebarButton("profile", UIcons.User, "Profile")
+                .SetKeyboardShortcut("Ctrl", "Shift", "P")
+                .ShortcutOnlyOnHover()
+                .OnClick(() => Toast().Success("Profile")));
 
             sidebar.AddContent(new SidebarSeparator("sep1", "Grouping"));
 
@@ -125,7 +134,7 @@ namespace Tesserae.Tests.Samples
                .SampleTitle(typeof(SidebarSample), UIcons.Apps, "A sidebar navigation component")
                .FlatSection(Stack().Children(
                     Card(VStack().WS().Children(
-                    TextBlock("A fully featured Sidebar with Search, Navigation, Buttons, and Separators. The header shows a rounded (pill) primary button and a rounded search box, each with the shortcut that reaches it at its far end — enable the pill with .Rounded() and the shortcut with .SetKeyboardShortcut()."))).SetTitle("Overview"),
+                    TextBlock("A fully featured Sidebar with Search, Navigation, Buttons, and Separators. The header shows a rounded (pill) primary button and a rounded search box, each with the shortcut that reaches it at its far end — enable the pill with .Rounded() and the shortcut with .SetKeyboardShortcut(). Home and Profile carry keys too, but add .ShortcutOnlyOnHover(), so their chips wait for the pointer instead of standing in a column beside the labels."))).SetTitle("Overview"),
                     Card(VStack().WS().Children(
                         SplitView().WS().H(800).LeftIsSmaller(400.px()).Resizable()
                                    .Left(sidebar.S())

--- a/Tesserae/skills/references/sidebar.md
+++ b/Tesserae/skills/references/sidebar.md
@@ -34,7 +34,8 @@ Bring factories into scope with `using static Tesserae.UI;`.
 
 Common item types: `SidebarButton(id, UIcons icon, text)` (`.Selected()`,
 `.OnClick(...)`, `.Primary()`, `.Danger()`, `.Rounded()`,
-`.SetKeyboardShortcut("Ctrl", "Shift", "O")`, `.Tooltip(...)`),
+`.SetKeyboardShortcut("Ctrl", "Shift", "O")`, `.ShortcutOnlyOnHover()`,
+`.Tooltip(...)`),
 `SidebarSeparator(id, text)`, `SidebarNav(id, icon, text, initiallyCollapsed)`,
 `SidebarText(id, text)`,
 `SidebarSearchBox(id, placeholder)` (`.OnSearch(...)`, `.OnClick(...)`,
@@ -84,6 +85,21 @@ palette or page it opens is what owns that key — and answers it from inside a 
 field too, where a button's shortcut steps aside. Pass no keys and call
 `.SetKeyboardShortcut(...)` when the button itself should answer.
 
+`.ShortcutOnlyOnHover()` — on both `SidebarButton` and `SidebarSearchBox` — keeps
+the chip out of sight until the pointer is on the row, or something inside it has
+focus, so a row reached by tabbing shows its key too. For a rail where most rows
+carry a key: all the chips at once read as a column of noise beside the labels,
+while one chip on the row being pointed at is still how the key gets discovered.
+The binding is untouched, and the room the chip takes stays reserved, so no label
+re-flows as it fades in. Pass `false` for the default, a chip that is always there.
+
+```csharp
+sidebar.AddContent(new SidebarButton("home", UIcons.Home, "Home")
+    .SetKeyboardShortcut("Ctrl", "Shift", "H")
+    .ShortcutOnlyOnHover()
+    .OnClick(GoHome));
+```
+
 A `.Selected()` item is outlined in the theme's primary color and filled with a
 wash of it, rather than with the grey a hover uses — so where you are still
 reads while the pointer is somewhere else in the list. It follows
@@ -117,6 +133,8 @@ filters searchable items. Configure it fluently:
 - `.OnSearch(term => sidebar.Search(term))` — run on every keystroke.
 - `.SetKeyboardShortcut("Ctrl", "K")` — show a shortcut chip (renders ⌘K on
   macOS, Ctrl+K elsewhere) and focus the box when the shortcut is pressed.
+- `.ShortcutOnlyOnHover(bool = true)` — hide that chip until the box is hovered
+  or holds the caret; the key still works either way.
 - `.Rounded(BorderRadius = Full)` — render as a full bordered, rounded "pill".
 - `.Text` / `.SetText(text)` — read or replace what is in the box. Setting it
   does not raise `.OnSearch(...)`, so a caller that clears the box decides for

--- a/Tesserae/src/Components/Sidebar/SidebarButton.cs
+++ b/Tesserae/src/Components/Sidebar/SidebarButton.cs
@@ -440,6 +440,31 @@ namespace Tesserae
         }
 
         /// <summary>
+        /// Keeps the shortcut chip out of sight until the pointer is on the row - or something inside it has
+        /// focus, so a row reached by tabbing shows its key too. The binding is untouched: the key works the
+        /// same whether or not the chip is on screen.
+        /// <para>
+        /// For a rail where most rows carry a key: all the chips at once read as a column of noise beside the
+        /// labels, while one chip on the row being pointed at is still how the key gets discovered. The room
+        /// at the end stays reserved either way, so a label does not re-flow as the chip appears.
+        /// </para>
+        /// </summary>
+        /// <param name="onlyOnHover">Whether the chip waits for a hover. False shows it at all times, the default.</param>
+        public SidebarButton ShortcutOnlyOnHover(bool onlyOnHover = true)
+        {
+            if (onlyOnHover)
+            {
+                _open.Class("tss-sidebar-shortcut-on-hover");
+            }
+            else
+            {
+                _open.RemoveClass("tss-sidebar-shortcut-on-hover");
+            }
+
+            return this;
+        }
+
+        /// <summary>
         /// Whichever of the two renderings the user can actually see, or null when neither is. Mounted is not
         /// enough on its own: both are mounted at once while the sidebar hides the one it is not showing, and
         /// a collapsed button is mounted too.

--- a/Tesserae/src/Components/Sidebar/SidebarSearchBox.cs
+++ b/Tesserae/src/Components/Sidebar/SidebarSearchBox.cs
@@ -143,6 +143,22 @@ namespace Tesserae
             return this;
         }
 
+        /// <summary>
+        /// Keeps the shortcut chip out of sight until the pointer is on the box - or the caret is in it, so a
+        /// box reached by tabbing shows its key too. The binding is untouched: the key works the same whether
+        /// or not the chip is on screen.
+        /// <para>
+        /// The room the chip takes at the end is reserved either way, so what is typed does not re-flow as the
+        /// chip appears.
+        /// </para>
+        /// </summary>
+        /// <param name="onlyOnHover">Whether the chip waits for a hover. False shows it at all times, the default.</param>
+        public SidebarSearchBox ShortcutOnlyOnHover(bool onlyOnHover = true)
+        {
+            _openElement.classList.toggle("tss-sidebar-shortcut-on-hover", onlyOnHover);
+            return this;
+        }
+
         public void AddGroupIdentifier(string groupIdentifier)
         {
              Identifier = groupIdentifier + Sidebar.GroupIdentifierSeparator + Identifier;

--- a/Tesserae/tps/assets/css/tss.sidebar.css
+++ b/Tesserae/tps/assets/css/tss.sidebar.css
@@ -905,3 +905,23 @@
 .tss-sidebar.tss-sidebar-closed .tss-sidebar-btn-open > a > .tss-btn.tss-sidebar-btn-has-shortcut {
     padding-right: 0;
 }
+
+/* ...and the same chip only while the row is pointed at ---------------------------------------------- */
+
+/* See SidebarButton.ShortcutOnlyOnHover and SidebarSearchBox.ShortcutOnlyOnHover. On a rail where most rows
+   carry a key, every chip at once is a column of noise beside the labels, while one chip on the row under the
+   pointer is still how the key gets found. Faded rather than removed: the room it takes stays reserved, so no
+   label re-flows as it comes back. Focus counts as a hover, so a row reached by tabbing - or a box holding the
+   caret - shows its key too. The class sits on the open row, which both items share. */
+.tss-sidebar-btn-open.tss-sidebar-shortcut-on-hover .tss-sidebar-btn-shortcut,
+.tss-sidebar-btn-open.tss-sidebar-shortcut-on-hover .tss-searchbox-shortcut {
+    opacity: 0;
+    transition: opacity 0.167s ease 0s;
+}
+
+.tss-sidebar-btn-open.tss-sidebar-shortcut-on-hover:hover .tss-sidebar-btn-shortcut,
+.tss-sidebar-btn-open.tss-sidebar-shortcut-on-hover:focus-within .tss-sidebar-btn-shortcut,
+.tss-sidebar-btn-open.tss-sidebar-shortcut-on-hover:hover .tss-searchbox-shortcut,
+.tss-sidebar-btn-open.tss-sidebar-shortcut-on-hover:focus-within .tss-searchbox-shortcut {
+    opacity: 1;
+}


### PR DESCRIPTION
## Summary

Adds a new `ShortcutOnlyOnHover()` fluent method to `SidebarButton` and `SidebarSearchBox` that hides keyboard shortcut chips until the row/box is hovered or receives focus. This reduces visual noise in sidebars where most rows carry shortcuts.

## Changes

- **SidebarButton.cs**: Added `ShortcutOnlyOnHover(bool onlyOnHover = true)` method that toggles the `tss-sidebar-shortcut-on-hover` CSS class
- **SidebarSearchBox.cs**: Added matching `ShortcutOnlyOnHover(bool onlyOnHover = true)` method with the same behavior
- **tss.sidebar.css**: Added CSS rules to fade shortcut chips (opacity 0→1) on hover or focus-within, with smooth 0.167s transition. The chip space is reserved at all times so labels don't reflow
- **sidebar.md**: Updated reference documentation with method signature, explanation, and code example showing typical usage
- **SidebarSample.cs**: Updated sample to demonstrate the feature on Home and Profile buttons with keyboard shortcuts

## Implementation Details

- The shortcut chip remains in the DOM but invisible (opacity: 0) when the class is applied, preserving layout space
- Focus-within is included so keyboard navigation (Tab) also reveals the shortcut
- The binding itself is unaffected—the key works whether the chip is visible or not
- Smooth CSS transition (0.167s ease) provides visual feedback without jarring appearance/disappearance

https://claude.ai/code/session_017Lo613WHiYxtLCTT5LF2og