### PR TITLE
Anchor samples to fixed dates and seeded randomness

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -301,3 +301,42 @@ whether it still renders the same. See
 [`Tesserae.Bench/README.md`](Tesserae.Bench/README.md) and the
 `tesserae-benchmarking` skill. One-off probe scripts go in
 `Tesserae.Bench/playwright/_*.js`, which is gitignored.
+
+### Samples must render the same on every run
+
+A sample that fakes data uses `SampleRandom`
+([`Tesserae.Tests/src/Samples/SampleRandom.cs`](Tesserae.Tests/src/Samples/SampleRandom.cs)) —
+a seeded `Random` — **not** `new Random()`, `Math.Random()` or `Guid.NewGuid()`. Two
+captures of the gallery have to differ only where the change under test made them differ,
+and an unseeded generator makes `textdiff-samples.js` report noise on every run. Each
+sample constructs its own `SampleRandom` with its own fixed seed, so the sequence a page
+sees does not depend on which samples were opened before it — which matters with the
+on-demand module loading. `SampleRandom.NextId()` replaces `Guid.NewGuid().ToString()`
+where a sample shows its own ids (`NodeViewSample` prints its state as JSON).
+
+The clock is the same problem: a date rendered as text makes a page differ from itself
+minute to minute. Values a sample *displays* come from `SampleDate`
+([`SampleDate.cs`](Tesserae.Tests/src/Samples/SampleDate.cs)) — May 25th of the **current**
+year, so the page is stable within a run without looking stale a year later. Validation
+rules that judge what the user just typed stay on the real clock; they are about the
+person using the page and render nothing until someone interacts.
+
+Not everything is anchored yet: `DetailsListSample`, `NotificationCenterSample`, the
+month/week pickers and `PivotSample` still render clock-derived text, so they drift
+across days (or, for Pivot, every second). `PixelAvatar`'s timing jitter is deliberately
+left random — it is an animation, not data.
+
+### Expected console noise
+
+The **Sandbox** sample logs a browser error on load, and it is correct:
+
+```
+Blocked script execution in 'about:srcdoc' because the document's frame is sandboxed
+and the 'allow-scripts' permission is not set.
+```
+
+That is the "Fit height to content (host-side, no scripts)" demo, which sets
+`.AllowScripts(false)` on purpose to prove the host-side measurement path works with no
+script in the frame. The browser blocks `Sandbox`'s injected bootstrap script and says
+so; the frame still resizes because the host measures it through `AllowSameOrigin`.
+Don't "fix" it, and don't let a test fail the run on it.

--- a/Tesserae.Tests/src/Samples/Collections/KeyedObservableStackSample.cs
+++ b/Tesserae.Tests/src/Samples/Collections/KeyedObservableStackSample.cs
@@ -16,6 +16,10 @@ namespace Tesserae.Tests.Samples
         private static int _elementIndex = 4;
         private static ObservableList<IComponentWithID> _stackElementsList;
 
+        // Fixed seed: the item colours and the "Randomize Order" shuffle are the same on every run,
+        // so two captures of this page only differ where the reconciliation actually differs.
+        private static readonly SampleRandom _rng = new SampleRandom(2_468);
+
         public class StackElement : IComponentWithID
         {
             public string Id { get; set; }
@@ -28,7 +32,7 @@ namespace Tesserae.Tests.Samples
             {
                 Id = id;
                 DisplayName = displayName;
-                Color = '#' + Math.Floor(Math.Random() * 16777215).ToString(16).PadLeft(6, '0');
+                Color = '#' + Math.Floor(_rng.NextDouble() * 16777215).ToString(16).PadLeft(6, '0');
             }
 
             public HTMLElement Render()
@@ -64,7 +68,7 @@ namespace Tesserae.Tests.Samples
                     SplitView().Height(500.px()).WS()
                        .Left(VStack().Children(
                             HStack().Children(
-                                Button("Randomize Order").OnClick(() => _stackElementsList.ReplaceAll(_stackElementsList.Value.OrderBy(_ => Math.Random()).ToList())),
+                                Button("Randomize Order").OnClick(() => _stackElementsList.ReplaceAll(_stackElementsList.Value.OrderBy(_ => _rng.NextDouble()).ToList())),
                                 Button("Add New Item").Primary().OnClick(() => AddItem())
                             ).MB(16),
                             Label("Edit items in-place:").SemiBold(),

--- a/Tesserae.Tests/src/Samples/Collections/MasonrySample.cs
+++ b/Tesserae.Tests/src/Samples/Collections/MasonrySample.cs
@@ -33,7 +33,7 @@ namespace Tesserae.Tests.Samples
 
         private IEnumerable<IComponent> GetCards(int count)
         {
-            var rng = new Random();
+            var rng = new SampleRandom(5_004);
             for (int i = 0; i < count; i++)
             {
                 var height = 80 + (int)(rng.NextDouble() * 4) * 40;

--- a/Tesserae.Tests/src/Samples/Components/ChartsSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/ChartsSample.cs
@@ -20,6 +20,10 @@ namespace Tesserae.Tests.Samples
             // An observable series so the chart re-renders when the data changes.
             var liveData = new SettableObservable<double[]>(new double[] { 5, 8, 6, 12, 9, 15 });
 
+            // Seeded, and outside the click handler: every click still shows different numbers, but
+            // the Nth click of a given session always shows the same ones.
+            var randomizer = new SampleRandom(3_101);
+
             var lineChart = LineChart()
                .Series(new ChartSeries("Revenue", revenue), new ChartSeries("Costs", costs))
                .XAxis(months)
@@ -81,9 +85,8 @@ namespace Tesserae.Tests.Samples
                         HStack().WS().Children(
                             Button("Randomize data").SetIcon(UIcons.Dice).OnClick(() =>
                             {
-                                var rnd = new Random();
                                 var next = new double[6];
-                                for (var i = 0; i < next.Length; i++) next[i] = rnd.Next(2, 30);
+                                for (var i = 0; i < next.Length; i++) next[i] = randomizer.Next(2, 30);
                                 liveData.Value = next;
                             })))).SetTitle("AreaChart + observable")))
                .Section(Stack().Children(
@@ -103,8 +106,11 @@ namespace Tesserae.Tests.Samples
         // which is what OnRangeChanged + XRange are for (XRange itself never re-raises the event).
         private static IComponent BuildTimeSeriesSection()
         {
-            var start = DateTimeOffset.UtcNow.AddHours(-2).ToUnixTimeSeconds();
-            var rnd   = new Random();
+            // Anchored to SampleDate rather than "two hours ago": the axis labels are rendered text,
+            // so a clock-driven start makes this page differ from itself every minute.
+            var start = SampleDate.UnixSeconds(SampleDate.Now);
+
+            var rnd = new SampleRandom(7_720);
 
             var times = new double[120];
             var cpu   = new double[120];

--- a/Tesserae.Tests/src/Samples/Components/ChatSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/ChatSample.cs
@@ -24,7 +24,7 @@ namespace Tesserae.Tests.Samples
                 "Excellent! Let's proceed with the proposed plan."
             };
 
-            var random = new Random();
+            var random = new SampleRandom(1_337);
 
             // Shared cancellation flag — set to true to abort the current typing animation
             var cancelled = false;

--- a/Tesserae.Tests/src/Samples/Components/DatePickerSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/DatePickerSample.cs
@@ -12,8 +12,9 @@ namespace Tesserae.Tests.Samples
 
         public DatePickerSample()
         {
-            var from = DateTime.Now.AddDays(-7);
-            var to   = DateTime.Now.AddDays(7);
+            // Anchored to SampleDate rather than the clock: these dates are rendered as text.
+            var from = SampleDate.Now.AddDays(-7);
+            var to   = SampleDate.Now.AddDays(7);
 
             _content = SectionStack().Secondary()
                .SampleTitle(typeof(DatePickerSample), UIcons.Calendar, "A component to select a date")
@@ -29,7 +30,7 @@ namespace Tesserae.Tests.Samples
                     SampleSubTitle("Basic DatePicker"),
                     VStack().Children(
                         Label("Standard").SetContent(DatePicker()),
-                        Label("Pre-selected Date (Next Week)").SetContent(DatePicker(DateTime.Now.AddDays(7))),
+                        Label("Pre-selected Date (A Week On)").SetContent(DatePicker(SampleDate.Now.AddDays(7))),
                         Label("Disabled").Disabled().SetContent(DatePicker().Disabled())
                     ),
                     SampleSubTitle("Range and Constraints"),

--- a/Tesserae.Tests/src/Samples/Components/DateRangePickerSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/DateRangePickerSample.cs
@@ -22,10 +22,11 @@ namespace Tesserae.Tests.Samples
                     Card(VStack().WS().Children(
                     SampleSubTitle("Basic"),
                     Label("Pick a range").SetContent(DateRangePicker()),
-                    SampleSubTitle("Pre-filled (today → next week)"),
-                    Label("Selected range").SetContent(DateRangePicker(DateTime.Today, DateTime.Today.AddDays(7))),
+                    // SampleDate rather than DateTime.Today: the picker renders the dates as text.
+                    SampleSubTitle("Pre-filled (a day → a week later)"),
+                    Label("Selected range").SetContent(DateRangePicker(SampleDate.Today, SampleDate.Today.AddDays(7))),
                     SampleSubTitle("Reactive"),
-                    DateRangePicker(DateTime.Today, DateTime.Today.AddDays(14))
+                    DateRangePicker(SampleDate.Today, SampleDate.Today.AddDays(14))
                         .OnChange(r => Toast().Information($"{r.From:d} → {r.To:d}"))
                 )).SetTitle("Usage")))
                .SeeAlso(typeof(DatePickerSample), typeof(DateTimePickerSample), typeof(TimeHistogramPickerSample), typeof(MonthPickerSample));

--- a/Tesserae.Tests/src/Samples/Components/DateTimePickerSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/DateTimePickerSample.cs
@@ -12,8 +12,9 @@ namespace Tesserae.Tests.Samples
 
         public DateTimePickerSample()
         {
-            var from = DateTime.Now.AddDays(-7);
-            var to   = DateTime.Now.AddDays(7);
+            // Anchored to SampleDate rather than the clock: these dates are rendered as text.
+            var from = SampleDate.Now.AddDays(-7);
+            var to   = SampleDate.Now.AddDays(7);
 
             _content = SectionStack().Secondary()
                .SampleTitle(typeof(DateTimePickerSample), UIcons.Calendar, "A control to pick a date and time")
@@ -29,7 +30,7 @@ namespace Tesserae.Tests.Samples
                     SampleSubTitle("Basic DateTimePicker"),
                     VStack().Children(
                         Label("Standard").SetContent(DateTimePicker()),
-                        Label("Pre-selected (Now)").SetContent(DateTimePicker(DateTime.Now)),
+                        Label("Pre-selected").SetContent(DateTimePicker(SampleDate.Now)),
                         Label("Disabled").Disabled().SetContent(DateTimePicker().Disabled())
                     ),
                     SampleSubTitle("Constraints"),

--- a/Tesserae.Tests/src/Samples/Components/TimeHistogramPickerSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/TimeHistogramPickerSample.cs
@@ -100,9 +100,12 @@ namespace Tesserae.Tests.Samples
 
         private static string DefaultRenderTime(DateTime time) => time.ToString("g");
 
+        // Every generator below is anchored to SampleDate rather than the clock: the picker renders
+        // its range as text ("25/05/2026 09:41 - ..."), so a clock-driven anchor would make this page
+        // differ from itself minute to minute.
         private static DateTime[] GetSmallValues()
         {
-            var now = DateTime.Now;
+            var now = SampleDate.Now;
             return new[]
             {
                 now.AddMinutes(30),
@@ -113,7 +116,7 @@ namespace Tesserae.Tests.Samples
 
         private static DateTime[] GetDenseValues()
         {
-            var start = DateTime.Today.AddHours(8);
+            var start = SampleDate.Today.AddHours(8);
             return Enumerable.Range(0, 720)
                .SelectMany(i => Enumerable.Range(0, 1 + (i % 9)).Select(j => start.AddMinutes(i).AddSeconds(j * 7)))
                .ToArray();
@@ -121,7 +124,7 @@ namespace Tesserae.Tests.Samples
 
         private static DateTime[] GetFineGrainedValues()
         {
-            var start = DateTime.Today.AddHours(14);
+            var start = SampleDate.Today.AddHours(14);
             return Enumerable.Range(0, 360)
                .SelectMany(second =>
                {
@@ -133,7 +136,7 @@ namespace Tesserae.Tests.Samples
 
         private static DateTime[] GetMultiYearValues()
         {
-            var start = DateTime.Today.AddYears(-6);
+            var start = SampleDate.Today.AddYears(-6);
             return Enumerable.Range(0, 180)
                .Select(i => start.AddDays((i * 17) % 2190).AddHours((i * 11) % 24))
                .ToArray();
@@ -141,7 +144,7 @@ namespace Tesserae.Tests.Samples
 
         private static DateTime[] GetGappedClusterValues()
         {
-            var start = DateTime.Today.AddYears(-4);
+            var start = SampleDate.Today.AddYears(-4);
 
             var tinyBurst = Enumerable.Range(0, 18)
                .Select(i => start.AddSeconds(i * 11));
@@ -168,7 +171,7 @@ namespace Tesserae.Tests.Samples
 
         private static TimeHistogramBucket[] GetDailyBackendBuckets()
         {
-            var start = DateTime.Today.AddDays(-18);
+            var start = SampleDate.Today.AddDays(-18);
             var counts = new[] { 12, 0, 3, 45, 0, 0, 18, 95, 30, 0, 4, 8, 0, 150, 70, 0, 22, 6, -5 };
 
             return counts
@@ -179,7 +182,7 @@ namespace Tesserae.Tests.Samples
 
         private static TimeHistogramBucket[] GetLongRangeBackendBuckets()
         {
-            var start = DateTime.Today.AddYears(-8);
+            var start = SampleDate.Today.AddYears(-8);
             var counts = new[] { 20, 0, 45, 140, 12, 0, 0, 260, 410, 90, 0, 35, 75, 0, 510, 180 };
 
             return counts.Select((count, i) =>
@@ -191,7 +194,7 @@ namespace Tesserae.Tests.Samples
 
         private static DateTime[] GetLargeValues()
         {
-            var start = DateTime.Today.AddYears(-1);
+            var start = SampleDate.Today.AddYears(-1);
             var minutesInYear = 365 * 24 * 60;
             return Enumerable.Range(0, 100000)
                .Select(i => start.AddMinutes((i * 37) % minutesInYear).AddSeconds(i % 60))

--- a/Tesserae.Tests/src/Samples/Components/UptimeSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/UptimeSample.cs
@@ -10,6 +10,10 @@ namespace Tesserae.Tests.Samples
     {
         private readonly IComponent _content;
 
+        // Fixed seed: the fake 90 days of history has to render the same on every run, so a diff of
+        // the gallery only shows what a change actually did.
+        private readonly SampleRandom _rng = new SampleRandom(90_210);
+
         public UptimeSample()
         {
             var barsItems = new List<(UptimeStatus, IComponent)>();
@@ -53,7 +57,7 @@ namespace Tesserae.Tests.Samples
 
         private UptimeStatus GetRandomStatus()
         {
-            var r = Math.Random();
+            var r = _rng.NextDouble();
             if (r > 0.95) return UptimeStatus.Major;
             if (r > 0.90) return UptimeStatus.Minor;
             if (r > 0.85) return UptimeStatus.Maintenance;

--- a/Tesserae.Tests/src/Samples/SampleDate.cs
+++ b/Tesserae.Tests/src/Samples/SampleDate.cs
@@ -1,0 +1,28 @@
+using System;
+
+namespace Tesserae.Tests.Samples
+{
+    /// <summary>
+    /// The instant the samples pretend "now" is. A sample that renders a date — a pre-filled picker,
+    /// a chart's time axis, a histogram of events — reads as stale if it is pinned to a date in the
+    /// past, but reads differently on every run if it is pinned to the clock, which is noise in any
+    /// diff of the gallery. This is the compromise: a fixed day of the *current* year, so the page
+    /// never looks out of date and still renders the same text all year.
+    /// </summary>
+    /// <remarks>
+    /// Only the values a sample *displays* are anchored here. Validation rules that judge what the
+    /// user just typed (<c>Validation.NotInThePast</c> and friends) stay on the real clock — they
+    /// are about the person using the page, and they render nothing until someone interacts.
+    /// </remarks>
+    public static class SampleDate
+    {
+        /// <summary>May 25th of the current year, at midnight.</summary>
+        public static DateTime Today => new DateTime(DateTime.Today.Year, 5, 25);
+
+        /// <summary>May 25th of the current year, at 09:41.</summary>
+        public static DateTime Now => Today.AddHours(9).AddMinutes(41);
+
+        /// <summary>The given moment as seconds since the Unix epoch, for charts on a time axis.</summary>
+        public static double UnixSeconds(DateTime value) => (value - new DateTime(1970, 1, 1)).TotalSeconds;
+    }
+}

--- a/Tesserae.Tests/src/Samples/SampleRandom.cs
+++ b/Tesserae.Tests/src/Samples/SampleRandom.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Text;
+
+namespace Tesserae.Tests.Samples
+{
+    /// <summary>
+    /// A seeded random number generator for the samples. Samples that fake data (uptime history,
+    /// metrics, card heights, chat replies, node ids) used to call <c>new Random()</c>,
+    /// <c>Math.Random()</c> or <c>Guid.NewGuid()</c>, so every reload rendered something different
+    /// and any two captures of the gallery differed for reasons that had nothing to do with the
+    /// change under test. Each sample owns a <see cref="SampleRandom"/> with a fixed seed instead,
+    /// so a page renders the same numbers on every run and a text or pixel diff only shows real
+    /// differences.
+    /// </summary>
+    /// <remarks>
+    /// It is a thin wrapper over a seeded <see cref="Random"/> rather than its own generator:
+    /// Transpose's <c>Random</c> is a faithful port of the .NET one, sequence-compatible value for
+    /// value, so a seed is all determinism takes. What this type adds is that a seed is the *only*
+    /// way to construct it, a name that says why, and the few helpers the samples need.
+    /// <para>
+    /// Each sample passes its own seed so two samples on screen do not show the same shape of data,
+    /// and so the sequence a page sees does not depend on which pages were opened before it. The
+    /// seed value itself carries no meaning beyond "always the same".
+    /// </para>
+    /// </remarks>
+    public sealed class SampleRandom
+    {
+        /// <summary>The seed used when a sample does not care to pick one.</summary>
+        public const int DefaultSeed = 20240613;
+
+        private const string HexDigits = "0123456789abcdef";
+
+        private readonly int    _seed;
+        private          Random _random;
+
+        /// <param name="seed">Any integer, as long as it is a constant.</param>
+        public SampleRandom(int seed = DefaultSeed)
+        {
+            _seed   = seed;
+            _random = new Random(seed);
+        }
+
+        /// <summary>Rewinds to the seed, so the next call starts the same sequence over again.</summary>
+        public void Reset() => _random = new Random(_seed);
+
+        /// <summary>Returns a value in [0, 1).</summary>
+        public double NextDouble() => _random.NextDouble();
+
+        /// <summary>Returns a value in [minInclusive, maxExclusive).</summary>
+        public double NextDouble(double minInclusive, double maxExclusive)
+        {
+            if (maxExclusive <= minInclusive) return minInclusive;
+            return minInclusive + NextDouble() * (maxExclusive - minInclusive);
+        }
+
+        /// <summary>Returns an integer in [0, maxExclusive).</summary>
+        public int Next(int maxExclusive) => maxExclusive <= 0 ? 0 : _random.Next(maxExclusive);
+
+        /// <summary>Returns an integer in [minInclusive, maxExclusive).</summary>
+        public int Next(int minInclusive, int maxExclusive)
+        {
+            if (maxExclusive <= minInclusive) return minInclusive;
+            return _random.Next(minInclusive, maxExclusive);
+        }
+
+        /// <summary>Picks one of the items, or the type's default when the array is empty.</summary>
+        public T Pick<T>(T[] items)
+        {
+            if (items == null || items.Length == 0) return default(T);
+            return items[Next(items.Length)];
+        }
+
+        /// <summary>
+        /// A stand-in for <c>Guid.NewGuid().ToString()</c>: an id of the same shape
+        /// (<c>8-4-4-4-12</c> lowercase hex) drawn from this generator, so a sample that shows its
+        /// own ids — the NodeView sample prints its state as JSON — shows the same ones every run.
+        /// Unique within a sequence, not universally unique; these ids never leave the page.
+        /// </summary>
+        public string NextId()
+        {
+            var id = new StringBuilder(36);
+
+            for (var i = 0; i < 32; i++)
+            {
+                if (i == 8 || i == 12 || i == 16 || i == 20) id.Append('-');
+                id.Append(HexDigits[Next(16)]);
+            }
+
+            return id.ToString();
+        }
+    }
+}

--- a/Tesserae.Tests/src/Samples/Utilities/NodeViewSample.cs
+++ b/Tesserae.Tests/src/Samples/Utilities/NodeViewSample.cs
@@ -61,9 +61,14 @@ namespace Tesserae.Tests.Samples
 
             var stateBuilder = NodeView.State();
 
-            var node1_id  = Guid.NewGuid().ToString();
-            var node1_inp = Guid.NewGuid().ToString();
-            var node1_out = Guid.NewGuid().ToString();
+            // Seeded ids rather than Guid.NewGuid(): the node view prints its whole state as JSON in
+            // the text area below, ids included, so fresh guids would make this page differ from
+            // itself on every load.
+            var ids = new SampleRandom(6_180);
+
+            var node1_id  = ids.NextId();
+            var node1_inp = ids.NextId();
+            var node1_out = ids.NextId();
 
 
             stateBuilder.AddNode(node1_id, "Hello World", "My First Node", 100, 100, 200, nb => nb
@@ -71,15 +76,15 @@ namespace Tesserae.Tests.Samples
                 .AddOutput("out", node1_out)
             );
 
-            var node2_id      = Guid.NewGuid().ToString();
-            var node2_text_id = Guid.NewGuid().ToString(); 
-            var node2_int_id  = Guid.NewGuid().ToString();
-            var node2_num_id  = Guid.NewGuid().ToString();
-            var node2_btn_id  = Guid.NewGuid().ToString();
-            var node2_chk_id  = Guid.NewGuid().ToString();
-            var node2_sel_id  = Guid.NewGuid().ToString();
-            var node2_sld_id  = Guid.NewGuid().ToString();
-            var node2_out_id = Guid.NewGuid().ToString();
+            var node2_id      = ids.NextId();
+            var node2_text_id = ids.NextId(); 
+            var node2_int_id  = ids.NextId();
+            var node2_num_id  = ids.NextId();
+            var node2_btn_id  = ids.NextId();
+            var node2_chk_id  = ids.NextId();
+            var node2_sel_id  = ids.NextId();
+            var node2_sld_id  = ids.NextId();
+            var node2_out_id = ids.NextId();
 
             stateBuilder.AddNode(node2_id, "Complex", "A Complex Node", 400, 100, 320, nb => nb
                 .AddInput("text", node2_text_id , "World")

--- a/Tesserae.Tests/src/Samples/Utilities/TippySample.cs
+++ b/Tesserae.Tests/src/Samples/Utilities/TippySample.cs
@@ -43,7 +43,7 @@ namespace Tesserae.Tests.Samples
 
             content.WhenMounted(() =>
             {
-                var rng = new Random();
+                var rng = new SampleRandom(8_808);
                 var repeat = window.setInterval(_ =>
                 {
                     size.Value = rng.Next(0, 10) * 50 + 50;

--- a/Tesserae/src/Components/PixelAvatar.Data.cs
+++ b/Tesserae/src/Components/PixelAvatar.Data.cs
@@ -275,10 +275,17 @@ namespace Tesserae
     }
 
     /// <summary>
-    /// Random numbers for the avatar's own timing. Exists because
-    /// <c>Random.Next(minValue, maxValue)</c> is broken under Transpose - it always returns
-    /// minValue - so everything goes through the single-argument overload, which works.
+    /// Random numbers for the avatar's own timing: an inclusive-range draw and the jitter every
+    /// timing here is spread by, in one place so the animation code reads as intent rather than
+    /// arithmetic.
     /// </summary>
+    /// <remarks>
+    /// This used to say <c>Random.Next(minValue, maxValue)</c> was broken under Transpose (always
+    /// returning minValue), which is why everything goes through the single-argument overload. That
+    /// is no longer true - the current compiler emits the two-argument overload correctly and its
+    /// output matches .NET value for value for a given seed - so the workaround is only a habit now,
+    /// kept because <see cref="Between"/> is inclusive of its upper bound and <c>Next</c> is not.
+    /// </remarks>
     [Transpose.Name("tss.PixelAvatarRandom")]
     internal static class PixelAvatarRandom
     {


### PR DESCRIPTION
Samples that render faked data now use deterministic sources instead of the clock and unseeded randomness, so gallery captures differ only where the change under test made them differ.

## Summary

Two new utilities stabilize sample rendering:

- **`SampleRandom`**: A seeded `Random` wrapper that replaces `new Random()`, `Math.Random()`, and `Guid.NewGuid()` in samples. Each sample owns an instance with a fixed seed, so the sequence of generated values is identical on every run and across page reloads. `NextId()` generates GUID-shaped hex strings (8-4-4-4-12 format) for samples that display their own ids (e.g., `NodeViewSample` prints state as JSON).

- **`SampleDate`**: A static class that anchors displayed dates to May 25th of the current year (at midnight for `Today`, 09:41 for `Now`), so pages render stable text all year without looking stale. Validation rules that judge user input stay on the real clock—they are about the person using the page, not the sample's fake data.

## Changes

- **New files**:
  - `Tesserae.Tests/src/Samples/SampleRandom.cs` — seeded RNG with helpers for doubles, ints, array picks, and GUID-shaped ids
  - `Tesserae.Tests/src/Samples/SampleDate.cs` — fixed-year date anchors for display values

- **Updated samples** to use `SampleRandom` and `SampleDate`:
  - `NodeViewSample` — replaces `Guid.NewGuid()` with `SampleRandom.NextId()` for node and port ids
  - `TimeHistogramPickerSample` — anchors all date generators to `SampleDate`
  - `ChartsSample` — seeded randomizer for the "Randomize data" button; time-series start anchored to `SampleDate`
  - `DatePickerSample`, `DateRangePickerSample`, `DateTimePickerSample` — use `SampleDate` for pre-filled and constraint dates
  - `UptimeSample` — seeded RNG for 90-day fake history
  - `KeyedObservableStackSample` — seeded RNG for item colors and shuffle order
  - `MasonrySample`, `ChatSample`, `TippySample` — seeded RNG for card heights, message selection, and animation timing

- **Documentation** (`CLAUDE.md`):
  - New section "Samples must render the same on every run" explaining the rationale and usage
  - Note on expected console noise from the Sandbox sample's intentional script blocking

- **Minor clarification** in `PixelAvatar.Data.cs` remarks: the Transpose `Random.Next(min, max)` bug mentioned in the old comment is no longer true; the workaround is kept only because `Between` is inclusive of its upper bound.

## Rationale

Unseeded randomness and clock-driven dates made every page load render different text and numbers, creating noise in text and pixel diffs of the gallery. With these anchors, a diff now shows only what the change under test actually changed, making it easier to spot regressions and validate visual updates.

https://claude.ai/code/session_01Dbf3gGrrdWuxYNTgxAoNPk