### PR TITLE
Show the row's live footer in the OmniResult modal

### DIFF
--- a/Tesserae/skills/references/omni-result.md
+++ b/Tesserae/skills/references/omni-result.md
@@ -159,16 +159,18 @@ and the detail are one object rather than two that have to be kept in step.
   and the title, so an opened result still shows what kind of thing it is. Everything the tile
   carries comes with it: the glyph or thumbnail, its tint, and any corner badges. Off by default.
 - `.ModalKeepsFooter(bool = true)` — keeps the footer (the source and the metadata beside it) as a
-  second line under the title, so where a result came from is still said once it is open. A clickable
-  source stays clickable. Off by default.
+  second line under the title, so where a result came from is still said once it is open. Off by
+  default.
 - `.SetModalHeader(Func<OmniResult<T>, IComponent>)` — replaces the default header (the same
   identifier, chevron and title the row shows, plus whatever the two options above kept) with one
   built from the result — for a header that also carries commands or status beside the title. Null
   goes back to the default.
 - `.ModalTitle()` — that default header on its own, to build around.
 
-Both options **copy** what the row drew rather than moving it, so opening a result never takes the
-tile or the footer out of the row behind it.
+The tile is **copied** into the header, so opening a result never takes it out of the row behind it.
+The footer is the row's **own** line, moved into the header with a copy left in the row's place and
+handed back when the modal hides — so an entry that only arrives once a query answers shows up in the
+open modal, and every entry stays as clickable there as it is in the row.
 - `.ToModal()` — a `Modal` with that header and content, at that size, or null when the row has no
   modal content. Dismissal, bounds and how it is shown are still the caller's.
 - `.CurrentModal` — the modal `ToModal()` last built, or null.

--- a/Tesserae/src/Components/OmniResult.cs
+++ b/Tesserae/src/Components/OmniResult.cs
@@ -130,6 +130,7 @@ namespace Tesserae
         private bool                                  _modalKeepsIcon;
         private bool                                  _modalKeepsFooter;
 
+        private HTMLElement           _footerStandIn;
         private Modal                 _modal;
         private Action<OmniResult<T>> _modalCommands;
         private Action<OmniResult<T>> _modalFullScreen;
@@ -1166,8 +1167,13 @@ namespace Tesserae
 
         /// <summary>
         /// Keeps the footer - the source and the metadata beside it - as a second line under the title in the
-        /// modal's header, so where a result came from is still said once it is open. The source stays
-        /// clickable when the row's is. Off by default.
+        /// modal's header, so where a result came from is still said once it is open. Off by default.
+        /// <para>
+        /// The modal shows the row's own footer line, not a snapshot of it: entries that only arrive once a
+        /// query answers show up in the open modal, and every entry stays as clickable as it is in the row.
+        /// The row keeps a copy of the line in its place while the modal holds the original, and gets the
+        /// original back when the modal hides.
+        /// </para>
         /// </summary>
         public OmniResult<T> ModalKeepsFooter(bool value = true)
         {
@@ -1201,6 +1207,9 @@ namespace Tesserae
             _modal = modal;
 
             modal.HideCloseButton().SetHeaderCommands(ModalHeaderCommands());
+
+            //The header borrowed the row's own footer line; the row gets it back when the sheet closes.
+            if (_modalKeepsFooter) modal.OnHide(_ => ReturnFooterToRow());
 
             if (_modalShortcuts) modal.SetFooter(ModalShortcutsBar());
 
@@ -1450,9 +1459,11 @@ namespace Tesserae
 
             var main = Div(Att("tss-omniresult-modal-main"), titleRow);
 
-            if (_modalKeepsFooter && _footerContainer.childElementCount > 0)
+            //Not gated on the footer having entries yet: the line hides itself while it is empty, so one that
+            //is still waiting on a query shows up in the open modal once the query answers.
+            if (_modalKeepsFooter)
             {
-                main.appendChild(CopyOfFooter());
+                main.appendChild(FooterForModal());
             }
 
             var header = Div(Att("tss-omniresult-modal-header"));
@@ -1464,8 +1475,41 @@ namespace Tesserae
             return Raw(header);
         }
 
-        // The row keeps its own tile and footer - the modal gets copies of them, so opening a result never
-        // takes anything out of the row behind it.
+        // The modal shows the row's own footer rather than a copy of it: an entry that only arrives once a
+        // query answers lands in the open modal, and the handlers on the entries already there still answer.
+        // A copy takes its place in the row behind - so nothing disappears from under the sheet - and the row
+        // gets the original back when the modal hides.
+        private HTMLElement FooterForModal()
+        {
+            if (_footerContainer.parentElement == _mainContainer)
+            {
+                _footerStandIn = CopyOfFooter();
+
+                _mainContainer.replaceChild(_footerStandIn, _footerContainer);
+            }
+
+            return _footerContainer;
+        }
+
+        private void ReturnFooterToRow()
+        {
+            if (_footerStandIn is null) return;
+
+            var standIn = _footerStandIn;
+
+            _footerStandIn = null;
+
+            //The modal keeps a copy of the line it is handing back, so showing it again doesn't show a header
+            //with a gap where the footer was.
+            _footerContainer.parentElement?.replaceChild(CopyOfFooter(), _footerContainer);
+
+            standIn.parentElement?.replaceChild(_footerContainer, standIn);
+
+            UpdateFooterVisibility();
+        }
+
+        // The row keeps its own tile - the modal gets a copy of it, so opening a result never takes the tile
+        // out of the row behind it.
         private HTMLElement CopyOfIcon()
         {
             var copy = _iconHolder.cloneNode(true).As<HTMLElement>();


### PR DESCRIPTION
## The bug

The footer an `OmniResult` is configured with was not the footer that ended up in its modal.

`ModalTitle()` put a `cloneNode(true)` **snapshot** of `_footerContainer` into the modal's header, taken at `ToModal()` time. Where the row exists only to build the modal — which is how Curiosity's `NodePreview` uses it, the row from `PreviewAsync` is never mounted anywhere — the live footer stayed in a detached element while the sheet showed a dead copy:

- Entries that arrive after the modal opens never showed. `WithNeighborFooterEntries`, `NeighborAsInlineLabel` and the replies count all fill themselves in when a query answers, into the original.
- A clone carries no listeners, so clickable entries were inert in the modal. Only the source was re-hooked by hand.
- The `childElementCount > 0` gate also meant a footer still waiting on its first query got no footer line in the modal at all.

## The change

The modal now borrows the row's **own** footer element. A copy takes its place in the row, so nothing disappears from a row behind the sheet, and `ToModal()` registers an `OnHide` that hands the original back (leaving the modal a copy, so re-showing it isn't a header with a gap). The `childElementCount` gate is gone — the footer line already hides itself while empty, so a late entry makes it appear.

The icon tile is still copied, as before.

`ModalKeepsFooter`'s doc comment and `skills/references/omni-result.md` are updated to describe the borrow-and-return behaviour.

## Verification

`dotnet build` clean, and the `OmniResult` sample driven with Playwright:

- the modal header holds the original element (a JS marker `cloneNode` cannot copy survives there; the row holds a copy), and the row looks unchanged while the sheet is open
- an entry appended to the live footer after the modal opened shows up in the open modal
- the source stays clickable inside the modal
- on close the original is back in the row, live and clickable, with exactly one footer element in it and no page errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NLhsE4H832BNp7VtwXteFK

---
_Generated by [Claude Code](https://claude.ai/code/session_01NLhsE4H832BNp7VtwXteFK)_