### PR TITLE
Fix FileDropArea(component) not opening the file dialog on click

### DIFF
--- a/Tesserae.Tests/src/Samples/Utilities/FileSelectorAndDropAreaSample.cs
+++ b/Tesserae.Tests/src/Samples/Utilities/FileSelectorAndDropAreaSample.cs
@@ -34,7 +34,20 @@ namespace Tesserae.Tests.Samples
                         {
                             droppedFiles.Add(TextBlock(file.name).Small());
                         }
-                    }).Multiple()
+                    }).Multiple(),
+                    SampleSubTitle("File Drop Area wrapping your own content"),
+                    TextBlock("Clicking anywhere opens the file dialog, except on the button below, which keeps its own click.").Small(),
+                    FileDropArea(VStack().WS().AlignItemsCenter().P(16).Children(
+                        TextBlock("Drag and drop a file here").SemiBold().PB(4),
+                        TextBlock("or click to browse").Small(),
+                        Button("I have my own click").PT(12).OnClick(() => droppedFiles.Add(TextBlock("button clicked").Small()))
+                    )).OnFilesDropped((s, e) =>
+                    {
+                        foreach (var file in e)
+                        {
+                            droppedFiles.Add(TextBlock(file.name).Small());
+                        }
+                    }).Multiple().WS()
                 )).SetTitle("Usage")))
                .SeeAlso(typeof(OmniBoxSample), typeof(ChatSample), typeof(ContextCardSample), typeof(ValidatorSample));
         }

--- a/Tesserae/skills/references/file-selector-and-drop-area.md
+++ b/Tesserae/skills/references/file-selector-and-drop-area.md
@@ -28,6 +28,8 @@ Bring factories into scope with `using static Tesserae.UI;`.
 - `.OnFilesDropped((sender, File[] files) => …)` — handler.
 - `.SetContent(IComponent)` / `.OpenFileSelection()` / `.Reset()`.
 
+Both overloads open the file dialog on click. With `FileDropArea(component)`, a click that lands on an interactive element of your own content (`a`, `button`, `input`, `select`, `textarea`, `label`, `[role=button]`, `[role=link]`, `[contenteditable=true]`) runs that element's handler instead, so wrapped content can keep its own buttons.
+
 ## Example
 
 ```csharp

--- a/Tesserae/src/Components/FileDropArea.cs
+++ b/Tesserae/src/Components/FileDropArea.cs
@@ -31,18 +31,7 @@ namespace Tesserae
 
             _container = CreateDefaultDropArea();
 
-            _fileInput.onchange = (e) => triggerDroppedOnFile();
-
-            void triggerDroppedOnFile()
-            {
-                if (_fileInput.files.length > 0)
-                {
-                    FilesDropped(this,
-                        IsMultiple
-                            ? _fileInput.files.ToArray()
-                            : new[] { _fileInput.files.First() });
-                }
-            }
+            _fileInput.onchange = (e) => OnFileInputChanged();
         }
 
         /// <summary>
@@ -54,18 +43,17 @@ namespace Tesserae
 
             _container = CreateWrappedDropArea(component);
 
-            _fileInput.onchange = (e) => triggerDroppedOnFile();
+            _fileInput.onchange = (e) => OnFileInputChanged();
+        }
 
-            void triggerDroppedOnFile()
-            {
-                if (_fileInput.files.length > 0)
-                {
-                    FilesDropped(this,
-                        IsMultiple
-                            ? _fileInput.files.ToArray()
-                            : new[] { _fileInput.files.First() });
-                }
-            }
+        private void OnFileInputChanged()
+        {
+            if (_fileInput.files.length == 0) return;
+
+            FilesDropped?.Invoke(this,
+                IsMultiple
+                    ? _fileInput.files.ToArray()
+                    : new[] { _fileInput.files.First() });
         }
 
         /// <summary>
@@ -107,10 +95,18 @@ namespace Tesserae
         {
             var wrapper = Div(Att("tss-filedroparea-wrapper"));
             wrapper.appendChild(_fileInput);
-            wrapper.appendChild(component.Render());
+
+            _raw = Raw(component);
+            wrapper.appendChild(_raw.Render());
 
             var overlay = Div(Att("tss-filedroparea-overlay"), Div(Att("tss-filedroparea-message"), I(Att($"{UIcons.Upload} tss-filedroparea-icon")), TextBlock("Drop files here").SemiBold().Render()));
             wrapper.appendChild(overlay);
+
+            wrapper.onclick = (e) =>
+            {
+                if (IsOwnClickOfWrappedContent(e)) return;
+                _fileInput.click();
+            };
 
             int dragCounter = 0;
 
@@ -152,6 +148,17 @@ namespace Tesserae
             };
 
             return wrapper;
+        }
+
+        // The wrapped content brings its own buttons and links, and the hidden file input re-dispatches
+        // the click we open it with - those clicks belong to the element that was hit, not to browsing.
+        private static bool IsOwnClickOfWrappedContent(MouseEvent e)
+        {
+            var target = e?.target.As<HTMLElement>();
+
+            if (target is null) return false;
+
+            return target.closest("a, button, input, select, textarea, label, [role=button], [role=link], [contenteditable=true]") is object;
         }
 
         private HTMLElement CreateDefaultDropArea()

--- a/Tesserae/tps/assets/css/tss.files.css
+++ b/Tesserae/tps/assets/css/tss.files.css
@@ -109,7 +109,18 @@
     position: relative;
     display: inline-flex;
     flex-direction: column;
+    cursor: pointer;
 }
+
+    .tss-filedroparea-wrapper a,
+    .tss-filedroparea-wrapper button,
+    .tss-filedroparea-wrapper input,
+    .tss-filedroparea-wrapper select,
+    .tss-filedroparea-wrapper textarea,
+    .tss-filedroparea-wrapper [role="button"],
+    .tss-filedroparea-wrapper [role="link"] {
+        cursor: revert;
+    }
 
 .tss-filedroparea-overlay {
     position: absolute;


### PR DESCRIPTION
## The bug

`FileDropArea` has two constructors, and only the parameterless one wired up click-to-browse:

```csharp
// CreateDefaultDropArea
dropArea.onclick = (e) => { _fileInput.click(); };
```

`CreateWrappedDropArea` — the `FileDropArea(IComponent)` overload — wired `ondragenter` / `ondragleave` / `ondragover` / `ondrop` but no `onclick`, so the hidden `<input type=file>` was never triggered. Drag-and-drop worked; clicking did nothing.

This is a bug against the documented contract — the shipped skill reference already says FileDropArea "also opens the file dialog on click" for both overloads — and `.tss-filedroparea-wrapper` didn't even set `cursor: pointer`, so the area never read as clickable.

It was reported from Curiosity Workspace's **Import data** page, whose drop area renders the copy "or click to browse" over a dead click target. Every consumer of the wrapped overload is affected: `ImportLandingView`, `CsvImportView` (both showing "or click to browse"), and `StageView.BuildResultsHeader`.

## The fix

- `CreateWrappedDropArea` now sets `wrapper.onclick` to open the file input.
- A click landing on an interactive element of the wrapped content (`a`, `button`, `input`, `select`, `textarea`, `label`, `[role=button]`, `[role=link]`, `[contenteditable=true]`) is left to that element. This matters because wrapped content can carry its own controls — `StageView`'s results header nests an "Upload files" button that would otherwise fire its handler *and* the file dialog on one click. The same check absorbs the click `input.click()` re-dispatches up through the wrapper.
- `cursor: pointer` on `.tss-filedroparea-wrapper`, reverted for those interactive descendants so a nested button keeps its own cursor.

Two related defects in the same constructor, fixed alongside:

- `SetContent` / `Content` was a silent no-op on wrapped instances — `_raw` was only assigned by `CreateDefaultDropArea`, and the setter is `_raw?.Content(value)`. The wrapped path now hosts its content in a `Raw`.
- Both `onchange` handlers called `FilesDropped(this, …)` with no null check, so an instance with no `OnFilesDropped` registered threw on file selection. The drop path already used `FilesDropped?.Invoke`. The duplicated local function in both constructors is now one `OnFileInputChanged` method that does.

## Verification

`dotnet build` is clean (0 warnings, 0 errors) for `Tesserae.csproj` and the full solution. The built sample site was driven in Chromium with Playwright:

```
cursor on wrapper: pointer
TEST 1 - click on wrapper opens file dialog: PASS
TEST 2a - inner button does NOT open dialog: PASS
TEST 2b - inner button ran its own handler: PASS
TEST 3 - unwrapped drop area still opens dialog: PASS
```

The Playwright script is intentionally not committed, per the repo's local-only rule for `Tesserae.Tests/playwright/`.

## Also in this PR

- `FileSelectorAndDropAreaSample` gains a wrapped-overload sample that exercises both the click and the inner-button exception — the regressed path had no sample coverage.
- `references/file-selector-and-drop-area.md` documents the interactive-element exception.

## Downstream note

Curiosity Workspace consumes Tesserae as a NuGet package and is already on the newest published version (`2026.8.69509`), so no change is needed on that side — but the Import data page only picks this up once a Tesserae package newer than `2026.8.69509` is cut and the `PackageReference` in `Curiosity.FrontEnd.Core.csproj` is bumped.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bp9LzEG9UptD5U6zBfbYHS)_