### PR TITLE
Compact density for Tree, and seedable OmniBox filter chips

### DIFF
--- a/Tesserae.Tests/src/Samples/Components/TreeSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/TreeSample.cs
@@ -45,6 +45,21 @@ namespace Tesserae.Tests.Samples
                             new Tree.Item("MarkdownRenderer...", UIcons.File)
                         )
                     ),
+                    SampleSubTitle("Compact Tree"),
+                    new Tree().Compact().Items(
+                        new Tree.Item("skills", UIcons.Folder).Expanded().Items(
+                            new Tree.Item("docx", UIcons.Folder).Expanded().Items(
+                                new Tree.Item("examples", UIcons.Folder),
+                                new Tree.Item("ooxml", UIcons.Folder).Expanded().Items(
+                                    new Tree.Item("comments.md", UIcons.File),
+                                    new Tree.Item("hyperlinks_and_fields.md", UIcons.File),
+                                    new Tree.Item("rels_and_content_types.md", UIcons.File),
+                                    new Tree.Item("tracked_changes.md", UIcons.File)
+                                )
+                            ),
+                            new Tree.Item("pptx", UIcons.Folder)
+                        )
+                    ),
                     SampleSubTitle("Asynchronous Tree"),
                     new Tree().Items(
                         new Tree.Item("Lazy Loaded Folder", UIcons.Folder).ItemsAsync(async () =>

--- a/Tesserae/skills/references/tree.md
+++ b/Tesserae/skills/references/tree.md
@@ -19,6 +19,7 @@ A vertically-stacked tree of `Tree.Item` nodes. Nodes expand/collapse to reveal 
 
 - `.Items(params Tree.Item[])` — add top-level nodes.
 - `.SelectionEnabled(bool = true)` — turn on item selection.
+- `.Compact(bool = true)` — compact density (22px rows, 13px text, 8px indent), matching a code editor's file explorer.
 - `.OnSelected((s, item) => ...)` — fires when selection changes; `SelectedItem` holds the current.
 - `.Clear()` / `.Replace(newItem, oldItem)` — manage nodes.
 
@@ -36,7 +37,7 @@ A vertically-stacked tree of `Tree.Item` nodes. Nodes expand/collapse to reveal 
 ```csharp
 using static Tesserae.UI;
 
-var tree = new Tree().SelectionEnabled().Items(
+var tree = new Tree().Compact().SelectionEnabled().Items(
     new Tree.Item("src", UIcons.Folder).Expanded().Items(
         new Tree.Item("index.tsx", UIcons.File).Selected(),
         new Tree.Item("Button.tsx", UIcons.File)

--- a/Tesserae/src/Components/Tree.cs
+++ b/Tesserae/src/Components/Tree.cs
@@ -83,6 +83,24 @@ namespace Tesserae
         }
 
         /// <summary>
+        /// Switches the tree to a compact density, matching the row height, font size and indentation of a code
+        /// editor's file explorer.
+        /// </summary>
+        public Tree Compact(bool compact = true)
+        {
+            if (compact)
+            {
+                InnerElement.classList.add("tss-tree-compact");
+            }
+            else
+            {
+                InnerElement.classList.remove("tss-tree-compact");
+            }
+
+            return this;
+        }
+
+        /// <summary>
         /// Enables or disables item selection on the tree.
         /// </summary>
         public Tree SelectionEnabled(bool enabled = true)

--- a/Tesserae/tps/assets/css/tss.tree.css
+++ b/Tesserae/tps/assets/css/tss.tree.css
@@ -143,6 +143,43 @@
     display: flex;
 }
 
+/* Compact density - row height, font size and indentation matching a code editor's file explorer */
+.tss-tree-compact .tss-tree-item-content {
+    padding: 0 6px;
+    border-radius: 3px;
+}
+
+.tss-tree-compact .tss-tree-text {
+    min-height: 22px;
+    line-height: 22px;
+    font-size: 13px;
+}
+
+.tss-tree-compact .tss-tree-chevron {
+    width: 14px;
+    height: 14px;
+    font-size: 11px;
+    margin-right: 2px;
+}
+
+.tss-tree-compact .tss-tree-icon,
+.tss-tree-compact .tss-tree-checkbox {
+    font-size: 14px;
+    margin-right: 5px;
+}
+
+.tss-tree-compact .tss-tree-children {
+    margin-left: 8px;
+}
+
+.tss-tree-compact .tss-tree-commands > .tss-tree-command,
+.tss-tree-compact .tss-tree-commands > a > .tss-tree-command {
+    min-width: 18px;
+    height: 18px;
+    padding: 0 3px;
+    font-size: 12px;
+}
+
 .tss-tree-menu {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
Two additions the Curiosity Build admin view needs.

## 1. `Tree.Compact()`

Switches the tree to the row height, font size and indentation of a code editor's file explorer, for trees that act as a file/content explorer rather than a form control.

It toggles a `tss-tree-compact` class on the tree's root `ul`; everything else is CSS in `tss.tree.css`, scoped under that class:

| | default | compact |
| --- | --- | --- |
| row height | 36px | 22px |
| text | inherited | 13px |
| indent per level | 16px | 8px |
| icon / checkbox | 16px | 14px |
| chevron | 16px box | 14px box, 11px glyph |
| row commands | 20px | 18px |

Measured in the browser against the sample gallery: compact rows come out at exactly 22px, default rows at 36px.

Nothing changes for existing trees — the class is only added when `Compact()` is called.

`TreeSample` gains a "Compact Tree" section so the density is visible in the gallery next to the default one.

## 2. `OmniBox.AddFilterSnap()` / `OmniBox.ClearSnaps()`

`AddFilterSnap(handler, value, trigger = null)` adds an active filter chip as if the user had typed the trigger and picked the value; `ClearSnaps()` drops them all again. Both re-run the search.

Constructing one was impossible from outside the assembly: `FilterSnap` is public, but the `InlineFilterChip` overload that carries one is `internal` — so a palette that wants to open pre-filtered, showing the filters the view behind it already applies, had no way to say so.

## Docs

`skills/references/tree.md` and `skills/references/omni-box.md` updated for both.