### PR TITLE
Add header action buttons to ToolCall and ToolsUsed

### DIFF
--- a/Tesserae.Tests/src/Samples/Components/ToolCallSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/ToolCallSample.cs
@@ -95,6 +95,16 @@ namespace Tesserae.Tests.Samples
                         _inlineTools,
                         Button("Add a tool").OnClick(() => AddInlineTool()),
 
+                        SampleSubTitle("A button on the header"),
+                        TextBlock("AddAction puts an icon button between the progress and the chevron, for a way into what the call stands for that isn't its content - the run it started, say. Clicking it runs the handler only: the call is neither expanded nor collapsed by it. A ToolsUsed group takes the same button on its summary pill."),
+                        ToolCall(UIcons.UserRobot, "Invoke agent \"researcher\"", () => TextBlock("Summarised 4 sources.").BreakSpaces())
+                           .AddAction(UIcons.Eye, "Watch this agent run", () => Toast().Information("Opening the run...")),
+                        ToolsUsed(
+                            ToolCall(UIcons.Search, "Search documentation", () => TextBlock("3 pages matched.").BreakSpaces()),
+                            ToolCall(UIcons.Eye, "Read README.md", () => TextBlock("# Needle").BreakSpaces())
+                        ).SetSummary("researcher").Inline()
+                         .AddAction(UIcons.Eye, "Watch this agent run", () => Toast().Information("Opening the run...")),
+
                         SampleSubTitle("Live progress while a call runs"),
                         TextBlock("A ToolCall can carry a LiveProgress line on its header row: SetProgress writes into the line already on screen, so a stream of updates never re-renders the call and never replays an animation. Hovering the line shows its full text; expanding the call still opens the content full width underneath."),
                         _runningCall,

--- a/Tesserae/skills/references/tool-call.md
+++ b/Tesserae/skills/references/tool-call.md
@@ -30,6 +30,10 @@ Both carry an 8px bottom margin, so when you stack a pill above the answer text 
   the line already on screen, so a stream of updates never re-renders the call, and expanding it
   still opens the content full width underneath.
 - `Progress` — the `LiveProgress` itself, for finer control.
+- `.AddAction(UIcons icon, string tooltip, Action)` (also `Action<ToolCall>`) / `.ClearActions()` — an
+  icon button on the header row, between the progress and the chevron. Clicking it runs the handler
+  only, never expanding or collapsing the call. Use it for a way into what the call stands for that
+  isn't its content — opening the run it started, retrying it.
 - `IsExpanded`, `HasContent`, `Icon`, `Text` — read state.
 
 Expansion is per instance, so a host that rebuilds its layout into a diffing container (a streaming
@@ -45,6 +49,9 @@ the line on screen keeps the last text it was given.
 - `.SetSummary(label)` / `.SetTitle(title)` / `.SetIcon(icon)` — customise.
 - `.SetProgress(string)` / `.SetProgress(IObservable<string>)` / `.ClearProgress()` / `Progress` —
   same live progress line, on the summary pill.
+- `.AddAction(UIcons icon, string tooltip, Action)` (also `Action<ToolsUsed>`) / `.ClearActions()` —
+  the same icon button, on the summary pill, for an action that belongs to the group rather than to
+  one of its calls (opening the run whose calls it lists, say). It does not open or fold the group.
 - `.Inline()` — render the tools in place instead of in the modal (see below).
 - `.Show()` / `.Hide()` — open/close (the modal, or the inline list when `.Inline()` is set).
 - `.Expand()` / `.Collapse()` / `.Toggle()` / `.Expanded(bool)` / `.OnToggle(tu => ...)` —

--- a/Tesserae/src/Components/ToolCall.cs
+++ b/Tesserae/src/Components/ToolCall.cs
@@ -6,6 +6,29 @@ using static Tesserae.UI;
 namespace Tesserae
 {
     /// <summary>
+    /// The buttons a <see cref="ToolCall"/> / <see cref="ToolsUsed"/> header carries, built the same
+    /// way for both so an action looks identical whether it sits on a single call or on a group.
+    /// </summary>
+    internal static class ToolCallActions
+    {
+        internal static HTMLElement Build(UIcons icon, string tooltip, Action onClick)
+        {
+            var button = UI.Button(Att("tss-toolcall-action", type: "button", ariaLabel: tooltip), I(icon));
+
+            // The header toggles the call, so an action inside it has to keep its click to itself.
+            button.addEventListener("click", ev =>
+            {
+                StopEvent(ev);
+                onClick?.Invoke();
+            });
+
+            if (!string.IsNullOrEmpty(tooltip)) Raw(button).Tooltip(tooltip);
+
+            return button;
+        }
+    }
+
+    /// <summary>
     /// Inline tool-call indicator that expands accordion-style to show the
     /// associated content. The content component is created lazily the first
     /// time the user expands the tool call.
@@ -18,6 +41,7 @@ namespace Tesserae
         private readonly HTMLElement      _textContainer;
         private readonly HTMLElement      _chevron;
         private readonly HTMLElement      _content;
+        private          HTMLElement      _actions;
         private          UIcons           _icon;
         private          string           _text;
         private          Func<IComponent> _contentFactory;
@@ -186,6 +210,44 @@ namespace Tesserae
         }
 
         /// <summary>
+        /// Adds a button to the header of this call, next to the chevron - a way into whatever the call
+        /// stands for that doesn't fit inside its content (opening the run it started, retrying it, ...).
+        /// Clicking it runs the handler only: the call is neither expanded nor collapsed by it.
+        /// </summary>
+        public ToolCall AddAction(UIcons icon, string tooltip, Action<ToolCall> onClick)
+        {
+            EnsureActions().appendChild(ToolCallActions.Build(icon, tooltip, () => onClick?.Invoke(this)));
+
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a button to the header of this call, next to the chevron.
+        /// </summary>
+        public ToolCall AddAction(UIcons icon, string tooltip, Action onClick) => AddAction(icon, tooltip, _ => onClick?.Invoke());
+
+        /// <summary>
+        /// Removes every button added with <see cref="AddAction(UIcons, string, Action{ToolCall})"/>.
+        /// </summary>
+        public ToolCall ClearActions()
+        {
+            if (_actions is object) ClearChildren(_actions);
+
+            return this;
+        }
+
+        private HTMLElement EnsureActions()
+        {
+            if (_actions is null)
+            {
+                _actions = Div(Att("tss-toolcall-actions"));
+                _header.insertBefore(_actions, _chevron);
+            }
+
+            return _actions;
+        }
+
+        /// <summary>
         /// Configures the not expandable on the component.
         /// </summary>
         public ToolCall NotExpandable()
@@ -303,6 +365,7 @@ namespace Tesserae
         private readonly HTMLElement      _summaryChevron;
         private readonly HTMLElement      _inlineList;
         private readonly List<ToolCall>   _tools;
+        private          HTMLElement      _actions;
         private          LiveProgress     _progress;
         private          string           _summaryLabel;
         private          UIcons           _summaryIconKind = UIcons.Tools;
@@ -591,6 +654,44 @@ namespace Tesserae
             }
 
             return _progress;
+        }
+
+        /// <summary>
+        /// Adds a button to the summary of this group, next to the chevron - a way into whatever the
+        /// group stands for (the run whose calls it lists, for instance) that isn't one of the calls
+        /// themselves. Clicking it runs the handler only: the group is neither opened nor folded by it.
+        /// </summary>
+        public ToolsUsed AddAction(UIcons icon, string tooltip, Action<ToolsUsed> onClick)
+        {
+            EnsureActions().appendChild(ToolCallActions.Build(icon, tooltip, () => onClick?.Invoke(this)));
+
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a button to the summary of this group, next to the chevron.
+        /// </summary>
+        public ToolsUsed AddAction(UIcons icon, string tooltip, Action onClick) => AddAction(icon, tooltip, _ => onClick?.Invoke());
+
+        /// <summary>
+        /// Removes every button added with <see cref="AddAction(UIcons, string, Action{ToolsUsed})"/>.
+        /// </summary>
+        public ToolsUsed ClearActions()
+        {
+            if (_actions is object) ClearChildren(_actions);
+
+            return this;
+        }
+
+        private HTMLElement EnsureActions()
+        {
+            if (_actions is null)
+            {
+                _actions = Div(Att("tss-toolsused-actions"));
+                _header.insertBefore(_actions, _summaryChevron);
+            }
+
+            return _actions;
         }
 
         /// <summary>

--- a/Tesserae/tps/assets/css/tss.toolcall.css
+++ b/Tesserae/tps/assets/css/tss.toolcall.css
@@ -63,6 +63,40 @@
     margin-left: 8px;
 }
 
+/* Header actions — a way into what the call stands for, sitting between the progress and the chevron. */
+.tss-toolcall-actions,
+.tss-toolsused-actions {
+    display: flex;
+    align-items: center;
+    gap: 2px;
+    flex-shrink: 0;
+}
+
+.tss-toolcall-action {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 22px;
+    height: 22px;
+    padding: 0;
+    border: none;
+    border-radius: 50%;
+    background: transparent;
+    cursor: pointer;
+    color: var(--tss-colors-neutral-500, #6b7280);
+    font-size: 12px;
+}
+
+.tss-toolcall-action:hover {
+    background: var(--tss-colors-neutral-100, #f3f4f6);
+    color: var(--tss-colors-neutral-800, #1f2937);
+}
+
+.tss-toolcall-action:focus-visible {
+    outline: 2px solid var(--tss-primary-background-color);
+    outline-offset: 1px;
+}
+
 .tss-toolcall-chevron {
     transition: transform 200ms ease;
     font-size: 12px;


### PR DESCRIPTION
A `ToolCall` (or a `ToolsUsed` group) can now carry icon buttons on its header row, between the live progress and the chevron:

```csharp
ToolCall(UIcons.UserRobot, "Invoke agent \"researcher\"", () => TextBlock("Summarised 4 sources."))
   .AddAction(UIcons.Eye, "Watch this agent run", () => OpenTheRun());
```

The motivating case is a chat transcript where a call delegated to an agent: watching that agent work is not one of the call's own contents, so it needs a way in that isn't "expand the call". Clicking an action runs its handler only — the call is neither expanded nor collapsed by it, and the group is neither opened nor folded.

### What's here

- `ToolCall.AddAction(UIcons, string tooltip, Action)` / `Action<ToolCall>`, and `ClearActions()`.
- `ToolsUsed.AddAction(...)` / `ClearActions()` — the same button on the summary pill, for an action belonging to the group rather than to one of its calls.
- One shared builder for both, so an action looks identical wherever it sits: a round 22px icon button that stops its click from reaching the header, with the tooltip as its `aria-label`.
- CSS for the button and its hover/focus states, in `tss.toolcall.css`.
- `references/tool-call.md` documents both, and `ToolCallSample` gains a section showing an action on a call and on a group.

### Verification

`dotnet build` is clean for both `Tesserae` and `Tesserae.Tests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A634469b8MhDLAGY1FibwZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01A634469b8MhDLAGY1FibwZ)_