### PR TITLE
Update Transpose.Build.Target and dependency packages

### DIFF
--- a/Tesserae.Bench/Tesserae.Bench.csproj
+++ b/Tesserae.Bench/Tesserae.Bench.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Transpose.Build.Target/26.7.3049">
+﻿<Project Sdk="Transpose.Build.Target/26.8.4125">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <!-- playwright/node_modules sits inside this folder; keep the default globs away from it -->
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Transpose.BCL" Version="26.8.4093" />
+    <PackageReference Include="Transpose.BCL" Version="26.8.4131" />
     <PackageReference Include="Transpose.Core" Version="26.7.3304" />
   </ItemGroup>
 

--- a/Tesserae.Tests/Tesserae.Tests.csproj
+++ b/Tesserae.Tests/Tesserae.Tests.csproj
@@ -1,10 +1,10 @@
-﻿<Project Sdk="Transpose.Build.Target/26.7.3049">
+﻿<Project Sdk="Transpose.Build.Target/26.8.4125">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Transpose.BCL" Version="26.8.4102" />
+    <PackageReference Include="Transpose.BCL" Version="26.8.4131" />
     <PackageReference Include="Transpose.Core" Version="26.7.3304" />
   </ItemGroup>
 

--- a/Tesserae/Tesserae.csproj
+++ b/Tesserae/Tesserae.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Transpose.Build.Target/26.7.3049">
+﻿<Project Sdk="Transpose.Build.Target/26.8.4125">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>tss</AssemblyName>
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Transpose.BCL" Version="26.8.4102" />
+    <PackageReference Include="Transpose.BCL" Version="26.8.4131" />
     <PackageReference Include="Transpose.Core" Version="26.7.3304" />
-    <PackageReference Include="Transpose.Newtonsoft.Json" Version="26.8.4104" />
+    <PackageReference Include="Transpose.Newtonsoft.Json" Version="26.8.4126" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
## Summary
Updates the Transpose build toolchain and related package dependencies across all project files to their latest versions.

## Changes
- **Transpose.Build.Target**: Updated from `26.7.3049` to `26.8.4125` in:
  - `Tesserae/Tesserae.csproj`
  - `Tesserae.Bench/Tesserae.Bench.csproj`
  - `Tesserae.Tests/Tesserae.Tests.csproj`

- **Transpose.BCL**: Updated to `26.8.4131` in:
  - `Tesserae/Tesserae.csproj` (from `26.8.4102`)
  - `Tesserae.Bench/Tesserae.Bench.csproj` (from `26.8.4093`)
  - `Tesserae.Tests/Tesserae.Tests.csproj` (from `26.8.4102`)

- **Transpose.Newtonsoft.Json**: Updated from `26.8.4104` to `26.8.4126` in `Tesserae/Tesserae.csproj`

- **Transpose.Core**: Remains at `26.7.3304` (no change needed)

## Notes
These are routine dependency updates to keep the Transpose compiler toolchain and base class library current across all project configurations.

https://claude.ai/code/session_01L1ApbzAXFovgmCfPfeVfkd