### PR TITLE
Keep a Grid at its content height inside a stack

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -253,6 +253,15 @@ A component can still take charge of its own styling by implementing
 write onto that container. This is how nested containers (e.g. a `Grid` inside a
 `Stack`) route sizing to the right element.
 
+The other half of that story is the flex **automatic minimum size**, which a flex
+item only gets while its own `overflow` is `visible`. `.tss-grid` sets
+`overflow: auto`, so once the grid was the stack item itself a column stack whose
+content did not fit squeezed every grid in it to a sliver with its own scrollbar —
+the wrapper div used to carry that floor. `.tss-grid` now declares
+`min-height: min-content` to restore it, and the two grids that really are scroll
+viewports (`ItemsList`, `InfiniteScrollingList`) opt out with `.MinHeight(0.px())`.
+A component whose stylesheet sets a non-visible `overflow` needs the same thought.
+
 **Debugging tip:** if `.WS()` "doesn't work", inspect the rendered DOM — the
 sizing styles are on the element you called the helper on, unless the component
 is inside a Masonry/SectionStack, where they are on its wrapper.

--- a/Tesserae.Tests/src/Samples/Layout/GridSample.cs
+++ b/Tesserae.Tests/src/Samples/Layout/GridSample.cs
@@ -21,6 +21,18 @@ namespace Tesserae.Tests.Samples
             gridAutoSize.Gap(8.px());
             Enumerable.Range(1, 10).ForEach(v => gridAutoSize.Add(Card(TextBlock($"Responsive Item {v}").TextCenter())));
 
+            Grid section(int group)
+            {
+                var s = Grid(new UnitSize("repeat(auto-fit, minmax(min(160px, 100%), 1fr))")).Gap(8.px()).WS();
+                Enumerable.Range(1, 12).ForEach(v => s.Add(Button().SetText($"Filter {group}.{v}").WS()));
+                return s;
+            }
+
+            var scrollingSections = VStack().WS().H(220).ScrollY().Children(
+                TextBlock("Group A").SemiBold().PB(8), section(1),
+                TextBlock("Group B").SemiBold().PT(16).PB(8), section(2),
+                TextBlock("Group C").SemiBold().PT(16).PB(8), section(3));
+
             _content = SectionStack().Secondary()
                .SampleTitle(typeof(GridSample), UIcons.Table, "A component to display a grid")
                .FlatSection(VStack().Children(
@@ -37,7 +49,10 @@ namespace Tesserae.Tests.Samples
                     grid,
                     SampleSubTitle("Responsive Auto-fit Grid"),
                     TextBlock("This grid automatically adjusts the number of columns based on the available width (min 200px per item)."),
-                    gridAutoSize
+                    gridAutoSize,
+                    SampleSubTitle("Sections in a Scrolling Stack"),
+                    TextBlock("Each grid keeps its whole content height inside a stack that is too short for all of them: the stack scrolls, the sections don't shrink."),
+                    scrollingSections
                 )).SetTitle("Usage")))
                .SeeAlso(typeof(StackSample), typeof(SplitViewSample), typeof(MasonrySample), typeof(FloatSample), typeof(SectionStackSample));
         }

--- a/Tesserae/skills/references/grid.md
+++ b/Tesserae/skills/references/grid.md
@@ -31,6 +31,17 @@ Bring factories into scope with `using static Tesserae.UI;`.
 Place children (call **before** `.Add`, via `IComponent` extensions):
 `.GridColumn(start, end)` / `.GridColumnStretch()` / `.GridRow(start, end)` / `.GridRowStretch()`.
 
+## Height inside a Stack
+
+A grid keeps its content height when it is a child of a vertical `Stack`, even when the
+stack's children together overflow it — the stack scrolls (or clips), the sections inside
+it do not shrink. That is what `min-height: min-content` on `.tss-grid` guarantees, and it
+is what a page of grouped sections needs.
+
+A grid that *is* a scroll viewport wants the opposite: give it a definite size with
+`.Height(...)` (or `.MinHeight(0.px())` alongside `.MaxHeight(...)`) plus `.Scroll()` /
+`.ScrollY()`, and it will shrink to the space it is given and scroll its own content.
+
 ## Example
 
 ```csharp

--- a/Tesserae/src/Components/InfiniteScrollingList.cs
+++ b/Tesserae/src/Components/InfiniteScrollingList.cs
@@ -58,7 +58,8 @@ namespace Tesserae
             }
             else
             {
-                _grid = Grid(columns).WS().MaxHeight(100.percent()).GridColumnStretch().Scroll();
+                //MinHeight(0) opts out of the min-content floor .tss-grid carries: this grid is the list's scroll viewport, so it has to shrink to whatever height it is given.
+                _grid = Grid(columns).WS().MinHeight(0.px()).MaxHeight(100.percent()).GridColumnStretch().Scroll();
             }
             _emptyListMessageGenerator = null;
             AddItems(items);

--- a/Tesserae/src/Components/ItemsList.cs
+++ b/Tesserae/src/Components/ItemsList.cs
@@ -51,7 +51,8 @@ namespace Tesserae
             }
             else
             {
-                _grid = Grid(columns).NoDefaultMargin().WS().MaxHeight(100.percent()).Scroll();
+                //MinHeight(0) opts out of the min-content floor .tss-grid carries: this grid is the list's scroll viewport, so it has to shrink to whatever height it is given.
+                _grid = Grid(columns).NoDefaultMargin().WS().MinHeight(0.px()).MaxHeight(100.percent()).Scroll();
             }
 
             _emptyListMessageGenerator = null;

--- a/Tesserae/tps/assets/css/tss.grid.css
+++ b/Tesserae/tps/assets/css/tss.grid.css
@@ -1,6 +1,14 @@
-﻿/* Stack */
+﻿/* Grid */
+
+/* A flex item only gets its content-based automatic minimum size while its overflow is visible, so
+   the moment the grid became the stack item itself, `overflow: auto` here let a column stack squeeze
+   every grid in it down to a sliver with its own scrollbar whenever the content did not fit. The
+   wrapper div used to carry that floor; min-content restores it. An explicit .Height() — or
+   .MinHeight(0) on a grid that is meant to be a scroll viewport — writes min-height inline and still
+   wins. */
 .tss-grid {
     display: grid;
-    overflow:auto;
-    padding:4px;
+    overflow: auto;
+    padding: 4px;
+    min-height: min-content;
 }


### PR DESCRIPTION
## What broke

Removing the `tss-stack-item` wrapper made each stack child the flex item itself — and a flex item only gets its content-based automatic minimum size while its own `overflow` is `visible`. `.tss-grid` sets `overflow: auto`, so its automatic minimum height resolved to `0` and a column stack whose children did not all fit **squeezed every grid inside it down to a sliver with its own scrollbar**. The wrapper div (`height: auto`, overflow visible) had been carrying that floor.

Mosaik's Filters modal is the reported case: its list is `VStack().WS().H(10).Grow().ScrollY()` holding a title + `Grid(...)` per facet group, and measured against the published `tss.css` each group rendered **42px tall with an inner scrollbar instead of the 108px its facets asked for** — one clipped row visible. The modal's mount-time auto-height then sized the modal to that squashed content.

## The fix

- `.tss-grid` declares `min-height: min-content`, restoring the floor.
- `ItemsList` and `InfiniteScrollingList` opt out with `.MinHeight(0.px())`: they pair `MaxHeight(100%)` with `Scroll()`, and a min-content floor beats a max-height, which would have made every `SearchableList` as tall as its content. An explicit `.Height()` already writes `min-height: 0` inline, so the `.H(10).Grow().ScrollY()` idiom needs nothing.

Two alternatives were measured and rejected: dropping `overflow: auto` breaks a grid that scrolls on an explicit height, and `flex-shrink: 0` breaks a grid in a *horizontal* stack (400px → 1020px, overflowing its row instead of scrolling).

| scenario | before | `min-height: min-content` |
|---|---|---|
| grid section in an overflowing column stack | 82px, inner scrollbar | **144px, no scrollbar** |
| grid with `.H(200)` and 504px of content | 200px, scrolls | 200px, scrolls |
| grid with `.H(10).Grow().ScrollY()` | 260px, scrolls | 260px, scrolls |
| `ItemsList` shape (`MaxHeight(100%)` + `Scroll()`) | 300px, scrolls | 300px, scrolls |
| grid in a horizontal stack, 1020px of tracks | 400px wide, scrolls | 400px wide, scrolls |

## Verification

Samples gallery, baseline vs this build: **129 of 132 samples identical by text-run position** (`textdiff-samples.js`) and **126 of 127 by geometry** (`compare-samples.js`). Every difference also shows up comparing a build against *itself* — the Pivot clock, Spinner, Progress Ring, and a single 1px animation frame.

The Grid sample gains a "Sections in a Scrolling Stack" demo so the shape that regressed is covered from now on (verified: 220px list scrolls, each section stays at its 104px content height). `CLAUDE.md` and `skills/references/grid.md` document the rule; the matching page in the `documentation` repo under `tesserae/` still wants the same note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014HkC469XX5nyVfS2sg9ZTD

---
_Generated by [Claude Code](https://claude.ai/code/session_014HkC469XX5nyVfS2sg9ZTD)_