### PR TITLE
Add Dropdown.SearchAsync for lazily loaded option lists

### DIFF
--- a/Tesserae.Tests/src/Samples/Components/DropdownSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/DropdownSample.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using static Transpose.Core.dom;
 using static Tesserae.Tests.Samples.SamplesHelper;
@@ -77,6 +78,14 @@ namespace Tesserae.Tests.Samples
                         )),
                         Label("Empty State").SetContent(Dropdown("No items available").Items(new Dropdown.Item[0]))
                     ),
+                    SampleSubTitle("Lazy Search (SearchAsync)"),
+                    VStack().Children(
+                        TextBlock("With thousands of options there is no loading them all up front. Seed the dropdown with the first page, and let SearchAsync fetch the rest as the User types - the items it returns are added to the ones already there, so the seed and the current selection survive every lookup. This example holds 5,000 people and seeds only the first 20.").Medium(),
+                        Label("Search 5,000 people").SetContent(
+                            Dropdown()
+                               .Items(FirstPageOfPeople())
+                               .SearchAsync(SearchPeopleAsync, placeholder: "Type a name..."))
+                    ),
                     SampleSubTitle("Validation"),
                     VStack().Children(
                         Label("Required Dropdown").SetContent(Dropdown().Required().Items(
@@ -109,6 +118,29 @@ namespace Tesserae.Tests.Samples
                 return Label($"Loaded {text}");
             }, loadMessage: Skeleton().Animated().W(500).H(32)));
         }
+
+        // Stands in for the server: 5,000 options that would be senseless to render up front.
+        private static readonly string[] _people = Enumerable.Range(1, 5000).Select(i => $"Person {i:0000}").ToArray();
+
+        private static Dropdown.Item[] FirstPageOfPeople() => _people.Take(20).Select(PersonItem).ToArray();
+
+        // Whatever this returns is ADDED to the items already in the dropdown, and anything whose key
+        // is already listed is dropped - so returning a page that overlaps the seed is harmless.
+        private static async Task<Dropdown.Item[]> SearchPeopleAsync(string searchTerm)
+        {
+            await Task.Delay(400); // The round trip a real lookup would pay for
+
+            if (string.IsNullOrWhiteSpace(searchTerm)) return FirstPageOfPeople();
+
+            return _people.Where(p => p.ToLower().Contains(searchTerm.ToLower()))
+                          .Take(50)
+                          .Select(PersonItem)
+                          .ToArray();
+        }
+
+        // The key is what tells two options apart when their text is not unique, and what lets a
+        // lookup return options the dropdown already knows about without duplicating them.
+        private static Dropdown.Item PersonItem(string person) => DropdownItem(person).SetKey(person);
 
         private async Task<Dropdown.Item[]> GetItemsAsync()
         {

--- a/Tesserae/skills/references/dropdown.md
+++ b/Tesserae/skills/references/dropdown.md
@@ -21,9 +21,11 @@ Bring factories into scope with `using static Tesserae.UI;`.
 Dropdown:
 
 - `.Items(params Dropdown.Item[])` — set options (replaces existing).
+- `.AddItems(params Dropdown.Item[])` — append options, keeping the current ones and the selection; items whose `Key` is already listed are skipped.
 - `.Items(Func<Task<Item[]>>)` + `.LoadItemsAsync()` — async loading (auto-loaded when opened).
 - `.Single()` / `.Multi()` — selection mode.
 - `.Searchable(string placeholder = "Search")` — add a search box.
+- `.SearchAsync(Func<string, Task<Item[]>> searcher, string placeholder = "Search", int debounceMilliseconds = 250)` — lazy loading for lists too large to load up front; see below.
 - `.Required()` / `.Disabled()` / `.NoBorder()` / `.NoBackground()` / `.FitContent()`.
 - `.Placeholder(string|IComponent)` — empty-state text.
 - `.Attach(handler)` — fires on selection change (use for validation: set `.IsInvalid` and `.Error`).
@@ -34,6 +36,7 @@ Dropdown.Item:
 - `.Selected()` / `.SelectedIf(bool)` / `.IsSelected` — selection state.
 - `.Header()` / `.Divider()` — non-option rows.
 - `.Disabled()`, `.SetData<T>(T)` / `.GetDataAs<T>()`, `.OnSelected(...)`.
+- `.SetKey(string)` / `.Key` — stable identity, used to dedupe when appending. Defaults to the item's text, so set it whenever the text is not unique.
 
 ## Example
 
@@ -52,6 +55,33 @@ dd.Attach(d =>
     if (!ok) d.Error = "Please select 'Option 1'";
 });
 ```
+
+## Lazy search (thousands of options)
+
+`.SearchAsync(...)` turns the built-in search box into a lazy loader. The term the
+User types is handed to your callback (debounced, newest term wins), and the items
+it returns are **added** to the ones already rendered rather than replacing them —
+so the seed items and, above all, the current selection survive every lookup.
+Items whose `Key` is already listed are dropped, so a lookup that returns options
+the dropdown already knows about does not duplicate them. The normal client-side
+filter still runs on top. `SearchAsync` enables the search box itself, so
+`.Searchable(...)` is not needed as well.
+
+Seed the dropdown with the first page (plus whatever must be selectable without
+searching, such as the current value), and let the callback fill in the rest:
+
+```csharp
+var dd = Dropdown()
+   .Items(currentUserItem, firstPageItems)          // what is selectable without searching
+   .SearchAsync(async term =>
+    {
+        var found = await API.Users.SearchAsync(term, limit: 100);
+        return found.Select(u => DropdownItem(u.Name).SetKey(u.UID)).ToArray();
+    }, placeholder: "Search users...");
+```
+
+The callback is also called with an empty string when the User clears the box, so
+returning the first page for an empty term restores the seed list.
 
 ## Related
 

--- a/Tesserae/src/Components/Dropdown.cs
+++ b/Tesserae/src/Components/Dropdown.cs
@@ -39,6 +39,11 @@ namespace Tesserae
         private int                      _latestRequestID;
         private Func<Item[], IComponent> _customRenderer;
 
+        private Func<string, Task<Item[]>> _asyncSearcher;
+        private int                        _asyncSearchDebounce;
+        private double                     _asyncSearchTimeout;
+        private int                        _latestAsyncSearchID;
+
         private readonly Action<Event> _onWindowClickAction;
         private readonly Action<Event> _onPopupKeyDownAction;
 
@@ -505,8 +510,85 @@ namespace Tesserae
                 _search = e;
                 SearchItems();
                 RecomputePopupPosition();
+                QueueAsyncSearch();
             });
             return this;
+        }
+
+        /// <summary>
+        /// Turns the built-in search box into a lazy loader, for option lists too large to load up
+        /// front. Whatever the User types is handed to <paramref name="searcher"/> (debounced), and
+        /// the items it returns are <b>added</b> to the ones already rendered rather than replacing
+        /// them - so the seed items, and above all the current selection, survive every lookup.
+        /// Items whose <see cref="Item.Key"/> is already listed are dropped, so a lookup that
+        /// returns options the dropdown already knows about does not duplicate them. The normal
+        /// client-side filter still runs on top, so the list stays narrowed to the search term.
+        /// <para>
+        /// Seed the dropdown with <see cref="Items(Item[])"/> as usual (the first page of options,
+        /// plus whatever has to be selectable without searching), and let this fill in the rest.
+        /// This also enables the search box, so <see cref="Searchable"/> does not need to be called
+        /// as well.
+        /// </para>
+        /// </summary>
+        /// <param name="searcher">Looks up the options matching a search term. Called with an empty string when the User clears the box.</param>
+        /// <param name="placeholder">Placeholder of the search box.</param>
+        /// <param name="debounceMilliseconds">How long typing has to pause before a lookup is issued.</param>
+        public Dropdown SearchAsync(Func<string, Task<Item[]>> searcher, string placeholder = "Search", int debounceMilliseconds = 250)
+        {
+            _asyncSearcher              = searcher ?? throw new ArgumentNullException(nameof(searcher));
+            _asyncSearchDebounce        = debounceMilliseconds;
+
+            return Searchable(placeholder);
+        }
+
+        private void QueueAsyncSearch()
+        {
+            if (_asyncSearcher is null) return;
+
+            window.clearTimeout(_asyncSearchTimeout);
+
+            _asyncSearchTimeout = window.setTimeout(_ => RunAsyncSearchAsync(_search).FireAndForget(), _asyncSearchDebounce);
+        }
+
+        private async Task RunAsyncSearchAsync(string searchTerm)
+        {
+            var searcher = _asyncSearcher;
+
+            if (searcher is null) return;
+
+            // Terms typed while a lookup is in flight supersede it - only the newest one gets to add its items.
+            var currentRequestID = ++_latestAsyncSearchID;
+
+            SetAsyncSearchBusy(true);
+
+            try
+            {
+                var found = await searcher(searchTerm ?? string.Empty);
+
+                if (currentRequestID != _latestAsyncSearchID) return;
+
+                if (found is object && found.Length > 0)
+                {
+                    AddItems(found);
+
+                    // The items that just arrived have never been through the filter for the term they were fetched for.
+                    if (_searchBox is object) SearchItems();
+                }
+
+                if (IsVisible) RecomputePopupPosition();
+            }
+            finally
+            {
+                if (currentRequestID == _latestAsyncSearchID) SetAsyncSearchBusy(false);
+            }
+        }
+
+        private void SetAsyncSearchBusy(bool isBusy)
+        {
+            if (_searchBox is null) return;
+
+            if (isBusy) _searchBox.Render().classList.add("tss-dropdown-searchbox-busy");
+            else _searchBox.Render().classList.remove("tss-dropdown-searchbox-busy");
         }
 
         /// <summary>
@@ -585,6 +667,57 @@ namespace Tesserae
                 Disabled(true);
                 _noItemsSpan.style.display = "";
             }
+
+            return this;
+        }
+
+        /// <summary>
+        /// Appends options to the ones already rendered, instead of replacing them the way
+        /// <see cref="Items(Item[])"/> does - so the current selection is untouched. Items whose
+        /// <see cref="Item.Key"/> matches one that is already listed are skipped, which is what lets
+        /// a <see cref="SearchAsync"/> lookup return options the dropdown already knows about
+        /// without duplicating them.
+        /// </summary>
+        public Dropdown AddItems(params Item[] children)
+        {
+            if (children is null || children.Length == 0) return this;
+
+            var existing = new List<Item>(_lastRenderedItems ?? new Item[0]);
+            var known    = new HashSet<string>();
+
+            foreach (var item in existing)
+            {
+                var key = item.Key;
+
+                if (!string.IsNullOrEmpty(key)) known.Add(key);
+            }
+
+            var added = 0;
+
+            foreach (var child in children)
+            {
+                var key = child.Key;
+
+                if (!string.IsNullOrEmpty(key) && !known.Add(key)) continue;
+
+                _childContainer.appendChild(child.Render());
+                child.SelectedItem -= OnItemSelected; //Ensure OnItemSelected is only hooked once
+                child.SelectedItem += OnItemSelected;
+
+                existing.Add(child);
+                added++;
+            }
+
+            if (added == 0) return this;
+
+            _lastRenderedItems = existing.ToArray();
+
+            EnsureAsyncLoadingStateDisabled();
+
+            UpdateStateBasedUponCurrentSelections();
+
+            Disabled(false);
+            _noItemsSpan.style.display = "none";
 
             return this;
         }
@@ -1214,6 +1347,25 @@ namespace Tesserae
             {
                 get => InnerElement.innerText;
                 set => InnerElement.innerText = value;
+            }
+
+            /// <summary>
+            /// A stable identity for this option, used to tell it apart from an option that merely
+            /// reads the same - <see cref="Dropdown.AddItems"/> drops an incoming item whose key is
+            /// already listed, which is how a <see cref="Dropdown.SearchAsync"/> lookup avoids
+            /// duplicating options that are already there. Defaults to the item's text, so give a
+            /// key whenever the text is not unique (two people with the same name, …).
+            /// </summary>
+            public string Key => string.IsNullOrEmpty(_key) ? InnerElement.textContent : _key;
+            private string _key;
+
+            /// <summary>
+            /// Sets the item's <see cref="Key"/>.
+            /// </summary>
+            public Item SetKey(string key)
+            {
+                _key = key;
+                return this;
             }
 
             /// <summary>

--- a/Tesserae/tps/assets/css/tss.dropdown.css
+++ b/Tesserae/tps/assets/css/tss.dropdown.css
@@ -356,3 +356,25 @@
 .tss-dropdown-layer {
     align-items: flex-start;
 }
+
+/* SearchAsync: while a lookup is in flight the search box swaps its magnifier for a spinner. The
+   glyph lives on a span inside the icon container, so hide that and draw the spinner on the
+   container itself rather than fighting the icon font's own ::before. */
+.tss-dropdown-popup .tss-dropdown-searchbox.tss-dropdown-searchbox-busy > .tss-searchbox-icon > span {
+    display: none;
+}
+
+.tss-dropdown-popup .tss-dropdown-searchbox.tss-dropdown-searchbox-busy > .tss-searchbox-icon::after {
+    content: "";
+    align-self: center;
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    border: 1.5px solid;
+    border-color: var(--tss-primary-background-color) var(--tss-progress-background-color) var(--tss-progress-background-color);
+    box-sizing: border-box;
+    animation-name: tss-spinner-animation;
+    animation-duration: 1.3s;
+    animation-iteration-count: infinite;
+    animation-timing-function: cubic-bezier(0.53, 0.21, 0.29, 0.67);
+}


### PR DESCRIPTION
A dropdown backed by thousands of options has nowhere to go today: `Items(...)` wants the whole list up front, the async overload still loads it in one go, and `Searchable()` only filters what is already rendered. So callers either render everything or cap the list and hope the option someone needs is in it.

## `SearchAsync`

```csharp
Dropdown()
   .Items(currentUserItem, firstPageItems)          // selectable without searching
   .SearchAsync(async term =>
    {
        var found = await API.Users.SearchAsync(term, limit: 100);
        return found.Select(u => DropdownItem(u.Name).SetKey(u.UID)).ToArray();
    }, placeholder: "Search users...");
```

The term the User types is handed to the callback — debounced, newest term wins — and the items it returns are **added** to the ones already rendered rather than replacing them, so the seed items and, above all, the current selection survive every lookup. The normal client-side filter still runs on top, so the list stays narrowed to the term while the lookup is in flight. The search box shows a spinner in place of its magnifier while one is running.

`SearchAsync` enables the search box itself, so `Searchable(...)` is not needed as well. The callback is also called with an empty string when the box is cleared, so returning the first page there restores the seed list.

## Supporting additions

- **`Dropdown.AddItems(params Item[])`** — appends options instead of replacing them, which `Items(...)` cannot do without dropping the selection.
- **`Dropdown.Item.SetKey(string)` / `.Key`** — a stable identity for an option, so `AddItems` can drop an item the dropdown already lists. It defaults to the item's text, so it only needs setting when the text is not unique (two people with the same name, say).

## Sample

A **Lazy Search (SearchAsync)** section on the Dropdown page, holding 5,000 people and seeding only the first 20.

## Verification

Built and driven in Chromium against the samples app:

- the seed renders (20 items on open);
- typing `Person 12` fetches and appends only the 50 options that are new (70 items total, 51 visible — the 50 fetched plus the seeded `Person 0012`);
- the busy spinner appears while the lookup runs and clears when it lands;
- an option selected before a second, unrelated search is still selected after it.

Docs: `Tesserae/skills/references/dropdown.md` updated with `SearchAsync`, `AddItems`, `Key`, and a lazy-search section.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BENiGwxQA8YXmJL8sztGWL)_