### PR TITLE
Add custom format support to ModalNavigation pagination

### DIFF
--- a/Tesserae/skills/references/omni-result.md
+++ b/Tesserae/skills/references/omni-result.md
@@ -200,10 +200,11 @@ full-screen, so a modal never offers something the host didn't wire up:
 - Call it more than once for several: the first stays the button, the rest hang off an arrow beside it
   that opens them as a menu. `.NoOpenInSource()` clears them; `OpenActions` / `CanOpenInSource` read
   them; `.Open(bool inNewTab = false)` runs the primary one from code.
-- `.ModalNavigation(Action<OmniResult<T>> onPrevious, Action<OmniResult<T>> onNext, int position = 0, int count = 0)`
+- `.ModalNavigation(Action<OmniResult<T>> onPrevious, Action<OmniResult<T>> onNext, int position = 0, int count = 0, Func<int, int, string> format = null)`
   — an `InlinePagination` (`inline-pagination.md`): the ‹ › chevrons with "2 of 7" between them when a
   position and count are given (both 1-based). A null handler greys its chevron out, which is how the
-  first and last result say so.
+  first and last result say so. The `format` writes that label another way — "2 / 7", or "2 of many"
+  for a count too large to be worth spelling out.
 - `.ModalCommands(Action<OmniResult<T>>)` — the `[...]` button; read `CommandsEvent` in the handler to
   place a command surface of the host's own where the user clicked. Null leaves the button out.
 - `.ModalFullScreen(Action<OmniResult<T>>)` — what `[⤢]` does; without one it grows the modal to fill

--- a/Tesserae/src/Components/OmniResult.cs
+++ b/Tesserae/src/Components/OmniResult.cs
@@ -130,16 +130,17 @@ namespace Tesserae
         private bool                                  _modalKeepsIcon;
         private bool                                  _modalKeepsFooter;
 
-        private HTMLElement           _footerStandIn;
-        private Modal                 _modal;
-        private Action<OmniResult<T>> _modalCommands;
-        private Action<OmniResult<T>> _modalFullScreen;
-        private bool                  _modalHasFullScreen = true;
-        private Action<OmniResult<T>> _modalPrevious;
-        private Action<OmniResult<T>> _modalNext;
-        private int                   _modalPosition;
-        private int                   _modalCount;
-        private bool                  _modalShortcuts = true;
+        private HTMLElement            _footerStandIn;
+        private Modal                  _modal;
+        private Action<OmniResult<T>>  _modalCommands;
+        private Action<OmniResult<T>>  _modalFullScreen;
+        private bool                   _modalHasFullScreen = true;
+        private Action<OmniResult<T>>  _modalPrevious;
+        private Action<OmniResult<T>>  _modalNext;
+        private int                    _modalPosition;
+        private int                    _modalCount;
+        private Func<int, int, string> _modalCountFormat;
+        private bool                   _modalShortcuts = true;
 
         private event Action<OmniResult<T>, bool> SelectionChanged;
         private event Action<OmniResult<T>>       RangeSelectionRequested;
@@ -1076,14 +1077,22 @@ namespace Tesserae
         /// Puts the previous/next arrows in the modal's header, so a result opened out of a list can be
         /// stepped through without going back to it. A null handler greys its arrow out - that is how the
         /// first and the last result say so. Passing a position and a count (both 1-based, the count being
-        /// how many results there are) draws "3 of 27" between the arrows.
+        /// how many results there are) draws "3 of 27" between the arrows, and a <paramref name="format"/>
+        /// writes that label another way - "3 / 27", or "3 of many" for a count too large to be worth
+        /// spelling out.
         /// </summary>
-        public OmniResult<T> ModalNavigation(Action<OmniResult<T>> onPrevious, Action<OmniResult<T>> onNext, int position = 0, int count = 0)
+        public OmniResult<T> ModalNavigation(
+            Action<OmniResult<T>>  onPrevious,
+            Action<OmniResult<T>>  onNext,
+            int                    position = 0,
+            int                    count    = 0,
+            Func<int, int, string> format   = null)
         {
-            _modalPrevious = onPrevious;
-            _modalNext     = onNext;
-            _modalPosition = position;
-            _modalCount    = count;
+            _modalPrevious    = onPrevious;
+            _modalNext        = onNext;
+            _modalPosition    = position;
+            _modalCount       = count;
+            _modalCountFormat = format;
 
             return this;
         }
@@ -1369,6 +1378,7 @@ namespace Tesserae
 
             return InlinePagination(_modalPosition, _modalCount)
                .Class("tss-omniresult-modal-nav")
+               .SetFormat(_modalCountFormat)
                .SetTooltips("Previous result", "Next result")
                .OnPrevious(_modalPrevious is null ? null : (Action<InlinePagination>)(_ => _modalPrevious(this)))
                .OnNext(_modalNext is null ? null : (Action<InlinePagination>)(_ => _modalNext(this)));


### PR DESCRIPTION
## Summary

Extends `OmniResult<T>.ModalNavigation()` to accept an optional custom format function for the position/count label displayed between the modal navigation arrows, allowing consumers to customize the pagination text (e.g., "3 / 27" instead of "3 of 27").

## Changes

- **OmniResult.cs**
  - Added `_modalCountFormat` field to store the custom format function
  - Extended `ModalNavigation()` method signature with optional `Func<int, int, string> format` parameter
  - Updated `BuildModalNavigation()` to pass the format function to `InlinePagination` via `.SetFormat()`
  - Aligned field declarations for consistency

- **omni-result.md**
  - Updated method signature documentation to include the new `format` parameter
  - Added explanation of the format function's purpose with examples ("2 / 7", "2 of many")

## Implementation Details

The format function receives position and count (both 1-based) and returns a custom string representation. When null (the default), the existing "X of Y" format is used, maintaining backward compatibility. The function is passed through to the underlying `InlinePagination` component which handles the actual rendering.

https://claude.ai/code/session_01S7ywhjm9RV6MzFEAceQzLy