### PR TITLE
Add continuous X scale, zoom/pan, spikelines, and PNG export to charts

### DIFF
--- a/Tesserae.Tests/src/Samples/Components/ChartsSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/ChartsSample.cs
@@ -32,6 +32,15 @@ namespace Tesserae.Tests.Samples
                .Legend()
                .Rounded(3);
 
+            var stackedChart = BarChart()
+               .Series(new ChartSeries("Chat", new double[] { 120, 180, 150, 260, 240, 310 }),
+                       new ChartSeries("Search", new double[] { 80, 95, 130, 140, 175, 205 }),
+                       new ChartSeries("Indexing", new double[] { 40, 35, 60, 55, 70, 90 }))
+               .XAxis(months)
+               .Stacked()
+               .Legend(ChartLegendPosition.Bottom)
+               .Rounded(1);
+
             var areaChart = AreaChart()
                .Series(liveData, "Sessions")
                .XAxis(months);
@@ -42,11 +51,17 @@ namespace Tesserae.Tests.Samples
                .Donut()
                .Legend();
 
+            var gapsChart = LineChart()
+               .Series("With a dropout", new double[] { 14, 17, double.NaN, double.NaN, 21, 19, 24 })
+               .XAxis("Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun")
+               .ConnectGaps(false)
+               .Legend();
+
             _content = SectionStack().Secondary()
                .SampleTitle(typeof(ChartsSample), UIcons.ChartHistogram, "Lightweight, dependency-free SVG charts")
                .Section(Stack().Children(
                     Card(VStack().WS().Children(
-                        TextBlock("LineChart, BarChart, AreaChart and PieChart render as responsive, dependency-free SVG that scales to its container, adapts to the light/dark theme, and exposes hover tooltips plus a role=\"img\" accessibility summary. Data can be supplied as plain values or as an observable that re-renders the chart on change."))).SetTitle("Overview")))
+                        TextBlock("LineChart, BarChart, AreaChart and PieChart render as responsive, dependency-free SVG that scales to its container, adapts to the light/dark theme, and exposes hover tooltips plus a role=\"img\" accessibility summary. Data can be supplied as plain values, as an observable that re-renders the chart on change, or as (x, y) pairs on a continuous scale that supports zoom, pan and a spikeline readout."))).SetTitle("Overview")))
                .Section(Stack().Children(
                     Card(VStack().WS().Children(
                         SampleSubTitle("Line chart"),
@@ -55,6 +70,10 @@ namespace Tesserae.Tests.Samples
                     Card(VStack().WS().Children(
                         SampleSubTitle("Bar chart (grouped series)"),
                         barChart.H(280).WS())).SetTitle("BarChart")))
+               .Section(Stack().Children(
+                    Card(VStack().WS().Children(
+                        SampleSubTitle("Stacked bars with the legend below"),
+                        stackedChart.H(300).WS())).SetTitle("BarChart (stacked)")))
                .Section(Stack().Children(
                     Card(VStack().WS().Children(
                         SampleSubTitle("Area chart bound to an observable"),
@@ -71,7 +90,74 @@ namespace Tesserae.Tests.Samples
                     Card(VStack().WS().Children(
                         SampleSubTitle("Donut chart"),
                         pieChart.H(280).WS())).SetTitle("PieChart")))
+               .Section(Stack().Children(
+                    Card(VStack().WS().Children(
+                        SampleSubTitle("Missing samples: NaN breaks the line when gaps are not connected"),
+                        gapsChart.H(260).WS())).SetTitle("Gaps")))
+               .Section(Stack().Children(
+                    Card(BuildTimeSeriesSection()).SetTitle("Time series: continuous X, zoom, spikelines")))
                .SeeAlso(typeof(SparklineSample), typeof(MetricSample), typeof(ContributionBarSample), typeof(DeltaComponentSample), typeof(TimeHistogramPickerSample));
+        }
+
+        // Two charts sharing one timeline: zooming or panning either one pushes its range onto the other,
+        // which is what OnRangeChanged + XRange are for (XRange itself never re-raises the event).
+        private static IComponent BuildTimeSeriesSection()
+        {
+            var start = DateTimeOffset.UtcNow.AddHours(-2).ToUnixTimeSeconds();
+            var rnd   = new Random();
+
+            var times = new double[120];
+            var cpu   = new double[120];
+            var ram   = new double[120];
+
+            double cpuValue = 35;
+            double ramValue = 1400;
+
+            for (var i = 0; i < times.Length; i++)
+            {
+                times[i] = start + i * 60;
+
+                cpuValue = Math.Max(2, Math.Min(98, cpuValue + rnd.Next(-6, 7)));
+                ramValue = Math.Max(600, ramValue + rnd.Next(-40, 55));
+
+                cpu[i] = cpuValue;
+                ram[i] = ramValue;
+            }
+
+            var cpuChart = AreaChart()
+               .Series(new ChartSeries("CPU %", times, cpu) { LineWidth = 1, FillOpacity = 0.2 })
+               .XAxisTime()
+               .FormatValues(v => v.ToString("0") + "%")
+               .Zoomable()
+               .Spikelines()
+               .ExportButton(fileName: "cpu")
+               .Legend();
+
+            var ramChart = LineChart()
+               .Series(new ChartSeries("Working set (MB)", times, ram) { LineWidth = 1 })
+               .XAxisTime()
+               .Points(false)
+               .Zoomable()
+               .Spikelines()
+               .ExportButton(fileName: "working-set")
+               .Legend();
+
+            cpuChart.OnRangeChanged(range =>
+            {
+                if (range.IsAutoRange) ramChart.AutoRangeX();
+                else ramChart.XRange(range.Min, range.Max);
+            });
+
+            ramChart.OnRangeChanged(range =>
+            {
+                if (range.IsAutoRange) cpuChart.AutoRangeX();
+                else cpuChart.XRange(range.Min, range.Max);
+            });
+
+            return VStack().WS().Children(
+                SampleSubTitle("Wheel to zoom, drag to pan, double-click to reset — both charts stay on the same timeline"),
+                cpuChart.H(200).WS(),
+                ramChart.H(200).WS().PT(8));
         }
 
         public HTMLElement Render() => _content.Render();

--- a/Tesserae/skills/references/charts.md
+++ b/Tesserae/skills/references/charts.md
@@ -1,13 +1,14 @@
 ---
 name: charts
-description: Four dependency-free responsive SVG charts — LineChart, BarChart, AreaChart, PieChart — with a shared fluent series/palette API, tooltips, legend, and observable-driven updates. Use to plot trends, comparisons, or part-to-whole data in a Tesserae (C#/Transpose) app.
+description: Four dependency-free responsive SVG charts — LineChart, BarChart, AreaChart, PieChart — with a shared fluent series/palette API, tooltips, legend, stacking, a continuous/time X axis, zoom and pan, spikelines, PNG export and observable-driven updates. Use to plot trends, comparisons, part-to-whole data or live time series in a Tesserae (C#/Transpose) app.
 ---
 
 # Charts
 
 Four SVG chart types share a fluent API. Cartesian charts (`LineChart`, `BarChart`,
-`AreaChart`) take X-axis categories; `PieChart` renders part-to-whole and can be a donut.
-Each fills its container via a `ResizeObserver` — give it a height (e.g. `.H(200.px())`).
+`AreaChart`) plot against either X-axis categories or a continuous X scale; `PieChart`
+renders part-to-whole and can be a donut. Each fills its container via a
+`ResizeObserver` — give it a height (e.g. `.H(200.px())`).
 
 ## Create
 
@@ -22,19 +23,67 @@ Data (all types):
 - `.Data(double[])` — one unnamed series.
 - `.Series(string name, double[] values, string color = null)` — append a named series.
 - `.Series(IObservable<double[]> values, ...)` — bind to an observable; re-renders on change.
+- `.Series(params ChartSeries[])` / `.Series(IObservable<ChartSeries[]>)` — full control.
+- `double.NaN` marks a missing sample. `.ConnectGaps(false)` breaks the line at a gap
+  instead of drawing straight across it.
+
+`ChartSeries` carries `Name`, `Values`, `Color`, plus `XValues` (continuous X positions),
+`LineWidth` (default 2) and `FillOpacity` (default 0.45, area charts):
+
+```csharp
+new ChartSeries("CPU %", times, values) { LineWidth = 1, FillOpacity = 0.2 }
+```
 
 Appearance (all types):
 
-- `.Colors(params string[])`, `.Legend(bool = true)`, `.Tooltips(bool = true)`,
-  `.Title(string)` (aria summary), `.FormatValues(Func<double,string>)`.
+- `.Colors(params string[])`, `.Tooltips(bool = true)`, `.Title(string)` (aria summary),
+  `.FormatValues(Func<double,string>)`.
+- `.Legend(bool = true)` and `.Legend(ChartLegendPosition)` — `Top` (default), `Bottom`,
+  `Left`, `Right`. `PieChart` defaults to `Right`.
+- `.ExportButton()` — a hover-revealed button that saves the chart as a PNG.
+  `.ExportPng(fileName)` does the same from code (CSS-variable colors are flattened
+  first, so the image matches the current theme).
 
 Cartesian (`Line`/`Bar`/`Area`):
 
-- `.XAxis(params string[])`, `.XAxisTitle(string)`, `.YAxisTitle(string)`,
-  `.Grid(bool)`, `.Axes(bool)`.
-- `LineChart`/`AreaChart`: `.Points(bool)`. `BarChart`: `.Rounded(double radius = 2)`.
+- `.XAxis(params string[])` — evenly spaced categories.
+- `.XAxisTitle(string)`, `.YAxisTitle(string)`, `.Grid(bool)`, `.Axes(bool)`.
+- `.MaxXTicks(int)` — cap the tick labels; 0 (default) derives the cap from the width.
+- `LineChart`/`AreaChart`: `.Points(bool)`. `BarChart`: `.Rounded(double radius = 2)`,
+  `.Stacked()`.
+
+Markers (and their tooltips) are suppressed above 300 points in a series — use
+`.Spikelines()` for dense data instead.
 
 PieChart: `.Labels(params string[])`, `.Donut(double holeRatio = 0.6)`.
+
+## Continuous / time X axis
+
+Give the points real X positions and the chart switches from evenly spaced categories to
+a continuous scale, so each series can have its own X values, its own point count and
+irregular spacing:
+
+- `.XValues(double[])` — shared X positions for every series.
+- `ChartSeries.XValues` — per-series positions (these win over the shared array).
+- `.FormatXAxis(Func<double,string>)` — tick label formatter.
+- `.XAxisTime(string format = "HH:mm")` — treats X as Unix seconds and formats as local time.
+
+## Zoom, pan and spikelines
+
+- `.Zoomable()` — wheel zooms the X axis, drag pans it, double-click resets. The value
+  axis rescales to the visible window.
+- `.Spikelines()` — a vertical line follows the cursor with a readout of the X position
+  and each series' nearest value.
+- `.XRange(min, max)` / `.AutoRangeX()` / `.TryGetXRange(out min, out max)` / `.IsXRangePinned`.
+- `.OnRangeChanged(Action<ChartRange>)` — raised on user zoom/pan/reset only. `.XRange()`
+  never re-raises it, so pushing a range onto sibling charts cannot loop.
+
+Keeping two charts on one timeline:
+
+```csharp
+a.OnRangeChanged(r => { if (r.IsAutoRange) b.AutoRangeX(); else b.XRange(r.Min, r.Max); });
+b.OnRangeChanged(r => { if (r.IsAutoRange) a.AutoRangeX(); else a.XRange(r.Min, r.Max); });
+```
 
 ## Example
 
@@ -46,6 +95,14 @@ var chart = LineChart()
     .Series("Target",  new double[] { 15, 15, 20, 20, 25 })
     .XAxis("Mon", "Tue", "Wed", "Thu", "Fri")
     .Legend()
+    .WS().H(200.px());
+
+var live = AreaChart()
+    .Series(new ChartSeries("CPU %", unixSeconds, values) { LineWidth = 1, FillOpacity = 0.2 })
+    .XAxisTime()
+    .Zoomable()
+    .Spikelines()
+    .ExportButton()
     .WS().H(200.px());
 ```
 

--- a/Tesserae/skills/references/charts.md
+++ b/Tesserae/skills/references/charts.md
@@ -49,8 +49,14 @@ Cartesian (`Line`/`Bar`/`Area`):
 - `.XAxis(params string[])` — evenly spaced categories.
 - `.XAxisTitle(string)`, `.YAxisTitle(string)`, `.Grid(bool)`, `.Axes(bool)`.
 - `.MaxXTicks(int)` — cap the tick labels; 0 (default) derives the cap from the width.
+- `.ZeroBaseline(bool)` — override whether the value axis includes zero. Bar and area
+  default to including it, line to fitting the data; a metric that hovers far from zero
+  reads better fitted (`.ZeroBaseline(false)`) with the fill still running to the bottom.
 - `LineChart`/`AreaChart`: `.Points(bool)`. `BarChart`: `.Rounded(double radius = 2)`,
   `.Stacked()`.
+
+The value axis sizes its own margin to the widest tick label, so a formatter that
+produces long strings (byte counts, currency) is not clipped.
 
 Markers (and their tooltips) are suppressed above 300 points in a series — use
 `.Spikelines()` for dense data instead.
@@ -66,7 +72,10 @@ irregular spacing:
 - `.XValues(double[])` — shared X positions for every series.
 - `ChartSeries.XValues` — per-series positions (these win over the shared array).
 - `.FormatXAxis(Func<double,string>)` — tick label formatter.
-- `.XAxisTime(string format = "HH:mm")` — treats X as Unix seconds and formats as local time.
+- `.XAxisTime(string format = null)` — treats X as Unix seconds and formats as local time.
+  Ticks land on whole seconds/minutes/hours/days, and with no explicit format the labels
+  follow the tick step (`HH:mm:ss` zoomed into a minute, `HH:mm`, `MM-dd`, `yyyy-MM`), so
+  neighbouring labels never read the same.
 
 ## Zoom, pan and spikelines
 

--- a/Tesserae/src/Components/AreaChart.cs
+++ b/Tesserae/src/Components/AreaChart.cs
@@ -22,7 +22,7 @@ namespace Tesserae
         public AreaChart Points(bool show = true) { _showPoints = show; QueueRender(); return this; }
 
         // Areas read most naturally filled down to a zero baseline.
-        protected override bool IncludeZeroBaseline => true;
+        protected override bool DefaultIncludeZeroBaseline => true;
 
         protected override void RenderSeries()
         {

--- a/Tesserae/src/Components/AreaChart.cs
+++ b/Tesserae/src/Components/AreaChart.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Linq;
+using System.Collections.Generic;
 using static Transpose.Core.dom;
 
 namespace Tesserae
@@ -48,55 +48,82 @@ namespace Tesserae
                 var stop1 = El("stop");
                 Attr(stop1, "offset", "0%");
                 Attr(stop1, "stop-color", color);
-                Attr(stop1, "stop-opacity", "0.45");
+                Attr(stop1, "stop-opacity", series.FillOpacity.ToString("0.###"));
                 var stop2 = El("stop");
                 Attr(stop2, "offset", "100%");
                 Attr(stop2, "stop-color", color);
-                Attr(stop2, "stop-opacity", "0.02");
+                Attr(stop2, "stop-opacity", (series.FillOpacity * 0.045).ToString("0.####"));
                 linearGradient.appendChild(stop1);
                 linearGradient.appendChild(stop2);
                 defs.appendChild(linearGradient);
-                _svg.appendChild(defs);
+                _plotSurface.appendChild(defs);
 
-                var linePoints = string.Join(" ", series.Values.Select((v, i) => $"{PointX(i).ToString("0.###")},{PixelY(v).ToString("0.###")}"));
+                foreach (var run in SeriesRuns(series))
+                {
+                    if (run.Count == 0) continue;
 
-                var firstX = PointX(0).ToString("0.###");
-                var lastX  = PointX(series.Values.Length - 1).ToString("0.###");
+                    var segments = BuildSegments(series, run);
+                    var linePath = "M " + segments;
 
-                var polygon = El("polygon");
-                Attr(polygon, "fill", "url(#" + gradientId + ")");
-                Attr(polygon, "points", $"{firstX},{baselineY.ToString("0.###")} {linePoints} {lastX},{baselineY.ToString("0.###")}");
-                _svg.appendChild(polygon);
+                    var firstX = SeriesPointX(series, run[0]).ToString("0.###");
+                    var lastX  = SeriesPointX(series, run[run.Count - 1]).ToString("0.###");
+                    var baseY  = baselineY.ToString("0.###");
 
-                var polyline = El("polyline");
-                Attr(polyline, "fill", "none");
-                Attr(polyline, "stroke", color);
-                Attr(polyline, "stroke-width", 2);
-                Attr(polyline, "stroke-linejoin", "round");
-                Attr(polyline, "stroke-linecap", "round");
-                Attr(polyline, "points", linePoints);
-                _svg.appendChild(polyline);
+                    var polygon = El("path");
+                    Attr(polygon, "fill", "url(#" + gradientId + ")");
+                    Attr(polygon, "stroke", "none");
+                    Attr(polygon, "d", $"M {firstX} {baseY} L {segments} L {lastX} {baseY} Z");
+                    _plotSurface.appendChild(polygon);
 
-                if (_showPoints)
+                    var line = El("path");
+                    Attr(line, "fill", "none");
+                    Attr(line, "stroke", color);
+                    Attr(line, "stroke-width", series.LineWidth);
+                    Attr(line, "stroke-linejoin", "round");
+                    Attr(line, "stroke-linecap", "round");
+                    Attr(line, "d", linePath);
+                    _plotSurface.appendChild(line);
+                }
+
+                if (_showPoints && series.Values.Length <= MaxMarkersPerSeries)
                 {
                     for (int i = 0; i < series.Values.Length; i++)
                     {
+                        if (double.IsNaN(series.Values[i])) continue;
+
                         var circle = El("circle");
-                        Attr(circle, "cx", PointX(i));
+                        Attr(circle, "cx", SeriesPointX(series, i));
                         Attr(circle, "cy", PixelY(series.Values[i]));
                         Attr(circle, "r", 3);
                         Attr(circle, "fill", color);
                         AttachPointTooltip(circle, TooltipFor(series, i));
-                        _svg.appendChild(circle);
+                        _plotSurface.appendChild(circle);
                     }
                 }
             }
         }
 
+        // "x y L x y L …" — usable both as the line's own path and as the top edge of the filled polygon.
+        private string BuildSegments(ChartSeries series, List<int> run)
+        {
+            var parts = new List<string>();
+
+            for (int p = 0; p < run.Count; p++)
+            {
+                var i = run[p];
+                parts.Add(SeriesPointX(series, i).ToString("0.###") + " " + PixelY(series.Values[i]).ToString("0.###"));
+            }
+
+            return string.Join(" L ", parts);
+        }
+
         private string TooltipFor(ChartSeries series, int i)
         {
-            var label = i < _categories.Length ? _categories[i] : "#" + (i + 1);
-            var name  = string.IsNullOrEmpty(series.Name) ? "" : series.Name + " — ";
+            var label = _continuousX
+                ? FormatXValue(XOf(series, i))
+                : (i < _categories.Length ? _categories[i] : "#" + (i + 1));
+
+            var name = string.IsNullOrEmpty(series.Name) ? "" : series.Name + " — ";
             return $"{name}{label}: {_valueFormatter(series.Values[i])}";
         }
     }

--- a/Tesserae/src/Components/BarChart.cs
+++ b/Tesserae/src/Components/BarChart.cs
@@ -1,16 +1,19 @@
 using System;
+using System.Collections.Generic;
 using static Transpose.Core.dom;
 
 namespace Tesserae
 {
     /// <summary>
-    /// A lightweight, dependency-free SVG bar chart. Renders grouped bars per category (one bar per series),
-    /// with a zero baseline, value gridlines, category labels, hover tooltips and a theme-aware palette.
+    /// A lightweight, dependency-free SVG bar chart. Renders grouped bars per category (one bar per series) or,
+    /// with <see cref="Stacked"/>, one stacked column per category, with a zero baseline, value gridlines,
+    /// category labels, hover tooltips and a theme-aware palette.
     /// </summary>
     [Transpose.Name("tss.BarChart")]
     public sealed class BarChart : CartesianChartBase<BarChart>
     {
         private double _cornerRadius = 2;
+        private bool   _stacked;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="BarChart"/> class.
@@ -20,10 +23,54 @@ namespace Tesserae
         /// <summary>Sets the corner radius of the bars.</summary>
         public BarChart Rounded(double radius = 2) { _cornerRadius = radius; QueueRender(); return this; }
 
+        /// <summary>
+        /// Stacks the series into one column per category instead of drawing them side by side. Positive and
+        /// negative values stack away from the baseline independently.
+        /// </summary>
+        public BarChart Stacked(bool stacked = true) { _stacked = stacked; QueueRender(); return this; }
+
         // Bars are read against a zero baseline.
         protected override bool IncludeZeroBaseline => true;
 
+        /// <inheritdoc />
+        protected override void CollectRangeValues(List<double> into)
+        {
+            if (!_stacked)
+            {
+                base.CollectRangeValues(into);
+                return;
+            }
+
+            // A stacked column reaches the sum of its parts, so the axis has to fit the totals, not the values.
+            for (int i = 0; i < _pointCount; i++)
+            {
+                double positive = 0;
+                double negative = 0;
+
+                for (int s = 0; s < _series.Count; s++)
+                {
+                    var values = _series[s].Values;
+                    if (i >= values.Length) continue;
+
+                    var v = values[i];
+                    if (double.IsNaN(v)) continue;
+
+                    if (v >= 0) positive += v;
+                    else negative += v;
+                }
+
+                into.Add(positive);
+                into.Add(negative);
+            }
+        }
+
         protected override void RenderSeries()
+        {
+            if (_stacked) RenderStacked();
+            else RenderGrouped();
+        }
+
+        private void RenderGrouped()
         {
             var baselineY  = PixelY(0);
             var slotWidth  = _plotWidth / _pointCount;
@@ -41,24 +88,74 @@ namespace Tesserae
                     if (i >= series.Values.Length) continue;
 
                     var value = series.Values[i];
-                    var color = ColorFor(s, series);
+                    if (double.IsNaN(value)) continue;
 
                     var yValue = PixelY(value);
                     var x      = slotLeft + barWidth * s;
                     var top    = Math.Min(yValue, baselineY);
                     var height = Math.Abs(baselineY - yValue);
 
-                    var rect = El("rect");
-                    Attr(rect, "x", x);
-                    Attr(rect, "y", top);
-                    Attr(rect, "width", Math.Max(0, barWidth - 1));
-                    Attr(rect, "height", height);
-                    Attr(rect, "rx", _cornerRadius);
-                    Attr(rect, "fill", color);
-                    AttachPointTooltip(rect, TooltipFor(series, i));
-                    _svg.appendChild(rect);
+                    DrawBar(x, top, Math.Max(0, barWidth - 1), height, ColorFor(s, series), TooltipFor(series, i));
                 }
             }
+        }
+
+        private void RenderStacked()
+        {
+            var baselineY  = PixelY(0);
+            var slotWidth  = _plotWidth / _pointCount;
+            var groupInset = slotWidth * 0.15;
+            var barWidth   = slotWidth - groupInset * 2;
+
+            for (int i = 0; i < _pointCount; i++)
+            {
+                var x = _plotLeft + slotWidth * i + groupInset;
+
+                double positiveTop = 0;
+                double negativeTop = 0;
+
+                for (int s = 0; s < _series.Count; s++)
+                {
+                    var series = _series[s];
+                    if (i >= series.Values.Length) continue;
+
+                    var value = series.Values[i];
+                    if (double.IsNaN(value) || value == 0) continue;
+
+                    double top;
+                    double height;
+
+                    if (value >= 0)
+                    {
+                        var from = positiveTop;
+                        positiveTop += value;
+                        top    = PixelY(positiveTop);
+                        height = Math.Abs(PixelY(from) - PixelY(positiveTop));
+                    }
+                    else
+                    {
+                        var from = negativeTop;
+                        negativeTop += value;
+                        top    = PixelY(from);
+                        height = Math.Abs(PixelY(from) - PixelY(negativeTop));
+                    }
+
+                    DrawBar(x, top, Math.Max(0, barWidth - 1), height, ColorFor(s, series), TooltipFor(series, i));
+                }
+            }
+        }
+
+        private void DrawBar(double x, double y, double width, double height, string color, string tooltip)
+        {
+            var rect = El("rect");
+            Attr(rect, "x", x);
+            Attr(rect, "y", y);
+            Attr(rect, "width", width);
+            Attr(rect, "height", height);
+            Attr(rect, "rx", _cornerRadius);
+            Attr(rect, "fill", color);
+            AttachPointTooltip(rect, tooltip);
+            _plotSurface.appendChild(rect);
         }
 
         private string TooltipFor(ChartSeries series, int i)

--- a/Tesserae/src/Components/BarChart.cs
+++ b/Tesserae/src/Components/BarChart.cs
@@ -30,7 +30,7 @@ namespace Tesserae
         public BarChart Stacked(bool stacked = true) { _stacked = stacked; QueueRender(); return this; }
 
         // Bars are read against a zero baseline.
-        protected override bool IncludeZeroBaseline => true;
+        protected override bool DefaultIncludeZeroBaseline => true;
 
         /// <inheritdoc />
         protected override void CollectRangeValues(List<double> into)

--- a/Tesserae/src/Components/ChartBase.cs
+++ b/Tesserae/src/Components/ChartBase.cs
@@ -8,6 +8,48 @@ using static Tesserae.UI;
 namespace Tesserae
 {
     /// <summary>
+    /// Where a chart draws its legend.
+    /// </summary>
+    [Transpose.Name("tss.ChartLegendPosition")]
+    public enum ChartLegendPosition
+    {
+        /// <summary>A horizontal row of swatches above the plot.</summary>
+        Top,
+        /// <summary>A horizontal row of swatches below the plot.</summary>
+        Bottom,
+        /// <summary>A vertical column of swatches to the left of the plot.</summary>
+        Left,
+        /// <summary>A vertical column of swatches to the right of the plot.</summary>
+        Right
+    }
+
+    /// <summary>
+    /// The visible X range of a cartesian chart, reported when the user zooms or pans.
+    /// </summary>
+    [Transpose.Name("tss.ChartRange")]
+    public sealed class ChartRange
+    {
+        /// <summary>The lowest visible X value.</summary>
+        public double Min { get; set; }
+
+        /// <summary>The highest visible X value.</summary>
+        public double Max { get; set; }
+
+        /// <summary>True when the chart is back to fitting its data instead of showing an explicit range.</summary>
+        public bool IsAutoRange { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ChartRange"/> class.
+        /// </summary>
+        public ChartRange(double min, double max, bool isAutoRange)
+        {
+            Min         = min;
+            Max         = max;
+            IsAutoRange = isAutoRange;
+        }
+    }
+
+    /// <summary>
     /// A single named data series for a chart, with an optional explicit color (falling back to the chart palette).
     /// </summary>
     [Transpose.Name("tss.ChartSeries")]
@@ -16,11 +58,24 @@ namespace Tesserae
         /// <summary>The series display name, used in the legend, tooltips and accessibility summary.</summary>
         public string Name { get; set; }
 
-        /// <summary>The series values, one per category/point.</summary>
+        /// <summary>The series values, one per category/point. <see cref="double.NaN"/> marks a missing sample.</summary>
         public double[] Values { get; set; }
 
         /// <summary>An optional explicit CSS color; when null the chart assigns a palette color by index.</summary>
         public string Color { get; set; }
+
+        /// <summary>
+        /// Optional X positions for this series' values, one per entry in <see cref="Values"/>. Setting these on
+        /// any series switches the chart to a continuous X scale, which lets each series carry its own X positions
+        /// (irregular sampling, differing time windows, differing point counts) instead of sharing one category list.
+        /// </summary>
+        public double[] XValues { get; set; }
+
+        /// <summary>The stroke width of this series' line, in pixels (line and area charts).</summary>
+        public double LineWidth { get; set; } = 2;
+
+        /// <summary>The opacity of this series' area fill at its peak, fading to near-transparent at the baseline (area charts).</summary>
+        public double FillOpacity { get; set; } = 0.45;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ChartSeries"/> class.
@@ -31,12 +86,24 @@ namespace Tesserae
             Values = values ?? new double[0];
             Color  = color;
         }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ChartSeries"/> class with explicit X positions,
+        /// putting the chart on a continuous X scale.
+        /// </summary>
+        public ChartSeries(string name, double[] xValues, double[] values, string color = null)
+        {
+            Name    = name;
+            Values  = values ?? new double[0];
+            Color   = color;
+            XValues = xValues;
+        }
     }
 
     /// <summary>
     /// Shared base for Tesserae's lightweight, dependency-free SVG charts. Handles the responsive SVG surface
     /// (sized 1:1 to its container via a <see cref="ResizeObserver"/>), the series/palette model, observable-driven
-    /// re-rendering, theme colors, tooltips (reusing tippy) and the role="img" accessibility summary.
+    /// re-rendering, theme colors, tooltips (reusing tippy), PNG export and the role="img" accessibility summary.
     /// Mirrors <see cref="Sparkline"/>'s SVG rendering style.
     /// </summary>
     [Transpose.Name("tss.ChartBase")]
@@ -44,6 +111,13 @@ namespace Tesserae
     {
         /// <summary>The SVG namespace used for every chart element.</summary>
         protected const string SvgNs = "http://www.w3.org/2000/svg";
+
+        /// <summary>
+        /// Above this many points in a series, per-point markers (and their tooltips) are suppressed: one DOM
+        /// node plus one tooltip per sample stops being readable long before it stops being expensive. Use the
+        /// spikeline readout instead of markers for dense series.
+        /// </summary>
+        protected const int MaxMarkersPerSeries = 300;
 
         /// <summary>The default theme-aware palette (CSS variables that adapt to light/dark mode).</summary>
         protected static readonly string[] DefaultPalette =
@@ -79,13 +153,35 @@ namespace Tesserae
         /// <summary>Whether to render the legend.</summary>
         protected bool _showLegend = false;
 
+        /// <summary>Where the legend is drawn.</summary>
+        protected ChartLegendPosition _legendPosition = ChartLegendPosition.Top;
+
+        /// <summary>Whether a line/area series draws straight across a <see cref="double.NaN"/> gap instead of breaking.</summary>
+        protected bool _connectGaps = true;
+
         /// <summary>An optional caption used as the accessibility summary; falls back to a generated description.</summary>
         protected string _title;
 
         /// <summary>Optional formatter for values shown in tooltips / axis labels.</summary>
         protected Func<double, string> _valueFormatter = v => v.ToString("0.##");
 
+        /// <summary>The element subclasses draw their series into; clipped to the plot rectangle on cartesian charts.</summary>
+        protected Element _plotSurface;
+
+        /// <summary>Space the legend claimed at the top of the surface, in pixels.</summary>
+        protected double _legendInsetTop;
+
+        /// <summary>Space the legend claimed at the bottom of the surface, in pixels.</summary>
+        protected double _legendInsetBottom;
+
+        /// <summary>Space the legend claimed on the left of the surface, in pixels.</summary>
+        protected double _legendInsetLeft;
+
+        /// <summary>Space the legend claimed on the right of the surface, in pixels.</summary>
+        protected double _legendInsetRight;
+
         private bool _renderQueued;
+        private Button _exportButton;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ChartBase{T}"/> class.
@@ -97,6 +193,7 @@ namespace Tesserae
             _container.style.height    = "100%";
             _container.style.minWidth  = minWidth + "px";
             _container.style.minHeight = minHeight + "px";
+            _container.style.position  = "relative";
             _container.setAttribute("role", "img");
 
             _svg = document.createElementNS(SvgNs, "svg");
@@ -104,6 +201,8 @@ namespace Tesserae
             _svg.setAttribute("height", "100%");
             _svg.As<HTMLElement>().style.display = "block";
             _container.appendChild(_svg);
+
+            _plotSurface = _svg;
 
             _resizeObserver = new ResizeObserver((entries, obs) => QueueRender());
             _resizeObserver.observe(_container);
@@ -189,11 +288,130 @@ namespace Tesserae
         /// <summary>Enables or disables the legend.</summary>
         public T Legend(bool show = true) { _showLegend = show; QueueRender(); return Self; }
 
+        /// <summary>Sets which edge of the chart the legend is drawn on (and enables it).</summary>
+        public T Legend(ChartLegendPosition position)
+        {
+            _legendPosition = position;
+            _showLegend     = true;
+            QueueRender();
+            return Self;
+        }
+
+        /// <summary>
+        /// When true (the default) a line or area series draws straight across a <see cref="double.NaN"/> value;
+        /// when false the line breaks, leaving the gap visible.
+        /// </summary>
+        public T ConnectGaps(bool connect = true) { _connectGaps = connect; QueueRender(); return Self; }
+
         /// <summary>Sets an accessibility caption / summary for the chart.</summary>
         public T Title(string title) { _title = title; QueueRender(); return Self; }
 
         /// <summary>Sets the formatter used for values in tooltips and labels.</summary>
         public T FormatValues(Func<double, string> formatter) { if (formatter != null) _valueFormatter = formatter; QueueRender(); return Self; }
+
+        /// <summary>
+        /// Shows a small download button in the chart's top-right corner (revealed on hover) that saves the
+        /// chart as a PNG.
+        /// </summary>
+        public T ExportButton(bool show = true, string fileName = null)
+        {
+            if (!show)
+            {
+                if (_exportButton is object)
+                {
+                    _container.removeChild(_exportButton.Render());
+                    _exportButton = null;
+                }
+                return Self;
+            }
+
+            if (_exportButton is object) return Self;
+
+            //Bound through a local so the click handler keeps this chart as its receiver.
+            var chart = this;
+
+            _exportButton = Button().Compact().SetIcon(UIcons.Download).Tooltip("Save as PNG").OnClick(() => chart.ExportPng(fileName));
+
+            var el = _exportButton.Render();
+            el.style.position   = "absolute";
+            el.style.top        = "2px";
+            el.style.right      = "2px";
+            el.style.opacity    = "0";
+            el.style.transition = "opacity 0.15s";
+
+            _container.addEventListener("mouseenter", (Action<Event>)(_ => el.style.opacity = "1"));
+            _container.addEventListener("mouseleave", (Action<Event>)(_ => el.style.opacity = "0"));
+
+            _container.appendChild(el);
+            return Self;
+        }
+
+        /// <summary>
+        /// Saves the chart as a PNG. CSS-variable colors are resolved to concrete values first, so the exported
+        /// image matches the theme the chart is currently rendered in.
+        /// </summary>
+        public void ExportPng(string fileName = null)
+        {
+            var name = string.IsNullOrEmpty(fileName)
+                ? (string.IsNullOrEmpty(_title) ? "chart" : _title)
+                : fileName;
+
+            if (!name.EndsWith(".png")) name = name + ".png";
+
+            var rect       = _container.getBoundingClientRect().As<DOMRect>();
+            var width      = Math.Max(1, rect.width);
+            var height     = Math.Max(1, rect.height);
+            var background = Color.EvalVar(Theme.Default.Background);
+
+            //Through a local: the template below runs inside an IIFE, so a substituted `this._svg` would
+            //resolve `this` to undefined.
+            var surface = _svg;
+
+            //Serialising a live SVG needs the var(--tss-*) colors flattened and the result rasterised through an
+            //Image, neither of which has a typed binding here.
+            Script.Write(@"(function () {
+                var svg = {0}.cloneNode(true);
+                var computed = window.getComputedStyle(document.body);
+                function flatten(el) {
+                    ['fill', 'stroke', 'stop-color'].forEach(function (attribute) {
+                        var value = el.getAttribute(attribute);
+                        if (value && value.indexOf('var(') === 0) {
+                            el.setAttribute(attribute, computed.getPropertyValue(value.substring(4, value.length - 1)).trim());
+                        }
+                    });
+                }
+                flatten(svg);
+                var all = svg.querySelectorAll('*');
+                for (var i = 0; i < all.length; i++) flatten(all[i]);
+                svg.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
+                svg.setAttribute('width', {1});
+                svg.setAttribute('height', {2});
+                var serialized = new XMLSerializer().serializeToString(svg);
+                var image = new Image();
+                image.onload = function () {
+                    var scale = window.devicePixelRatio > 1 ? 2 : 1;
+                    var canvas = document.createElement('canvas');
+                    canvas.width = {1} * scale;
+                    canvas.height = {2} * scale;
+                    var ctx = canvas.getContext('2d');
+                    ctx.scale(scale, scale);
+                    ctx.fillStyle = {3};
+                    ctx.fillRect(0, 0, {1}, {2});
+                    ctx.drawImage(image, 0, 0);
+                    canvas.toBlob(function (blob) {
+                        var url = URL.createObjectURL(blob);
+                        var link = document.createElement('a');
+                        link.href = url;
+                        link.download = {4};
+                        document.body.appendChild(link);
+                        link.click();
+                        document.body.removeChild(link);
+                        window.setTimeout(function () { URL.revokeObjectURL(url); }, 1000);
+                    });
+                };
+                image.src = 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(serialized);
+            })();", surface, width, height, background, name);
+        }
 
         /// <summary>Returns the color for the series at the given index (explicit color or palette by index).</summary>
         protected string ColorFor(int index, ChartSeries series) => series.Color ?? _palette[index % _palette.Length];
@@ -313,6 +531,8 @@ namespace Tesserae
             _svg.setAttribute("preserveAspectRatio", "none");
 
             ClearSvg();
+            _plotSurface = _svg;
+            ResetLegendInsets();
             RenderChart(w, h);
             _container.setAttribute("aria-label", BuildAriaLabel());
         }
@@ -331,50 +551,105 @@ namespace Tesserae
 
             var parts = _series.Select(s =>
             {
-                var name = string.IsNullOrEmpty(s.Name) ? "series" : s.Name;
-                if (s.Values.Length == 0) return name + " (empty)";
-                return $"{name}: {s.Values.Length} points, from {_valueFormatter(s.Values.Min())} to {_valueFormatter(s.Values.Max())}";
+                var name   = string.IsNullOrEmpty(s.Name) ? "series" : s.Name;
+                var actual = s.Values.Where(v => !double.IsNaN(v)).ToArray();
+                if (actual.Length == 0) return name + " (empty)";
+                return $"{name}: {actual.Length} points, from {_valueFormatter(actual.Min())} to {_valueFormatter(actual.Max())}";
             });
 
             return $"{kind}. " + string.Join("; ", parts);
         }
 
-        /// <summary>Renders the legend swatches into the supplied container element, returning its height.</summary>
-        protected double RenderLegend(double width, double y)
+        /// <summary>Clears the space reserved for the legend, before a fresh render measures it again.</summary>
+        protected void ResetLegendInsets()
         {
-            if (!_showLegend || _series.Count == 0) return 0;
+            _legendInsetTop    = 0;
+            _legendInsetBottom = 0;
+            _legendInsetLeft   = 0;
+            _legendInsetRight  = 0;
+        }
 
-            const double swatch = 10;
-            const double gap    = 6;
-            const double itemGap = 16;
-            double x = 8;
+        /// <summary>Renders the legend for the chart's series, recording the space it consumed in the legend insets.</summary>
+        protected void RenderLegend(double width, double height)
+        {
+            if (_series.Count == 0) return;
+
+            var labels = new string[_series.Count];
+            var colors = new string[_series.Count];
 
             for (int i = 0; i < _series.Count; i++)
             {
-                var color = ColorFor(i, _series[i]);
-                var name  = string.IsNullOrEmpty(_series[i].Name) ? $"Series {i + 1}" : _series[i].Name;
-
-                var rect = El("rect");
-                Attr(rect, "x", x);
-                Attr(rect, "y", y);
-                Attr(rect, "width", swatch);
-                Attr(rect, "height", swatch);
-                Attr(rect, "rx", 2);
-                Attr(rect, "fill", color);
-                _svg.appendChild(rect);
-
-                var text = El("text");
-                Attr(text, "x", x + swatch + gap);
-                Attr(text, "y", y + swatch);
-                Attr(text, "font-size", "11");
-                Attr(text, "fill", Theme.Default.Foreground);
-                text.textContent = name;
-                _svg.appendChild(text);
-
-                x += swatch + gap + name.Length * 6.5 + itemGap;
+                labels[i] = string.IsNullOrEmpty(_series[i].Name) ? $"Series {i + 1}" : _series[i].Name;
+                colors[i] = ColorFor(i, _series[i]);
             }
 
-            return 22;
+            RenderLegend(labels, colors, width, height);
+        }
+
+        /// <summary>
+        /// Renders a legend of the given labels and colors on the configured edge, recording the space it
+        /// consumed in <see cref="_legendInsetTop"/> and friends so the caller can lay the plot out around it.
+        /// </summary>
+        protected void RenderLegend(string[] labels, string[] colors, double width, double height)
+        {
+            if (!_showLegend || labels == null || labels.Length == 0) return;
+
+            const double swatch  = 10;
+            const double gap     = 6;
+            const double itemGap = 16;
+            const double rowStep = 18;
+
+            if (_legendPosition == ChartLegendPosition.Left || _legendPosition == ChartLegendPosition.Right)
+            {
+                var columnWidth = labels.Max(l => l.Length) * 6.5 + swatch + gap + 16;
+                columnWidth     = Math.Min(columnWidth, Math.Max(40, width * 0.4));
+
+                var x = _legendPosition == ChartLegendPosition.Left ? 8 : width - columnWidth + 8;
+                var y = Math.Max(8, height / 2 - labels.Length * rowStep / 2);
+
+                for (int i = 0; i < labels.Length; i++)
+                {
+                    DrawLegendEntry(labels[i], colors[i], x, y, swatch, gap);
+                    y += rowStep;
+                }
+
+                if (_legendPosition == ChartLegendPosition.Left) _legendInsetLeft = columnWidth;
+                else _legendInsetRight = columnWidth;
+
+                return;
+            }
+
+            var rowY = _legendPosition == ChartLegendPosition.Top ? 6 : height - 16;
+            double cursor = 8;
+
+            for (int i = 0; i < labels.Length; i++)
+            {
+                DrawLegendEntry(labels[i], colors[i], cursor, rowY, swatch, gap);
+                cursor += swatch + gap + labels[i].Length * 6.5 + itemGap;
+            }
+
+            if (_legendPosition == ChartLegendPosition.Top) _legendInsetTop = 22;
+            else _legendInsetBottom = 22;
+        }
+
+        private void DrawLegendEntry(string label, string color, double x, double y, double swatch, double gap)
+        {
+            var rect = El("rect");
+            Attr(rect, "x", x);
+            Attr(rect, "y", y);
+            Attr(rect, "width", swatch);
+            Attr(rect, "height", swatch);
+            Attr(rect, "rx", 2);
+            Attr(rect, "fill", color);
+            _svg.appendChild(rect);
+
+            var text = El("text");
+            Attr(text, "x", x + swatch + gap);
+            Attr(text, "y", y + swatch);
+            Attr(text, "font-size", "11");
+            Attr(text, "fill", Theme.Default.Foreground);
+            text.textContent = label;
+            _svg.appendChild(text);
         }
 
         /// <summary>
@@ -386,7 +661,8 @@ namespace Tesserae
     /// <summary>
     /// Base for cartesian (x/y) charts — line, bar and area. Draws the value (Y) gridlines and labels, the
     /// category (X) axis labels, the axis lines, and computes the plot rectangle and value-to-pixel scale that
-    /// subclasses use to plot their series.
+    /// subclasses use to plot their series. Also owns the continuous X scale, tick thinning, zoom/pan and the
+    /// spikeline readout.
     /// </summary>
     [Transpose.Name("tss.CartesianChartBase")]
     public abstract class CartesianChartBase<T> : ChartBase<T> where T : CartesianChartBase<T>
@@ -422,6 +698,28 @@ namespace Tesserae
         /// <summary>The number of categories/points along the X axis.</summary>
         protected int _pointCount;
 
+        /// <summary>True when the chart plots against a continuous X scale rather than evenly spaced categories.</summary>
+        protected bool _continuousX;
+
+        /// <summary>The lowest visible X value on a continuous scale.</summary>
+        protected double _viewXMin;
+
+        /// <summary>The highest visible X value on a continuous scale.</summary>
+        protected double _viewXMax;
+
+        private double[] _sharedX;
+        private Func<double, string> _xFormatter;
+        private int _maxXTicks;
+        private bool _hasExplicitRange;
+        private double _rangeMin;
+        private double _rangeMax;
+        private bool _zoomable;
+        private bool _showSpikes;
+        private bool _interactionsAttached;
+        private Action<ChartRange> _onRangeChanged;
+        private Element _overlay;
+        private readonly string _clipId = "tss-chart-clip-" + Guid.NewGuid().ToString("N").Substring(0, 8);
+
         /// <summary>
         /// Initializes a new instance of the <see cref="CartesianChartBase{T}"/> class.
         /// </summary>
@@ -431,6 +729,33 @@ namespace Tesserae
 
         /// <summary>Sets the category labels along the X axis.</summary>
         public T XAxis(params string[] categories) { _categories = categories ?? new string[0]; QueueRender(); return Self; }
+
+        /// <summary>
+        /// Sets shared X positions for every series, putting the chart on a continuous X scale so points sit at
+        /// their real distance apart instead of being evenly spaced. Per-series positions
+        /// (<see cref="ChartSeries.XValues"/>) win over these.
+        /// </summary>
+        public T XValues(double[] values) { _sharedX = values; QueueRender(); return Self; }
+
+        /// <summary>Sets the formatter used for continuous X axis tick labels (and the spikeline readout).</summary>
+        public T FormatXAxis(Func<double, string> formatter) { _xFormatter = formatter; QueueRender(); return Self; }
+
+        /// <summary>
+        /// Formats continuous X values as local times, treating them as Unix timestamps in seconds. Pass a
+        /// standard or custom .NET date format string.
+        /// </summary>
+        public T XAxisTime(string format = "HH:mm")
+        {
+            _xFormatter = v => DateTimeOffset.FromUnixTimeSeconds((long)v).ToLocalTime().ToString(format);
+            QueueRender();
+            return Self;
+        }
+
+        /// <summary>
+        /// Caps how many X axis tick labels are drawn; categories beyond the cap are skipped evenly. Pass 0
+        /// (the default) to derive the cap from the available width, which keeps dense axes readable.
+        /// </summary>
+        public T MaxXTicks(int count) { _maxXTicks = Math.Max(0, count); QueueRender(); return Self; }
 
         /// <summary>Sets the X axis title.</summary>
         public T XAxisTitle(string title) { _xAxisTitle = title; QueueRender(); return Self; }
@@ -444,6 +769,75 @@ namespace Tesserae
         /// <summary>Shows or hides the axes and their labels.</summary>
         public T Axes(bool show = true) { _showAxes = show; QueueRender(); return Self; }
 
+        /// <summary>
+        /// Allows the user to zoom the X axis with the wheel, pan it by dragging, and reset to the full data
+        /// range by double-clicking. Only meaningful on a continuous X scale.
+        /// </summary>
+        public T Zoomable(bool enable = true)
+        {
+            _zoomable = enable;
+            if (enable) EnsureInteractions();
+            return Self;
+        }
+
+        /// <summary>
+        /// Draws a vertical spikeline that follows the cursor across the plot, with a readout of the X position
+        /// and each series' nearest value. The readable alternative to a marker per sample on a dense series.
+        /// </summary>
+        public T Spikelines(bool enable = true)
+        {
+            _showSpikes = enable;
+            if (enable) EnsureInteractions();
+            return Self;
+        }
+
+        /// <summary>
+        /// Pins the visible X range on a continuous scale. Setting the range does not raise
+        /// <see cref="OnRangeChanged"/>, so charts can be kept in sync with each other without a re-entrancy guard.
+        /// </summary>
+        public T XRange(double min, double max)
+        {
+            if (max <= min) return Self;
+
+            _hasExplicitRange = true;
+            _rangeMin         = min;
+            _rangeMax         = max;
+
+            //Apply to the visible range now rather than waiting for the queued render: TryGetXRange and the
+            //range reported to OnRangeChanged both read these, and a zoom that published the pre-zoom range
+            //would hand a sibling chart the range it already had.
+            _viewXMin = min;
+            _viewXMax = max;
+
+            QueueRender();
+            return Self;
+        }
+
+        /// <summary>Returns the chart to fitting the full X extent of its data, undoing any zoom or pan.</summary>
+        public T AutoRangeX()
+        {
+            _hasExplicitRange = false;
+            QueueRender();
+            return Self;
+        }
+
+        /// <summary>Gets the X range the chart is currently showing. False when the chart has no continuous X data yet.</summary>
+        public bool TryGetXRange(out double min, out double max)
+        {
+            min = _viewXMin;
+            max = _viewXMax;
+            return _continuousX && _viewXMax > _viewXMin;
+        }
+
+        /// <summary>True when the visible X range came from a zoom / pan rather than fitting the data.</summary>
+        public bool IsXRangePinned => _hasExplicitRange;
+
+        /// <summary>
+        /// Raised when the user zooms, pans or resets the X axis — not when <see cref="XRange"/> is called, so a
+        /// handler that pushes the range onto sibling charts cannot loop.
+        /// </summary>
+        public T OnRangeChanged(Action<ChartRange> handler) { _onRangeChanged = handler; return Self; }
+
         /// <summary>When true the value axis always includes zero as a baseline (bar/area); when false it fits the data.</summary>
         protected virtual bool IncludeZeroBaseline => true;
 
@@ -455,17 +849,69 @@ namespace Tesserae
             return _plotTop + _plotHeight - ((value - _minValue) / range) * _plotHeight;
         }
 
+        /// <summary>Maps a continuous X value to its pixel X coordinate within the plot area.</summary>
+        protected double PixelXForValue(double x)
+        {
+            var range = _viewXMax - _viewXMin;
+            if (range <= 0) range = 1;
+            return _plotLeft + ((x - _viewXMin) / range) * _plotWidth;
+        }
+
+        /// <summary>Returns the X position of point <paramref name="index"/> of a series on a continuous scale.</summary>
+        protected double XOf(ChartSeries series, int index)
+        {
+            if (series.XValues != null) return index < series.XValues.Length ? series.XValues[index] : index;
+            if (_sharedX != null) return index < _sharedX.Length ? _sharedX[index] : index;
+            return index;
+        }
+
+        /// <summary>
+        /// Returns the pixel X coordinate for point <paramref name="index"/> of <paramref name="series"/>, using
+        /// the continuous scale when the chart has X values and evenly spaced slots otherwise.
+        /// </summary>
+        protected double SeriesPointX(ChartSeries series, int index) => _continuousX ? PixelXForValue(XOf(series, index)) : PointX(index);
+
+        /// <summary>
+        /// Splits a series into runs of consecutive plottable points, breaking at <see cref="double.NaN"/> gaps.
+        /// Returns a single run covering every non-gap point when gaps are connected.
+        /// </summary>
+        protected List<List<int>> SeriesRuns(ChartSeries series)
+        {
+            var runs    = new List<List<int>>();
+            var current = new List<int>();
+
+            for (int i = 0; i < series.Values.Length; i++)
+            {
+                if (double.IsNaN(series.Values[i]))
+                {
+                    if (!_connectGaps && current.Count > 0)
+                    {
+                        runs.Add(current);
+                        current = new List<int>();
+                    }
+                    continue;
+                }
+
+                current.Add(i);
+            }
+
+            if (current.Count > 0) runs.Add(current);
+            return runs;
+        }
+
         /// <inheritdoc />
         protected override void RenderChart(double width, double height)
         {
-            _pointCount = _series.Count == 0 ? 0 : _series.Max(s => s.Values.Length);
+            _pointCount  = _series.Count == 0 ? 0 : _series.Max(s => s.Values.Length);
+            _continuousX = _sharedX != null || _series.Any(s => s.XValues != null);
 
-            var legendHeight = RenderLegend(width, 6);
+            ResolveXRange();
+            RenderLegend(width, height);
 
-            double marginTop    = 8 + legendHeight;
-            double marginRight  = 12;
-            double marginBottom = _showAxes ? (_categories.Length > 0 || !string.IsNullOrEmpty(_xAxisTitle) ? 34 : 18) : 6;
-            double marginLeft   = _showAxes ? 44 : 6;
+            double marginTop    = 8 + _legendInsetTop;
+            double marginRight  = 12 + _legendInsetRight;
+            double marginBottom = (_showAxes ? (_categories.Length > 0 || _continuousX || !string.IsNullOrEmpty(_xAxisTitle) ? 34 : 18) : 6) + _legendInsetBottom;
+            double marginLeft   = (_showAxes ? 44 : 6) + _legendInsetLeft;
 
             _plotLeft   = marginLeft;
             _plotTop    = marginTop;
@@ -476,14 +922,121 @@ namespace Tesserae
 
             if (_showGrid || _showAxes) DrawGridAndAxes();
 
-            if (_pointCount > 0) RenderSeries();
+            if (_pointCount > 0)
+            {
+                _plotSurface = CreateClippedPlotSurface();
+                RenderSeries();
+            }
+
+            _overlay = El("g");
+            _svg.appendChild(_overlay);
+
+            if (_zoomable || _showSpikes) EnsureInteractions();
+        }
+
+        // Zoom clips a series to the plot rectangle; without it a panned line draws over the axis labels.
+        private Element CreateClippedPlotSurface()
+        {
+            var defs = El("defs");
+            var clip = El("clipPath");
+            Attr(clip, "id", _clipId);
+
+            var rect = El("rect");
+            Attr(rect, "x", _plotLeft);
+            Attr(rect, "y", _plotTop);
+            Attr(rect, "width", _plotWidth);
+            Attr(rect, "height", _plotHeight);
+            clip.appendChild(rect);
+            defs.appendChild(clip);
+            _svg.appendChild(defs);
+
+            var group = El("g");
+            Attr(group, "clip-path", "url(#" + _clipId + ")");
+            _svg.appendChild(group);
+            return group;
+        }
+
+        private void ResolveXRange()
+        {
+            if (!_continuousX)
+            {
+                _viewXMin = 0;
+                _viewXMax = Math.Max(1, _pointCount - 1);
+                return;
+            }
+
+            if (_hasExplicitRange)
+            {
+                _viewXMin = _rangeMin;
+                _viewXMax = _rangeMax;
+                return;
+            }
+
+            var min = double.MaxValue;
+            var max = double.MinValue;
+
+            for (int s = 0; s < _series.Count; s++)
+            {
+                var series = _series[s];
+                for (int i = 0; i < series.Values.Length; i++)
+                {
+                    if (double.IsNaN(series.Values[i])) continue;
+                    var x = XOf(series, i);
+                    if (x < min) min = x;
+                    if (x > max) max = x;
+                }
+            }
+
+            if (min > max)
+            {
+                _viewXMin = 0;
+                _viewXMax = 1;
+                return;
+            }
+
+            if (min == max)
+            {
+                _viewXMin = min - 1;
+                _viewXMax = max + 1;
+                return;
+            }
+
+            _viewXMin = min;
+            _viewXMax = max;
+        }
+
+        /// <summary>
+        /// Collects the values the Y axis must accommodate. Only points inside the visible X window count on a
+        /// continuous scale, so zooming rescales the value axis to what is on screen.
+        /// </summary>
+        protected virtual void CollectRangeValues(List<double> into)
+        {
+            for (int s = 0; s < _series.Count; s++)
+            {
+                var series = _series[s];
+
+                for (int i = 0; i < series.Values.Length; i++)
+                {
+                    var v = series.Values[i];
+                    if (double.IsNaN(v)) continue;
+
+                    if (_continuousX)
+                    {
+                        var x = XOf(series, i);
+                        if (x < _viewXMin || x > _viewXMax) continue;
+                    }
+
+                    into.Add(v);
+                }
+            }
         }
 
         private void ComputeValueRange()
         {
-            var all = _series.SelectMany(s => s.Values).ToArray();
+            var all = new List<double>();
+            CollectRangeValues(all);
 
-            if (all.Length == 0)
+            if (all.Count == 0)
             {
                 _minValue = 0;
                 _maxValue = 1;
@@ -515,6 +1068,15 @@ namespace Tesserae
             _minValue = dataMin;
             _maxValue = dataMax;
         }
+
+        private int EffectiveMaxXTicks()
+        {
+            if (_maxXTicks > 0) return _maxXTicks;
+            return Math.Max(2, (int)(_plotWidth / 70));
+        }
+
+        /// <summary>Formats a continuous X value using the configured X formatter, falling back to a plain number.</summary>
+        protected string FormatXValue(double value) => _xFormatter is object ? _xFormatter(value) : value.ToString("0.##");
 
         private void DrawGridAndAxes()
         {
@@ -554,22 +1116,10 @@ namespace Tesserae
 
             if (!_showAxes) return;
 
-            // X category labels
-            if (_categories.Length > 0 && _pointCount > 0)
-            {
-                for (int i = 0; i < _categories.Length && i < _pointCount; i++)
-                {
-                    var x = CategoryCenterX(i);
-                    var label = El("text");
-                    Attr(label, "x", x);
-                    Attr(label, "y", _plotTop + _plotHeight + 14);
-                    Attr(label, "text-anchor", "middle");
-                    Attr(label, "font-size", "10");
-                    Attr(label, "fill", textColor);
-                    label.textContent = _categories[i];
-                    _svg.appendChild(label);
-                }
-            }
+            if (_continuousX) DrawContinuousXLabels(textColor);
+            else DrawCategoryXLabels(textColor);
+
+            DrawAxisTitles(textColor);
 
             // Axis lines
             var axis = El("line");
@@ -580,6 +1130,117 @@ namespace Tesserae
             Attr(axis, "stroke", textColor);
             Attr(axis, "stroke-width", 1);
             _svg.appendChild(axis);
+        }
+
+        private void DrawCategoryXLabels(string textColor)
+        {
+            if (_categories.Length == 0 || _pointCount == 0) return;
+
+            var count = Math.Min(_categories.Length, _pointCount);
+            var step  = Math.Max(1, (int)Math.Ceiling(count / (double)EffectiveMaxXTicks()));
+
+            for (int i = 0; i < count; i += step)
+            {
+                var label = El("text");
+                Attr(label, "x", CategoryCenterX(i));
+                Attr(label, "y", _plotTop + _plotHeight + 14);
+                Attr(label, "text-anchor", "middle");
+                Attr(label, "font-size", "10");
+                Attr(label, "fill", textColor);
+                label.textContent = _categories[i];
+                _svg.appendChild(label);
+            }
+        }
+
+        private void DrawContinuousXLabels(string textColor)
+        {
+            var tickValues = NiceTicks(_viewXMin, _viewXMax, EffectiveMaxXTicks());
+
+            foreach (var tick in tickValues)
+            {
+                if (tick < _viewXMin || tick > _viewXMax) continue;
+
+                var x = PixelXForValue(tick);
+
+                if (_showGrid)
+                {
+                    var line = El("line");
+                    Attr(line, "x1", x);
+                    Attr(line, "y1", _plotTop);
+                    Attr(line, "x2", x);
+                    Attr(line, "y2", _plotTop + _plotHeight);
+                    Attr(line, "stroke", Theme.Colors.Neutral500Alpha);
+                    Attr(line, "stroke-width", 1);
+                    _svg.appendChild(line);
+                }
+
+                var label = El("text");
+                Attr(label, "x", x);
+                Attr(label, "y", _plotTop + _plotHeight + 14);
+                Attr(label, "text-anchor", "middle");
+                Attr(label, "font-size", "10");
+                Attr(label, "fill", textColor);
+                label.textContent = FormatXValue(tick);
+                _svg.appendChild(label);
+            }
+        }
+
+        // Ticks land on 1/2/5 x 10^n so labels read as round numbers (and round timestamps) at any zoom level.
+        private static List<double> NiceTicks(double min, double max, int maxCount)
+        {
+            var result = new List<double>();
+            var span   = max - min;
+
+            if (span <= 0 || maxCount < 1) return result;
+
+            var rough     = span / maxCount;
+            var magnitude = Math.Pow(10, Math.Floor(Math.Log10(rough)));
+            var normalized = rough / magnitude;
+
+            double stepMultiple;
+            if (normalized <= 1) stepMultiple = 1;
+            else if (normalized <= 2) stepMultiple = 2;
+            else if (normalized <= 5) stepMultiple = 5;
+            else stepMultiple = 10;
+
+            var step  = stepMultiple * magnitude;
+            var start = Math.Ceiling(min / step) * step;
+
+            for (var tick = start; tick <= max + step * 0.001; tick += step)
+            {
+                result.Add(tick);
+                if (result.Count > 200) break; // guard against a pathological step
+            }
+
+            return result;
+        }
+
+        private void DrawAxisTitles(string textColor)
+        {
+            if (!string.IsNullOrEmpty(_xAxisTitle))
+            {
+                var label = El("text");
+                Attr(label, "x", _plotLeft + _plotWidth / 2);
+                Attr(label, "y", _plotTop + _plotHeight + 30);
+                Attr(label, "text-anchor", "middle");
+                Attr(label, "font-size", "10");
+                Attr(label, "fill", textColor);
+                label.textContent = _xAxisTitle;
+                _svg.appendChild(label);
+            }
+
+            if (!string.IsNullOrEmpty(_yAxisTitle))
+            {
+                var label = El("text");
+                Attr(label, "x", 10);
+                Attr(label, "y", _plotTop + _plotHeight / 2);
+                Attr(label, "text-anchor", "middle");
+                Attr(label, "font-size", "10");
+                Attr(label, "fill", textColor);
+                Attr(label, "transform", $"rotate(-90 10 {(_plotTop + _plotHeight / 2).ToString("0.###")})");
+                label.textContent = _yAxisTitle;
+                _svg.appendChild(label);
+            }
         }
 
         /// <summary>Returns the pixel X coordinate of the center of category slot <paramref name="index"/>.</summary>
@@ -600,5 +1261,228 @@ namespace Tesserae
 
         /// <summary>Plots the series into the computed plot rectangle.</summary>
         protected abstract void RenderSeries();
+
+        // ===================================================================
+        //                     ZOOM / PAN / SPIKELINES
+        // ===================================================================
+
+        private void EnsureInteractions()
+        {
+            if (_interactionsAttached) return;
+            _interactionsAttached = true;
+
+            _svg.addEventListener("wheel", (Action<Event>)(e =>
+            {
+                if (!_zoomable || !_continuousX) return;
+
+                var we = e.As<WheelEvent>();
+                we.preventDefault();
+
+                var factor = we.deltaY < 0 ? 0.8 : 1.25;
+                ZoomAround(PlotXValueAt(we.clientX), factor);
+            }));
+
+            _svg.addEventListener("mousedown", (Action<Event>)(e =>
+            {
+                if (!_zoomable || !_continuousX) return;
+
+                var me = e.As<MouseEvent>();
+                me.preventDefault();
+                BeginPan(me.clientX);
+            }));
+
+            _svg.addEventListener("dblclick", (Action<Event>)(e =>
+            {
+                if (!_zoomable || !_continuousX || !_hasExplicitRange) return;
+
+                AutoRangeX();
+                ResolveXRange(); // so the reported range is the data extent, not the range we just dropped
+                RaiseRangeChanged(isAutoRange: true);
+            }));
+
+            _svg.addEventListener("mousemove", (Action<Event>)(e =>
+            {
+                if (!_showSpikes) return;
+                UpdateSpike(e.As<MouseEvent>().clientX);
+            }));
+
+            _svg.addEventListener("mouseleave", (Action<Event>)(_ => ClearOverlay()));
+        }
+
+        private double PlotXValueAt(double clientX)
+        {
+            var rect  = _container.getBoundingClientRect().As<DOMRect>();
+            var local = clientX - rect.left;
+            var ratio = (local - _plotLeft) / Math.Max(1, _plotWidth);
+
+            ratio = Math.Max(0, Math.Min(1, ratio));
+            return _viewXMin + (_viewXMax - _viewXMin) * ratio;
+        }
+
+        private void ZoomAround(double anchor, double factor)
+        {
+            var newSpan = (_viewXMax - _viewXMin) * factor;
+
+            if (newSpan <= 0) return;
+
+            var leftShare = (anchor - _viewXMin) / Math.Max(1e-9, _viewXMax - _viewXMin);
+
+            XRange(anchor - newSpan * leftShare, anchor + newSpan * (1 - leftShare));
+            RaiseRangeChanged(isAutoRange: false);
+        }
+
+        private void BeginPan(double startClientX)
+        {
+            var startMin = _viewXMin;
+            var startMax = _viewXMax;
+            var rect     = _container.getBoundingClientRect().As<DOMRect>();
+            var perPixel = (startMax - startMin) / Math.Max(1, _plotWidth);
+
+            Action<Event> onMove = null;
+            Action<Event> onUp   = null;
+
+            onMove = e =>
+            {
+                var delta = (e.As<MouseEvent>().clientX - startClientX) * perPixel;
+                XRange(startMin - delta, startMax - delta);
+            };
+
+            onUp = e =>
+            {
+                document.body.removeEventListener("mousemove", onMove);
+                document.body.removeEventListener("mouseup", onUp);
+                RaiseRangeChanged(isAutoRange: false);
+            };
+
+            document.body.addEventListener("mousemove", onMove);
+            document.body.addEventListener("mouseup", onUp);
+        }
+
+        private void RaiseRangeChanged(bool isAutoRange)
+        {
+            if (_onRangeChanged is null) return;
+            _onRangeChanged(new ChartRange(_viewXMin, _viewXMax, isAutoRange));
+        }
+
+        private void ClearOverlay()
+        {
+            if (_overlay is null) return;
+            while (_overlay.firstChild != null) _overlay.removeChild(_overlay.firstChild);
+        }
+
+        private void UpdateSpike(double clientX)
+        {
+            if (_overlay is null || _pointCount == 0) return;
+
+            ClearOverlay();
+
+            var rect  = _container.getBoundingClientRect().As<DOMRect>();
+            var pixel = clientX - rect.left;
+
+            if (pixel < _plotLeft || pixel > _plotLeft + _plotWidth) return;
+
+            var line = El("line");
+            Attr(line, "x1", pixel);
+            Attr(line, "y1", _plotTop);
+            Attr(line, "x2", pixel);
+            Attr(line, "y2", _plotTop + _plotHeight);
+            Attr(line, "stroke", Theme.Default.Foreground);
+            Attr(line, "stroke-width", 1);
+            Attr(line, "stroke-dasharray", "3 3");
+            Attr(line, "opacity", "0.6");
+            _overlay.appendChild(line);
+
+            var readout = new List<string>();
+            var xValue  = _continuousX ? PlotXValueAt(clientX) : 0.0;
+
+            if (_continuousX) readout.Add(FormatXValue(xValue));
+
+            for (int s = 0; s < _series.Count; s++)
+            {
+                var series = _series[s];
+                var index  = NearestIndex(series, pixel);
+
+                if (index < 0) continue;
+
+                var name = string.IsNullOrEmpty(series.Name) ? "" : series.Name + ": ";
+
+                if (!_continuousX && readout.Count == 0)
+                {
+                    readout.Add(index < _categories.Length ? _categories[index] : "#" + (index + 1));
+                }
+
+                readout.Add(name + _valueFormatter(series.Values[index]));
+
+                var marker = El("circle");
+                Attr(marker, "cx", SeriesPointX(series, index));
+                Attr(marker, "cy", PixelY(series.Values[index]));
+                Attr(marker, "r", 3.5);
+                Attr(marker, "fill", ColorFor(s, series));
+                Attr(marker, "stroke", Theme.Default.Background);
+                Attr(marker, "stroke-width", 1);
+                _overlay.appendChild(marker);
+            }
+
+            if (readout.Count > 0) DrawSpikeReadout(readout, pixel);
+        }
+
+        private int NearestIndex(ChartSeries series, double pixel)
+        {
+            var best         = -1;
+            var bestDistance = double.MaxValue;
+
+            for (int i = 0; i < series.Values.Length; i++)
+            {
+                if (double.IsNaN(series.Values[i])) continue;
+
+                var distance = Math.Abs(SeriesPointX(series, i) - pixel);
+
+                if (distance < bestDistance)
+                {
+                    bestDistance = distance;
+                    best         = i;
+                }
+            }
+
+            return best;
+        }
+
+        private void DrawSpikeReadout(List<string> lines, double pixel)
+        {
+            const double lineHeight = 13;
+            const double padding    = 5;
+
+            var boxWidth  = lines.Max(l => l.Length) * 6.2 + padding * 2;
+            var boxHeight = lines.Count * lineHeight + padding * 2;
+
+            // Flip to the other side of the spike when the box would overflow the plot.
+            var boxLeft = pixel + 10;
+            if (boxLeft + boxWidth > _plotLeft + _plotWidth) boxLeft = pixel - 10 - boxWidth;
+
+            var boxTop = _plotTop + 4;
+
+            var box = El("rect");
+            Attr(box, "x", boxLeft);
+            Attr(box, "y", boxTop);
+            Attr(box, "width", boxWidth);
+            Attr(box, "height", boxHeight);
+            Attr(box, "rx", 3);
+            Attr(box, "fill", Theme.Default.Background);
+            Attr(box, "stroke", Theme.Default.Border);
+            Attr(box, "stroke-width", 1);
+            Attr(box, "opacity", "0.95");
+            _overlay.appendChild(box);
+
+            for (int i = 0; i < lines.Count; i++)
+            {
+                var text = El("text");
+                Attr(text, "x", boxLeft + padding);
+                Attr(text, "y", boxTop + padding + lineHeight * (i + 1) - 3);
+                Attr(text, "font-size", "10");
+                Attr(text, "fill", Theme.Default.Foreground);
+                text.textContent = lines[i];
+                _overlay.appendChild(text);
+            }
+        }
     }
 }

--- a/Tesserae/src/Components/ChartBase.cs
+++ b/Tesserae/src/Components/ChartBase.cs
@@ -709,10 +709,14 @@ namespace Tesserae
 
         private double[] _sharedX;
         private Func<double, string> _xFormatter;
+        private bool _xIsTime;
+        private string _xTimeFormat;
+        private double _lastTimeStep;
         private int _maxXTicks;
         private bool _hasExplicitRange;
         private double _rangeMin;
         private double _rangeMax;
+        private bool? _zeroBaseline;
         private bool _zoomable;
         private bool _showSpikes;
         private bool _interactionsAttached;
@@ -741,12 +745,14 @@ namespace Tesserae
         public T FormatXAxis(Func<double, string> formatter) { _xFormatter = formatter; QueueRender(); return Self; }
 
         /// <summary>
-        /// Formats continuous X values as local times, treating them as Unix timestamps in seconds. Pass a
-        /// standard or custom .NET date format string.
+        /// Formats continuous X values as local times, treating them as Unix timestamps in seconds. With no
+        /// format the labels adapt to the visible span — seconds when zoomed into a minute, dates when showing
+        /// months — and the ticks land on whole seconds, minutes, hours or days rather than on powers of ten.
         /// </summary>
-        public T XAxisTime(string format = "HH:mm")
+        public T XAxisTime(string format = null)
         {
-            _xFormatter = v => DateTimeOffset.FromUnixTimeSeconds((long)v).ToLocalTime().ToString(format);
+            _xIsTime      = true;
+            _xTimeFormat  = format;
             QueueRender();
             return Self;
         }
@@ -838,8 +844,18 @@ namespace Tesserae
         /// </summary>
         public T OnRangeChanged(Action<ChartRange> handler) { _onRangeChanged = handler; return Self; }
 
-        /// <summary>When true the value axis always includes zero as a baseline (bar/area); when false it fits the data.</summary>
-        protected virtual bool IncludeZeroBaseline => true;
+        /// <summary>
+        /// Overrides whether the value axis includes zero, regardless of the chart type's default. An area chart
+        /// of a metric that hovers far from zero reads better fitted to its data, with the fill still running to
+        /// the bottom of the plot.
+        /// </summary>
+        public T ZeroBaseline(bool include = true) { _zeroBaseline = include; QueueRender(); return Self; }
+
+        /// <summary>The chart type's default: true when the value axis should always include zero as a baseline.</summary>
+        protected virtual bool DefaultIncludeZeroBaseline => true;
+
+        /// <summary>Whether the value axis includes zero, honouring <see cref="ZeroBaseline"/> over the type default.</summary>
+        protected bool IncludeZeroBaseline => _zeroBaseline ?? DefaultIncludeZeroBaseline;
 
         /// <summary>Maps a value to its pixel Y coordinate within the plot area.</summary>
         protected double PixelY(double value)
@@ -908,17 +924,19 @@ namespace Tesserae
             ResolveXRange();
             RenderLegend(width, height);
 
+            //Before the plot rectangle, because the value labels decide how much room the axis needs: a byte
+            //count formatted to ten characters would otherwise be clipped by a fixed margin.
+            ComputeValueRange();
+
             double marginTop    = 8 + _legendInsetTop;
             double marginRight  = 12 + _legendInsetRight;
             double marginBottom = (_showAxes ? (_categories.Length > 0 || _continuousX || !string.IsNullOrEmpty(_xAxisTitle) ? 34 : 18) : 6) + _legendInsetBottom;
-            double marginLeft   = (_showAxes ? 44 : 6) + _legendInsetLeft;
+            double marginLeft   = (_showAxes ? MeasureValueAxisWidth(width) : 6) + _legendInsetLeft;
 
             _plotLeft   = marginLeft;
             _plotTop    = marginTop;
             _plotWidth  = Math.Max(1, width - marginLeft - marginRight);
             _plotHeight = Math.Max(1, height - marginTop - marginBottom);
-
-            ComputeValueRange();
 
             if (_showGrid || _showAxes) DrawGridAndAxes();
 
@@ -1069,6 +1087,25 @@ namespace Tesserae
             _maxValue = dataMax;
         }
 
+        // The value-axis equivalent of Plotly's automargin: wide enough for the widest tick label it will draw.
+        private double MeasureValueAxisWidth(double width)
+        {
+            var widest = 0;
+
+            for (int i = 0; i <= ValueTicks; i++)
+            {
+                var text = _valueFormatter(_minValue + (_maxValue - _minValue) * i / ValueTicks);
+                if (text != null && text.Length > widest) widest = text.Length;
+            }
+
+            //~6px per character at the 10px label size, plus the 6px gap to the axis and a little slack.
+            var needed = widest * 6 + 12 + (string.IsNullOrEmpty(_yAxisTitle) ? 0 : 14);
+
+            return Math.Max(28, Math.Min(needed, width * 0.4));
+        }
+
+        private const int ValueTicks = 4;
+
         private int EffectiveMaxXTicks()
         {
             if (_maxXTicks > 0) return _maxXTicks;
@@ -1076,11 +1113,33 @@ namespace Tesserae
         }
 
         /// <summary>Formats a continuous X value using the configured X formatter, falling back to a plain number.</summary>
-        protected string FormatXValue(double value) => _xFormatter is object ? _xFormatter(value) : value.ToString("0.##");
+        protected string FormatXValue(double value)
+        {
+            if (_xIsTime)
+            {
+                var format = _xTimeFormat ?? AdaptiveTimeFormat(_viewXMax - _viewXMin);
+                return DateTimeOffset.FromUnixTimeSeconds((long)value).ToLocalTime().ToString(format);
+            }
+
+            return _xFormatter is object ? _xFormatter(value) : value.ToString("0.##");
+        }
+
+        // A fixed "HH:mm" prints the same label ten times across a one-minute window, and no time at all across
+        // a year, so the precision follows the tick step: sub-minute steps need seconds, day-scale steps need
+        // the date. Keyed off the step rather than the span so neighbouring ticks can never print the same label.
+        private string AdaptiveTimeFormat(double spanSeconds)
+        {
+            var step = _lastTimeStep > 0 ? _lastTimeStep : spanSeconds / 8;
+
+            if (step < 60) return "HH:mm:ss";
+            if (step < 86400) return "HH:mm";
+            if (step < 2592000) return "MM-dd";
+            return "yyyy-MM";
+        }
 
         private void DrawGridAndAxes()
         {
-            const int ticks = 4;
+            const int ticks = ValueTicks;
             var gridColor = Theme.Colors.Neutral500Alpha;
             var textColor = Theme.Default.Foreground;
 
@@ -1154,7 +1213,9 @@ namespace Tesserae
 
         private void DrawContinuousXLabels(string textColor)
         {
-            var tickValues = NiceTicks(_viewXMin, _viewXMax, EffectiveMaxXTicks());
+            var tickValues = _xIsTime
+                ? TimeTicks(_viewXMin, _viewXMax, EffectiveMaxXTicks())
+                : NiceTicks(_viewXMin, _viewXMax, EffectiveMaxXTicks());
 
             foreach (var tick in tickValues)
             {
@@ -1185,7 +1246,50 @@ namespace Tesserae
             }
         }
 
-        // Ticks land on 1/2/5 x 10^n so labels read as round numbers (and round timestamps) at any zoom level.
+        // Wall-clock steps, so a time axis reads 30s / 5min / 6h rather than the 20s and 50s a decimal
+        // 1/2/5 x 10^n progression would land on.
+        private static readonly double[] TimeSteps =
+        {
+            1, 2, 5, 10, 15, 30,                            // seconds
+            60, 120, 300, 600, 900, 1800,                   // minutes
+            3600, 7200, 10800, 21600, 43200,                // hours
+            86400, 172800, 604800, 1209600,                 // days and weeks
+            2592000, 7776000, 15552000, 31536000            // months and a year
+        };
+
+        private List<double> TimeTicks(double min, double max, int maxCount)
+        {
+            var span = max - min;
+
+            if (span <= 0 || maxCount < 1) return new List<double>();
+
+            var target = span / maxCount;
+            var step   = TimeSteps[TimeSteps.Length - 1];
+
+            for (int i = 0; i < TimeSteps.Length; i++)
+            {
+                if (TimeSteps[i] >= target)
+                {
+                    step = TimeSteps[i];
+                    break;
+                }
+            }
+
+            _lastTimeStep = step;
+
+            var result = new List<double>();
+            var start  = Math.Ceiling(min / step) * step;
+
+            for (var tick = start; tick <= max; tick += step)
+            {
+                result.Add(tick);
+                if (result.Count > 200) break;
+            }
+
+            return result;
+        }
+
+        // Ticks land on 1/2/5 x 10^n so labels read as round numbers at any zoom level.
         private static List<double> NiceTicks(double min, double max, int maxCount)
         {
             var result = new List<double>();

--- a/Tesserae/src/Components/LineChart.cs
+++ b/Tesserae/src/Components/LineChart.cs
@@ -1,10 +1,10 @@
-using System.Linq;
+using System.Collections.Generic;
 using static Transpose.Core.dom;
 
 namespace Tesserae
 {
     /// <summary>
-    /// A lightweight, dependency-free SVG line chart. Plots one or more series as connected polylines with
+    /// A lightweight, dependency-free SVG line chart. Plots one or more series as connected lines with
     /// hoverable points, value gridlines, category labels and a theme-aware palette. Fluent and responsive.
     /// </summary>
     [Transpose.Name("tss.LineChart")]
@@ -32,37 +32,60 @@ namespace Tesserae
 
                 if (series.Values.Length == 0) continue;
 
-                var points = string.Join(" ", series.Values.Select((v, i) => $"{PointX(i).ToString("0.###")},{PixelY(v).ToString("0.###")}"));
+                foreach (var run in SeriesRuns(series))
+                {
+                    if (run.Count == 0) continue;
 
-                var polyline = El("polyline");
-                Attr(polyline, "fill", "none");
-                Attr(polyline, "stroke", color);
-                Attr(polyline, "stroke-width", 2);
-                Attr(polyline, "stroke-linejoin", "round");
-                Attr(polyline, "stroke-linecap", "round");
-                Attr(polyline, "points", points);
-                _svg.appendChild(polyline);
+                    var path = El("path");
+                    Attr(path, "fill", "none");
+                    Attr(path, "stroke", color);
+                    Attr(path, "stroke-width", series.LineWidth);
+                    Attr(path, "stroke-linejoin", "round");
+                    Attr(path, "stroke-linecap", "round");
+                    Attr(path, "d", BuildPath(series, run));
+                    _plotSurface.appendChild(path);
+                }
 
-                if (_showPoints)
+                if (_showPoints && series.Values.Length <= MaxMarkersPerSeries)
                 {
                     for (int i = 0; i < series.Values.Length; i++)
                     {
+                        if (double.IsNaN(series.Values[i])) continue;
+
                         var circle = El("circle");
-                        Attr(circle, "cx", PointX(i));
+                        Attr(circle, "cx", SeriesPointX(series, i));
                         Attr(circle, "cy", PixelY(series.Values[i]));
                         Attr(circle, "r", 3);
                         Attr(circle, "fill", color);
                         AttachPointTooltip(circle, TooltipFor(series, i));
-                        _svg.appendChild(circle);
+                        _plotSurface.appendChild(circle);
                     }
                 }
             }
         }
 
+        private string BuildPath(ChartSeries series, List<int> run)
+        {
+            var d = "";
+
+            for (int p = 0; p < run.Count; p++)
+            {
+                var i = run[p];
+                var x = SeriesPointX(series, i).ToString("0.###");
+                var y = PixelY(series.Values[i]).ToString("0.###");
+                d += (p == 0 ? "M " : " L ") + x + " " + y;
+            }
+
+            return d;
+        }
+
         private string TooltipFor(ChartSeries series, int i)
         {
-            var label = i < _categories.Length ? _categories[i] : "#" + (i + 1);
-            var name  = string.IsNullOrEmpty(series.Name) ? "" : series.Name + " — ";
+            var label = _continuousX
+                ? FormatXValue(XOf(series, i))
+                : (i < _categories.Length ? _categories[i] : "#" + (i + 1));
+
+            var name = string.IsNullOrEmpty(series.Name) ? "" : series.Name + " — ";
             return $"{name}{label}: {_valueFormatter(series.Values[i])}";
         }
     }

--- a/Tesserae/src/Components/LineChart.cs
+++ b/Tesserae/src/Components/LineChart.cs
@@ -21,7 +21,7 @@ namespace Tesserae
         public LineChart Points(bool show = true) { _showPoints = show; QueueRender(); return this; }
 
         // Line charts fit the data range rather than forcing a zero baseline.
-        protected override bool IncludeZeroBaseline => false;
+        protected override bool DefaultIncludeZeroBaseline => false;
 
         protected override void RenderSeries()
         {

--- a/Tesserae/src/Components/PieChart.cs
+++ b/Tesserae/src/Components/PieChart.cs
@@ -18,7 +18,11 @@ namespace Tesserae
         /// <summary>
         /// Initializes a new instance of the <see cref="PieChart"/> class.
         /// </summary>
-        public PieChart() : base() { }
+        public PieChart() : base()
+        {
+            // A pie's slice labels read better in a column beside it than in a row above it.
+            _legendPosition = ChartLegendPosition.Right;
+        }
 
         /// <summary>Sets the per-slice labels.</summary>
         public PieChart Labels(params string[] labels) { _labels = labels ?? new string[0]; QueueRender(); return this; }
@@ -29,19 +33,16 @@ namespace Tesserae
         protected override void RenderChart(double width, double height)
         {
             var values = _series.Count > 0 ? _series[0].Values : new double[0];
-            var total  = values.Sum();
+            var total  = values.Where(v => !double.IsNaN(v)).Sum();
 
-            var legendWidth = 0.0;
-            if (_showLegend && values.Length > 0)
-            {
-                legendWidth = Math.Min(width * 0.4, 140);
-            }
+            DrawLegend(values, width, height);
 
-            var chartWidth = width - legendWidth;
-            var cx         = chartWidth / 2;
-            var cy         = height / 2;
-            var radius     = Math.Max(4, Math.Min(chartWidth, height) / 2 - 8);
-            var innerR     = radius * _donutRatio;
+            var chartWidth  = width - _legendInsetLeft - _legendInsetRight;
+            var chartHeight = height - _legendInsetTop - _legendInsetBottom;
+            var cx          = _legendInsetLeft + chartWidth / 2;
+            var cy          = _legendInsetTop + chartHeight / 2;
+            var radius      = Math.Max(4, Math.Min(chartWidth, chartHeight) / 2 - 8);
+            var innerR      = radius * _donutRatio;
 
             if (total <= 0 || values.Length == 0)
             {
@@ -52,7 +53,7 @@ namespace Tesserae
 
             for (int i = 0; i < values.Length; i++)
             {
-                if (values[i] <= 0) continue;
+                if (double.IsNaN(values[i]) || values[i] <= 0) continue;
 
                 var sweep    = values[i] / total * Math.PI * 2;
                 var endAngle = startAngle + sweep;
@@ -68,8 +69,6 @@ namespace Tesserae
 
                 startAngle = endAngle;
             }
-
-            DrawLegend(values, chartWidth, height);
         }
 
         private string SlicePath(double cx, double cy, double ro, double ri, double a0, double a1, double sweep)
@@ -99,37 +98,21 @@ namespace Tesserae
 
         private static string F(double v) => v.ToString("0.###");
 
-        private void DrawLegend(double[] values, double chartWidth, double height)
+        // A pie legend labels slices, not series, so it feeds the shared renderer its own labels and colors.
+        private void DrawLegend(double[] values, double width, double height)
         {
-            if (!_showLegend) return;
+            if (!_showLegend || values.Length == 0) return;
 
-            double x = chartWidth + 8;
-            double y = Math.Max(12, height / 2 - values.Length * 9);
+            var labels = new string[values.Length];
+            var colors = new string[values.Length];
 
             for (int i = 0; i < values.Length; i++)
             {
-                var color = _palette[i % _palette.Length];
-                var label = i < _labels.Length ? _labels[i] : "#" + (i + 1);
-
-                var rect = El("rect");
-                Attr(rect, "x", x);
-                Attr(rect, "y", y);
-                Attr(rect, "width", 10);
-                Attr(rect, "height", 10);
-                Attr(rect, "rx", 2);
-                Attr(rect, "fill", color);
-                _svg.appendChild(rect);
-
-                var text = El("text");
-                Attr(text, "x", x + 16);
-                Attr(text, "y", y + 9);
-                Attr(text, "font-size", "11");
-                Attr(text, "fill", Theme.Default.Foreground);
-                text.textContent = label;
-                _svg.appendChild(text);
-
-                y += 18;
+                labels[i] = i < _labels.Length ? _labels[i] : "#" + (i + 1);
+                colors[i] = _palette[i % _palette.Length];
             }
+
+            RenderLegend(labels, colors, width, height);
         }
 
         private string TooltipFor(int i, double value, double total)
@@ -146,7 +129,7 @@ namespace Tesserae
             var values = _series.Count > 0 ? _series[0].Values : new double[0];
             if (values.Length == 0) return (_donutRatio > 0 ? "Donut" : "Pie") + " chart with no data";
 
-            var total = values.Sum();
+            var total = values.Where(v => !double.IsNaN(v)).Sum();
             var parts = values.Select((v, i) =>
             {
                 var label = i < _labels.Length ? _labels[i] : "#" + (i + 1);


### PR DESCRIPTION
## Summary

Extends the chart system with advanced features for plotting time series and continuous data: a continuous X scale (vs. categorical), zoom and pan interactions, a spikeline readout, PNG export, improved legend positioning, gap handling, and stacked bar charts.

## Key Changes

**New Types & Enums**
- `ChartLegendPosition` enum: `Top`, `Bottom`, `Left`, `Right` positioning for legends
- `ChartRange` class: represents the visible X range when zooming/panning, with `Min`, `Max`, and `IsAutoRange` properties

**ChartSeries Enhancements**
- `XValues` property: optional X positions for each value, enabling continuous X scales and irregular sampling
- `LineWidth` property (default 2): stroke width for line/area charts
- `FillOpacity` property (default 0.45): opacity of area fills
- New constructor overload accepting `xValues` parameter

**ChartBase Improvements**
- Legend positioning: `.Legend(ChartLegendPosition)` method and `_legendPosition` field; legends now support all four edges with proper inset tracking
- Gap handling: `.ConnectGaps(bool)` method to control whether lines bridge `double.NaN` gaps or break
- PNG export: `.ExportButton(bool, string)` method adds a hover-revealed download button; `.ExportPng(string)` serializes the SVG with resolved CSS variables and rasterizes via canvas
- Plot surface clipping: `_plotSurface` element for proper rendering bounds
- Legend inset tracking: `_legendInsetTop/Bottom/Left/Right` fields to reserve space for legends on any edge
- Improved accessibility: ARIA labels now exclude `NaN` values from min/max calculations

**CartesianChartBase (Line, Bar, Area)**
- Continuous X scale support: `_continuousX` flag, `_viewXMin/Max` for the visible range
- X axis configuration:
  - `.XValues(double[])`: shared X positions for all series
  - `.FormatXAxis(Func<double, string>)`: custom X tick formatting
  - `.XAxisTime(string)`: time-based formatting with adaptive tick intervals (seconds/minutes/hours/days)
  - `.MaxXTicks(int)`: cap on visible tick labels
- Zoom and pan:
  - `.Zoomable(bool)`: enable wheel zoom and drag pan
  - `.XRange(double, double)`: pin the visible range programmatically
  - `.AutoRangeX()`: reset to full data extent
  - `.TryGetXRange(out min, out max)`: query current visible range
  - `.IsXRangePinned`: check if range came from user interaction
  - `.OnRangeChanged(Action<ChartRange>)`: callback when user zooms/pans (not when `XRange()` is called, preventing re-entrancy)
- Spikelines: `.Spikelines(bool)` draws a vertical line following the cursor with X and Y readouts
- Gap handling: `SeriesRuns()` method splits series at `NaN` gaps; respects `_connectGaps` setting
- Marker suppression: `MaxMarkersPerSeries` constant (300) suppresses per-point markers on dense series to avoid DOM bloat
- Zero baseline override: `.ZeroBaseline(bool)` and `DefaultIncludeZeroBaseline` virtual property allow per-chart control
- Clipped plot surface: zoom/pan no longer draws over axis labels

**BarChart**
- Stacked mode: `.Stacked(bool)` renders one column per category with series stacked on top of each other
- Positive and negative values stack independently away from the baseline
- `CollectRangeValues()` override computes axis range from column totals, not individual values

**AreaChart & LineChart**
- Updated to use `SeriesRuns()` for gap-aware rendering
- Area charts respect `series.FillOpacity` in gradient stops
- Line charts respect `series.LineWidth`

**PieChart**
- Legend defaults to `Right` position (more natural for pie slices)
-

https://claude.ai/code/session_018wUwJsDvmFXkNc8BrpL2G3