### PR TITLE
PagesStack: reshape pages to match landscape thumbnails

### DIFF
--- a/Tesserae.Tests/src/Samples/Components/OmniResultSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/OmniResultSample.cs
@@ -531,6 +531,14 @@ namespace Tesserae.Tests.Samples
                 "./assets/img/curiosity-logo.svg"
             };
 
+            var slides = new[]
+            {
+                "./assets/img/slide-16-9.svg",
+                "./assets/img/slide-16-9.svg",
+                "./assets/img/slide-16-9.svg",
+                "./assets/img/slide-16-9.svg"
+            };
+
             return FeatureCard("PagesStack", "The page preview on its own",
                 "PagesStack is the preview rail: up to five overlapping, slightly rotated pages that fan out on a shallow arc when hovered, with a +N badge over the stack counting the pages it doesn't draw. Given thumbnail urls it draws them (all cropped to one page size); given only a count it draws blank ruled pages. The holder is sized to the width the fan needs and pinned to its right edge, so opening the fan never widens the row — which is why a row can sit right beside it.",
                 HStack().WS().Wrap().Gap(32.px()).PT(8).PB(8).AlignItems(ItemAlign.End).Children(
@@ -541,6 +549,17 @@ namespace Tesserae.Tests.Samples
                     PagesLabel("Thumbnails", PagesStack(thumbnails).TotalPages(9)),
                     PagesLabel("Larger pages", PagesStack(4).PageSize(60, 78)),
                     PagesLabel("MaxVisible(3)", PagesStack(12).MaxVisible(3))),
+                TextBlock("The pages take their shape from the document: the first thumbnail that loads wider than it is tall turns the whole stack landscape, keeping the long side of the page size and taking the short one from the thumbnail's aspect ratio — so a deck of slides isn't drawn as a pile of portrait pages. MatchThumbnailShape(false) keeps the configured size whatever loads:").Small().MT(8).MB(8),
+                HStack().WS().Wrap().Gap(32.px()).PB(8).AlignItems(ItemAlign.End).Children(
+                    PagesLabel("16:9 slides", PagesStack(slides).TotalPages(18)),
+                    PagesLabel("Larger slides", PagesStack(slides).PageSize(60, 78)),
+                    PagesLabel("MatchThumbnailShape(false)", PagesStack(slides).MatchThumbnailShape(false))),
+                TextBlock("The reshaping is a rail the row was already holding open for the fan, so a deck previews in a result row the same way a document does:").Small().MT(8).MB(8),
+                OmniResult(Hits[1], "Q3 line review.pptx")
+                   .SetIcon("PPTX", "#f97316")
+                   .SetSource("#0061d5", "Box")
+                   .SetFooterEntries("18 slides", "4.1 MB", "Sep 30, 2024")
+                   .SetPages(PagesStack(slides).TotalPages(18).OnPageClick(page => Toast().Information($"Opening slide {page + 1}"))),
                 TextBlock("Held open with Fanned(), which is how OmniResult makes the stack follow hovering the whole row (PagesFanOnHover, on by default). OnPageClick makes each drawn page open the document at itself — the click is the page's alone, so it never also counts as a click on the row:").Small().MT(8).MB(8),
                 HStack().WS().Wrap().Gap(32.px()).AlignItems(ItemAlign.End).Children(
                     PagesLabel("Fanned()", PagesStack(5).TotalPages(19).Fanned()),

--- a/Tesserae.Tests/tps/assets/img/slide-16-9.svg
+++ b/Tesserae.Tests/tps/assets/img/slide-16-9.svg
@@ -1,0 +1,13 @@
+<svg width="320" height="180" viewBox="0 0 320 180" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="320" height="180" fill="#ffffff"/>
+  <rect x="24" y="24" width="150" height="14" rx="4" fill="#1f2933"/>
+  <rect x="24" y="52" width="110" height="8" rx="4" fill="#9aa5b1"/>
+  <rect x="24" y="70" width="132" height="8" rx="4" fill="#cbd2d9"/>
+  <rect x="24" y="88" width="96" height="8" rx="4" fill="#cbd2d9"/>
+  <rect x="196" y="52" width="100" height="72" rx="6" fill="#e4e7eb"/>
+  <rect x="208" y="96" width="14" height="18" rx="2" fill="#7b93db"/>
+  <rect x="228" y="82" width="14" height="32" rx="2" fill="#5c7cfa"/>
+  <rect x="248" y="70" width="14" height="44" rx="2" fill="#4263eb"/>
+  <rect x="268" y="88" width="14" height="26" rx="2" fill="#91a7ff"/>
+  <rect x="24" y="146" width="60" height="6" rx="3" fill="#cbd2d9"/>
+</svg>

--- a/Tesserae/skills/references/pages-stack.md
+++ b/Tesserae/skills/references/pages-stack.md
@@ -31,8 +31,17 @@ Also `new PagesStack(...)`. Bring factories into scope with `using static Tesser
   `+N` badge. A stack given thumbnails draws only those, so `PagesStack(4 urls).TotalPages(9)` is four
   thumbnails and a `+5`.
 - `.MaxVisible(int)` — how many pages are drawn before the rest collapse into the badge (5 by default).
-- `.PageSize(int width, int height)` — the size every page is drawn at (48×62 by default). The rail
-  width follows from it, so a larger page reserves more room for the fan.
+- `.PageSize(int width, int height)` — the size every page is drawn at, portrait (48×62 by default).
+  The rail width follows from it, so a larger page reserves more room for the fan.
+- `.MatchThumbnailShape(bool = true)` — on by default: the first thumbnail to load that is wider than
+  it is tall turns the pages landscape, keeping the long side of `PageSize` and taking the short one
+  from that thumbnail's aspect ratio (clamped at 3:1, so a panorama doesn't draw the stack as
+  slivers). All the pages of one document share the shape the first measured thumbnail reports —
+  reshaping per thumbnail would rewrite the row's layout on every image that arrived. The rail and the
+  page overlap are rewritten in place, without rebuilding the pages. Pass `false` to keep the
+  configured size whatever loads.
+- `IsLandscape` / `DrawnPageWidth` / `DrawnPageHeight` — the shape the pages are actually drawn at
+  right now, which is `PageSize`'s until a landscape thumbnail has reshaped them.
 - `.Fanned(bool = true)` — hold the stack open, for a host that wants the fan to follow hovering
   something larger than the stack. `OmniResult` does exactly this for the row it sits in
   (`PagesFanOnHover`, on by default).
@@ -55,6 +64,9 @@ var preview = PagesStack(5).TotalPages(24);
 
 // Real thumbnails, and more pages than there are thumbnails for.
 var thumbs = PagesStack(page1Url, page2Url, page3Url).TotalPages(12);
+
+// A deck: the slides load landscape, so the pages turn landscape with them.
+var deck = PagesStack(slideUrls).TotalPages(32);
 
 // Where it usually goes: the preview rail of a search result.
 var row = OmniResult(hit, hit.Name)

--- a/Tesserae/src/Components/PagesStack.cs
+++ b/Tesserae/src/Components/PagesStack.cs
@@ -19,6 +19,11 @@ namespace Tesserae
     /// (<see cref="PagesStack(int)"/>), for a document whose thumbnails haven't been generated - or aren't
     /// worth generating - yet.
     /// </para>
+    /// <para>
+    /// Pages are drawn portrait until a thumbnail says otherwise: the first one that loads wider than it is
+    /// tall turns the whole stack landscape, so a deck of slides isn't previewed as a pile of A4. See
+    /// <see cref="MatchThumbnailShape(bool)"/>.
+    /// </para>
     /// </summary>
     [Transpose.Name("tss.PagesStack")]
     public sealed class PagesStack : ComponentBase<PagesStack, HTMLElement>
@@ -33,8 +38,13 @@ namespace Tesserae
         private const float REST_ROTATION       = 1.2f; // degrees added per page at rest
         private const float FAN_ROTATION        = 7f;   // degrees the outermost pages reach when fanned
 
-        private readonly HTMLElement _stack;
-        private readonly HTMLElement _more;
+        // A landscape page is drawn as wide as a portrait one is tall, so past this the pages would be
+        // slivers - a panorama thumbnail should not flatten the stack out of being read as pages.
+        private const float MAX_LANDSCAPE_ASPECT = 3f;
+
+        private readonly HTMLElement       _stack;
+        private readonly HTMLElement       _more;
+        private readonly List<HTMLElement> _pages;
 
         private List<string> _urls;
         private int          _pageCount;
@@ -42,6 +52,9 @@ namespace Tesserae
         private int          _pageWidth  = DEFAULT_PAGE_WIDTH;
         private int          _pageHeight = DEFAULT_PAGE_HEIGHT;
         private Action<int>  _pageClickHandler;
+        private bool         _matchThumbnailShape = true;
+        private bool         _thumbnailMeasured;
+        private float        _landscapeAspect; // 0 until a landscape thumbnail has reported its size
 
         /// <summary>
         /// Initializes a new instance of this class showing the given thumbnails, at most
@@ -72,6 +85,7 @@ namespace Tesserae
             InnerElement = Div(Att("tss-pagesstack-holder"), _stack);
 
             _urls      = new List<string>();
+            _pages     = new List<HTMLElement>();
             _pageCount = 0;
 
             _more.style.display = "none";
@@ -96,6 +110,31 @@ namespace Tesserae
         public bool IsFanned => InnerElement.classList.contains("tss-pagesstack-fanned");
 
         /// <summary>
+        /// Returns a value indicating whether the pages are drawn landscape, which they are once a
+        /// thumbnail has loaded that is wider than it is tall - see
+        /// <see cref="MatchThumbnailShape(bool)"/>.
+        /// </summary>
+        public bool IsLandscape => _landscapeAspect > 0;
+
+        /// <summary>
+        /// Gets the width every page is currently drawn at, which is <see cref="PageSize(int,int)"/>'s
+        /// width unless a landscape thumbnail has reshaped the pages.
+        /// </summary>
+        public int DrawnPageWidth => IsLandscape ? LongSide : _pageWidth;
+
+        /// <summary>
+        /// Gets the height every page is currently drawn at, which is <see cref="PageSize(int,int)"/>'s
+        /// height unless a landscape thumbnail has reshaped the pages.
+        /// </summary>
+        public int DrawnPageHeight => IsLandscape
+            ? Math.Max(1, (int)Math.Round((double)LongSide / _landscapeAspect))
+            : _pageHeight;
+
+        // A landscape page keeps the long side of the configured page size and takes its short side from
+        // the thumbnail, so a page of a landscape document is the portrait page turned on its side.
+        private int LongSide => Math.Max(_pageWidth, _pageHeight);
+
+        /// <summary>
         /// Renders the component's root HTML element.
         /// </summary>
         public override HTMLElement Render() => InnerElement;
@@ -118,6 +157,8 @@ namespace Tesserae
 
             _pageCount = _urls.Count;
 
+            ForgetThumbnailShape();
+
             return Rebuild();
         }
 
@@ -128,6 +169,8 @@ namespace Tesserae
         {
             _urls      = new List<string>();
             _pageCount = pages < 0 ? 0 : pages;
+
+            ForgetThumbnailShape();
 
             return Rebuild();
         }
@@ -155,14 +198,34 @@ namespace Tesserae
         }
 
         /// <summary>
-        /// Sets the size every page is drawn at. All pages share one size, whatever their thumbnails'
-        /// aspect ratios are (a thumbnail is cropped to fill), so the stack reads as one document.
+        /// Sets the size every page is drawn at, portrait. All pages share one size, whatever their
+        /// individual thumbnails' aspect ratios are (a thumbnail is cropped to fill), so the stack reads
+        /// as one document - though the shape the pages share follows the document's own, see
+        /// <see cref="MatchThumbnailShape(bool)"/>.
         /// </summary>
         public PagesStack PageSize(int width, int height)
         {
             _pageWidth  = width  < 1 ? 1 : width;
             _pageHeight = height < 1 ? 1 : height;
 
+            return Rebuild();
+        }
+
+        /// <summary>
+        /// Sets whether the pages take their shape from the thumbnails, which they do by default: the
+        /// first thumbnail to load that is wider than it is tall turns the pages landscape - keeping the
+        /// long side of <see cref="PageSize(int,int)"/> and taking the short one from the thumbnail's
+        /// aspect ratio - so a deck of slides isn't drawn as a stack of portrait pages. Pass false to keep
+        /// the configured page size whatever the thumbnails turn out to be.
+        /// </summary>
+        public PagesStack MatchThumbnailShape(bool value = true)
+        {
+            _matchThumbnailShape = value;
+
+            ForgetThumbnailShape();
+
+            // Rebuilt rather than just resized: the pages that were measured are replaced by ones whose
+            // load fires again, so switching this back on re-measures instead of waiting for new urls.
             return Rebuild();
         }
 
@@ -195,20 +258,19 @@ namespace Tesserae
         {
             ClearChildren(_stack);
 
+            _pages.Clear();
+
             var shown = VisiblePageCount;
-
-            // The rail is as wide as the fan gets, so the pages have room to open into without the row
-            // they sit in reflowing. The few extra pixels are for the rotation of the outermost pages.
-            var railWidth = shown < 1 ? 0 : _pageWidth + (shown - 1) * FAN_STEP + 4;
-
-            InnerElement.style.width     = $"{railWidth}px";
-            InnerElement.style.flexBasis = $"{railWidth}px";
-            InnerElement.style.height    = $"{_pageHeight + 12}px";
 
             for (int i = 0; i < shown; i++)
             {
-                _stack.appendChild(BuildPage(i, shown));
+                var page = BuildPage(i, shown);
+
+                _pages.Add(page);
+                _stack.appendChild(page);
             }
+
+            ApplyPageMetrics();
 
             var hidden = _pageCount - shown;
 
@@ -222,16 +284,89 @@ namespace Tesserae
             return this;
         }
 
+        /// <summary>
+        /// Writes the page size and everything measured from it: the rail the fan opens into, and how far
+        /// each page is pulled back over the one in front of it. Kept out of <see cref="BuildPage"/> so a
+        /// thumbnail that turns out to be landscape can reshape a stack that is already on screen without
+        /// the pages - and the thumbnails inside them - being built again.
+        /// </summary>
+        private void ApplyPageMetrics()
+        {
+            var shown  = _pages.Count;
+            var width  = DrawnPageWidth;
+            var height = DrawnPageHeight;
+
+            // The rail is as wide as the fan gets, so the pages have room to open into without the row
+            // they sit in reflowing. The few extra pixels are for the rotation of the outermost pages.
+            var railWidth = shown < 1 ? 0 : width + (shown - 1) * FAN_STEP + 4;
+
+            InnerElement.style.width     = $"{railWidth}px";
+            InnerElement.style.flexBasis = $"{railWidth}px";
+            InnerElement.style.height    = $"{height + 12}px";
+
+            for (int i = 0; i < shown; i++)
+            {
+                var page = _pages[i];
+
+                page.style.width  = $"{width}px";
+                page.style.height = $"{height}px";
+
+                // At rest: the first page in place, every other one pulled back over it. The margin is the
+                // resting layout and never animates - see the fan shift in BuildPage.
+                page.style.setProperty("--tss-pagesstack-rest-offset", i == 0 ? "0px" : $"-{width - REST_STEP}px");
+            }
+        }
+
+        /// <summary>
+        /// Takes the page shape from the first thumbnail to report a natural size. The pages of one
+        /// document share one shape - and a stack that reshaped itself once per thumbnail would rewrite
+        /// the layout of the row it sits in on every image that arrived - so the first one that loads
+        /// speaks for all of them.
+        /// </summary>
+        private void MeasureThumbnail(HTMLImageElement image)
+        {
+            if (!_matchThumbnailShape || _thumbnailMeasured) return;
+
+            var w = image.naturalWidth;
+            var h = image.naturalHeight;
+
+            // Not decoded yet, or an image that never will be - either way there is nothing to measure.
+            if (w <= 0 || h <= 0) return;
+
+            _thumbnailMeasured = true;
+
+            // Portrait and square thumbnails already match the shape the pages are drawn at by default.
+            if (w <= h) return;
+
+            var aspect = (float)w / h;
+
+            _landscapeAspect = aspect > MAX_LANDSCAPE_ASPECT ? MAX_LANDSCAPE_ASPECT : aspect;
+
+            ApplyPageMetrics();
+        }
+
+        private void ForgetThumbnailShape()
+        {
+            _thumbnailMeasured = false;
+            _landscapeAspect   = 0;
+        }
+
         private HTMLElement BuildPage(int index, int shown)
         {
             var page = Div(Att("tss-pagesstack-page"));
 
-            page.style.width  = $"{_pageWidth}px";
-            page.style.height = $"{_pageHeight}px";
-
             if (index < _urls.Count)
             {
-                page.appendChild(Image(Att("tss-pagesstack-image", src: _urls[index])));
+                var image = Image(Att("tss-pagesstack-image", src: _urls[index]));
+
+                // A thumbnail only knows its own shape once it has loaded, hence measuring on the event
+                // rather than here - and hence the second check, for one served from cache and already
+                // decoded by the time this runs, whose load event has been and gone.
+                image.onload = _ => MeasureThumbnail(image);
+
+                if (image.complete) MeasureThumbnail(image);
+
+                page.appendChild(image);
             }
             else
             {
@@ -242,9 +377,8 @@ namespace Tesserae
             // behind it shows on the right, the way a pile of paper nudged sideways looks.
             page.style.zIndex = $"{shown - index}";
 
-            // At rest: the first page in place, every other one pulled back over it with a growing tilt.
-            // The margin is the resting layout and never animates - see the fan shift below.
-            page.style.setProperty("--tss-pagesstack-rest-offset",   index == 0 ? "0px" : $"-{_pageWidth - REST_STEP}px");
+            // At rest, the pages tilt a little more the further back they are. How far each is pulled back
+            // over the one in front depends on the page size, so ApplyPageMetrics writes that part.
             page.style.setProperty("--tss-pagesstack-rest-rotation", $"{REST_ROTATION * index}deg");
 
             // Fanned: wider gaps, and the pages lifted along a shallow arc, tilting out from the middle.


### PR DESCRIPTION
## Summary

Adds automatic landscape reshaping to `PagesStack`: when the first thumbnail loads that is wider than it is tall, the entire stack reshapes to landscape orientation, keeping the long side of the configured page size and deriving the short side from the thumbnail's aspect ratio. This prevents decks of slides from being previewed as stacks of portrait pages.

## Key Changes

- **Landscape detection and reshaping**: Added `IsLandscape`, `DrawnPageWidth`, and `DrawnPageHeight` properties that reflect the actual drawn dimensions. Pages reshape in place when a landscape thumbnail is measured, without rebuilding the page elements themselves.

- **Thumbnail measurement**: New `MeasureThumbnail()` method measures the first thumbnail to load and, if it's landscape (and wider than the configured `MAX_LANDSCAPE_ASPECT` ratio of 3:1), updates the page metrics. Handles both async-loaded and cached images via the `load` event and `image.complete` check.

- **Configurable behavior**: New `MatchThumbnailShape(bool)` fluent method (default `true`) lets callers opt out of automatic reshaping and keep the configured page size regardless of thumbnail aspect ratios.

- **Decoupled metrics from page building**: Extracted page sizing logic into `ApplyPageMetrics()` so the rail width, page dimensions, and rest-state offsets can be recalculated when a landscape thumbnail arrives, without rebuilding the DOM.

- **State tracking**: Added `_pages` list to track built page elements, `_thumbnailMeasured` flag to ensure only the first landscape thumbnail reshapes the stack, and `_landscapeAspect` to store the measured aspect ratio (clamped at 3:1 to prevent panoramas from flattening the stack).

## Implementation Details

- The reshaping reuses the existing fan and rotation mechanics; only the page dimensions and rail width change.
- All pages of one document share the shape the first measured thumbnail reports, preventing layout thrashing as images arrive.
- The aspect ratio is clamped at 3:1 so extreme panoramas don't reduce pages to slivers.
- `ForgetThumbnailShape()` resets the landscape state when pages or the `MatchThumbnailShape` setting change, triggering a rebuild so cached images are re-measured.

## Documentation & Samples

- Updated `pages-stack.md` reference with new methods and properties.
- Added sample slide deck (16:9 SVG) and demo in `OmniResultSample` showing landscape reshaping in action, including an `OmniResult` row with a landscape `PagesStack` to demonstrate the layout behavior.

https://claude.ai/code/session_011Qa7yMeJKnZiYEWCPo98MC