### PR TITLE
Rename PropagateToStackItemParent to PropagateStylesToWrapper

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,9 +194,13 @@ Defined in `Tesserae/src/Extensions/IComponentExtensions.cs`:
   `.GridRowStretch()` — placement inside a `Grid` (call before `Add`).
 - `.AlignStretch()` — `align-self: stretch` on the stack item.
 
-All of these write the CSS property to the element, tag it with a marker
-attribute (`tss-stk-w`, `tss-stk-h`, `tss-stk-fg`, `tss-grd-c`, …), and — if
-the component has already been wrapped — mirror the value onto its wrapper.
+All of these write the CSS property to the element and tag it with a marker
+attribute (`tss-stk-w`, `tss-stk-h`, `tss-stk-fg`, `tss-grd-c`, …) so that a
+container which *does* build a wrapper can hoist the property onto it — see
+`CopyStylesDefinedWithExtension` below. A component implementing
+`ISpecialCaseStyling` suppresses the tagging by answering `false` to
+`PropagateStylesToWrapper`, which is what a component that sizes its own
+container (Masonry, Modal, DetailsList, Diagram) does.
 
 ### How a child becomes a stack/grid item
 

--- a/Tesserae/src/Components/CardPivot.cs
+++ b/Tesserae/src/Components/CardPivot.cs
@@ -37,9 +37,9 @@ namespace Tesserae
         public HTMLElement StylingContainer { get; }
 
         /// <summary>
-        /// Gets whether styling should propagate to the stack item parent.
+        /// Gets whether a sizing helper applied to this component should tag it so a wrapper-building container hoists the style onto the wrapper.
         /// </summary>
-        public bool PropagateToStackItemParent => true;
+        public bool PropagateStylesToWrapper => true;
 
         /// <summary>
         /// Initializes a new instance of this class.

--- a/Tesserae/src/Components/DetailsList.cs
+++ b/Tesserae/src/Components/DetailsList.cs
@@ -61,9 +61,9 @@ namespace Tesserae
         public HTMLElement StylingContainer => _container;
 
         /// <summary>
-        /// Gets or sets the propagate to stack item parent.
+        /// Gets whether a sizing helper applied to this component should tag it so a wrapper-building container hoists the style onto the wrapper.
         /// </summary>
-        public bool PropagateToStackItemParent => false;
+        public bool PropagateStylesToWrapper => false;
 
         /// <summary>
         /// Gets or sets a value indicating whether the component is rendered in compact form.

--- a/Tesserae/src/Components/Diagram.cs
+++ b/Tesserae/src/Components/Diagram.cs
@@ -33,9 +33,9 @@ namespace Tesserae
         public HTMLElement StylingContainer => _container;
 
         /// <summary>
-        /// Gets whether styling should propagate to the stack item parent.
+        /// Gets whether a sizing helper applied to this component should tag it so a wrapper-building container hoists the style onto the wrapper.
         /// </summary>
-        public bool PropagateToStackItemParent => false;
+        public bool PropagateStylesToWrapper => false;
 
         /// <summary>
         /// Initializes a new instance of this class.

--- a/Tesserae/src/Components/Grid.cs
+++ b/Tesserae/src/Components/Grid.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using static Transpose.Core.dom;
 using static Tesserae.UI;
@@ -32,9 +32,9 @@ namespace Tesserae
         public HTMLElement StylingContainer => _grid;
 
         /// <summary>
-        /// Gets or sets the propagate to stack item parent.
+        /// Gets whether a sizing helper applied to this component should tag it so a wrapper-building container hoists the style onto the wrapper.
         /// </summary>
-        public bool PropagateToStackItemParent { get; private set; } = true;
+        public bool PropagateStylesToWrapper { get; private set; } = true;
 
         /// <summary>
         /// Initializes a new instance of this class.
@@ -125,11 +125,6 @@ namespace Tesserae
         {
             HTMLElement item = null;
 
-            if (component.HasOwnProperty("GridItem"))
-            {
-                item = component["GridItem"].As<HTMLElement>();
-            }
-
             if (item is null)
             {
                 var rendered = component.Render();
@@ -185,17 +180,12 @@ namespace Tesserae
         /// </summary>
         public static void SetGridColumn(IComponent component, int start, int end)
         {
-            var (item, rememberAndPropagate) = GetCorrectItemToApplyStyle(component);
-            item.style.gridColumn            = $"{start} / {end}";
+            var (item, markForWrapper) = GetCorrectItemToApplyStyle(component);
+            item.style.gridColumn      = $"{start} / {end}";
 
-            if (rememberAndPropagate)
+            if (markForWrapper)
             {
                 item.setAttribute("tss-grd-c", "");
-
-                if (component.HasOwnProperty("GridItem"))
-                {
-                    component["GridItem"].As<HTMLElement>().style.gridColumn = item.style.gridColumn;
-                }
             }
         }
 
@@ -204,25 +194,20 @@ namespace Tesserae
         /// </summary>
         public static void SetGridRow(IComponent component, int start, int end)
         {
-            var (item, rememberAndPropagate) = GetCorrectItemToApplyStyle(component);
-            item.style.gridRow               = $"{start} / {end}";
+            var (item, markForWrapper) = GetCorrectItemToApplyStyle(component);
+            item.style.gridRow         = $"{start} / {end}";
 
-            if (rememberAndPropagate)
+            if (markForWrapper)
             {
                 item.setAttribute("tss-grd-r", "");
-
-                if (component.HasOwnProperty("GridItem"))
-                {
-                    component["GridItem"].As<HTMLElement>().style.gridRow = item.style.gridRow;
-                }
             }
         }
 
-        internal static (HTMLElement item, bool remember) GetCorrectItemToApplyStyle(IComponent component)
+        internal static (HTMLElement item, bool markForWrapper) GetCorrectItemToApplyStyle(IComponent component)
         {
             if (component is ISpecialCaseStyling specialCase)
             {
-                return (specialCase.StylingContainer, specialCase.PropagateToStackItemParent);
+                return (specialCase.StylingContainer, specialCase.PropagateStylesToWrapper);
             }
             else
             {
@@ -366,7 +351,7 @@ namespace Tesserae
         /// </summary>
         public Grid RemovePropagation()
         {
-            PropagateToStackItemParent = false;
+            PropagateStylesToWrapper = false;
             return this;
         }
 

--- a/Tesserae/src/Components/HorizontalSplitView.cs
+++ b/Tesserae/src/Components/HorizontalSplitView.cs
@@ -27,9 +27,9 @@ namespace Tesserae
         public HTMLElement StylingContainer => _splitContainer;
 
         /// <summary>
-        /// Gets whether styling should propagate to the stack item parent.
+        /// Gets whether a sizing helper applied to this component should tag it so a wrapper-building container hoists the style onto the wrapper.
         /// </summary>
-        public bool PropagateToStackItemParent => true;
+        public bool PropagateStylesToWrapper => true;
 
         /// <summary>
         /// Initializes a new instance of this class.

--- a/Tesserae/src/Components/Image.cs
+++ b/Tesserae/src/Components/Image.cs
@@ -16,9 +16,9 @@ namespace Tesserae
         public HTMLElement StylingContainer => InnerElement;
 
         /// <summary>
-        /// Gets or sets the propagate to stack item parent.
+        /// Gets whether a sizing helper applied to this component should tag it so a wrapper-building container hoists the style onto the wrapper.
         /// </summary>
-        public bool PropagateToStackItemParent { get; private set; }
+        public bool PropagateStylesToWrapper { get; private set; }
 
         /// <summary>
         /// Initializes a new instance of this class.
@@ -45,7 +45,7 @@ namespace Tesserae
                 InnerElement = UI.Image(Att("tss-image", src: source));
             }
 
-            PropagateToStackItemParent = true;
+            PropagateStylesToWrapper = true;
             AttachClick();
             AttachContextMenu();
         }
@@ -136,7 +136,7 @@ namespace Tesserae
         public Image Circle()
         {
             InnerElement.style.borderRadius = "50%";
-            PropagateToStackItemParent      = false;
+            PropagateStylesToWrapper      = false;
             return this;
         }
 

--- a/Tesserae/src/Components/InfiniteScrollingList.cs
+++ b/Tesserae/src/Components/InfiniteScrollingList.cs
@@ -39,9 +39,9 @@ namespace Tesserae
         public HTMLElement StylingContainer => _container;
 
         /// <summary>
-        /// Gets or sets the propagate to stack item parent.
+        /// Gets whether a sizing helper applied to this component should tag it so a wrapper-building container hoists the style onto the wrapper.
         /// </summary>
-        public bool PropagateToStackItemParent => true;
+        public bool PropagateStylesToWrapper => true;
 
 
         /// <summary>

--- a/Tesserae/src/Components/ItemsList.cs
+++ b/Tesserae/src/Components/ItemsList.cs
@@ -33,9 +33,9 @@ namespace Tesserae
         public HTMLElement StylingContainer => _defered.Container;
 
         /// <summary>
-        /// Gets or sets the propagate to stack item parent.
+        /// Gets whether a sizing helper applied to this component should tag it so a wrapper-building container hoists the style onto the wrapper.
         /// </summary>
-        public bool PropagateToStackItemParent => true;
+        public bool PropagateStylesToWrapper => true;
 
         /// <summary>
         /// Initializes a new instance of this class.

--- a/Tesserae/src/Components/KeyedObservableStack.cs
+++ b/Tesserae/src/Components/KeyedObservableStack.cs
@@ -109,9 +109,9 @@ namespace Tesserae
         public HTMLElement StylingContainer => InnerElement;
 
         /// <summary>
-        /// Gets or sets the propagate to stack item parent.
+        /// Gets whether a sizing helper applied to this component should tag it so a wrapper-building container hoists the style onto the wrapper.
         /// </summary>
-        public bool PropagateToStackItemParent { get; private set; } = true;
+        public bool PropagateStylesToWrapper { get; private set; } = true;
 
 
         /// <summary>
@@ -190,7 +190,7 @@ namespace Tesserae
         /// </summary>
         public KeyedObservableStack RemovePropagation()
         {
-            PropagateToStackItemParent = false;
+            PropagateStylesToWrapper = false;
             return this;
         }
 

--- a/Tesserae/src/Components/Label.cs
+++ b/Tesserae/src/Components/Label.cs
@@ -105,7 +105,7 @@ namespace Tesserae
         }
 
         HTMLElement ISpecialCaseStyling.StylingContainer           => InnerElement;
-        bool ISpecialCaseStyling.       PropagateToStackItemParent => true;
+        bool ISpecialCaseStyling.       PropagateStylesToWrapper => true;
 
         /// <summary>
         /// Sets the content of the component.

--- a/Tesserae/src/Components/Masonry.cs
+++ b/Tesserae/src/Components/Masonry.cs
@@ -35,9 +35,9 @@ namespace Tesserae
         public  HTMLElement StylingContainer => _masonry;
         private double      _timeout;
         /// <summary>
-        /// Gets or sets the propagate to stack item parent.
+        /// Gets whether a sizing helper applied to this component should tag it so a wrapper-building container hoists the style onto the wrapper.
         /// </summary>
-        public  bool        PropagateToStackItemParent => false;
+        public  bool        PropagateStylesToWrapper => false;
 
         /// <summary>
         /// Initializes a new instance of this class.

--- a/Tesserae/src/Components/Modal.cs
+++ b/Tesserae/src/Components/Modal.cs
@@ -57,9 +57,9 @@ namespace Tesserae
         public HTMLElement StylingContainer => _modal;
 
         /// <summary>
-        /// Gets or sets the propagate to stack item parent.
+        /// Gets whether a sizing helper applied to this component should tag it so a wrapper-building container hoists the style onto the wrapper.
         /// </summary>
-        public bool PropagateToStackItemParent => false;
+        public bool PropagateStylesToWrapper => false;
 
         /// <summary>
         /// Gets or sets the CSS background of the component.

--- a/Tesserae/src/Components/Pivot.cs
+++ b/Tesserae/src/Components/Pivot.cs
@@ -78,9 +78,9 @@ namespace Tesserae
         public HTMLElement StylingContainer { get; }
 
         /// <summary>
-        /// Gets or sets the propagate to stack item parent.
+        /// Gets whether a sizing helper applied to this component should tag it so a wrapper-building container hoists the style onto the wrapper.
         /// </summary>
-        public bool PropagateToStackItemParent => true;
+        public bool PropagateStylesToWrapper => true;
 
         /// <summary>
         /// Configures the component to justified.

--- a/Tesserae/src/Components/PivotSelector.cs
+++ b/Tesserae/src/Components/PivotSelector.cs
@@ -37,9 +37,9 @@ namespace Tesserae
         public HTMLElement StylingContainer { get; }
 
         /// <summary>
-        /// Gets whether styling should propagate to the stack item parent.
+        /// Gets whether a sizing helper applied to this component should tag it so a wrapper-building container hoists the style onto the wrapper.
         /// </summary>
-        public bool PropagateToStackItemParent => true;
+        public bool PropagateStylesToWrapper => true;
 
         /// <summary>
         /// Initializes a new instance of this class.

--- a/Tesserae/src/Components/PixelAvatar.cs
+++ b/Tesserae/src/Components/PixelAvatar.cs
@@ -989,8 +989,8 @@ namespace Tesserae
         /// avatar stays anchored to the target's edges.</summary>
         public HTMLElement StylingContainer => _host;
 
-        /// <summary>Gets whether styling should propagate to the stack item parent.</summary>
-        public bool PropagateToStackItemParent => true;
+        /// <summary>Gets whether a sizing helper applied to this component should tag it so a wrapper-building container hoists the style onto the wrapper.</summary>
+        public bool PropagateStylesToWrapper => true;
 
         /// <summary>
         /// Moves the avatar to a different edge of the target.

--- a/Tesserae/src/Components/Sandbox.cs
+++ b/Tesserae/src/Components/Sandbox.cs
@@ -73,8 +73,8 @@ namespace Tesserae
 
         /// <summary>The element that receives sizing styles (the iframe itself).</summary>
         public HTMLElement StylingContainer           => InnerElement;
-        /// <summary>Styling propagates up to the stack item parent.</summary>
-        public bool        PropagateToStackItemParent => true;
+        /// <summary>Gets whether a sizing helper applied to this component should tag it so a wrapper-building container hoists the style onto the wrapper.</summary>
+        public bool        PropagateStylesToWrapper => true;
 
         private string _html;
         private string _url;

--- a/Tesserae/src/Components/SearchableGroupedList.cs
+++ b/Tesserae/src/Components/SearchableGroupedList.cs
@@ -35,9 +35,9 @@ namespace Tesserae
         /// </summary>
         public HTMLElement                StylingContainer           => _stack.InnerElement;
         /// <summary>
-        /// Gets or sets the propagate to stack item parent.
+        /// Gets whether a sizing helper applied to this component should tag it so a wrapper-building container hoists the style onto the wrapper.
         /// </summary>
-        public bool                       PropagateToStackItemParent => true;
+        public bool                       PropagateStylesToWrapper => true;
         /// <summary>
         /// Adds the given items to the component.
         /// </summary>

--- a/Tesserae/src/Components/SearchableList.cs
+++ b/Tesserae/src/Components/SearchableList.cs
@@ -37,9 +37,9 @@ namespace Tesserae
         /// </summary>
         public  HTMLElement       StylingContainer           => _stack.InnerElement;
         /// <summary>
-        /// Gets or sets the propagate to stack item parent.
+        /// Gets whether a sizing helper applied to this component should tag it so a wrapper-building container hoists the style onto the wrapper.
         /// </summary>
-        public  bool              PropagateToStackItemParent => true;
+        public  bool              PropagateStylesToWrapper => true;
         /// <summary>
         /// Adds the given items to the component.
         /// </summary>

--- a/Tesserae/src/Components/SectionStack.cs
+++ b/Tesserae/src/Components/SectionStack.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using Transpose;
 using static Tesserae.UI;
 using static Transpose.Core.dom;
@@ -58,11 +58,6 @@ namespace Tesserae
                 item.style.overflow  = "hidden";
 
                 (component as dynamic).SectionStackItem = item;
-            }
-
-            if (component.HasOwnProperty("StackItem"))
-            {
-                Transpose.Script.Delete(component["StackItem"]);
             }
 
             item.style.height     = grow ? "10px" : "auto";

--- a/Tesserae/src/Components/SegmentedPivot.cs
+++ b/Tesserae/src/Components/SegmentedPivot.cs
@@ -53,9 +53,9 @@ namespace Tesserae
         public HTMLElement StylingContainer { get; }
 
         /// <summary>
-        /// Gets whether styling should propagate to the stack item parent.
+        /// Gets whether a sizing helper applied to this component should tag it so a wrapper-building container hoists the style onto the wrapper.
         /// </summary>
-        public bool PropagateToStackItemParent => true;
+        public bool PropagateStylesToWrapper => true;
 
         /// <summary>
         /// Initializes a new instance of this class.

--- a/Tesserae/src/Components/SortableStack/SortableStack.cs
+++ b/Tesserae/src/Components/SortableStack/SortableStack.cs
@@ -156,8 +156,8 @@ namespace Tesserae
         /// <summary>Gets the styling container.</summary>
         public dom.HTMLElement StylingContainer           => _container.StylingContainer;
 
-        /// <summary>Gets whether styling should propagate to the stack item parent.</summary>
-        public bool            PropagateToStackItemParent => _container.PropagateToStackItemParent;
+        /// <summary>Gets whether a sizing helper applied to this component should tag it so a wrapper-building container hoists the style onto the wrapper.</summary>
+        public bool            PropagateStylesToWrapper => _container.PropagateStylesToWrapper;
 
         /// <summary>Gets or sets whether the stack can wrap its items.</summary>
         public bool CanWrap

--- a/Tesserae/src/Components/SplitView.cs
+++ b/Tesserae/src/Components/SplitView.cs
@@ -27,9 +27,9 @@ namespace Tesserae
         public HTMLElement StylingContainer => _splitContainer;
 
         /// <summary>
-        /// Gets whether styling should propagate to the stack item parent.
+        /// Gets whether a sizing helper applied to this component should tag it so a wrapper-building container hoists the style onto the wrapper.
         /// </summary>
-        public bool PropagateToStackItemParent => true;
+        public bool PropagateStylesToWrapper => true;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SplitView"/> class.

--- a/Tesserae/src/Components/Stack.cs
+++ b/Tesserae/src/Components/Stack.cs
@@ -78,8 +78,8 @@ namespace Tesserae
         /// <summary>Gets the styling container.</summary>
         public HTMLElement StylingContainer => InnerElement;
 
-        /// <summary>Gets or sets whether to propagate styling to the stack item parent.</summary>
-        public bool PropagateToStackItemParent { get; private set; } = true;
+        /// <summary>Gets whether a sizing helper applied to this component should tag it so a wrapper-building container hoists the style onto the wrapper.</summary>
+        public bool PropagateStylesToWrapper { get; private set; } = true;
 
         /// <summary>
         /// Sets the alignment for a component within a stack.
@@ -88,7 +88,7 @@ namespace Tesserae
         /// <param name="align">The alignment.</param>
         public static void SetAlign(IComponent component, ItemAlign align)
         {
-            var (item, remember) = GetCorrectItemToApplyStyle(component);
+            var (item, markForWrapper) = GetCorrectItemToApplyStyle(component);
             var cssAlign = align.ToString();
 
             if (cssAlign == "end" || cssAlign == "start")
@@ -98,18 +98,9 @@ namespace Tesserae
 
             item.style.alignSelf = cssAlign;
 
-            if (remember)
+            if (markForWrapper)
             {
                 Mark(item, "tss-stk-as");
-
-                if (component.HasOwnProperty("StackItem"))
-                {
-                    component["StackItem"].As<HTMLElement>().style.alignSelf = item.style.alignSelf;
-                }
-                else if (component.HasOwnProperty("GridItem"))
-                {
-                    component["GridItem"].As<HTMLElement>().style.justifySelf = item.style.justifySelf;
-                }
             }
         }
 
@@ -120,7 +111,7 @@ namespace Tesserae
         /// <param name="align">The justification.</param>
         public static void SetJustify(IComponent component, ItemJustify align)
         {
-            var (item, remember) = GetCorrectItemToApplyStyle(component);
+            var (item, markForWrapper) = GetCorrectItemToApplyStyle(component);
             var cssAlign = align.ToString();
 
             if (cssAlign == "end" || cssAlign == "start")
@@ -130,18 +121,9 @@ namespace Tesserae
 
             item.style.justifySelf = cssAlign;
 
-            if (remember)
+            if (markForWrapper)
             {
                 Mark(item, "tss-stk-js");
-
-                if (component.HasOwnProperty("StackItem"))
-                {
-                    component["StackItem"].As<HTMLElement>().style.justifySelf = item.style.justifySelf;
-                }
-                else if (component.HasOwnProperty("GridItem"))
-                {
-                    component["GridItem"].As<HTMLElement>().style.justifySelf = item.style.justifySelf;
-                }
             }
         }
 
@@ -260,11 +242,11 @@ namespace Tesserae
             return this;
         }
 
-        internal static (HTMLElement item, bool remember) GetCorrectItemToApplyStyle(IComponent component)
+        internal static (HTMLElement item, bool markForWrapper) GetCorrectItemToApplyStyle(IComponent component)
         {
             if (component is ISpecialCaseStyling specialCase)
             {
-                return (specialCase.StylingContainer, specialCase.PropagateToStackItemParent);
+                return (specialCase.StylingContainer, specialCase.PropagateStylesToWrapper);
             }
             else
             {
@@ -273,12 +255,12 @@ namespace Tesserae
         }
 
         /// <summary>
-        /// Disables propagation of styling to the stack item parent.
+        /// Stops sizing helpers applied to this stack from being tagged for a wrapper-building container to hoist.
         /// </summary>
         /// <returns>The current instance.</returns>
         public Stack RemovePropagation()
         {
-            PropagateToStackItemParent = false;
+            PropagateStylesToWrapper = false;
             return this;
         }
 
@@ -296,227 +278,162 @@ namespace Tesserae
 
         public static void SetWidth(IComponent component, UnitSize unitSize)
         {
-            var (item, remember) = GetCorrectItemToApplyStyle(component);
-            item.style.width     = unitSize.ToString();
+            var (item, markForWrapper) = GetCorrectItemToApplyStyle(component);
+            item.style.width           = unitSize.ToString();
 
             if (!item.hasAttribute(ExplicitMinWidth)) item.style.minWidth = "0";
 
-            if (remember)
+            if (markForWrapper)
             {
                 Mark(item, "tss-stk-w");
-
-                if (component.HasOwnProperty("StackItem"))
-                {
-                    component["StackItem"].As<HTMLElement>().style.width = item.style.width;
-                }
             }
         }
 
         /// <summary>Sets the minimum width of a component within a stack.</summary>
         public static void SetMinWidth(IComponent component, UnitSize unitSize)
         {
-            var (item, remember) = GetCorrectItemToApplyStyle(component);
-            item.style.minWidth  = unitSize.ToString();
+            var (item, markForWrapper) = GetCorrectItemToApplyStyle(component);
+            item.style.minWidth        = unitSize.ToString();
             item.setAttribute(ExplicitMinWidth, "");
 
-            if (remember)
+            if (markForWrapper)
             {
                 Mark(item, "tss-stk-mw");
-
-                if (component.HasOwnProperty("StackItem"))
-                {
-                    component["StackItem"].As<HTMLElement>().style.minWidth = item.style.minWidth;
-                }
             }
         }
 
         /// <summary>Sets the maximum width of a component within a stack.</summary>
         public static void SetMaxWidth(IComponent component, UnitSize unitSize)
         {
-            var (item, remember) = GetCorrectItemToApplyStyle(component);
-            item.style.maxWidth  = unitSize.ToString();
+            var (item, markForWrapper) = GetCorrectItemToApplyStyle(component);
+            item.style.maxWidth        = unitSize.ToString();
 
-            if (remember)
+            if (markForWrapper)
             {
                 Mark(item, "tss-stk-mxw");
-
-                if (component.HasOwnProperty("StackItem"))
-                {
-                    component["StackItem"].As<HTMLElement>().style.maxWidth = item.style.maxWidth;
-                }
             }
         }
 
         /// <summary>Sets the height of a component within a stack.</summary>
         public static void SetHeight(IComponent component, UnitSize unitSize)
         {
-            var (item, remember) = GetCorrectItemToApplyStyle(component);
-            item.style.height    = unitSize.ToString();
+            var (item, markForWrapper) = GetCorrectItemToApplyStyle(component);
+            item.style.height          = unitSize.ToString();
 
             if (!item.hasAttribute(ExplicitMinHeight)) item.style.minHeight = "0";
 
-            if (remember)
+            if (markForWrapper)
             {
                 Mark(item, "tss-stk-h");
-
-                if (component.HasOwnProperty("StackItem"))
-                {
-                    component["StackItem"].As<HTMLElement>().style.height = item.style.height;
-                }
             }
         }
 
         /// <summary>Sets the minimum height of a component within a stack.</summary>
         public static void SetMinHeight(IComponent component, UnitSize unitSize)
         {
-            var (item, remember) = GetCorrectItemToApplyStyle(component);
-            item.style.minHeight = unitSize.ToString();
+            var (item, markForWrapper) = GetCorrectItemToApplyStyle(component);
+            item.style.minHeight       = unitSize.ToString();
             item.setAttribute(ExplicitMinHeight, "");
 
-            if (remember)
+            if (markForWrapper)
             {
                 Mark(item, "tss-stk-mh");
-
-                if (component.HasOwnProperty("StackItem"))
-                {
-                    component["StackItem"].As<HTMLElement>().style.minHeight = item.style.minHeight;
-                }
             }
         }
 
         /// <summary>Sets the maximum height of a component within a stack.</summary>
         public static void SetMaxHeight(IComponent component, UnitSize unitSize)
         {
-            var (item, remember) = GetCorrectItemToApplyStyle(component);
-            item.style.maxHeight = unitSize.ToString();
+            var (item, markForWrapper) = GetCorrectItemToApplyStyle(component);
+            item.style.maxHeight       = unitSize.ToString();
 
-            if (remember)
+            if (markForWrapper)
             {
                 Mark(item, "tss-stk-mxh");
-
-                if (component.HasOwnProperty("StackItem"))
-                {
-                    component["StackItem"].As<HTMLElement>().style.maxHeight = item.style.maxHeight;
-                }
             }
         }
 
         /// <summary>Sets the left margin of a component within a stack.</summary>
         public static void SetMarginLeft(IComponent component, UnitSize unitSize)
         {
-            var (item, remember)  = GetCorrectItemToApplyStyle(component);
-            item.style.marginLeft = unitSize.ToString();
+            var (item, markForWrapper) = GetCorrectItemToApplyStyle(component);
+            item.style.marginLeft      = unitSize.ToString();
 
-            if (remember)
+            if (markForWrapper)
             {
                 Mark(item, "tss-stk-m");
-
-                if (component.HasOwnProperty("StackItem"))
-                {
-                    component["StackItem"].As<HTMLElement>().style.marginLeft = item.style.marginLeft;
-                }
             }
         }
 
         /// <summary>Sets the right margin of a component within a stack.</summary>
         public static void SetMarginRight(IComponent component, UnitSize unitSize)
         {
-            var (item, remember)   = GetCorrectItemToApplyStyle(component);
-            item.style.marginRight = unitSize.ToString();
+            var (item, markForWrapper) = GetCorrectItemToApplyStyle(component);
+            item.style.marginRight     = unitSize.ToString();
 
-            if (remember)
+            if (markForWrapper)
             {
                 Mark(item, "tss-stk-m");
-
-                if (component.HasOwnProperty("StackItem"))
-                {
-                    component["StackItem"].As<HTMLElement>().style.marginRight = item.style.marginRight;
-                }
             }
         }
 
         /// <summary>Sets the top margin of a component within a stack.</summary>
         public static void SetMarginTop(IComponent component, UnitSize unitSize)
         {
-            var (item, remember) = GetCorrectItemToApplyStyle(component);
-            item.style.marginTop = unitSize.ToString();
+            var (item, markForWrapper) = GetCorrectItemToApplyStyle(component);
+            item.style.marginTop       = unitSize.ToString();
 
-            if (remember)
+            if (markForWrapper)
             {
                 Mark(item, "tss-stk-m");
-
-                if (component.HasOwnProperty("StackItem"))
-                {
-                    component["StackItem"].As<HTMLElement>().style.marginTop = item.style.marginTop;
-                }
             }
         }
 
         /// <summary>Sets the bottom margin of a component within a stack.</summary>
         public static void SetMarginBottom(IComponent component, UnitSize unitSize)
         {
-            var (item, remember)    = GetCorrectItemToApplyStyle(component);
-            item.style.marginBottom = unitSize.ToString();
+            var (item, markForWrapper) = GetCorrectItemToApplyStyle(component);
+            item.style.marginBottom    = unitSize.ToString();
 
-            if (remember)
+            if (markForWrapper)
             {
                 Mark(item, "tss-stk-m");
-
-                if (component.HasOwnProperty("StackItem"))
-                {
-                    component["StackItem"].As<HTMLElement>().style.marginBottom = item.style.marginBottom;
-                }
             }
         }
 
         /// <summary>Sets the left padding of a component within a stack.</summary>
         public static void SetPaddingLeft(IComponent component, UnitSize unitSize)
         {
-            var (item, remember)   = GetCorrectItemToApplyStyle(component);
-            item.style.paddingLeft = unitSize.ToString();
+            var (item, markForWrapper) = GetCorrectItemToApplyStyle(component);
+            item.style.paddingLeft     = unitSize.ToString();
 
-            if (remember)
+            if (markForWrapper)
             {
                 Mark(item, "tss-stk-p");
-
-                if (component.HasOwnProperty("StackItem"))
-                {
-                    component["StackItem"].As<HTMLElement>().style.paddingLeft = item.style.paddingLeft;
-                }
             }
         }
 
         /// <summary>Sets the right padding of a component within a stack.</summary>
         public static void SetPaddingRight(IComponent component, UnitSize unitSize)
         {
-            var (item, remember)    = GetCorrectItemToApplyStyle(component);
-            item.style.paddingRight = unitSize.ToString();
+            var (item, markForWrapper) = GetCorrectItemToApplyStyle(component);
+            item.style.paddingRight    = unitSize.ToString();
 
-            if (remember)
+            if (markForWrapper)
             {
                 Mark(item, "tss-stk-p");
-
-                if (component.HasOwnProperty("StackItem"))
-                {
-                    component["StackItem"].As<HTMLElement>().style.paddingRight = item.style.paddingRight;
-                }
             }
         }
 
         /// <summary>Sets the top padding of a component within a stack.</summary>
         public static void SetPaddingTop(IComponent component, UnitSize unitSize)
         {
-            var (item, remember)  = GetCorrectItemToApplyStyle(component);
-            item.style.paddingTop = unitSize.ToString();
+            var (item, markForWrapper) = GetCorrectItemToApplyStyle(component);
+            item.style.paddingTop      = unitSize.ToString();
 
-            if (remember)
+            if (markForWrapper)
             {
                 Mark(item, "tss-stk-p");
-
-                if (component.HasOwnProperty("StackItem"))
-                {
-                    component["StackItem"].As<HTMLElement>().style.paddingTop = item.style.paddingTop;
-                }
             }
 
         }
@@ -524,17 +441,12 @@ namespace Tesserae
         /// <summary>Sets the bottom padding of a component within a stack.</summary>
         public static void SetPaddingBottom(IComponent component, UnitSize unitSize)
         {
-            var (item, remember)     = GetCorrectItemToApplyStyle(component);
-            item.style.paddingBottom = unitSize.ToString();
+            var (item, markForWrapper) = GetCorrectItemToApplyStyle(component);
+            item.style.paddingBottom   = unitSize.ToString();
 
-            if (remember)
+            if (markForWrapper)
             {
                 Mark(item, "tss-stk-p");
-
-                if (component.HasOwnProperty("StackItem"))
-                {
-                    component["StackItem"].As<HTMLElement>().style.paddingBottom = item.style.paddingBottom;
-                }
             }
 
         }
@@ -542,34 +454,24 @@ namespace Tesserae
         /// <summary>Sets the flex-grow of a component within a stack.</summary>
         public static void SetGrow(IComponent component, int grow)
         {
-            var (item, remember) = GetCorrectItemToApplyStyle(component);
-            item.style.flexGrow  = grow.ToString();
+            var (item, markForWrapper) = GetCorrectItemToApplyStyle(component);
+            item.style.flexGrow        = grow.ToString();
 
-            if (remember)
+            if (markForWrapper)
             {
                 Mark(item, "tss-stk-fg");
-
-                if (component.HasOwnProperty("StackItem"))
-                {
-                    component["StackItem"].As<HTMLElement>().style.flexGrow = item.style.flexGrow;
-                }
             }
         }
 
         /// <summary>Sets the flex-shrink of a component within a stack.</summary>
         public static void SetShrink(IComponent component, bool shrink)
         {
-            var (item, remember)  = GetCorrectItemToApplyStyle(component);
-            item.style.flexShrink = shrink ? "1" : "0";
+            var (item, markForWrapper) = GetCorrectItemToApplyStyle(component);
+            item.style.flexShrink      = shrink ? "1" : "0";
 
-            if (remember)
+            if (markForWrapper)
             {
                 Mark(item, "tss-stk-fs");
-
-                if (component.HasOwnProperty("StackItem"))
-                {
-                    component["StackItem"].As<HTMLElement>().style.flexShrink = item.style.flexShrink;
-                }
             }
         }
 
@@ -785,11 +687,6 @@ namespace Tesserae
                 {
                     item = component["SectionStackItem"] as HTMLElement;
                 }
-            }
-
-            if (item is null && component.HasOwnProperty("StackItem"))
-            {
-                item = component["StackItem"] as HTMLElement;
             }
 
             if (item is null)

--- a/Tesserae/src/Components/TutorialModal.cs
+++ b/Tesserae/src/Components/TutorialModal.cs
@@ -27,9 +27,9 @@ namespace Tesserae
         public HTMLElement StylingContainer => _modal.StylingContainer;
 
         /// <summary>
-        /// Gets whether styling should propagate to the stack item parent.
+        /// Gets whether a sizing helper applied to this component should tag it so a wrapper-building container hoists the style onto the wrapper.
         /// </summary>
-        public bool PropagateToStackItemParent => _modal.PropagateToStackItemParent;
+        public bool PropagateStylesToWrapper => _modal.PropagateStylesToWrapper;
 
         /// <summary>
         /// Initializes a new instance of the TutorialModal class.

--- a/Tesserae/src/Interfaces/ISpecialCaseStyling.cs
+++ b/Tesserae/src/Interfaces/ISpecialCaseStyling.cs
@@ -10,8 +10,13 @@ namespace Tesserae
     public interface ISpecialCaseStyling
     {
         /// <summary>Gets the HTMLElement that should receive styling.</summary>
-        HTMLElement StylingContainer           { get; }
-        /// <summary>Gets whether styling should propagate to the stack item parent.</summary>
-        bool        PropagateToStackItemParent { get; }
+        HTMLElement StylingContainer         { get; }
+        // Stack and Grid no longer wrap their children, so there is no stack-item parent to
+        // propagate to — this now only decides whether a sizing helper also tags the element with
+        // the tss-stk-*/tss-grd-* markers. Masonry, SectionStack and KeyedObservableStack still
+        // build real wrappers, and CopyStylesDefinedWithExtension reads those markers to move the
+        // property onto the wrapper. A component that sizes its own container says false.
+        /// <summary>Gets whether a sizing helper applied to this component should also tag it, so a wrapper-building container hoists the style onto the wrapper.</summary>
+        bool        PropagateStylesToWrapper { get; }
     }
 }


### PR DESCRIPTION
## Summary

Refactors the `ISpecialCaseStyling` interface and all implementing components to clarify the semantics of the `PropagateToStackItemParent` property. The property is renamed to `PropagateStylesToWrapper` and its documentation is updated to reflect that it controls whether sizing helpers tag elements with marker attributes (`tss-stk-*`, `tss-grd-*`) for wrapper-building containers to hoist styles onto, rather than directly propagating to a stack item parent.

## Key Changes

- **Interface update** (`ISpecialCaseStyling.cs`): Renamed `PropagateToStackItemParent` → `PropagateStylesToWrapper` with clarified documentation explaining that Stack and Grid no longer wrap their children, but containers like Masonry, SectionStack, and KeyedObservableStack still do and use the marker attributes to move properties onto wrappers.

- **Stack.cs**: 
  - Renamed property and updated all references throughout sizing helper methods (`SetWidth`, `SetHeight`, `SetMargin*`, `SetPadding*`, `SetGrow`, `SetShrink`, `SetAlign`, `SetJustify`)
  - Removed redundant code that directly mirrored styles onto `StackItem` and `GridItem` properties—this is now handled by `CopyStylesDefinedWithExtension` reading the marker attributes
  - Renamed local variable `remember` → `markForWrapper` for clarity
  - Updated `RemovePropagation()` method documentation

- **Grid.cs**: 
  - Renamed property and updated `SetGridColumn` and `SetGridRow` methods
  - Removed redundant style mirroring code
  - Renamed local variable `rememberAndPropagate` → `markForWrapper`
  - Updated `RemovePropagation()` method documentation

- **All implementing components** (Image, KeyedObservableStack, CardPivot, DetailsList, Diagram, HorizontalSplitView, InfiniteScrollingList, ItemsList, Masonry, Modal, Pivot, PivotSelector, PixelAvatar, Sandbox, SearchableGroupedList, SearchableList, SegmentedPivot, SortableStack, SplitView, TutorialModal, Label): Updated property name and documentation.

- **SectionStack.cs**: Removed code that deleted the `StackItem` property from components.

- **CLAUDE.md**: Updated documentation to explain the new marker-based approach and how `CopyStylesDefinedWithExtension` uses the markers to hoist styles onto wrappers.

## Implementation Details

The refactoring clarifies the architecture: sizing helpers now consistently tag elements with marker attributes when `PropagateStylesToWrapper` is true, and wrapper-building containers (Masonry, SectionStack, KeyedObservableStack) read those markers via `CopyStylesDefinedWithExtension` to move the properties onto their wrappers. Components that size their own container (Modal, DetailsList, Diagram) return false to suppress tagging since they don't need the hoisting behavior.

https://claude.ai/code/session_01KesU8QToAN1NtAxPzgdnJp