### PR TITLE
Add UnsavedChangesGuard and TabSaveIndicator

### DIFF
--- a/Tesserae.Tests/src/Samples/Utilities/UnsavedChangesGuardSample.cs
+++ b/Tesserae.Tests/src/Samples/Utilities/UnsavedChangesGuardSample.cs
@@ -1,0 +1,90 @@
+using static Transpose.Core.dom;
+using static Tesserae.UI;
+using static Tesserae.Tests.Samples.SamplesHelper;
+
+namespace Tesserae.Tests.Samples
+{
+    [SampleDetails(Group = "Utilities", Order = 32, Icon = UIcons.Disk)]
+    public class UnsavedChangesGuardSample : IComponent, ISample
+    {
+        private readonly IComponent _content;
+
+        public UnsavedChangesGuardSample()
+        {
+            var isDirty    = new SettableObservable<bool>(false);
+            var status     = TextBlock("Clean ✔");
+            var attemptLog = TextBlock("");
+            const string key = "sample-editor";
+
+            var textBox = TextBox("");
+            textBox.OnInput((s, e) =>
+            {
+                isDirty.Value = textBox.Text.Length > 0;
+                status.Text   = isDirty.Value ? "Dirty — has unsaved changes ●" : "Clean ✔";
+            });
+
+            UnsavedChangesGuard.Track(
+                key:     key,
+                name:    () => "Sample editor",
+                isDirty: () => isDirty.Value,
+                save: () =>
+                {
+                    isDirty.Value = false;
+                    status.Text   = "Clean ✔ (just saved)";
+                    return System.Threading.Tasks.Task.FromResult(true);
+                });
+
+            var btnTryLeave = Button("Simulate navigating away").OnClick((s, e) =>
+            {
+                var allowed = UnsavedChangesGuard.CanNavigateAway(new Router.State("#/elsewhere"));
+                attemptLog.Text = allowed
+                    ? "Nothing was dirty — navigation would proceed immediately."
+                    : "Navigation was blocked — the confirmation dialog took over.";
+            });
+
+            // TabSaveIndicator side: a Pivot tab shows the same "*" a real hosting
+            // view (e.g. one tab per open editor) would toggle.
+            const string tabId  = "tab-sample-doc";
+            var tabTextBox      = TextBox("");
+            tabTextBox.OnInput((s, e) =>
+            {
+                if (tabTextBox.Text.Length > 0) TabSaveIndicator.MarkDirty(tabId); else TabSaveIndicator.MarkClean(tabId);
+            });
+
+            TabSaveIndicator.OnSave(tabId, () =>
+            {
+                TabSaveIndicator.MarkClean(tabId);
+                return System.Threading.Tasks.Task.FromResult(true);
+            });
+
+            var pivot = Pivot()
+               .Pivot("doc", () => TextBlock("Document").Id(tabId), () => Card(VStack().WS().Children(
+                    TextBlock("Typing below marks this tab dirty; the pivot title shows a \"*\" via TabSaveIndicator.MarkDirty."),
+                    tabTextBox)));
+
+            _content = SectionStack().Secondary()
+               .SampleTitle(typeof(UnsavedChangesGuardSample), UIcons.Disk, "Warn before losing an editor's unsaved changes")
+               .FlatSection(Stack().Children(
+                    Card(VStack().WS().Children(
+                    TextBlock("UnsavedChangesGuard stops an editor's changes from being lost silently: a beforeunload listener warns on tab close/reload, and — once wired into Router.OnBeforeNavigate — CanNavigateAway blocks in-app navigation until the user saves, discards, or stays. TabSaveIndicator is the companion for editors hosted as Pivot tabs: it toggles a \"*\" on the tab title and lets the guard save a tab without knowing what kind of editor it holds."))).SetTitle("Overview")))
+               .FlatSection(Stack().Children(
+                    Card(VStack().WS().Children(
+                    TextBlock("Always pair Track(...) with Forget(key) on the editor's close path, and TrackOpenTabs()/ForgetOpenTabs() on the hosting view's mount/removal — an editor that never calls Forget keeps the guard asking about it forever. Router only keeps one OnBeforeNavigate handler, so call CanNavigateAway explicitly from inside whatever handler the app already registers."))).SetTitle("Best Practices")))
+               .FlatSection(Stack().Children(
+                    Card(VStack().WS().Children(
+                        SampleSubTitle("Track() a single editor"),
+                        VStack().Gap(8.px()).Children(
+                            Label("Type to make this editor dirty").SetContent(textBox),
+                            status,
+                            btnTryLeave,
+                            attemptLog))).SetTitle("Usage")))
+               .FlatSection(Stack().Children(
+                    Card(VStack().WS().Children(
+                        SampleSubTitle("TabSaveIndicator on a Pivot tab"),
+                        pivot)).SetTitle("Usage")))
+               .SeeAlso(typeof(PivotSample), typeof(ValidatorSample), typeof(SaveButtonSample));
+        }
+
+        public HTMLElement Render() => _content.Render();
+    }
+}

--- a/Tesserae/skills/SKILL.md
+++ b/Tesserae/skills/SKILL.md
@@ -175,7 +175,7 @@ segmented-pivot · split-view · tabbed-modal · tool-agent-selector · tutorial
 **Utilities** (non-visual helpers, theming, gestures)
 color-palette · command-palette · defer · defer-with-progress · emoji ·
 file-selector-and-drop-area · gestures · gradients · keyboard-shortcut ·
-node-view · notification-center · tippy · toast · uicons · validator
+node-view · notification-center · tippy · toast · uicons · unsaved-changes-guard · validator
 
 To find the reference for a component, lowercase-kebab its name and open
 `references/<that>.md` (e.g. `DetailsList` → `references/details-list.md`). If you

--- a/Tesserae/skills/references/pivot.md
+++ b/Tesserae/skills/references/pivot.md
@@ -43,4 +43,5 @@ var pivot = Pivot()
 - SegmentedPivot — `segmented-pivot.md`
 - CardPivot — `card-pivot.md`
 - TabbedModal — `tabbed-modal.md`
+- UnsavedChangesGuard / TabSaveIndicator (warn before losing a dirty tab) — `unsaved-changes-guard.md`
 - Full docs & API: `/tesserae/surfaces/pivot`

--- a/Tesserae/skills/references/routing.md
+++ b/Tesserae/skills/references/routing.md
@@ -89,4 +89,5 @@ private static void Show(IComponent page) { Content.Clear(); Content.Add(page); 
 ## Related
 
 - Core Concepts (observables, Defer) — `.core-concepts.md`
+- UnsavedChangesGuard (blocks navigation while an editor is dirty, via `OnBeforeNavigate`) — `unsaved-changes-guard.md`
 - Full docs & API: `/tesserae/get-started/routing`

--- a/Tesserae/skills/references/unsaved-changes-guard.md
+++ b/Tesserae/skills/references/unsaved-changes-guard.md
@@ -1,0 +1,133 @@
+---
+name: unsaved-changes-guard
+description: Stops an editor's unsaved changes from being lost silently — warns on tab close/reload and blocks in-app navigation until the user saves, discards, or stays. Use when building an editor (form, code editor, settings panel) whose changes can be navigated or reloaded away from in a Tesserae (C#/Transpose) app.
+---
+
+# UnsavedChangesGuard / TabSaveIndicator
+
+Two static helpers that cooperate to stop unsaved editor state from disappearing
+without the user choosing that:
+
+- **`UnsavedChangesGuard`** — the guard itself. Listens for `beforeunload` (tab
+  close/reload) and, when wired into `Router.OnBeforeNavigate`, intercepts
+  in-app navigation, shows a "Save and leave / Leave without saving / Stay
+  here" dialog, and only lets the navigation through once the user decides.
+- **`TabSaveIndicator`** — a companion for editors hosted as `Pivot` tabs. It
+  toggles a CSS class on the tab's title element to show a "*" and lets the
+  editor register a save handler the guard can call, so a view with many open
+  tabs doesn't need its own bookkeeping of which tabs are dirty and how to
+  save each one.
+
+Use `UnsavedChangesGuard` directly for a single editor (a `Modal`, a
+standalone view). Add `TabSaveIndicator` on top when the editor is one of
+several tabs in a `Pivot` and the host wants "leaving loses everything that's
+dirty" semantics across all of them at once.
+
+## UnsavedChangesGuard
+
+- `Track(string key, Func<string> name, Func<bool> isDirty, Func<Task<bool>> save)`
+  — registers a single editor for as long as it's on screen. `key` identifies
+  it (re-registering the same key replaces the entry), `name` is what the user
+  is told has unsaved changes, `isDirty` is polled on every navigation attempt
+  and unload, `save` returns whether the save actually went through.
+- `Forget(string key)` — call on the editor's close/removal path. Always pair
+  every `Track` with a matching `Forget`, or the guard keeps asking about an
+  editor that's gone.
+- `TrackOpenTabs()` / `ForgetOpenTabs()` — call when a view hosting editors as
+  `Pivot` tabs mounts/unmounts. While active, the guard also reads
+  `TabSaveIndicator.DirtyTabIds()` off the DOM instead of requiring every tab
+  to register itself individually.
+- `CanNavigateAway(Router.State target)` — the `Router.OnBeforeNavigate` answer.
+  Returns `true` when nothing would be lost. Otherwise it cancels this
+  navigation attempt, shows the confirmation dialog, and — if the user
+  chooses to leave (with or without saving) — re-issues the navigation itself
+  once they've decided, since the router can't `await` inside its own hook.
+
+`Router` only keeps a single `OnBeforeNavigate` handler (see `routing.md`), so
+an app with other before-navigate logic (e.g. closing a preview panel) has to
+call `CanNavigateAway` explicitly from inside its own handler rather than
+relying on the guard to register itself:
+
+```csharp
+Router.OnBeforeNavigate((newState, currentState, isBack) =>
+{
+    if (SomeOtherReasonToBlock(newState)) return false;
+
+    return UnsavedChangesGuard.CanNavigateAway(newState);
+});
+```
+
+Closing a modal directly (its own close button, a light-dismiss click) is
+**not** covered by the guard — that path never reaches `Router`, so it has to
+ask its own confirmation before hiding the modal.
+
+## TabSaveIndicator
+
+- `TabId(string itemType, object uid)` — a stable id convention, e.g.
+  `tab-endpoint-{uid}`. Any stable string works; this is just a helper for the
+  common "one editor per graph node" case.
+- `MarkDirty(string tabIndicatorId)` / `MarkClean(string tabIndicatorId)` —
+  toggle the tab's "*" indicator. Call from the editor's own change-tracking
+  (a `TextArea.OnChanged`, a `Validator`, a `SettingsHolder.HasChanged`
+  check, …).
+- `IsDirty(string tabIndicatorId)` — read back the current state, e.g. to
+  decide whether Ctrl+S has anything to do.
+- `OnSave(string tabIndicatorId, Func<Task<bool>> saveAsync)` — registers the
+  tab's save handler, so `UnsavedChangesGuard` (and anything else) can save it
+  without knowing what kind of editor it is. `SaveAsync(tabIndicatorId)` runs
+  it back; `CanSave(tabIndicatorId)` reports whether one was registered.
+- `Forget(string tabIndicatorId)` — drop the save handler when the tab closes.
+- `DirtyTabIds()` / `TitleOf(string tabIndicatorId)` — used internally by
+  `UnsavedChangesGuard.TrackOpenTabs()`; reading the dirty set off the DOM
+  (rather than a registry) means a torn-down tab can't leave a stale entry
+  behind.
+
+The tab title element needs the matching `id` for any of this to find it —
+give the `IComponent` returned by your `PivotTitle`-equivalent that `id` (see
+`.Id(...)` in `icomponent.md`).
+
+## Example
+
+```csharp
+using static Tesserae.UI;
+
+// One editor hosted in a Modal — no Pivot involved.
+var isDirty = new SettableObservable<bool>(false);
+
+Func<Task<bool>> saveAsync = async () =>
+{
+    var ok = await SaveDocumentAsync();
+    if (ok) isDirty.Value = false;
+    return ok;
+};
+
+editor.WhenMounted(() => UnsavedChangesGuard.Track(
+    key:     "doc-editor",
+    name:    () => "My document",
+    isDirty: () => isDirty.Value,
+    save:    saveAsync));
+
+editor.WhenRemoved(() => UnsavedChangesGuard.Forget("doc-editor"));
+```
+
+```csharp
+// A Pivot-hosted editor tab: the host tracks all open tabs at once,
+// each editor only has to maintain its own indicator + save handler.
+const string tabIndicatorId = "tab-endpoint-abc123";
+
+hostView.WhenMounted(() => UnsavedChangesGuard.TrackOpenTabs());
+hostView.WhenRemoved(() => UnsavedChangesGuard.ForgetOpenTabs());
+
+codeEditor.OnChanged(() => TabSaveIndicator.MarkDirty(tabIndicatorId));
+TabSaveIndicator.OnSave(tabIndicatorId, SaveEndpointAsync);
+
+// when the tab closes:
+TabSaveIndicator.Forget(tabIndicatorId);
+```
+
+## Related
+
+- Routing (`Router.OnBeforeNavigate`, `Router.Navigate`) — `routing.md`
+- Pivot (tabbed hosting) — `pivot.md`
+- Dialog (what the confirmation prompt is built from) — `dialog.md`
+- Validator (a common `isDirty` source) — `validator.md`

--- a/Tesserae/src/Helpers/UnsavedChanges/TabSaveIndicator.cs
+++ b/Tesserae/src/Helpers/UnsavedChanges/TabSaveIndicator.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Transpose;
+using static Transpose.Core.dom;
+
+namespace Tesserae
+{
+    /// <summary>
+    /// Toggles a CSS class on a <see cref="Pivot"/> tab title element so it can show an
+    /// "unsaved changes" indicator (a "*" rendered via <c>::after</c>).
+    /// </summary>
+    /// <remarks>
+    /// An editor hosted as a pivot tab calls <see cref="MarkDirty"/> / <see cref="MarkClean"/>
+    /// from inside its own validation / save handling. The host gives the tab title element an
+    /// <c>id</c> (any string that is stable for as long as the tab is open) and the editor
+    /// references that same id, so the host and the editor don't need to pass tab/component
+    /// references back and forth.
+    ///
+    /// An editor also registers its save handler here via <see cref="OnSave"/>, which is what
+    /// lets <see cref="UnsavedChangesGuard"/> offer to save the tab instead of only offering to
+    /// discard it.
+    /// </remarks>
+    [Transpose.Name("tss.TabSaveIndicator")]
+    public static class TabSaveIndicator
+    {
+        public const string NeedsSavingClass = "tss-pivot-tab-needs-saving";
+
+        // Save handler per tab indicator id. Registered by the editor hosted in
+        // the tab, dropped by the host when the tab closes (see Forget).
+        private static readonly Dictionary<string, Func<Task<bool>>> _saveHandlers = new Dictionary<string, Func<Task<bool>>>();
+
+        /// <summary>Builds a stable tab indicator id from an item type and uid, e.g. <c>tab-endpoint-{uid}</c>.</summary>
+        public static string TabId(string itemType, object uid) => $"tab-{itemType}-{uid}";
+
+        public static void MarkDirty(string tabIndicatorId)
+        {
+            if (string.IsNullOrEmpty(tabIndicatorId)) return;
+            var el = document.getElementById(tabIndicatorId);
+            el?.classList.add(NeedsSavingClass);
+        }
+
+        public static void MarkClean(string tabIndicatorId)
+        {
+            if (string.IsNullOrEmpty(tabIndicatorId)) return;
+            var el = document.getElementById(tabIndicatorId);
+            el?.classList.remove(NeedsSavingClass);
+        }
+
+        /// <summary>Whether the tab currently shows the unsaved-changes indicator.</summary>
+        public static bool IsDirty(string tabIndicatorId)
+        {
+            if (string.IsNullOrEmpty(tabIndicatorId)) return false;
+            var el = document.getElementById(tabIndicatorId);
+            return el is object && el.classList.contains(NeedsSavingClass);
+        }
+
+        /// <summary>
+        /// Registers the editor's save handler for <paramref name="tabIndicatorId"/>.
+        /// It must return whether the save actually succeeded — an editor that
+        /// refuses to save (incomplete form, compile error, …) returns false and
+        /// is expected to tell the user why.
+        /// </summary>
+        public static void OnSave(string tabIndicatorId, Func<Task<bool>> saveAsync)
+        {
+            if (string.IsNullOrEmpty(tabIndicatorId) || saveAsync is null) return;
+            _saveHandlers[tabIndicatorId] = saveAsync;
+        }
+
+        /// <summary>Drops the registered save handler — call this when the tab closes.</summary>
+        public static void Forget(string tabIndicatorId)
+        {
+            if (string.IsNullOrEmpty(tabIndicatorId)) return;
+            _saveHandlers.Remove(tabIndicatorId);
+        }
+
+        /// <summary>Whether an editor registered a save handler for this tab.</summary>
+        public static bool CanSave(string tabIndicatorId)
+        {
+            return !string.IsNullOrEmpty(tabIndicatorId) && _saveHandlers.ContainsKey(tabIndicatorId);
+        }
+
+        /// <summary>
+        /// Runs the tab's registered save handler. Returns false when the tab has
+        /// no handler or the editor reported the save didn't go through.
+        /// </summary>
+        public static Task<bool> SaveAsync(string tabIndicatorId)
+        {
+            if (string.IsNullOrEmpty(tabIndicatorId) || !_saveHandlers.TryGetValue(tabIndicatorId, out var save)) return Task.FromResult(false);
+            return save();
+        }
+
+        /// <summary>
+        /// The ids of every tab currently showing the unsaved-changes indicator.
+        /// Reading them back off the DOM (rather than a registry we'd have to keep
+        /// in sync) means a tab that was torn down can't leave a stale entry behind.
+        /// </summary>
+        public static string[] DirtyTabIds()
+        {
+            var ids = new List<string>();
+
+            foreach (var el in (IEnumerable<HTMLElement>)document.querySelectorAll<HTMLElement>("." + NeedsSavingClass))
+            {
+                if (!string.IsNullOrEmpty(el.id)) ids.Add(el.id);
+            }
+
+            return ids.ToArray();
+        }
+
+        /// <summary>The tab's visible title, used when telling the user which editors are unsaved.</summary>
+        public static string TitleOf(string tabIndicatorId)
+        {
+            if (string.IsNullOrEmpty(tabIndicatorId)) return null;
+            var el = document.getElementById(tabIndicatorId);
+            return el is object ? el.textContent?.Trim() : null;
+        }
+    }
+}

--- a/Tesserae/src/Helpers/UnsavedChanges/UnsavedChangesGuard.cs
+++ b/Tesserae/src/Helpers/UnsavedChanges/UnsavedChangesGuard.cs
@@ -1,0 +1,287 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using TNT;
+using static Transpose.Core.dom;
+using static Tesserae.UI;
+using static TNT.T;
+
+namespace Tesserae
+{
+    /// <summary>
+    /// Stops an editor carrying unsaved changes from being thrown away without the user
+    /// saying so. Two ways of losing one are covered:
+    ///
+    /// <list type="bullet">
+    /// <item>reloading / closing the browser tab — a <c>beforeunload</c> listener asks
+    /// the browser to show its native "leave site?" prompt;</item>
+    /// <item>navigating to another route — <see cref="CanNavigateAway"/> (wire it into
+    /// <see cref="Router.OnBeforeNavigate"/>) cancels the navigation, asks whether to
+    /// save, and only then lets it through.</item>
+    /// </list>
+    ///
+    /// There are two ways to feed it. A modal or a standalone editor registers itself with
+    /// <see cref="Track"/> and drops out with <see cref="Forget"/>. A view hosting editors
+    /// as pivot tabs instead calls <see cref="TrackOpenTabs"/>, which reads the dirty tabs
+    /// straight off the DOM via <see cref="TabSaveIndicator"/> — tabs come and go faster
+    /// than registrations can be kept honest, and a torn-down tab can't leave a stale entry
+    /// behind that way.
+    ///
+    /// Closing a modal directly (its own close button, a light-dismiss click) is NOT covered
+    /// here — that path has to ask its own confirmation before the modal hides, since by the
+    /// time it is gone there is nothing left to intercept.
+    /// </summary>
+    [Transpose.Name("tss.UnsavedChangesGuard")]
+    public static class UnsavedChangesGuard
+    {
+        private static Action<Event> _beforeUnload;
+
+        // Editors that registered themselves, keyed so re-opening the same one replaces it.
+        private static readonly Dictionary<string, TrackedEditor> _tracked = new Dictionary<string, TrackedEditor>();
+
+        // Whether to also treat the dirty pivot tabs found in the DOM as unsaved editors.
+        private static bool _watchingOpenTabs;
+
+        // The navigation the user already confirmed: the router hook has to cancel the
+        // first attempt (it can't await the dialog), so the re-issued navigation needs a
+        // way past the guard while the editors are still dirty.
+        private static string _confirmedTarget;
+        private static bool   _asking;
+
+        /// <summary>
+        /// Registers a single editor for as long as it is on screen. <paramref name="key"/>
+        /// identifies it (re-opening the same editor replaces its entry),
+        /// <paramref name="name"/> is what the user is told has unsaved changes, and
+        /// <paramref name="save"/> returns whether the save actually went through.
+        /// Always pair this with <see cref="Forget"/> on the editor's close / removal path.
+        /// </summary>
+        public static void Track(string key, Func<string> name, Func<bool> isDirty, Func<Task<bool>> save)
+        {
+            if (string.IsNullOrEmpty(key) || isDirty is null) return;
+
+            _tracked[key] = new TrackedEditor { Name = name, IsDirty = isDirty, Save = save };
+            RefreshUnloadListener();
+        }
+
+        /// <summary>Drops a <see cref="Track"/>ed editor — call it when that editor closes.</summary>
+        public static void Forget(string key)
+        {
+            if (string.IsNullOrEmpty(key) || !_tracked.Remove(key)) return;
+            RefreshUnloadListener();
+        }
+
+        /// <summary>Starts watching the open editor tabs — call it when the hosting view is mounted.</summary>
+        public static void TrackOpenTabs()
+        {
+            _watchingOpenTabs = true;
+            RefreshUnloadListener();
+        }
+
+        /// <summary>Stops watching the open editor tabs — call it when the hosting view is removed.</summary>
+        public static void ForgetOpenTabs()
+        {
+            _watchingOpenTabs = false;
+            _confirmedTarget  = null;
+            RefreshUnloadListener();
+        }
+
+        /// <summary>
+        /// A <see cref="Router.OnBeforeNavigate"/> answer. Returns true when nothing would be
+        /// lost; otherwise cancels this navigation and asks the user what to do with the
+        /// unsaved editors, re-issuing the navigation once they have decided.
+        /// </summary>
+        public static bool CanNavigateAway(Router.State target)
+        {
+            if (target is null) return true;
+
+            if (_confirmedTarget is object && SameRoute(_confirmedTarget, target.FullPath))
+            {
+                _confirmedTarget = null;
+                return true;
+            }
+
+            var unsaved = CollectUnsaved();
+
+            if (unsaved.Count == 0) return true;
+            if (_asking) return false;
+
+            AskThenNavigateAsync(target.FullPath, unsaved).FireAndForget();
+            return false;
+        }
+
+        /// <summary>Every editor that currently holds changes the user has not saved.</summary>
+        private static List<UnsavedEditor> CollectUnsaved()
+        {
+            var unsaved = new List<UnsavedEditor>();
+
+            if (_watchingOpenTabs)
+            {
+                foreach (var dirtyTabId in TabSaveIndicator.DirtyTabIds())
+                {
+                    var tabIndicatorId = dirtyTabId;
+
+                    unsaved.Add(new UnsavedEditor(
+                        TabSaveIndicator.TitleOf(tabIndicatorId),
+                        TabSaveIndicator.CanSave(tabIndicatorId),
+                        () => TabSaveIndicator.SaveAsync(tabIndicatorId)));
+                }
+            }
+
+            foreach (var editor in _tracked.Values)
+            {
+                if (!editor.IsDirty()) continue;
+                unsaved.Add(new UnsavedEditor(editor.Name?.Invoke(), editor.Save is object, editor.Save));
+            }
+
+            return unsaved;
+        }
+
+        /// <summary>
+        /// The <c>beforeunload</c> listener only needs to exist while something is being
+        /// watched, so adding and removing it follows the two registration paths.
+        /// </summary>
+        private static void RefreshUnloadListener()
+        {
+            var needed = _watchingOpenTabs || _tracked.Count > 0;
+
+            if (needed == (_beforeUnload is object)) return;
+
+            if (needed)
+            {
+                _beforeUnload = ev =>
+                {
+                    if (CollectUnsaved().Count == 0) return;
+                    ev.preventDefault();
+                    // Some browsers still need `returnValue` set to trigger the prompt.
+                    Transpose.Script.Write("{0}.returnValue = ''", ev);
+                };
+
+                window.addEventListener("beforeunload", _beforeUnload);
+            }
+            else
+            {
+                window.removeEventListener("beforeunload", _beforeUnload);
+                _beforeUnload = null;
+            }
+        }
+
+        private static async Task AskThenNavigateAsync(string targetFullPath, List<UnsavedEditor> unsaved)
+        {
+            _asking = true;
+
+            try
+            {
+                var response = await Dialog(
+                        title: TextBlock("Unsaved changes".t()).SemiBold(),
+                        content: TextBlock(DescribeUnsaved(unsaved)))
+                   .Dark()
+                   .YesNoCancelAsync(
+                        btnYes: b =>
+                        {
+                            b.SetText("Save and leave".t()).SetIcon(UIcons.Disk).Primary();
+                            if (!unsaved.All(e => e.CanSave)) b.Disabled();
+                            return b;
+                        },
+                        btnNo: b => b.SetText("Leave without saving".t()).Danger(),
+                        btnCancel: b => b.SetText("Stay here".t()));
+
+                if (response != Dialog.Response.Yes && response != Dialog.Response.No) return;
+                if (response == Dialog.Response.Yes && !await SaveAllAsync(unsaved)) return;
+
+                _confirmedTarget = targetFullPath;
+                Router.Navigate(targetFullPath);
+            }
+            finally
+            {
+                _asking = false;
+            }
+        }
+
+        /// <summary>
+        /// Saves every unsaved editor, stopping at the first one that refuses. Editors say
+        /// what went wrong themselves, but not all of them do — so name the one we stopped
+        /// on, otherwise "Save and leave" would look like it did nothing.
+        /// </summary>
+        private static async Task<bool> SaveAllAsync(List<UnsavedEditor> unsaved)
+        {
+            foreach (var editor in unsaved)
+            {
+                bool saved;
+
+                // A save that throws is a save that didn't happen: report it and stay put,
+                // rather than letting the rejection escape and navigating away regardless.
+                try
+                {
+                    saved = editor.Save is object && await editor.Save();
+                }
+                catch (Exception e)
+                {
+                    Toast().Error("Failed to save".t(), e.Message);
+                    return false;
+                }
+
+                if (saved) continue;
+
+                Toast().Warning("Not saved".t(), string.IsNullOrEmpty(editor.Name)
+                    ? "An editor could not be saved, so you are still on this page.".t()
+                    : string.Format("\"{0}\" could not be saved, so you are still on this page.".t(), editor.Name));
+
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Whether two full URLs address the same route. Only the hash carries the route, and
+        /// the browser may hand back a differently-spelled absolute URL for the same one.
+        /// </summary>
+        private static bool SameRoute(string a, string b)
+        {
+            if (a == b) return true;
+
+            var hashA = a.IndexOf('#');
+            var hashB = b.IndexOf('#');
+
+            return hashA >= 0 && hashB >= 0 && a.Substring(hashA) == b.Substring(hashB);
+        }
+
+        private static string DescribeUnsaved(List<UnsavedEditor> unsaved)
+        {
+            var names = new List<string>(unsaved.Count);
+
+            foreach (var editor in unsaved)
+            {
+                if (!string.IsNullOrEmpty(editor.Name)) names.Add(editor.Name);
+            }
+
+            if (names.Count == 0) return "You have unsaved changes that will be lost if you leave this page. Do you want to save them first?".t();
+            if (names.Count == 1) return string.Format("\"{0}\" has unsaved changes that will be lost if you leave this page. Do you want to save it first?".t(), names[0]);
+
+            return string.Format("{0} have unsaved changes that will be lost if you leave this page. Do you want to save them first?".t(), string.Join(", ", names.Select(n => "\"" + n + "\"")));
+        }
+
+        private sealed class TrackedEditor
+        {
+            public Func<string>     Name    { get; set; }
+            public Func<bool>       IsDirty { get; set; }
+            public Func<Task<bool>> Save    { get; set; }
+        }
+
+        /// <summary>One editor holding unsaved changes, flattened from whichever source found it.</summary>
+        private sealed class UnsavedEditor
+        {
+            public UnsavedEditor(string name, bool canSave, Func<Task<bool>> save)
+            {
+                Name    = name;
+                CanSave = canSave;
+                Save    = save;
+            }
+
+            public string           Name    { get; }
+            public bool             CanSave { get; }
+            public Func<Task<bool>> Save    { get; }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `UnsavedChangesGuard`, a static helper that stops an editor's unsaved changes from being lost silently: a `beforeunload` listener covers tab close/reload, and `CanNavigateAway` (wired into `Router.OnBeforeNavigate`) blocks in-app navigation until the user saves, discards, or stays.
- Adds `TabSaveIndicator`, the companion for editors hosted as `Pivot` tabs — toggles a "*" indicator on a tab's title element and lets an editor register a save handler so the guard can save a tab without knowing what kind of editor it holds.
- Both live under `Tesserae/src/Helpers/UnsavedChanges/`.
- Adds the `unsaved-changes-guard` skill reference (`Tesserae/skills/references/unsaved-changes-guard.md`), links it from the `SKILL.md` index and from `routing.md`/`pivot.md`, and adds a `Tesserae.Tests` sample (`UnsavedChangesGuardSample`).

This was ported over from a Mosaik-only helper that turned out to have no actual Mosaik dependency once written directly against `Router`, `Dialog`, `Toast` and the vendored `TNT.T` translation helper — all of which already live in this package. A follow-up Mosaik PR (curiosity-ai/mosaik) removes the duplicate Mosaik-side copy and switches its call sites over to this package once a new Tesserae version is published.

## Test plan

- [x] `dotnet build Tesserae/Tesserae.csproj` — clean, 0 warnings/errors.
- [x] `dotnet build Tesserae.Tests/Tesserae.Tests.csproj` — clean, 0 warnings/errors (covers the new sample).
- [x] Packed a local verification build (`dotnet pack`) and built the Mosaik front-end against it end-to-end to confirm the API is usable from a real consumer before opening the companion PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FG3dMieKZbVKpihYgWbZhF)_