### PR TITLE
Make TextArea fill the height it is given

### DIFF
--- a/Tesserae.Tests/src/Samples/Components/TextAreaSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/TextAreaSample.cs
@@ -36,6 +36,14 @@ namespace Tesserae.Tests.Samples
                         Label("AutoResize (minHeight = 100)").SetContent(TextArea("Type here...").AutoResize(minHeight: 100)),
                         Label("AutoResize (maxHeight = 150)").SetContent(TextArea("Type many lines to see scrolling...").AutoResize(maxHeight: 150))
                     ),
+                    SampleSubTitle("Filling the available height"),
+                    VStack().Children(
+                        TextBlock("A TextArea with Grow() stretches to fill whatever height is left over in its parent stack."),
+                        VStack().WS().H(220).Children(
+                            TextBlock("Fixed header"),
+                            TextArea("This text area fills the rest of the 220px stack.").Grow().WS()
+                        )
+                    ),
                     SampleSubTitle("Validation"),
                     VStack().Children(
                         Label("Required").Required().SetContent(TextArea()),

--- a/Tesserae/skills/references/text-area.md
+++ b/Tesserae/skills/references/text-area.md
@@ -28,6 +28,22 @@ returns a `TextArea`. Bring factories into scope with `using static Tesserae.UI;
   — grow with content; clamp with min/max pixel heights.
 - `.Focus()` — scroll into view and focus.
 
+## Sizing
+
+A `TextArea` fills whatever height it is given, so the usual sizing helpers work:
+`.Height(200)` for a fixed height, and `.Grow()` / `.HS()` inside a `Stack` to take
+the leftover space.
+
+```csharp
+VStack().H(220).Children(
+    TextBlock("Fixed header"),
+    TextArea().Grow().WS()   // fills the rest of the 220px
+);
+```
+
+`.AutoResize(...)` is the opposite mode — the height follows the content — so don't
+combine it with `.Grow()` / `.Height(...)`; use `minHeight`/`maxHeight` instead.
+
 ## Example
 
 ```csharp

--- a/Tesserae/src/Components/TextArea.cs
+++ b/Tesserae/src/Components/TextArea.cs
@@ -21,11 +21,11 @@ namespace Tesserae
         {
             InnerElement = UI.TextArea(Att("tss-textbox tss-textarea", type: "text", value: text));
             _errorSpan   = Span(Att("tss-textbox-error"));
-            _container   = Div(Att("tss-textbox-container"), InnerElement, _errorSpan);
 
-            //TODO: Need to make container display:flex, and use flex-grow to have correct sizing with _errorSpan
-            InnerElement.style.width  = "100%";
-            InnerElement.style.height = "100%";
+            // tss-textarea-container is a flex column of full height, so the text area fills whatever
+            // height the container gets from its parent (e.g. when Grow() stretches the stack item)
+            // while the error message keeps its own space. See tss.textarea.css.
+            _container = Div(Att("tss-textbox-container tss-textarea-container"), InnerElement, _errorSpan);
 
             _observable = new SettableObservable<string>(text);
             AttachChange();
@@ -265,6 +265,9 @@ namespace Tesserae
         /// <returns>The current instance.</returns>
         public TextArea AutoResize(bool allowShrink = true, int? minHeight = null, int? maxHeight = null)
         {
+            // Opts the text area out of filling the container's height, since here the height is driven by the content
+            InnerElement.classList.add("tss-textarea-autoresize");
+
             if (minHeight.HasValue)
             {
                 InnerElement.style.minHeight = minHeight.Value + "px";

--- a/Tesserae/tps/assets/css/tss.textarea.css
+++ b/Tesserae/tps/assets/css/tss.textarea.css
@@ -3,3 +3,26 @@
     resize: none;
 }
 
+/* The container is a full-height flex column so that whenever it is given a height -
+   directly with .Height(...), or indirectly because .Grow()/.HS() stretched the
+   tss-stack-item that wraps it - the text area fills that height instead of staying at
+   its intrinsic size, and the error message still gets its own space below it. */
+.tss-textarea-container {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    min-height: 0;
+}
+
+    .tss-textarea-container > .tss-textarea {
+        flex: 1 1 auto;
+        width: 100%;
+        height: 100%;
+        min-height: 0;
+    }
+
+/* AutoResize() drives the height from scrollHeight, so it must not be stretched by the flex line. */
+.tss-textarea-container > .tss-textarea.tss-textarea-autoresize {
+    flex: 0 0 auto;
+    height: auto;
+}


### PR DESCRIPTION
TextArea rendered its container as a plain block and sized the inner
<textarea> with an inline height: 100%. When the component was placed in a
Stack with Grow() (or HS(), or Height(...)), the sizing helpers moved the
style onto the tss-stack-item wrapper, which stretched correctly, but the
tss-textbox-container inside kept its intrinsic height - so the percentage
on the textarea resolved against an auto-height parent and the field stayed
at ~32px inside a 200px slot.

The container is now a full-height flex column (tss-textarea-container) with
the textarea as a flex item, so it fills whatever height the container
receives and the error span still gets its own space below it - which is
what the TODO this replaces asked for.

AutoResize() drives the height from scrollHeight, so it opts out via
tss-textarea-autoresize and stays content-sized.

Also adds a sample for the grow-to-fill case and a Sizing section to the
TextArea skill reference.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015o9zivyi65jN9SqfLf3gsW