### PR TITLE
Build as JavaScript modules, keeping the UI facade intact

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,6 +148,12 @@ dotnet serve --port 5000
 - Component creation goes through the static `UI` class (`UI.Components.cs`), which exposes factory methods like `UI.Button`, `UI.TextBlock`, etc.
 - `UI` is a static partial class with a static constructor used as the central entry point.
 - Components are configured via fluent-style extension methods (e.g., `UI.Id`, `UI.Class`, `UI.Do`).
+- `UI` carries **`[Transpose.SkipTypeClustering]`**, which is load-bearing for the module build and
+  must stay. A module chunk is a strongly-connected component of the reference graph, and a facade
+  whose factories construct half the library — while every component calls back into it for
+  `Div`/`VStack` — fuses that half into one 1.6 MB chunk. The attribute moves the facade's outgoing
+  edges to its call sites, where a static method body actually runs. See
+  [docs/module-output.md](docs/module-output.md).
 
 ## Conventions
 
@@ -263,6 +269,21 @@ is inside a Masonry/SectionStack, where they are on its wrapper.
 - Variable-height tile feed → `Masonry`.
 - Modal/popover that must escape clipping → `Layer` (usually wrapped by
   higher-level components like `Dialog`, `Modal`, `ContextMenu`).
+
+## Module output
+
+`Tesserae/tps.json` and `Tesserae.Tests/tps.json` set `"outputBy": "Module"`, so `tps` emits one ES
+module per chunk and the gallery fetches a sample's code when it is opened — 1,055 KB of initial
+JavaScript instead of 3,542 KB. Two consequences to know about when working here:
+
+- **Constructing a deferred type is asynchronous.** `Activator.CreateInstanceAsync` loads the module
+  and then constructs; the synchronous `Activator.CreateInstance` throws and names the module. That
+  is why `Sample.ContentGenerator` returns a `Task<IComponent>`.
+- **Reflection still sees everything.** A deferred type is registered as a stub carrying its name,
+  interfaces and attributes, so `Assembly.GetTypes()`, `IsAssignableFrom` and `GetCustomAttributes`
+  work with the code absent — which is what keeps the sample discovery working.
+
+[docs/module-output.md](docs/module-output.md) has the numbers and the full change list.
 
 ## Testing
 

--- a/Tesserae.Bench/Tesserae.Bench.csproj
+++ b/Tesserae.Bench/Tesserae.Bench.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Transpose.BCL" Version="26.8.4045" />
+    <PackageReference Include="Transpose.BCL" Version="26.8.4093" />
     <PackageReference Include="Transpose.Core" Version="26.7.3304" />
   </ItemGroup>
 

--- a/Tesserae.Tests/Tesserae.Tests.csproj
+++ b/Tesserae.Tests/Tesserae.Tests.csproj
@@ -4,7 +4,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Transpose.BCL" Version="26.8.4045" />
+    <PackageReference Include="Transpose.BCL" Version="26.8.4093" />
     <PackageReference Include="Transpose.Core" Version="26.7.3304" />
   </ItemGroup>
 

--- a/Tesserae.Tests/src/App.cs
+++ b/Tesserae.Tests/src/App.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -91,9 +91,9 @@ namespace Tesserae.Tests
             searchBox.OnSearch((term) => sidebar.Search(term));
             sidebar.AddHeader(searchBox);
 
-            var contentArea = DeferSync(currentPage, page => page is null
+            var contentArea = Defer(currentPage, async page => page is null
                 ? (IComponent)CenteredCardWithBackground(Message("Welcome to Tesserae", "Select a component to see more details").Icon(UIcons.Search))
-                : VStack().S().ScrollY().Children(page.ContentGenerator().WS().MinHeight(100.percent())));
+                : VStack().S().ScrollY().Children((await page.ContentGenerator()).WS().MinHeight(100.percent())));
 
             // On mobile the sidebar is a fixed top navbar, so the layout is vertical (sidebar then content).
             // On desktop the layout is horizontal (sidebar left, content right).
@@ -120,7 +120,7 @@ namespace Tesserae.Tests
                    var group = sg is object ? sg.Group : "Others";
                    int order = sg is object ? sg.Order : 0;
                    UIcons icon = sg is object ? sg.Icon : UIcons.Circle;
-                   return new Sample(sampleType.Name, Sample.FormatSampleName(sampleType), group, order, icon, () => Activator.CreateInstance(sampleType) as IComponent);
+                   return new Sample(sampleType.Name, Sample.FormatSampleName(sampleType), group, order, icon, async () => await Activator.CreateInstanceAsync(sampleType) as IComponent);
                })
                .ToDictionary(s => s.Name, s => s);
 

--- a/Tesserae.Tests/src/Samples/Sample.cs
+++ b/Tesserae.Tests/src/Samples/Sample.cs
@@ -10,9 +10,9 @@ namespace Tesserae.Tests
         public string           Group            { get; }
         public int              Order            { get; }
         public UIcons           Icon             { get; }
-        public Func<IComponent> ContentGenerator { get; }
+        public Func<System.Threading.Tasks.Task<IComponent>> ContentGenerator { get; }
 
-        public Sample(string type, string name, string group, int order, UIcons icon, Func<IComponent> contentGenerator)
+        public Sample(string type, string name, string group, int order, UIcons icon, Func<System.Threading.Tasks.Task<IComponent>> contentGenerator)
         {
             Type             = type;
             Name             = name;

--- a/Tesserae.Tests/tps.json
+++ b/Tesserae.Tests/tps.json
@@ -1,6 +1,7 @@
 {
     "output": "$(OutDir)/tps/",
     "fileName": "app.js",
+    "outputBy": "Module",
     "outputFormatting": "Minified",
     "html": {
         "disabled": false,

--- a/Tesserae/Tesserae.csproj
+++ b/Tesserae/Tesserae.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Transpose.BCL" Version="26.8.4045" />
+    <PackageReference Include="Transpose.BCL" Version="26.8.4093" />
     <PackageReference Include="Transpose.Core" Version="26.7.3304" />
     <PackageReference Include="Transpose.Newtonsoft.Json" Version="26.7.3305" />
   </ItemGroup>

--- a/Tesserae/src/Base/UI.Components.cs
+++ b/Tesserae/src/Base/UI.Components.cs
@@ -10,6 +10,7 @@ namespace Tesserae
     /// Static class containing factory methods for all Tesserae components and various UI helpers.
     /// </summary>
     [Transpose.Name("tss.UI")]
+    [Transpose.SkipTypeClustering]
     public static partial class UI
     {
         static UI()

--- a/Tesserae/tps.json
+++ b/Tesserae/tps.json
@@ -1,6 +1,7 @@
 ﻿{
     "output": "$(OutDir)/tps/",
     "outputFormatting": "Both",
+    "outputBy": "Module",
     "reflection": {
         "disabled": true,
         "target": "file"

--- a/docs/module-output.md
+++ b/docs/module-output.md
@@ -1,0 +1,104 @@
+# Loading the sample gallery as JavaScript modules
+
+Both `Tesserae` and `Tesserae.Tests` build with `outputBy: "Module"`, so `tps` emits one ES module
+per chunk instead of a single bundle. Only the code needed to draw the shell ships up front; each
+sample's chunk — and each Tesserae component's — is fetched when something actually needs it.
+
+Requires `Transpose.Compiler` 26.8.4092 / `Transpose.BCL` 26.8.4093 or newer.
+
+## What it costs, what it saves
+
+Tesserae's and the gallery's own JavaScript — `tss` + the app, leaving out the `tps` runtime and the
+third-party bundle, which are the same either way:
+
+| | initial JavaScript |
+| --- | --- |
+| single bundle (`tss.js` + `app.js`) | 3,542 KB raw / 547 KB gzipped |
+| both as modules | **1,055 KB raw / 188 KB gzipped** |
+
+70% of the raw bytes and 66% of the gzipped ones. Counting everything the page loads — runtime,
+metadata, `tss-dep.js` — it is 7,029 KB → 4,542 KB raw and 1,120 KB → 761 KB gzipped.
+
+682 chunks (521 from Tesserae, 161 from the gallery, 3,280 KB raw in total), of which **121 load up
+front** and 561 on demand.
+
+The rendered page is unchanged. Built both ways and compared with
+[`Tesserae.Bench/playwright/textdiff-samples.js`](../Tesserae.Bench/playwright/textdiff-samples.js),
+126 of 132 samples are identical run for run, and every difference it reports also appears when the
+module build is compared **against itself** — the Charts run count, three clock timestamps, Progress
+Ring's animated fill and Masonry's debounced relayout. All 141 sidebar entries render with zero
+console errors.
+
+## The four changes it needed
+
+**1. `[SkipTypeClustering]` on `UI`.** This is the one that matters. A chunk is a strongly-connected
+component of the reference graph, so a static facade whose 300 factories construct half the library
+fuses that half into a single chunk: `UI` reaches every component, and every component calls back
+into `UI` for `Div`/`VStack`. The attribute drops the edges *out of* the facade and attributes each
+member's dependencies to the code that **calls** it, which is where a static method body actually
+runs:
+
+```csharp
+[Transpose.SkipTypeClustering]
+public static partial class UI
+```
+
+Without it the largest library chunk is **193 types / 1,612 KB** and 213 chunks load up front. With
+it the largest is 5 types / 67 KB, 513 of the 521 library chunks hold exactly one type, and the eager
+payload is less than half. Nothing else about `UI` changes — every factory method stays.
+
+**2. `tps.json`** — opt in, in both the library and the app:
+
+```json
+"outputBy": "Module",
+```
+
+A library needs no other change: it defers everything, publishes a chunk map, and (because of the
+attribute) publishes the facade's per-member dependency sets so the consuming build can turn a
+`UI.Card(...)` call into an import of Card's chunk.
+
+**3 & 4. Instantiating a sample became asynchronous.** The gallery discovers samples by reflection
+(`typeof(ISample).Assembly.GetTypes()`) and constructs the selected one with `Activator`. Reflection
+keeps working against a deferred type — the runtime registers a stub carrying its name, interfaces
+and attributes — but *constructing* it has to fetch its module first, and fetching is asynchronous:
+
+```csharp
+// Sample.cs
+- public Func<IComponent> ContentGenerator { get; }
++ public Func<Task<IComponent>> ContentGenerator { get; }
+
+// App.cs — the factory
+- () => Activator.CreateInstance(sampleType) as IComponent
++ async () => await Activator.CreateInstanceAsync(sampleType) as IComponent
+
+// App.cs — the content area
+- DeferSync(currentPage, page => … page.ContentGenerator() …)
++ Defer(currentPage, async page => … (await page.ContentGenerator()) …)
+```
+
+`Defer` already existed for exactly this shape, so the change is two signatures and an `await`.
+Calling the synchronous `Activator.CreateInstance` on a deferred type throws and names the module
+rather than failing somewhere inside the constructor — the failure is loud, not silent.
+
+## Why not remove the `UI` facade instead
+
+That was tried first: deleting the same-named factory wrappers and rewriting every call site to
+`new Card(...)`. It works, but it is ~630 changed lines across 40 files, it has to be redone for
+every component added afterwards, and it is **worse** — 1,788 KB / 328 KB gzipped eager, against
+1,055 KB / 188 KB for the attribute. Removing the factories still leaves the `Div`/`VStack` helper
+edges that make `UI` a hub; the attribute removes the hub itself.
+
+## Trying it
+
+```bash
+dotnet build
+cd Tesserae.Tests/bin/Debug/netstandard2.0/tps/
+dotnet serve --port 5000
+```
+
+`index.html` carries a `<script type="module">` for each of `tss.js` and `app.js`; open the network
+panel and watch `chunks/<assembly>/cN.mjs` arrive as you click through the sidebar.
+
+The compiler-side design — why a chunk is a strongly-connected component, why a per-class split is
+unsound, and what `[SkipTypeClustering]` does to the graph — is in
+[`TODO.modules.md`](https://github.com/curiosity-ai/transpose/blob/master/TODO.modules.md).


### PR DESCRIPTION
`outputBy: "Module"` in both `tps.json` files makes `tps` emit one ES module per chunk instead of a single bundle, and the gallery fetches a sample's code when it is opened.

| | initial JavaScript (`tss` + app) |
| --- | --- |
| single bundle | 3,542 KB raw / 547 KB gzipped |
| as modules | **1,055 KB raw / 188 KB gzipped** |

70% of the raw bytes, 66% of the gzipped ones. 682 chunks (521 library, 161 app), of which 121 load up front.

## The change that makes it work is one attribute

A chunk is a strongly-connected component of the reference graph, so the `UI` facade — 300 factories constructing half the library, with every component calling back into it for `Div`/`VStack` — fused that half into a single chunk of **193 types / 1,612 KB**.

```csharp
[Transpose.SkipTypeClustering]
public static partial class UI
```

The attribute drops the edges *out of* the facade and attributes each member's dependencies to the code that **calls** it, which is where a static method body actually runs. The largest library chunk becomes 5 types / 67 KB, 513 of the 521 hold exactly one type, and eager chunks drop from 213 to 121. Every factory method stays exactly as it was.

## Why not remove the facade instead

That was the first approach on this branch, and it is in the history: delete the same-named factory wrappers, rewrite every call site to `new Card(...)`. It works, but it is ~630 changed lines across 40 files, has to be repeated for every component added afterwards, and measures **worse** — 1,788 KB / 328 KB gzipped eager against 1,055 KB / 188 KB. Removing the factories still leaves the `Div`/`VStack` helper edges that make `UI` a hub; the attribute removes the hub itself.

The branch has been rebuilt on top of current `master` with only the attribute-based change, so the invasive rewrite is gone.

## The rest of the diff

- **`tps.json`** — `"outputBy": "Module"` in the library and the app.
- **Constructing a sample became asynchronous.** Reflection keeps working against a deferred type (the runtime registers a stub carrying its name, interfaces and attributes), but *constructing* one has to fetch its module first: `Sample.ContentGenerator` returns `Task<IComponent>` and the gallery awaits `Activator.CreateInstanceAsync`. `Defer` already existed for that shape, so it is two signatures and an `await`. The synchronous `Activator.CreateInstance` throws and names the module rather than failing inside the constructor.
- **`Transpose.BCL` 26.8.4093** in all three projects (needs `Transpose.Compiler` 26.8.4092+).
- `docs/module-output.md` and a note in `CLAUDE.md` saying the attribute is load-bearing.

## Verification

Compared against a single-bundle build of the same tree with the repo's own [`Tesserae.Bench/playwright/textdiff-samples.js`](Tesserae.Bench/playwright/textdiff-samples.js): **126 of 132 samples identical**, and every difference it reports also appears when the module build is compared *against itself* — the Charts run count, three clock timestamps, Progress Ring's animated fill and Masonry's debounced relayout. All 141 sidebar entries render with **zero console errors**, and reflection still enumerates all 533 + 163 types.

Compiler side: curiosity-ai/transpose#121.
