### PR TITLE
Put the search text on the same line as the chat text in a SearchAndChat box

### DIFF
--- a/Tesserae/tps/assets/css/tss.omnibox.css
+++ b/Tesserae/tps/assets/css/tss.omnibox.css
@@ -381,10 +381,23 @@
     overflow: visible;
 }
 
+/* In a chat-and-search box the two halves swap in and out of the same slot, so the caret, the text
+   and the placeholder have to land on the same line whichever half is showing. The chat textarea sets
+   that line: its first line box is 20px tall and starts at the container's 12px top padding. The
+   search input and the token overlay take the same 20px box at top 0, so switching modes (and typing
+   the first character, which hands the drawing from the input's placeholder to the overlay) moves
+   nothing. The overlay's pills overhang that box by a few pixels and are meant to — hence the
+   overflow. */
+.tss-omnibox-container.tss-omnibox-chat-and-search .tss-omnibox-search-input {
+    height: 20px;
+    line-height: 20px;
+}
+
 .tss-omnibox-container.tss-omnibox-chat-and-search .tss-omnibox-search-tokens {
     position: absolute;
-    height: 34px;
-    top: -8px;
+    height: 20px;
+    line-height: 20px;
+    top: 0;
     overflow: visible;
 }
 


### PR DESCRIPTION
In an `OmniBox.Mode.SearchAndChat` box the two halves swap in and out of the same
slot, and three different elements draw that one line of text at three different
heights:

| draws | box | glyph centre, from the container's top |
|---|---|---|
| chat `<textarea>` | first line box, `line-height: 20px`, after the container's `12px` top padding | **22px** |
| search `<input>` — the **placeholder** | `position: absolute; top: 0`, `line-height: normal` → a 16px box | **20px** |
| token overlay — the **typed search text** | `height: 34px; top: -8px`, `align-items: center` | **21px** |

So the text jumps 2px when the mode toggle is used, and 1px more the moment the
first character is typed and the drawing passes from the input's placeholder to
the token overlay.

Both search-side boxes now take the chat textarea's 20px line box at `top: 0`,
which is where its first line already is. The `-8px / 34px` pair was compensating
for the same misalignment from the other direction, and goes.

The overlay's token pills overhang the shorter box by a few pixels — the existing
`overflow: visible` on the tokens, the input container and the search container
already allows for that, and the pills render unchanged.

## Verification

Measured in Chromium against the rebuilt bundle (not injected CSS), on the
`Mode.SearchAndChat` box in the OmniBox sample — glyph centre in viewport
coordinates:

| | chat text | search placeholder | search typed text |
|---|---|---|---|
| before | 769.02 | 767.02 | 768.02 |
| after | 769.02 | **769.02** | **769.02** |

Toggled both directions and typed `hello world and (a or b)` to exercise the
overlay's word / operator / paren pills.

Scope: every selector is under `.tss-omnibox-chat-and-search`, so `Mode.Search`
and `Mode.Chat` boxes are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011DYkGNnspJZjVmGTMqdiRx

---
_Generated by [Claude Code](https://claude.ai/code/session_011DYkGNnspJZjVmGTMqdiRx)_