### PR TITLE
Fix duplicated chart members breaking the master build, and ship the tab-save CSS

### DIFF
--- a/Tesserae/src/Components/ChartBase.cs
+++ b/Tesserae/src/Components/ChartBase.cs
@@ -197,21 +197,6 @@ namespace Tesserae
         /// <summary>Space the legend claimed on the right of the surface, in pixels.</summary>
         protected double _legendInsetRight;
 
-        /// <summary>The element subclasses draw their series into; clipped to the plot rectangle on cartesian charts.</summary>
-        protected Element _plotSurface;
-
-        /// <summary>Space the legend claimed at the top of the surface, in pixels.</summary>
-        protected double _legendInsetTop;
-
-        /// <summary>Space the legend claimed at the bottom of the surface, in pixels.</summary>
-        protected double _legendInsetBottom;
-
-        /// <summary>Space the legend claimed on the left of the surface, in pixels.</summary>
-        protected double _legendInsetLeft;
-
-        /// <summary>Space the legend claimed on the right of the surface, in pixels.</summary>
-        protected double _legendInsetRight;
-
         private bool _renderQueued;
         private Button _exportButton;
 
@@ -1154,56 +1139,6 @@ namespace Tesserae
             foreach (var tick in _valueTicks)
             {
                 var text = _valueFormatter(tick);
-                if (text != null && text.Length > widest) widest = text.Length;
-            }
-
-            //~6px per character at the 10px label size, plus the 6px gap to the axis and a little slack.
-            var needed = widest * 6 + 12 + (string.IsNullOrEmpty(_yAxisTitle) ? 0 : 14);
-
-            return Math.Max(28, Math.Min(needed, width * 0.4));
-        }
-
-        private const int ValueTicks = 4;
-
-        private int EffectiveMaxXTicks()
-        {
-            if (_maxXTicks > 0) return _maxXTicks;
-            return Math.Max(2, (int)(_plotWidth / 70));
-        }
-
-        /// <summary>Formats a continuous X value using the configured X formatter, falling back to a plain number.</summary>
-        protected string FormatXValue(double value)
-        {
-            if (_xIsTime)
-            {
-                var format = _xTimeFormat ?? AdaptiveTimeFormat(_viewXMax - _viewXMin);
-                return DateTimeOffset.FromUnixTimeSeconds((long)value).ToLocalTime().ToString(format);
-            }
-
-            return _xFormatter is object ? _xFormatter(value) : value.ToString("0.##");
-        }
-
-        // A fixed "HH:mm" prints the same label ten times across a one-minute window, and no time at all across
-        // a year, so the precision follows the tick step: sub-minute steps need seconds, day-scale steps need
-        // the date. Keyed off the step rather than the span so neighbouring ticks can never print the same label.
-        private string AdaptiveTimeFormat(double spanSeconds)
-        {
-            var step = _lastTimeStep > 0 ? _lastTimeStep : spanSeconds / 8;
-
-            if (step < 60) return "HH:mm:ss";
-            if (step < 86400) return "HH:mm";
-            if (step < 2592000) return "MM-dd";
-            return "yyyy-MM";
-        }
-
-        // The value-axis equivalent of Plotly's automargin: wide enough for the widest tick label it will draw.
-        private double MeasureValueAxisWidth(double width)
-        {
-            var widest = 0;
-
-            for (int i = 0; i <= ValueTicks; i++)
-            {
-                var text = _valueFormatter(_minValue + (_maxValue - _minValue) * i / ValueTicks);
                 if (text != null && text.Length > widest) widest = text.Length;
             }
 

--- a/Tesserae/tps/assets/css/tss.pivot.css
+++ b/Tesserae/tps/assets/css/tss.pivot.css
@@ -134,3 +134,11 @@
 .tss-pivot .tss-pivot-cached-hidden{
     display:none !important;
 }
+
+/* Unsaved-changes indicator toggled by TabSaveIndicator / UnsavedChangesGuard. */
+.tss-pivot-tab-needs-saving::after {
+    content: '*';
+    margin-left: 4px;
+    color: var(--tss-primary-background-color, currentColor);
+    font-weight: bold;
+}


### PR DESCRIPTION
## master does not compile

`ChartBase.cs` contains every member added by #326 **twice**. #327 squash-merged a branch that still carried those commits, applying them on top of the already-merged copy. The result is 51 errors (`CS0102` ×6, `CS0111` ×4, `CS0229` ×31, `CS0121` ×10):

```
error CS0102: The type 'ChartBase<T>' already contains a definition for '_plotSurface'
error CS0111: Type 'CartesianChartBase<T>' already defines a member called 'MeasureValueAxisWidth'
...
```

This is why no package has published since `2026.8.69591` — every build since has failed.

Two contiguous blocks were duplicated:

- the field block — `_plotSurface` and the four `_legendInset*` fields
- the method block — `MeasureValueAxisWidth`, `ValueTicks`, `EffectiveMaxXTicks`, `FormatXValue`, `AdaptiveTimeFormat`

**The two copies of `MeasureValueAxisWidth` were not identical**, so this needed care rather than deleting whichever came second. One iterates `_valueTicks` (the round-number axis from #327); the stale one still divides the data range into four. Keeping the wrong copy would have silently reverted the value axis to labels like `604971499.52` while still compiling. The file now matches the reviewed state byte for byte — verified by diffing against the pre-squash content.

## Tesserae now ships the tab-save indicator CSS

`TabSaveIndicator` toggles `tss-pivot-tab-needs-saving`, but Tesserae shipped no rule for it, so the class did nothing unless the consuming app happened to define its own `::after`. The rule now lives next to the rest of the pivot styling in `tss.pivot.css`.

The copy this was lifted from used `var(--tss-color-primary)`, which is not a token Tesserae defines — the asterisk was inheriting the tab's colour rather than being primary-coloured. This uses `--tss-primary-background-color` with a `currentColor` fallback.

## Verification

- `Tesserae.csproj` and `Tesserae.Tests.csproj` both build clean (master currently fails with 51 errors).
- The rule is present in the bundled stylesheet embedded in `tss.dll`.

## Coordination

`curiosity-ai/mosaik#1808` removes Curiosity's duplicate copy of this CSS, so it is currently ahead of the package. Once this merges and CI publishes, that repo's `Tesserae` pin gets bumped — which restores the asterisk and brings the round-number value axis, which `69591` predates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018wUwJsDvmFXkNc8BrpL2G3

---
_Generated by [Claude Code](https://claude.ai/code/session_018wUwJsDvmFXkNc8BrpL2G3)_