### PR TITLE
Keep page chrome banners above all layers

### DIFF
--- a/Tesserae/skills/references/layer.md
+++ b/Tesserae/skills/references/layer.md
@@ -22,6 +22,14 @@ host to confine layers to a sub-tree. Bring factories into scope with
 - `.IsVisible` — get/set visibility.
 - `.Host` — assign a `LayerHost` to control where content projects.
 
+## Stacking
+
+`Layers` hands out the z-indices. A custom overlay appended to the body yourself takes one with
+`Layers.PushLayer(element)`; `Layers.AboveCurrent()` is the value to sit just above whatever is
+showing (that is what popovers use). `Layers.PushAlwaysOnTop(element)` is for page chrome that lives
+outside the body box — an edge-to-edge `Toast().Banner()` — and keeps it above layers pushed later.
+Don't invent a z-index of your own.
+
 ## Example
 
 ```csharp

--- a/Tesserae/skills/references/toast.md
+++ b/Tesserae/skills/references/toast.md
@@ -31,6 +31,14 @@ Other: `.Banner(bool showHideButton = true)` (full-width banner that shifts page
 
 `.Hide()` / `.Remove()` dismiss programmatically.
 
+## Banner mode and stacking
+
+`.Banner()` pins the strip edge to edge and shrinks the page to make room for it, so it is page
+chrome rather than an overlay: it stays above every layer, and a `Modal`, `Panel` or node preview
+opened afterwards is stacked *under* it instead of covering it. A popover opened from inside the
+banner still lands in front of the banner itself. Nothing to configure — don't hand a banner a
+z-index of your own.
+
 ## Dismissing
 
 The banner's `[x]` is hooked to the toast's own hiding, chained *after* whatever `OnDismiss` handler

--- a/Tesserae/src/Components/Layers.cs
+++ b/Tesserae/src/Components/Layers.cs
@@ -10,11 +10,37 @@ namespace Tesserae
     public static class Layers
     {
         private const int BaseZIndex = 1000;
+
+        // Elements pinned above the whole layer stack. A full-width banner is page chrome: it shrinks the
+        // body and stays fixed to a viewport edge, so a modal opened after it must not cover it. Pushing a
+        // layer lifts them again, and AboveCurrent() counts them so a popover opened from inside one still
+        // lands in front of it.
+        private const string AlwaysOnTopClass    = "tss-always-on-top";
+        private const string AlwaysOnTopSelector = ".tss-always-on-top";
+
         /// <summary>
         /// Configures the push layer on the component.
         /// </summary>
         public static string PushLayer(HTMLElement element)
         {
+            int zIndex = CurrentZIndex() + 10;
+
+            foreach (HTMLElement pinned in document.querySelectorAll(AlwaysOnTopSelector))
+            {
+                pinned.style.zIndex = (zIndex + 5).ToString();
+            }
+
+            return zIndex.ToString();
+        }
+
+        /// <summary>
+        /// Pins an element above every layer and keeps it there: whatever is pushed afterwards lifts it
+        /// again rather than covering it. For page chrome that lives outside the body box, such as an
+        /// edge-to-edge banner - an ordinary overlay wants <see cref="PushLayer"/> instead.
+        /// </summary>
+        public static string PushAlwaysOnTop(HTMLElement element)
+        {
+            element.classList.add(AlwaysOnTopClass);
             return (CurrentZIndex() + 10).ToString();
         }
 
@@ -43,7 +69,14 @@ namespace Tesserae
         /// </summary>
         public static string AboveCurrent()
         {
-            return (CurrentZIndex() + 5).ToString();
+            int maxIndex = CurrentZIndex();
+
+            foreach (HTMLElement pinned in document.querySelectorAll(AlwaysOnTopSelector))
+            {
+                if (int.TryParse(pinned.style.zIndex, out var zIndex) && zIndex > maxIndex) maxIndex = zIndex;
+            }
+
+            return (maxIndex + 5).ToString();
         }
     }
 }

--- a/Tesserae/src/Components/Toast.cs
+++ b/Tesserae/src/Components/Toast.cs
@@ -608,6 +608,11 @@ namespace Tesserae
                 _renderedContent.classList.add("tss-toast-fullwidth-bottom");
             }
 
+            // A banner goes to the body on its own rather than through Layer.Show, so it takes its own place
+            // in the z-index stack - pinned above the layers, because it reserves its strip by shrinking the
+            // body and a modal opened later would otherwise cover it.
+            _renderedContent.style.zIndex = Layers.PushAlwaysOnTop(_renderedContent);
+
             document.body.appendChild(_renderedContent);
             var rect = _renderedContent.querySelector(".tss-toast-container").As<HTMLElement>().getBoundingClientRect().As<DOMRect>();
             var h    = rect.height + "px";

--- a/Tesserae/tps/assets/css/tss.toast.css
+++ b/Tesserae/tps/assets/css/tss.toast.css
@@ -111,3 +111,10 @@
     border-radius: 0px;
     padding: 0px;
 }
+
+/* The rule that divides the strip from the page goes on the edge facing the page, so a banner pinned
+   to the bottom draws it on top rather than off the bottom of the screen. */
+.tss-toast-fullwidth.tss-toast-fullwidth-bottom.tss-toast > .tss-toast-container {
+    border-bottom: none;
+    border-top: 1px solid var(--tss-default-border-color);
+}


### PR DESCRIPTION
## Summary

Adds support for pinning elements (like full-width banners) above the entire layer stack so they remain visible and unobstructed by modals, panels, and popovers opened after them.

## Changes

- **New `Layers.PushAlwaysOnTop()` method**: Pins an element above every layer. When subsequent layers are pushed, they are lifted above pinned elements rather than covering them.
- **Updated `Layers.PushLayer()`**: Now re-lifts all pinned elements whenever a new layer is pushed, ensuring they stay on top.
- **Updated `Layers.AboveCurrent()`**: Checks pinned elements' z-indices to ensure popovers opened from inside a pinned element still land in front of it.
- **Toast banner integration**: `Toast.ShowAsBanner()` now calls `PushAlwaysOnTop()` to pin banners above the layer stack, since they reserve page space by shrinking the body.
- **CSS fix for bottom banners**: Moved the border from bottom to top for bottom-positioned banners so the dividing line appears on the correct edge.
- **Documentation**: Added "Stacking" section to `layer.md` and "Banner mode and stacking" section to `toast.md` explaining the behavior and that custom z-indices should not be invented.

## Implementation Details

- Pinned elements are marked with the `tss-always-on-top` class and tracked via CSS selector queries.
- When `PushLayer()` is called, all pinned elements are lifted to `zIndex + 5`, keeping them above the new layer.
- `AboveCurrent()` scans pinned elements to find the highest z-index, ensuring popovers land above both regular layers and pinned chrome.
- The approach is non-invasive: banners opt-in via `PushAlwaysOnTop()` and the layer system automatically manages their stacking.

https://claude.ai/code/session_014mhHRWBsFqMrDuT75uNtuX