### PR TITLE
Forward Require to the Transpose runtime's loader

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,6 +157,19 @@ dotnet serve --port 5000
 
 ## Conventions
 
+### Loading a script, module or stylesheet at run time
+
+Use **`Transpose.Require.RequireAsync`** — the loader in the Transpose runtime. `Tesserae.Require`
+still exists so applications that call it keep compiling, but it is now four forwarding lines: the
+loading itself is shared with every other library on Transpose rather than reimplemented here.
+
+What the shared one does that the old `Require` did not: it picks the element from the URL (`.css`
+→ a stylesheet link, `.mjs` → a module, anything else → a classic script), resolves the URL against
+the document base first — so every spelling of one file is one entry, and a file `index.html`
+already carries is waited on rather than fetched twice — forgets a failed load instead of
+remembering it as done, and falls back between the `.js` and `.min.js` spellings of the same file,
+which is what lets a library published once work in a site built either way.
+
 ### Type safety
 
 Favor strong, static typing. Avoid `dynamic` unless absolutely necessary

--- a/Tesserae.Bench/Tesserae.Bench.csproj
+++ b/Tesserae.Bench/Tesserae.Bench.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Transpose.BCL" Version="26.8.4131" />
+    <PackageReference Include="Transpose.BCL" Version="26.8.4275" />
     <PackageReference Include="Transpose.Core" Version="26.7.3304" />
   </ItemGroup>
 

--- a/Tesserae.Tests/Tesserae.Tests.csproj
+++ b/Tesserae.Tests/Tesserae.Tests.csproj
@@ -4,7 +4,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Transpose.BCL" Version="26.8.4156" />
+    <PackageReference Include="Transpose.BCL" Version="26.8.4275" />
     <PackageReference Include="Transpose.Core" Version="26.7.3304" />
   </ItemGroup>
 

--- a/Tesserae/Tesserae.csproj
+++ b/Tesserae/Tesserae.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Transpose.BCL" Version="26.8.4156" />
+    <PackageReference Include="Transpose.BCL" Version="26.8.4275" />
     <PackageReference Include="Transpose.Core" Version="26.7.3304" />
     <PackageReference Include="Transpose.Newtonsoft.Json" Version="26.8.4126" />
   </ItemGroup>

--- a/Tesserae/skills/references/javascript-interop.md
+++ b/Tesserae/skills/references/javascript-interop.md
@@ -77,14 +77,38 @@ public class ReadOnlyArray<T>
 }
 ```
 
+## Loading a library at run time
+
+A bundle only some screens need does not belong in `index.html`. Fetch it when it is first
+used, through the Transpose runtime's loader:
+
+```csharp
+using Transpose;
+
+await Require.RequireAsync("assets/js/chart.min.js");                  // classic script
+await Require.RequireAsync("assets/css/chart.css", "assets/js/chart.js"); // in order: css, then js
+await Require.RequireAsync(RequireKind.Module, "./viewer.js");         // a module that keeps a .js name
+```
+
+It picks the element from the URL (`.css` → a stylesheet link, `.mjs` → a module, anything else →
+a classic script), resolves the URL against the document base, shares one fetch between every
+caller, and — the part worth knowing — **falls back between the `.js` and `.min.js` spellings** of
+the same file, because a site keeps whichever variant its own build produced. Several URLs load in
+order, so a plugin arrives after the library it extends.
+
+`Tesserae.Require` (`LoadScriptAsync` / `LoadModuleAsync` / `LoadStyle`) still works and forwards
+to exactly this.
+
 ## Gotchas
 
 - `Script.Write` strings are opaque to the compiler — typos surface only at
   runtime. Pass C# values as `{n}` placeholders rather than interpolating them
   into the string so they compile correctly under minification.
 - Property/feature checks: `Script.Write<bool>("(typeof {0}.disabled === 'undefined')", el)`.
-- Transpose renames JS files between Debug/Release (`.min.js`); any external script you
-  call must be bundled so the global exists at runtime — see `wrap-a-javascript-library`.
+- A Debug build and a Release build link different variants of a bundle (`x.js` vs `x.min.js`);
+  any external script you call must be bundled so the global exists at runtime — see
+  `wrap-a-javascript-library` — and fetched through `Require.RequireAsync`, which resolves the
+  variant difference for you.
 
 ## Related
 

--- a/Tesserae/src/Helpers/Code/Require.cs
+++ b/Tesserae/src/Helpers/Code/Require.cs
@@ -1,118 +1,45 @@
-﻿using System;
-using System.Threading.Tasks;
-using static Transpose.Core.dom;
+﻿using System.Threading.Tasks;
 
 namespace Tesserae
 {
+    /// <summary>
+    /// Loads a script, an ES module or a stylesheet at run time.
+    ///
+    /// <para>
+    /// The loading itself lives in the Transpose runtime now — <c>Transpose.Require</c> — so every
+    /// library and application on Transpose shares one implementation instead of each growing its
+    /// own. These members forward to it and stay for the applications that already call them; new
+    /// code can call <see cref="global::Transpose.Require.RequireAsync(string[])"/> directly, which
+    /// also picks the element from the URL rather than being told.
+    /// </para>
+    ///
+    /// <para>
+    /// What the shared loader adds over what this class used to do: URLs are resolved against the
+    /// document base before anything else, so every spelling of one file is one entry and a file
+    /// <c>index.html</c> already carries is waited on rather than fetched twice; a failed load is
+    /// forgotten rather than remembered as done; and a <c>.min.js</c> that is not there falls back to
+    /// the <c>.js</c> beside it (and the other way round), which is what lets a library published
+    /// once work in a site built either way.
+    /// </para>
+    /// </summary>
     [Transpose.Name("tss.Require")]
     public static class Require
     {
-        private static readonly SingleSemaphoreSlim singleCall = new SingleSemaphoreSlim();
+        /// <summary>Adds a stylesheet to the page, if it is not on it already. Fire and forget: a
+        /// stylesheet that cannot be fetched is reported to the console, as it always was.</summary>
         public static void LoadStyle(params string[] styles)
-        {
-            for (int i = 0; i < styles.Length; i++)
-            {
-                var url           = styles[i];
-                var existingStyle = document.querySelector($"link[href^='{url}']").As<HTMLElement>();
+            => LoadStyleAsync(styles).FireAndForget();
 
-                if (existingStyle == null)
-                {
-                    var l = document.createElement("link").As<HTMLLinkElement>();
-                    l.rel  = "stylesheet";
-                    l.href = url;
-                    document.head.appendChild(l);
-                }
-            }
-        }
+        /// <summary>Adds a stylesheet to the page and completes once the browser has applied it.</summary>
+        public static Task LoadStyleAsync(params string[] styles)
+            => global::Transpose.Require.RequireAsync(global::Transpose.RequireKind.Style, styles);
 
-        public static async Task LoadScriptAsync(params string[] libraries)
-        {
-            await singleCall.WaitAsync();
+        /// <summary>Loads classic scripts, in the order given.</summary>
+        public static Task LoadScriptAsync(params string[] libraries)
+            => global::Transpose.Require.RequireAsync(global::Transpose.RequireKind.Script, libraries);
 
-            try
-            {
-                var tcs = new TaskCompletionSource<bool>();
-                LoadScriptAsync(() => tcs.TrySetResult(true), (err) => tcs.TrySetException(new Exception(err)), false, libraries);
-                await tcs.Task;
-            }
-            finally
-            {
-                singleCall.Release();
-            }
-        }
-
-        public static async Task LoadModuleAsync(params string[] libraries)
-        {
-            await singleCall.WaitAsync();
-
-            try
-            {
-                var tcs = new TaskCompletionSource<bool>();
-                LoadScriptAsync(() => tcs.TrySetResult(true), (err) => tcs.TrySetException(new Exception(err)), true, libraries);
-                await tcs.Task;
-            }
-            finally
-            {
-                singleCall.Release();
-            }
-        }
-
-        private static void LoadScriptAsync(Action onComplete, Action<string> onFail, bool isModule, params string[] libraries)
-        {
-            var loadedCount = 0;
-
-            for (int i = 0; i < libraries.Length; i++)
-            {
-                var url         = libraries[i];
-                var existingLib = document.querySelector($"script[src^='{url}']").As<HTMLElement>();
-
-                if (existingLib != null)
-                {
-                    // Is already loaded?
-                    loadedCount++;
-                }
-                else
-                {
-                    var script = new HTMLScriptElement
-                    {
-                        type  = isModule ? "module" : "text/javascript",
-                        src   = url,
-                        async = true,
-                        onerror = e =>
-                        {
-                            onFail?.Invoke(url);
-                            loadedCount++;
-
-                            if (loadedCount == libraries.Length)
-                            {
-                                onComplete?.Invoke();
-                            }
-                        },
-                        onload = OnScriptLoaded
-                    };
-
-                    try
-                    {
-                        document.head.appendChild(script);
-                    }
-                    catch
-                    {
-                        onFail?.Invoke(url);
-                        loadedCount++;
-                    }
-                }
-            }
-
-            if (loadedCount == libraries.Length)
-            {
-                onComplete?.Invoke();
-            }
-
-            void OnScriptLoaded(Event e)
-            {
-                loadedCount++;
-                if (loadedCount == libraries.Length) onComplete?.Invoke();
-            }
-        }
+        /// <summary>Loads ES modules, in the order given.</summary>
+        public static Task LoadModuleAsync(params string[] libraries)
+            => global::Transpose.Require.RequireAsync(global::Transpose.RequireKind.Module, libraries);
     }
 }


### PR DESCRIPTION
`Tesserae.Require` had its own `<script>` / `<link>` injection, and so did every other library on Transpose. The loading now lives once, in the Transpose runtime (`Transpose.Require.RequireAsync`, shipped in `Transpose.BCL` 26.8.4275), and these four members forward to it.

Kept rather than deleted: `Require` is public API of a published package, so applications that call it keep compiling — and get the better behaviour for free.

## What the shared loader fixes

The old implementation:

- counted an element that was merely **present** as loaded, so a caller could proceed before the script had run;
- **remembered a failed load as done** — a fetch that failed once (offline, a half-deployed site) left every later caller believing the library was there;
- matched existing elements with a `src^=` **prefix** test, so `x.js` matched `x.json` and a cache-busting query defeated it;
- knew nothing about the `.js` / `.min.js` pair a site is built with.

The shared one resolves every URL against the document base first (one entry per file whatever the spelling, and a file `index.html` already carries is waited on rather than fetched twice), shares one fetch between callers, forgets a failed load so a later caller retries, and falls back between the `.js` and `.min.js` spellings of the same file — which is what lets a library published once work in a site built either way.

## API

- `LoadScriptAsync` / `LoadModuleAsync` / `LoadStyle` — unchanged signatures, now forwarders.
- `LoadStyleAsync` — new, for a caller that wants to know when the stylesheet has been applied. `LoadStyle` keeps its fire-and-forget shape (failures reach the console through `FireAndForget`, as before).

New code should call `Transpose.Require.RequireAsync` directly, which also picks the element from the URL instead of being told; the `javascript-interop` skill reference now documents it.

## Testing

`Transpose.BCL` pinned to 26.8.4275 (also in `Tesserae.Tests` and `Tesserae.Bench`, which was lagging at 26.8.4131 — nothing may bind against two different base libraries). Tesserae builds clean in Release against the published toolchain. The loader itself is covered upstream by `RequireLoaderTests` in the transpose repo, and was verified in a browser on the GraphKit sample, which fetches its bundle this way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X4V2aD4KX78rtdZ74RGThB

---
_Generated by [Claude Code](https://claude.ai/code/session_01X4V2aD4KX78rtdZ74RGThB)_