### PR TITLE
Keep a chart with a pinned range navigable when its data comes back e…

### DIFF
--- a/Tesserae.Tests/src/Samples/Components/ChartsSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/ChartsSample.cs
@@ -165,10 +165,23 @@ namespace Tesserae.Tests.Samples
                 else cpuChart.XRange(range.Min, range.Max);
             });
 
+            //The case a chart that fetches per range runs into: the user scrolls to a period the source has
+            //nothing for. The pinned range still draws its axis and still answers the wheel, so the period is
+            //navigable rather than a dead blank box.
+            var emptyChart = AreaChart()
+               .Series(new ChartSeries[0])
+               .XAxisTime()
+               .XRange(start - 7_200, start - 3_600)
+               .Zoomable()
+               .Spikelines()
+               .Legend();
+
             return VStack().WS().Children(
                 SampleSubTitle("Wheel to zoom, drag to pan, double-click to reset — both charts stay on the same timeline"),
                 cpuChart.H(200).WS(),
-                ramChart.H(200).WS().PT(8));
+                ramChart.H(200).WS().PT(8),
+                SampleSubTitle("A range the data does not cover still draws its axis, and still zooms and pans").PT(16),
+                emptyChart.H(140).WS());
         }
 
         public HTMLElement Render() => _content.Render();

--- a/Tesserae/skills/references/charts.md
+++ b/Tesserae/skills/references/charts.md
@@ -111,6 +111,10 @@ chart.ZoomLimits(minSpan: 10, maxSpan: 3600)          // 10s to 1h of samples
      .OnRangeChanged(r => ScheduleLoad(r.Min, r.Max)); // then chart.XRange(from, to) once loaded
 ```
 
+A pinned range is itself a continuous X scale, so a range the data does not cover still draws
+its axis and still answers the wheel and the drag — the period the user has to navigate out of
+is exactly the one with nothing in it.
+
 ## Example
 
 ```csharp

--- a/Tesserae/src/Components/ChartBase.cs
+++ b/Tesserae/src/Components/ChartBase.cs
@@ -956,7 +956,11 @@ namespace Tesserae
         protected override void RenderChart(double width, double height)
         {
             _pointCount  = _series.Count == 0 ? 0 : _series.Max(s => s.Values.Length);
-            _continuousX = _sharedX != null || _series.Any(s => s.XValues != null);
+            //A pinned range is a continuous X scale in its own right. A chart whose data came back empty for the
+            //range it was given still has to draw that range's axis, and above all has to go on answering the
+            //wheel and the drag: deciding the scale from the points alone leaves an empty period unnavigable,
+            //which is exactly the period the user needs to get out of.
+            _continuousX = _sharedX != null || _series.Any(s => s.XValues != null) || (_hasExplicitRange && _categories.Length == 0);
 
             ResolveXRange();
             RenderLegend(width, height);


### PR DESCRIPTION
…mpty

A chart decided it was on a continuous X scale by looking at its points, so a series that came back empty dropped it back to the category scale. Everything keyed off that: the wheel and the drag handlers both return early when the scale is not continuous, and the continuous axis labels are not drawn at all. The result was that scrolling to a period the source has no data for left a blank box that no longer answered the mouse — no axis to say which period it was, and no way to zoom or pan back out of it. Exactly the period a user needs to leave.

A pinned range is a continuous X scale in its own right, whatever the data currently holds, so an explicit XRange (with no categories set) now establishes one. The range draws its axis and goes on answering the wheel and the drag.

This is the case a chart that fetches per visible range runs into as soon as the user scrolls past the edge of what the source has, so the samples gallery now carries one.


Claude-Session: https://claude.ai/code/session_01SJ3YieuAX4zi9seDY86g8C