### PR TITLE
Take the rows down while a CommandPalette searches

### DIFF
--- a/Tesserae.Tests/src/Samples/Utilities/CommandPaletteSample.cs
+++ b/Tesserae.Tests/src/Samples/Utilities/CommandPaletteSample.cs
@@ -31,7 +31,7 @@ namespace Tesserae.Tests.Samples
             };
 
             //The search takes as long as a server would, so the box's magnifier turns into a spinner while it
-            //does - the rows from the last query stay where they are until the new ones are in.
+            //does, and the rows the last query left behind come down.
             searchPalette.OnSearch(async query =>
             {
                 await Task.Delay(700);
@@ -61,7 +61,7 @@ namespace Tesserae.Tests.Samples
                     TextBlock("SetResults puts rows of your own above the actions, and OnSearch refreshes them as the query changes — so a palette can answer a question rather than only list commands. The rows here are OmniResults, the same component a search page draws, and the last one is the way out to the full result list.").Small().Secondary().PB(8),
                     openSearchButton,
                     TextBlock("Type to filter, walk the rows with the arrow keys, and press Enter on one.").Small().Secondary().PT(12),
-                    TextBlock("This search waits 700ms, like a server would: while it does, the search box's magnifier turns into a spinner. The palette does that on its own while an OnSearch call is in flight — a palette that fills its rows some other way says it with SetSearching(true).").Small().Secondary().PT(8)
+                    TextBlock("This search waits 700ms, like a server would: while it does, the search box's magnifier turns into a spinner and the rows of the previous query come down, since they are not an answer to this one. The palette does that on its own while an OnSearch call is in flight — a palette that fills its rows some other way says it with SetSearching(true).").Small().Secondary().PT(8)
                )).SetTitle("Searching, with results of your own")))
                .SeeAlso(typeof(KeyboardShortcutSample), typeof(OmniBoxSample), typeof(SearchBoxSample), typeof(MenuSample), typeof(ContextMenuSample));
         }

--- a/Tesserae/skills/references/command-palette.md
+++ b/Tesserae/skills/references/command-palette.md
@@ -95,15 +95,15 @@ palette.OnSearch(async searchQuery =>
 ## Saying that a search is running
 
 A palette that reaches a server has a moment where the rows on screen answer the *previous* query. It says so
-by turning the search box's magnifier into a spinner (`OmniBox.SetSearching`, `omni-box.md`), and while it is
-searching it does not claim `EmptyText`: "No results" is only true once the search that would have found some
-has come back.
+by turning the search box's magnifier into a spinner (`OmniBox.SetSearching`, `omni-box.md`), and it takes
+those rows down — they are not an answer to what is being asked now, and a row that is still there is a row
+that gets clicked. While it is searching it does not claim `EmptyText` either: "No results" is only true once
+the search that would have found some has come back.
 
 `OnSearch` drives this on its own: the mode goes on when the call starts and off when it answers (or throws),
-and an answer to a query the user has already typed past leaves it alone. The rows from the last query stay
-where they are meanwhile, so the palette does not empty out and fill back up on every keystroke. A fast or
-cached answer shows nothing at all — the spinner crosses over with the magnifier only after ~140ms, so the
-button never blinks.
+and an answer to a query the user has already typed past leaves it alone. A fast or cached answer shows
+nothing at all — the spinner crosses over with the magnifier, and the rows come down, only after ~140ms, so
+an answer that is back before then replaces the rows outright instead of blinking through an empty list.
 
 A palette that fills its rows some other way says it itself:
 

--- a/Tesserae/src/Components/CommandPalette.cs
+++ b/Tesserae/src/Components/CommandPalette.cs
@@ -44,9 +44,16 @@ namespace Tesserae
         private int _activeIndex = -1;
         private HTMLElement _focusBeforeShow;
         private bool _isSearching;
+        private double _clearRowsTimer = -1;
 
         /// <summary>How long <see cref="Layer{T}"/> takes to fade a hidden layer out before removing it.</summary>
         private const int LAYER_FADE_OUT_MS = 150;
+
+        /// <summary>
+        /// How long the rows of the query before this one stay up once a search starts - the same grace the
+        /// search box takes to turn its magnifier into a spinner, so the two happen together.
+        /// </summary>
+        private const int SEARCHING_GRACE_MS = 140;
 
         private sealed class PaletteEntry
         {
@@ -249,8 +256,8 @@ namespace Tesserae
 
         /// <summary>
         /// Whether the palette is saying that a search is running - the search box's magnifier turns into a
-        /// spinner, and there is no "No results" until it is known that there are none. Kept up to date on
-        /// its own while an
+        /// spinner, the rows that answered the query before this one come down, and there is no "No results"
+        /// until it is known that there are none. Kept up to date on its own while an
         /// <see cref="OnSearch(Func{OmniBox.SearchQuery, Task{IEnumerable{CommandPaletteResult}}}, int)"/>
         /// call is in flight; set it with <see cref="SetSearching"/> for a palette that fills its rows some
         /// other way.
@@ -270,10 +277,34 @@ namespace Tesserae
 
             _searchBox.SetSearching(searching);
 
+            CancelPendingRowClear();
+
+            if (searching)
+            {
+                //Rows that answered the query before this one are not an answer to this one, so they come
+                //down while the search runs rather than staying up to be clicked by mistake - after the same
+                //grace the spinner waits, so an answer that is back before then replaces them outright
+                //instead of the palette blinking through an empty list.
+                _clearRowsTimer = window.setTimeout(_ =>
+                {
+                    _clearRowsTimer = -1;
+
+                    if (_isSearching) SetResults((IEnumerable<CommandPaletteResult>)null);
+                }, SEARCHING_GRACE_MS);
+            }
+
             //"No results" is only true once the search that would have found some has come back.
             UpdateEmptyState();
 
             return this;
+        }
+
+        private void CancelPendingRowClear()
+        {
+            if (_clearRowsTimer < 0) return;
+
+            window.clearTimeout(_clearRowsTimer);
+            _clearRowsTimer = -1;
         }
 
         /// <summary>

--- a/Tesserae/tps/assets/css/tss.commandpalette.css
+++ b/Tesserae/tps/assets/css/tss.commandpalette.css
@@ -88,6 +88,12 @@
     gap: 4px;
 }
 
+/* With no rows to show - while a search is running, or before one has been asked for - the list is not a
+   thinner list, it is not there: its padding alone would read as a strip of empty palette under the box. */
+.tss-commandpalette-results:empty {
+    display: none;
+}
+
 .tss-commandpalette-section {
     padding: 8px 12px 4px;
     font-size: 11px;


### PR DESCRIPTION
Rows that answered the query before this one are not an answer to the one being asked, and a row that is still on screen is a row that gets clicked. So the searching mode now empties the list as well as spinning the magnifier - after the same ~140ms grace, so an answer that is back before then replaces the rows outright instead of blinking through an empty palette.

An empty list is no longer a strip of padding under the box either: it collapses, so a searching palette is exactly its search box.


Claude-Session: https://claude.ai/code/session_01MoPYfU6irLCyW8B5c4CuX1