### PR TITLE
Show how much of a chat message's character budget is left

### DIFF
--- a/Tesserae.Tests/src/Samples/Components/OmniBoxSample.cs
+++ b/Tesserae.Tests/src/Samples/Components/OmniBoxSample.cs
@@ -30,6 +30,7 @@ namespace Tesserae.Tests.Samples
                .FlatSection(VStack().WS().Children(Help()))
                .FlatSection(VStack().WS().Children(InlineChips()))
                .FlatSection(VStack().WS().Children(FooterItems()))
+               .FlatSection(VStack().WS().Children(CharacterLimit()))
                .FlatSection(VStack().WS().Children(KeyboardShortcut()))
                .FlatSection(VStack().WS().Children(RoundedAndAskAI()))
                .FlatSection(VStack().WS().Children(FileDrop()))
@@ -387,6 +388,27 @@ namespace Tesserae.Tests.Samples
                 "Config.SearchFooter and Config.ChatFooter each take LeftSide / RightSide arrays of components, placed beside the built-in buttons of that mode — an attachment button, a mode dropdown, a dictate button. In SearchAndChat mode the items of the side that isn't active are hidden along with the rest of that mode's chrome.",
                 Label("Search footer").SetContent(searchBox),
                 Label("Chat footer").SetContent(chatBox).MT(6));
+        }
+
+        // ---------- Character limit ----------
+
+        private IComponent CharacterLimit()
+        {
+            var box = Track(OmniBox(new OmniBox.Config(OmniBox.Mode.Chat)
+            {
+                PlaceholderChat = "Type past 60 characters and the counter appears next to the send button",
+                MaxCharacters   = 120
+            })
+            .WS()
+            .OnChat((s, q) => Toast().Information(q.Text)));
+
+            var raise = Button("Raise the limit to 500").OnClick(() => box.MaxChatCharacters = 500);
+            var lift  = Button("Lift the limit").OnClick(() => box.MaxChatCharacters = 0);
+
+            return FeatureCard("Character limit", "A budget the composer shows as it runs out",
+                "Config.MaxCharacters caps how long a chat message can be: the input stops taking text at the limit, and a \"used / max\" counter sits next to the send button. It only shows past half the budget — below that it is collapsed, so a short message never has a number hanging off it. OmniBox.MaxChatCharacters changes the cap later, and zero lifts it.",
+                box,
+                HStack().MT(8).Children(raise, lift.ML(8)));
         }
 
         // ---------- Keyboard shortcut ----------

--- a/Tesserae/skills/references/omni-box.md
+++ b/Tesserae/skills/references/omni-box.md
@@ -28,6 +28,7 @@ Config (set via object initializer):
   roundness, so `.Rounded(BorderRadius.Full)` gives a pill-shaped selector.
 - `ChatHeader` (`IComponent`) — rendered inside the box above the chat input: what the message is being written against, e.g. a compact `ContextCards` group of the attached documents. Swap it later with `.SetChatHeader(component)`, or pass `null` to empty the slot — it takes up no space while empty. For individual cards *below* the input, use `.WithContextToAdd(...)`.
 - `GeneratingText` — label shown in the footer while generating (default `"Generating"`); the live elapsed time is appended, e.g. `"Generating, 1m 25s"`.
+- `MaxCharacters` (default `0`, no limit) — how long a chat message may be. The input stops taking text at the limit and a `"used / max"` counter appears in the footer next to the send button, in the secondary foreground colour. It only shows past half the budget; below that it is collapsed, so an ordinary message carries no number.
 - `AllowSendWhileGenerating` (default `false`) — when set, typing a message while `IsGenerating` is true sends it (`OnChat` fires) instead of the trigger stopping the reply, so the host can queue it for the turn in flight. The trigger still shows the stop icon while the input is empty and turns back into the send icon as soon as there is text.
 
 OmniBox:
@@ -35,6 +36,7 @@ OmniBox:
 - `.OnChat((sender, ChatMessage) => ...)`, `.OnStop(...)`, `.OnModelChanged(...)`.
 - `.IsGenerating` (bool) — toggles the footer spinner + elapsed-time indicator and swaps the send button for a stop button. `.GeneratingText` (string) — read/write the indicator label; setting it updates the footer live. `.AllowSendWhileGenerating` (bool) — read/write the config flag above.
 - `.SearchText` / `.ChatText` / `.SetSearchText(string)` — read/write input text.
+- `.MaxChatCharacters` (int) — read/write `Config.MaxCharacters` after construction; `0` lifts the limit.
 - `.ActiveMode` (`Mode`) — which half of a `SearchAndChat` box is showing. Setting it switches the box
   and moves the box's own toggle with it. `.ActiveModeObservable` follows it, and `.NoModeToggle()`
   takes the toggle out of the footer for a host that puts a mode control somewhere of its own (a page

--- a/Tesserae/src/Components/OmniBox.cs
+++ b/Tesserae/src/Components/OmniBox.cs
@@ -484,6 +484,14 @@ namespace Tesserae
             public bool AllowSendWhileGenerating { get; set; }
 
             /// <summary>
+            /// Gets or sets how many characters a chat message can hold. The input stops accepting text at
+            /// the limit, and the footer shows a "used / max" counter next to the send button once more than
+            /// half of it is spent - below that the counter is collapsed, so an ordinary message never has a
+            /// number hanging off it. Leave it unset (or at zero) for no limit and no counter.
+            /// </summary>
+            public int MaxCharacters { get; set; }
+
+            /// <summary>
             /// Gets or sets the chat footer.
             /// </summary>
             public FooterItems ChatFooter { get; set; }
@@ -597,6 +605,8 @@ namespace Tesserae
         private readonly HTMLDivElement   _contextContainer;
         private readonly List<ContextCard> _contextCards = new List<ContextCard>();
         private readonly Button           _chatTriggerBtn;
+        private readonly TextBlock        _chatCounter;
+        private int                       _maxChatCharacters;
         private Button                    _modelSelectorBtn;
         private List<ModelOption>         _models = new List<ModelOption>();
         private ModelOption               _selectedModel;
@@ -1084,6 +1094,7 @@ namespace Tesserae
                 _chatInput.addEventListener("input", (e) =>
                 {
                     UpdateChatTriggerActiveState();
+                    UpdateChatCounter();
                     ResizeChatInput();
                     Input?.Invoke(this, e);
                     TryUpdateChatMention();
@@ -1107,6 +1118,10 @@ namespace Tesserae
                 DomObserver.WhenMounted(_chatInput, ResizeChatInput);
 
                 _chatTriggerBtn = Button().SetIcon(config.IconChat).Class("tss-omnibox-chat-btn").OnClick(TriggerChat);
+
+                _chatCounter = TextBlock("").Small().Class("tss-omnibox-chat-counter").Foreground(Theme.Secondary.Foreground).Collapse();
+
+                MaxChatCharacters = config.MaxCharacters;
 
                 _modelSelectorBtn = Button().Class("tss-omnibox-model-selector-btn").NoBorder().NoBackground().OnClick(ShowModelPopover);
                 _modelSelectorBtn.Collapse();
@@ -1152,6 +1167,7 @@ namespace Tesserae
             if (_mode == Mode.Chat || _mode == Mode.SearchAndChat)
             {
                 footerEnd.Add(_modelSelectorBtn);
+                footerEnd.Add(_chatCounter);
                 footerEnd.Add(_chatTriggerBtn);
             }
 
@@ -2007,6 +2023,7 @@ namespace Tesserae
             _chatInput.setSelectionRange((uint)before.Length, (uint)before.Length);
 
             HideChatMention();
+            UpdateChatCounter();
             ResizeChatInput();
             _chatInput.focus();
         }
@@ -2692,6 +2709,7 @@ namespace Tesserae
             Chatted?.Invoke(this, new ChatMessage() { Text = val });
             _chatInput.value = "";
             UpdateChatTriggerActiveState();
+            UpdateChatCounter();
             ResizeChatInput();
         }
 
@@ -2724,6 +2742,28 @@ namespace Tesserae
             {
                 _chatTriggerBtn.SetIcon(_iconChat);
                 _chatTriggerBtn.IsDanger = false;
+            }
+        }
+
+        // Below this share of the budget the counter says nothing: a message nowhere near the limit
+        // has no use for a number next to the send button.
+        private const double CHAT_COUNTER_VISIBLE_FROM = 0.5;
+
+        // Shows how much of the character budget the message has spent, once it is worth knowing.
+        private void UpdateChatCounter()
+        {
+            if (_chatCounter is null || _chatInput is null) return;
+
+            var used = _chatInput.value is null ? 0 : _chatInput.value.Length;
+
+            if (_maxChatCharacters > 0 && used > _maxChatCharacters * CHAT_COUNTER_VISIBLE_FROM)
+            {
+                _chatCounter.Text = used + " / " + _maxChatCharacters;
+                _chatCounter.Show();
+            }
+            else
+            {
+                _chatCounter.Collapse();
             }
         }
 
@@ -3544,8 +3584,30 @@ namespace Tesserae
             {
                 _chatInput.value = value;
                 UpdateChatTriggerActiveState();
+                UpdateChatCounter();
                 ResizeChatInput();
                 Input?.Invoke(this, null);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets how many characters a chat message can hold, as <see cref="Config.MaxCharacters"/>
+        /// does at construction. Set it to zero to lift the limit again.
+        /// </summary>
+        public int MaxChatCharacters
+        {
+            get => _maxChatCharacters;
+            set
+            {
+                _maxChatCharacters = value > 0 ? value : 0;
+
+                if (_chatInput is object)
+                {
+                    if (_maxChatCharacters > 0) _chatInput.maxLength = _maxChatCharacters;
+                    else _chatInput.removeAttribute("maxlength");
+                }
+
+                UpdateChatCounter();
             }
         }
 

--- a/Tesserae/tps/assets/css/tss.omnibox.css
+++ b/Tesserae/tps/assets/css/tss.omnibox.css
@@ -504,6 +504,7 @@
 .tss-omnibox-container.tss-omnibox-mode-search .tss-omnibox-chat-container,
 .tss-omnibox-container.tss-omnibox-mode-search .tss-omnibox-context,
 .tss-omnibox-container.tss-omnibox-mode-search .tss-omnibox-chat-btn,
+.tss-omnibox-container.tss-omnibox-mode-search .tss-omnibox-chat-counter,
 .tss-omnibox-container.tss-omnibox-mode-search .tss-omnibox-chat-footer-item {
     display: none;
 }
@@ -642,6 +643,16 @@
 .tss-omnibox-help-example {
     color: var(--tss-secondary-foreground-color);
     opacity: 0.85;
+}
+
+/* How much of the message's character budget is spent, next to the send button. It only appears past
+   half the budget (the component collapses it below that), so it never crowds an ordinary message. */
+.tss-omnibox-chat-counter {
+    align-self: center;
+    flex-shrink: 0;
+    padding: 0 8px;
+    white-space: nowrap;
+    font-variant-numeric: tabular-nums;
 }
 
 /* Chat trigger (send) button */


### PR DESCRIPTION
## What

`OmniBox.Config` gains an optional `MaxCharacters`, so a host can cap how long a chat message may be:

- the chat input stops taking text at the limit (`maxlength` on the textarea);
- a `"used / max"` counter sits in the footer **next to the send button**, in the secondary foreground colour;
- it stays **collapsed until more than half** the budget is spent, so an ordinary short message never has a number hanging off it;
- `OmniBox.MaxChatCharacters` moves the cap after construction, and `0` lifts it (and drops the attribute).

Left unset (`0`) nothing changes: no limit, no counter.

## Changes

- `Tesserae/src/Components/OmniBox.cs` — `Config.MaxCharacters`, the `_chatCounter` TextBlock placed before the send button in the footer, `UpdateChatCounter()` called wherever the chat text changes (typing, send, `ChatText`, mention removal), and the public `MaxChatCharacters` property.
- `Tesserae/tps/assets/css/tss.omnibox.css` — `.tss-omnibox-chat-counter` (centred, non-shrinking, tabular numerals) and hiding it with the rest of the chat chrome while a `SearchAndChat` box is in search mode.
- `Tesserae.Tests/.../OmniBoxSample.cs` — a "Character limit" section: a box capped at 120 characters plus buttons that raise the cap to 500 and lift it entirely.
- `Tesserae/skills/references/omni-box.md` — documents both the config knob and the runtime property.

## Verification

`dotnet build` clean for both `Tesserae.csproj` and `Tesserae.Tests.csproj` (0 warnings, 0 errors). Drove the built gallery in Chromium via Playwright: the counter is absent at 40/120 characters, reads `70 / 120` at 70, typing past the cap leaves the value at 120 characters, "Raise the limit to 500" re-collapses it, and "Lift the limit" removes the `maxlength` attribute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LgXVz75XhK9YDn7un7mdLq