### PR TITLE
Let a Tree carry a multi-item selection

### DIFF
--- a/Tesserae.Tests/src/Samples/Lists/TreeSample.cs
+++ b/Tesserae.Tests/src/Samples/Lists/TreeSample.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
 using static Transpose.Core.dom;
 using static Tesserae.UI;
@@ -83,6 +84,10 @@ namespace Tesserae.Tests.Samples
                             new Tree.Item("Child D", UIcons.File)
                         )
                     ),
+                    SampleSubTitle("Multiple Selection, Cascading Into Folders"),
+                    TextBlock("Click a checkbox to pick one row, ctrl (or cmd) click a row to do the same, and shift-click one to pick everything up to it. Selecting a folder selects everything inside it; a folder only part of which is picked is drawn half-selected. The read-only file cannot be picked at all.").Small().Secondary(),
+                    MultipleSelectionTree(out var selectionLabel),
+                    selectionLabel,
                     SampleSubTitle("Tree with Commands and Context Menu"),
                     new Tree().Items(
                         new Tree.Item("src", UIcons.Folder,
@@ -113,6 +118,37 @@ namespace Tesserae.Tests.Samples
                     )
                )).SetTitle("Usage")))
                .SeeAlso(typeof(DetailsListSample), typeof(AccordionSample), typeof(PlanSample), typeof(NodeViewSample), typeof(SearchableGroupedListSample));
+        }
+
+        private static IComponent MultipleSelectionTree(out TextBlock selectionLabel)
+        {
+            var label = TextBlock("Nothing selected").Small().Secondary();
+
+            var tree = new Tree().Compact().Selectable(TreeSelectionMode.Multiple).CascadeSelection().Items(
+                new Tree.Item("config", UIcons.Folder).Expanded().Items(
+                    new Tree.Item("endpoints", UIcons.Folder).Expanded().Items(
+                        new Tree.Item("search.cs",   UIcons.File),
+                        new Tree.Item("upload.cs",   UIcons.File),
+                        new Tree.Item("webhook.cs",  UIcons.File)
+                    ),
+                    new Tree.Item("indexes", UIcons.Folder).Expanded().Items(
+                        new Tree.Item("people.json",    UIcons.File),
+                        new Tree.Item("documents.json", UIcons.File)
+                    ),
+                    new Tree.Item("workspace.json", UIcons.File).Selectable(false)
+                )
+            );
+
+            tree.OnSelectionChanged((_, items) =>
+            {
+                var files = items.Where(i => !i.HasChildren).Select(i => i.Text).ToArray();
+
+                label.Text = files.Length == 0 ? "Nothing selected" : files.Length + " selected: " + string.Join(", ", files);
+            });
+
+            selectionLabel = label;
+
+            return tree;
         }
 
         public HTMLElement Render() => _content.Render();

--- a/Tesserae/skills/references/tree.md
+++ b/Tesserae/skills/references/tree.md
@@ -18,9 +18,14 @@ A vertically-stacked tree of `Tree.Item` nodes. Nodes expand/collapse to reveal 
 `Tree`:
 
 - `.Items(params Tree.Item[])` — add top-level nodes.
-- `.SelectionEnabled(bool = true)` — turn on item selection.
+- `.Selectable(TreeSelectionMode = Multiple)` — turn on item selection: `None`, `Single` (one at a time), or `Multiple`.
+- `.SelectionEnabled(bool = true)` — shorthand for `Single` / `None`.
+- `.NotSelectable()` — take selection away again, unselecting whatever was selected.
+- `.CascadeSelection(bool = true)` — selecting a folder selects everything inside it, unselecting it unselects them, and a folder only part of which is picked is drawn half-selected (`IsPartiallySelected`).
 - `.Compact(bool = true)` — compact density (22px rows, 13px text, 8px indent), matching a code editor's file explorer.
-- `.OnSelected((s, item) => ...)` — fires when selection changes; `SelectedItem` holds the current.
+- `.OnSelected((s, item) => ...)` — fires when the selected item changes; `SelectedItem` holds the last one picked.
+- `.OnSelectionChanged((s, items) => ...)` — fires with everything selected; one call per gesture, even when a range or a cascade moved many rows.
+- `.ClearSelection()` / `.SelectAll()` — move the whole selection from code; `SelectedItems` reads it back, in tree order.
 - `.Clear()` / `.Replace(newItem, oldItem)` — manage nodes.
 
 `Tree.Item`:
@@ -28,9 +33,23 @@ A vertically-stacked tree of `Tree.Item` nodes. Nodes expand/collapse to reveal 
 - `.Items(params Tree.Item[])` — add children.
 - `.ItemsAsync(async () => Tree.Item[])` — lazy-load children on first expand (shows a spinner).
 - `.Expanded(bool = true)` / `.Selected(bool = true)` — initial state.
-- `.OnSelected(...)` / `.OnExpanded(...)` / `.OnCollapsed(...)` — node events.
+- `.Selectable(bool = true)` — say whether the row can be picked at all; one that cannot shows no checkbox and is skipped by ranges, cascades and `SelectAll`.
+- `.OnSelected(...)` / `.OnSelectionChanged((item, isSelected) => ...)` / `.OnExpanded(...)` / `.OnCollapsed(...)` — node events.
 - `.CommandsAlwaysVisible(bool)` — keep row commands visible (not hover-only).
-- `Text`, `Icon`, `IsExpanded`, `IsSelected`, `HasChildren` — read/write state.
+- `Text`, `Icon`, `IsExpanded`, `IsSelected`, `IsPartiallySelected`, `IsSelectable`, `HasChildren`, `Children`, `Parent` — read/write state.
+
+## Selection gestures
+
+`TreeSelectionMode.Multiple` gives a tree the gestures of a list of search results, with the checkbox
+of every row on show:
+
+- **Checkbox click** — picks that one row.
+- **Ctrl (or cmd) click on a row** — the same, without opening or expanding it.
+- **Shift-click on a row** — picks everything between the last row picked and this one, unselecting
+  what falls outside. The range runs over the rows on screen, so a collapsed folder counts as one row
+  (and, on a cascading tree, brings its contents with it).
+- **A plain click** is left alone: it expands the row and runs its `OnClick`, so a tree can both drive
+  a details pane and carry a selection.
 
 ## Example
 
@@ -48,6 +67,22 @@ var tree = new Tree().Compact().SelectionEnabled().Items(
         return new[] { new Tree.Item("child.cs", UIcons.File) };
     })
 ).OnSelected((s, item) => Console.WriteLine(item.Text));
+```
+
+Picking several files out of a folder tree, folders included:
+
+```csharp
+var files = new Tree().Compact().Selectable(TreeSelectionMode.Multiple).CascadeSelection().Items(
+    new Tree.Item("config", UIcons.Folder).Expanded().Items(
+        new Tree.Item("search.cs", UIcons.File),
+        new Tree.Item("upload.cs", UIcons.File),
+        new Tree.Item("workspace.json", UIcons.File).Selectable(false)   // nothing to do with this one
+    )
+).OnSelectionChanged((t, selected) =>
+{
+    var picked = selected.Where(i => !i.HasChildren).ToArray();
+    Console.WriteLine(picked.Length + " files selected");
+});
 ```
 
 ## Related

--- a/Tesserae/src/Components/Tree.cs
+++ b/Tesserae/src/Components/Tree.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -8,15 +8,36 @@ using static Tesserae.UI;
 namespace Tesserae
 {
     /// <summary>
+    /// How many items of a <see cref="Tree"/> can be selected at once, and with which gestures.
+    /// </summary>
+    public enum TreeSelectionMode
+    {
+        /// <summary>Items cannot be selected.</summary>
+        None,
+        /// <summary>One item at a time: selecting an item unselects whatever was selected before.</summary>
+        Single,
+        /// <summary>
+        /// Any number of items, with the gestures of a search-results list: the checkbox toggles one item,
+        /// ctrl (or cmd) clicking a row does the same, and shift-clicking a row selects everything between it
+        /// and the last item the user picked.
+        /// </summary>
+        Multiple
+    }
+
+    /// <summary>
     /// A vertically-stacked tree view with expand / collapse, keyboard navigation, selection and arbitrary item
     /// rendering.
     /// </summary>
     [Transpose.Name("tss.Tree")]
     public sealed class Tree : ComponentBase<Tree, HTMLUListElement>, IContainer<Tree.Item, Tree.Item>, IObservableComponent<Tree.Item>
     {
-        private readonly List<Item>               _children         = new List<Item>();
-        private readonly SettableObservable<Item> _observable       = new SettableObservable<Item>();
-        private          bool                     _selectionEnabled = false;
+        private readonly List<Item>               _children      = new List<Item>();
+        private readonly SettableObservable<Item> _observable    = new SettableObservable<Item>();
+        private          TreeSelectionMode        _selectionMode = TreeSelectionMode.None;
+        private          bool                     _cascade;
+        private          Item                     _anchor;
+        private          int                      _updateDepth;
+        private          bool                     _updatePending;
 
         /// <summary>
         /// Initializes a new instance of this class.
@@ -64,9 +85,24 @@ namespace Tesserae
         public override HTMLElement Render() => InnerElement;
 
         /// <summary>
-        /// Gets the currently selected item.
+        /// Gets the currently selected item - the last one the user picked when several are selected.
         /// </summary>
         public Item SelectedItem { get; private set; }
+
+        /// <summary>
+        /// Returns every selected item, in the order they appear in the tree.
+        /// </summary>
+        public Item[] SelectedItems => Flatten(includeCollapsed: true).Where(i => i.IsSelected).ToArray();
+
+        /// <summary>
+        /// Returns how many items of the tree can be selected at once.
+        /// </summary>
+        public TreeSelectionMode SelectionMode => _selectionMode;
+
+        /// <summary>
+        /// Returns a value indicating whether selecting an item also selects everything below it.
+        /// </summary>
+        public bool IsCascading => _cascade;
 
         /// <summary>
         /// Raised when selected item changed occurs.
@@ -74,11 +110,26 @@ namespace Tesserae
         public event ComponentEventHandler<Tree, Item> SelectedItemChanged;
 
         /// <summary>
+        /// Raised when any item is selected or unselected, with everything that is selected afterwards.
+        /// </summary>
+        public event ComponentEventHandler<Tree, Item[]> SelectionChanged;
+
+        /// <summary>
         /// Registers a callback invoked when the selected event fires.
         /// </summary>
         public Tree OnSelected(ComponentEventHandler<Tree, Item> onSelected)
         {
             SelectedItemChanged += onSelected;
+            return this;
+        }
+
+        /// <summary>
+        /// Registers a callback invoked whenever the selection changes, with every selected item. A gesture
+        /// that moves several items at once - a range, or a cascade into a folder's contents - runs it once.
+        /// </summary>
+        public Tree OnSelectionChanged(ComponentEventHandler<Tree, Item[]> onSelectionChanged)
+        {
+            SelectionChanged += onSelectionChanged;
             return this;
         }
 
@@ -101,27 +152,105 @@ namespace Tesserae
         }
 
         /// <summary>
-        /// Enables or disables item selection on the tree.
+        /// Enables or disables single-item selection on the tree. Shorthand for
+        /// <see cref="Selectable(TreeSelectionMode)"/> with <see cref="TreeSelectionMode.Single"/>.
         /// </summary>
-        public Tree SelectionEnabled(bool enabled = true)
+        public Tree SelectionEnabled(bool enabled = true) => Selectable(enabled ? TreeSelectionMode.Single : TreeSelectionMode.None);
+
+        /// <summary>
+        /// Makes the items of the tree selectable, as many at a time as the given mode allows. In
+        /// <see cref="TreeSelectionMode.Multiple"/> every item shows a checkbox, ctrl (or cmd) clicking a row
+        /// toggles it, and shift-clicking one selects everything between it and the last item picked.
+        /// </summary>
+        public Tree Selectable(TreeSelectionMode mode = TreeSelectionMode.Multiple)
         {
-            _selectionEnabled = enabled;
+            _selectionMode = mode;
 
-            if (enabled)
-            {
-                InnerElement.classList.add("tss-tree-selection-enabled");
-            }
-            else
-            {
-                InnerElement.classList.remove("tss-tree-selection-enabled");
-            }
+            InnerElement.UpdateClassIf(mode != TreeSelectionMode.None, "tss-tree-selection-enabled");
+            InnerElement.UpdateClassIf(mode == TreeSelectionMode.Multiple, "tss-tree-selection-multiple");
 
-            foreach (var item in _children)
+            if (mode == TreeSelectionMode.None)
             {
-                item.SelectionEnabled = enabled;
+                ClearSelection();
             }
 
             return this;
+        }
+
+        /// <summary>
+        /// Takes selection away again, unselecting whatever was selected.
+        /// </summary>
+        public Tree NotSelectable() => Selectable(TreeSelectionMode.None);
+
+        /// <summary>
+        /// Makes an item's selection carry to everything below it: selecting a folder selects every item
+        /// inside it, unselecting it unselects them, and a folder only some of whose contents are selected is
+        /// drawn as partially selected.
+        /// </summary>
+        public Tree CascadeSelection(bool cascade = true)
+        {
+            _cascade = cascade;
+
+            if (cascade) RefreshCascadeState();
+
+            return this;
+        }
+
+        /// <summary>
+        /// Unselects every item of the tree.
+        /// </summary>
+        public Tree ClearSelection()
+        {
+            BeginSelectionUpdate();
+
+            foreach (var item in Flatten(includeCollapsed: true))
+            {
+                item.SetSelected(false, cascade: false);
+            }
+
+            _anchor = null;
+
+            EndSelectionUpdate();
+
+            return this;
+        }
+
+        /// <summary>
+        /// Selects every selectable item of the tree.
+        /// </summary>
+        public Tree SelectAll()
+        {
+            if (_selectionMode != TreeSelectionMode.Multiple) return this;
+
+            BeginSelectionUpdate();
+
+            foreach (var item in Flatten(includeCollapsed: true))
+            {
+                item.SetSelected(true, cascade: false);
+            }
+
+            RefreshCascadeState();
+
+            EndSelectionUpdate();
+
+            return this;
+        }
+
+        /// <summary>
+        /// Re-reads every folder's state from its contents, deepest first.
+        /// </summary>
+        private void RefreshCascadeState()
+        {
+            if (!_cascade) return;
+
+            BeginSelectionUpdate();
+
+            foreach (var child in _children)
+            {
+                child.RefreshCascadeSubtree();
+            }
+
+            EndSelectionUpdate();
         }
 
         /// <summary>
@@ -129,21 +258,28 @@ namespace Tesserae
         /// </summary>
         public void Add(Item component)
         {
-            component.SelectionEnabled = _selectionEnabled;
+            component.AttachTo(this, null);
             _children.Add(component);
             InnerElement.appendChild(component.Render());
-            component.InternalSelectedItem += OnItemSelected;
+            component.InternalSelectionChanged += OnItemSelectionChanged;
+
+            if (_cascade)
+            {
+                BeginSelectionUpdate();
+                component.RefreshCascadeSubtree();
+                EndSelectionUpdate();
+            }
 
             if (component.IsSelected)
             {
-                if (SelectedItem != null) SelectedItem.IsSelected = false;
+                if (_selectionMode != TreeSelectionMode.Multiple && SelectedItem != null) SelectedItem.IsSelected = false;
                 SelectedItem      = component;
                 _observable.Value = component;
             }
 
             if (component.SelectedChild != null)
             {
-                if (SelectedItem != null) SelectedItem.IsSelected = false;
+                if (_selectionMode != TreeSelectionMode.Multiple && SelectedItem != null) SelectedItem.IsSelected = false;
                 SelectedItem = component.SelectedChild;
             }
         }
@@ -154,6 +290,8 @@ namespace Tesserae
         public void Clear()
         {
             _children.Clear();
+            _anchor      = null;
+            SelectedItem = null;
             ClearChildren(InnerElement);
         }
 
@@ -166,29 +304,37 @@ namespace Tesserae
 
             if (index >= 0)
             {
-                newComponent.SelectionEnabled = _selectionEnabled;
-                _children[index]              = newComponent;
+                newComponent.AttachTo(this, null);
+                _children[index] = newComponent;
                 InnerElement.replaceChild(newComponent.Render(), oldComponent.Render());
-                newComponent.InternalSelectedItem += OnItemSelected;
+                newComponent.InternalSelectionChanged += OnItemSelectionChanged;
 
                 if (newComponent.IsSelected)
                 {
-                    if (SelectedItem != null) SelectedItem.IsSelected = false;
+                    if (_selectionMode != TreeSelectionMode.Multiple && SelectedItem != null) SelectedItem.IsSelected = false;
                     SelectedItem = newComponent;
                 }
             }
         }
 
-        private void OnItemSelected(Item sender)
+        private void OnItemSelectionChanged(Item sender, bool isSelected)
         {
-            foreach (var c in _children)
+            if (isSelected)
             {
-                c.UnselectRecursively(sender);
+                if (_selectionMode != TreeSelectionMode.Multiple)
+                {
+                    foreach (var c in _children)
+                    {
+                        c.UnselectRecursively(sender);
+                    }
+                }
+
+                SelectedItem      = sender;
+                _observable.Value = sender;
+                SelectedItemChanged?.Invoke(this, sender);
             }
 
-            SelectedItem      = sender;
-            _observable.Value = sender;
-            SelectedItemChanged?.Invoke(this, sender);
+            RaiseSelectionChanged();
         }
 
         /// <summary>
@@ -205,13 +351,115 @@ namespace Tesserae
             return this;
         }
 
+        // A gesture moves several items at once - a range, or a folder cascading into its contents - and each
+        // of them reports its own change. The depth counter holds the tree-wide event back until the whole
+        // gesture has run, so a handler that reads SelectedItems never sees a half-applied selection.
+        internal void BeginSelectionUpdate() => _updateDepth++;
+
+        internal void EndSelectionUpdate()
+        {
+            _updateDepth--;
+
+            if (_updateDepth > 0) return;
+
+            _updateDepth = 0;
+
+            if (_updatePending)
+            {
+                _updatePending = false;
+                SelectionChanged?.Invoke(this, SelectedItems);
+            }
+        }
+
+        private void RaiseSelectionChanged()
+        {
+            if (_updateDepth > 0)
+            {
+                _updatePending = true;
+                return;
+            }
+
+            SelectionChanged?.Invoke(this, SelectedItems);
+        }
+
+        /// <summary>
+        /// Toggles the given item, and makes it the anchor the next shift-click ranges from.
+        /// </summary>
+        internal void ToggleSelection(Item item)
+        {
+            if (_selectionMode == TreeSelectionMode.None || !item.IsSelectable) return;
+
+            BeginSelectionUpdate();
+
+            item.SetSelected(!item.IsSelected, cascade: _cascade);
+            _anchor = item;
+
+            EndSelectionUpdate();
+        }
+
+        /// <summary>
+        /// Selects everything between the anchor - the last item the user picked - and the given item,
+        /// unselecting whatever falls outside it, the way a shift-click through a list of search results does.
+        /// The range runs over the rows that are actually on screen, so a collapsed folder counts as one row
+        /// (and, when the tree cascades, brings its contents with it).
+        /// </summary>
+        internal void SelectRangeTo(Item item)
+        {
+            if (_selectionMode != TreeSelectionMode.Multiple || !item.IsSelectable) return;
+
+            var visible = Flatten(includeCollapsed: false);
+            var to      = visible.IndexOf(item);
+
+            if (to < 0) return;
+
+            var from = _anchor is object ? visible.IndexOf(_anchor) : -1;
+
+            if (from < 0)
+            {
+                //Nothing to range from yet: this click becomes the anchor, the way the first shift-click on a
+                //list of search results does.
+                _anchor = item;
+                ToggleSelection(item);
+                return;
+            }
+
+            if (from > to)
+            {
+                var swap = from;
+                from     = to;
+                to       = swap;
+            }
+
+            BeginSelectionUpdate();
+
+            for (var i = 0; i < visible.Count; i++)
+            {
+                visible[i].SetSelected(i >= from && i <= to, cascade: _cascade);
+            }
+
+            EndSelectionUpdate();
+        }
+
+        private List<Item> Flatten(bool includeCollapsed)
+        {
+            var items = new List<Item>();
+
+            foreach (var child in _children)
+            {
+                child.Flatten(items, includeCollapsed);
+            }
+
+            return items;
+        }
+
         [Transpose.Name("tss.Tree.Item")]
         public class Item : ComponentBase<Item, HTMLLIElement>, IContainer<Item, Item>
         {
-            internal event ComponentEventHandler<Item> InternalSelectedItem;
+            internal event Action<Item, bool>          InternalSelectionChanged;
             private event  ComponentEventHandler<Item> SelectedItem;
             private event  ComponentEventHandler<Item> ExpandedItem;
             private event  ComponentEventHandler<Item> CollapsedItem;
+            private event  Action<Item, bool>          SelectionChangedItem;
 
             private readonly HTMLDivElement   _headerDiv;
             private readonly HTMLElement      _chevronSpan;
@@ -226,23 +474,14 @@ namespace Tesserae
             private readonly List<Item> _childItems = new List<Item>();
             private          bool       _isExpanded;
             private          bool       _isSelected;
-            private          bool       _selectionEnabled;
+            private          bool       _isPartiallySelected;
+            private          bool       _isSelectable = true;
+            private          Tree       _tree;
 
             internal Item SelectedChild { get; private set; }
 
-            internal bool SelectionEnabled
-            {
-                get => _selectionEnabled;
-                set
-                {
-                    _selectionEnabled = value;
-
-                    foreach (var child in _childItems)
-                    {
-                        child.SelectionEnabled = value;
-                    }
-                }
-            }
+            /// <summary>Gets the item this one hangs from, or null when it is a root of the tree.</summary>
+            public Item Parent { get; private set; }
 
             /// <summary>
             /// Initializes a new instance of this class.
@@ -389,38 +628,52 @@ namespace Tesserae
             }
 
             /// <summary>
-            /// Gets or sets a value indicating whether the component is selected.
+            /// Gets or sets a value indicating whether the component is selected. On a tree that cascades
+            /// (<see cref="Tree.CascadeSelection(bool)"/>) setting it carries to everything below the item.
             /// </summary>
             public bool IsSelected
             {
                 get => _isSelected;
-                set
-                {
-                    if (value != _isSelected)
-                    {
-                        _isSelected = value;
-                        InnerElement.setAttribute("aria-selected", _isSelected ? "true" : "false");
+                set => SetSelected(value, cascade: _tree is object && _tree.IsCascading);
+            }
 
-                        if (_isSelected)
-                        {
-                            _headerDiv.classList.add("tss-selected");
-                            _checkboxSpan.classList.replace(UIcons.Square.ToCssClass(), UIcons.Checkbox.ToCssClass());
-                            InternalSelectedItem?.Invoke(this);
-                            SelectedItem?.Invoke(this);
-                        }
-                        else
-                        {
-                            _headerDiv.classList.remove("tss-selected");
-                            _checkboxSpan.classList.replace(UIcons.Checkbox.ToCssClass(), UIcons.Square.ToCssClass());
-                        }
-                    }
+            /// <summary>
+            /// Returns a value indicating whether only some of the items below this one are selected. Only a
+            /// tree that cascades (<see cref="Tree.CascadeSelection(bool)"/>) ever reports this.
+            /// </summary>
+            public bool IsPartiallySelected => _isPartiallySelected;
+
+            /// <summary>
+            /// Returns a value indicating whether the item can be selected at all. An item that cannot is
+            /// skipped by a range, by a cascade, and by <see cref="Tree.SelectAll"/>, and shows no checkbox.
+            /// </summary>
+            public bool IsSelectable => _isSelectable;
+
+            /// <summary>
+            /// Says whether the item can be selected. Use it for a row that is there to be read rather than
+            /// picked - a file with nothing to import, a folder no action applies to.
+            /// </summary>
+            public Item Selectable(bool selectable = true)
+            {
+                _isSelectable = selectable;
+
+                InnerElement.UpdateClassIfNot(selectable, "tss-tree-item-not-selectable");
+
+                if (!selectable && _isSelected)
+                {
+                    SetSelected(false, cascade: false);
                 }
+
+                return this;
             }
 
             /// <summary>
             /// Returns a value indicating whether the component has the given children.
             /// </summary>
             public bool HasChildren => _childItems.Count > 0 || _childContainer.hasChildNodes();
+
+            /// <summary>Returns the items hanging from this one.</summary>
+            public Item[] Children => _childItems.ToArray();
 
             /// <summary>
             /// Renders the component's root HTML element.
@@ -435,28 +688,31 @@ namespace Tesserae
                 _childItems.Add(component);
                 _childContainer.appendChild(component.Render());
                 UpdateChevronVisibility();
-                component.InternalSelectedItem += OnChildSelected;
+                component.AttachTo(_tree, this);
+                component.InternalSelectionChanged += OnChildSelectionChanged;
 
                 if (component.IsSelected)
                 {
-                    InternalSelectedItem?.Invoke(component);
+                    InternalSelectionChanged?.Invoke(component, true);
 
-                    if (SelectedChild != null) SelectedChild.IsSelected = false;
+                    if (SelectedChild != null && !(_tree is object && _tree.SelectionMode == TreeSelectionMode.Multiple)) SelectedChild.IsSelected = false;
                     SelectedChild = component;
                 }
 
                 if (component.SelectedChild != null)
                 {
-                    InternalSelectedItem?.Invoke(component.SelectedChild);
+                    InternalSelectionChanged?.Invoke(component.SelectedChild, true);
 
-                    if (SelectedChild != null) SelectedChild.IsSelected = false;
+                    if (SelectedChild != null && !(_tree is object && _tree.SelectionMode == TreeSelectionMode.Multiple)) SelectedChild.IsSelected = false;
                     SelectedChild = component.SelectedChild;
                 }
+
+                RefreshSelectionFromChildren();
             }
 
-            private void OnChildSelected(Item sender)
+            private void OnChildSelectionChanged(Item sender, bool isSelected)
             {
-                InternalSelectedItem?.Invoke(sender);
+                InternalSelectionChanged?.Invoke(sender, isSelected);
             }
 
             /// <summary>
@@ -465,6 +721,7 @@ namespace Tesserae
             public void Clear()
             {
                 _childItems.Clear();
+                SelectedChild = null;
                 ClearChildren(_childContainer);
                 UpdateChevronVisibility();
             }
@@ -480,13 +737,167 @@ namespace Tesserae
                 {
                     _childItems[index] = newComponent;
                     _childContainer.replaceChild(newComponent.Render(), oldComponent.Render());
-                    newComponent.InternalSelectedItem += OnChildSelected;
+                    newComponent.AttachTo(_tree, this);
+                    newComponent.InternalSelectionChanged += OnChildSelectionChanged;
 
                     if (newComponent.IsSelected)
                     {
-                        InternalSelectedItem?.Invoke(newComponent);
+                        InternalSelectionChanged?.Invoke(newComponent, true);
                     }
                 }
+            }
+
+            internal void AttachTo(Tree tree, Item parent)
+            {
+                _tree  = tree;
+                Parent = parent;
+
+                foreach (var child in _childItems)
+                {
+                    child.AttachTo(tree, this);
+                }
+            }
+
+            internal void Flatten(List<Item> into, bool includeCollapsed)
+            {
+                into.Add(this);
+
+                if (!includeCollapsed && !_isExpanded) return;
+
+                foreach (var child in _childItems)
+                {
+                    child.Flatten(into, includeCollapsed);
+                }
+            }
+
+            /// <summary>
+            /// Sets the item's selection, optionally carrying it to everything below, and updates the
+            /// ancestors' partial state on the way back up.
+            /// </summary>
+            internal void SetSelected(bool value, bool cascade)
+            {
+                if (value && !_isSelectable) return;
+
+                _tree?.BeginSelectionUpdate();
+
+                ApplySelected(value);
+
+                if (cascade)
+                {
+                    foreach (var child in _childItems)
+                    {
+                        child.SetSelected(value, cascade: true);
+                    }
+
+                    Parent?.RefreshSelectionFromChildren();
+                }
+
+                _tree?.EndSelectionUpdate();
+            }
+
+            private void ApplySelected(bool value)
+            {
+                if (value == _isSelected && !_isPartiallySelected) return;
+
+                var wasSelected = _isSelected;
+
+                _isSelected          = value;
+                _isPartiallySelected = false;
+
+                InnerElement.setAttribute("aria-selected", _isSelected ? "true" : "false");
+                _headerDiv.UpdateClassIf(_isSelected, "tss-selected");
+                _headerDiv.classList.remove("tss-partially-selected");
+                UpdateCheckbox();
+
+                if (_isSelected == wasSelected) return;
+
+                if (_isSelected) SelectedItem?.Invoke(this);
+
+                SelectionChangedItem?.Invoke(this, _isSelected);
+                InternalSelectionChanged?.Invoke(this, _isSelected);
+            }
+
+            /// <summary>
+            /// Re-reads this item's state from its children - all selected, none, or some - and carries the
+            /// answer further up.
+            /// </summary>
+            internal void RefreshSelectionFromChildren()
+            {
+                if (_tree is null || !_tree.IsCascading) return;
+
+                RecomputeFromChildren();
+
+                Parent?.RefreshSelectionFromChildren();
+            }
+
+            /// <summary>
+            /// Re-reads the whole subtree's state, deepest item first, so a tree built bottom-up shows the
+            /// right folder states the moment it is added.
+            /// </summary>
+            internal void RefreshCascadeSubtree()
+            {
+                foreach (var child in _childItems)
+                {
+                    child.RefreshCascadeSubtree();
+                }
+
+                RecomputeFromChildren();
+            }
+
+            /// <summary>
+            /// A folder with nothing selectable inside it keeps whatever state it had.
+            /// </summary>
+            private void RecomputeFromChildren()
+            {
+                if (!_isSelectable) return;
+
+                var selectable = _childItems.Where(c => c.IsSelectable).ToArray();
+
+                if (selectable.Length == 0) return;
+
+                var selected  = selectable.Count(c => c.IsSelected);
+                var partial   = selectable.Any(c => c.IsPartiallySelected);
+
+                if (selected == selectable.Length && !partial)
+                {
+                    ApplySelected(true);
+                }
+                else if (selected > 0 || partial)
+                {
+                    ApplyPartiallySelected();
+                }
+                else
+                {
+                    ApplySelected(false);
+                }
+            }
+
+            private void ApplyPartiallySelected()
+            {
+                var wasSelected = _isSelected;
+
+                _isSelected          = false;
+                _isPartiallySelected = true;
+
+                InnerElement.setAttribute("aria-selected", "false");
+                _headerDiv.classList.remove("tss-selected");
+                _headerDiv.classList.add("tss-partially-selected");
+                UpdateCheckbox();
+
+                if (wasSelected)
+                {
+                    SelectionChangedItem?.Invoke(this, false);
+                    InternalSelectionChanged?.Invoke(this, false);
+                }
+            }
+
+            private void UpdateCheckbox()
+            {
+                var icon = _isSelected
+                    ? UIcons.Checkbox
+                    : (_isPartiallySelected ? UIcons.SquareMinus : UIcons.Square);
+
+                _checkboxSpan.className = "tss-tree-checkbox " + icon.ToCssClass();
             }
 
             internal void UnselectRecursively(Item sender)
@@ -500,7 +911,7 @@ namespace Tesserae
                 }
                 else if (!_childItems.Any(l => l.IsOrHasChild(sender)))
                 {
-                    IsSelected = false;
+                    SetSelected(false, cascade: false);
 
                     foreach (var child in _childItems)
                     {
@@ -589,6 +1000,15 @@ namespace Tesserae
             }
 
             /// <summary>
+            /// Registers a callback invoked whenever the item is selected or unselected, with the new state.
+            /// </summary>
+            public Item OnSelectionChanged(Action<Item, bool> onSelectionChanged)
+            {
+                SelectionChangedItem += onSelectionChanged;
+                return this;
+            }
+
+            /// <summary>
             /// Registers a callback invoked when the expanded event fires.
             /// </summary>
             public Item OnExpanded(ComponentEventHandler<Item> onExpanded)
@@ -610,7 +1030,25 @@ namespace Tesserae
             {
                 StopEvent(e);
 
-                if (SelectionEnabled && e.shiftKey)
+                var mode = _tree is object ? _tree.SelectionMode : TreeSelectionMode.None;
+
+                if (mode == TreeSelectionMode.Multiple && _isSelectable)
+                {
+                    //The gestures of a search-results list: ctrl (or cmd) picks one more, shift picks
+                    //everything up to here, and a plain click is left to the row's own handler.
+                    if (e.ctrlKey || e.metaKey)
+                    {
+                        _tree.ToggleSelection(this);
+                        return;
+                    }
+
+                    if (e.shiftKey)
+                    {
+                        _tree.SelectRangeTo(this);
+                        return;
+                    }
+                }
+                else if (mode == TreeSelectionMode.Single && e.shiftKey)
                 {
                     IsSelected = !IsSelected;
                 }
@@ -628,7 +1066,21 @@ namespace Tesserae
             {
                 StopEvent(e);
 
-                if (SelectionEnabled)
+                var mode = _tree is object ? _tree.SelectionMode : TreeSelectionMode.None;
+
+                if (mode == TreeSelectionMode.None || !_isSelectable) return;
+
+                if (mode == TreeSelectionMode.Multiple && e.shiftKey)
+                {
+                    _tree.SelectRangeTo(this);
+                    return;
+                }
+
+                if (_tree is object)
+                {
+                    _tree.ToggleSelection(this);
+                }
+                else
                 {
                     IsSelected = !IsSelected;
                 }

--- a/Tesserae/tps/assets/css/tss.tree.css
+++ b/Tesserae/tps/assets/css/tss.tree.css
@@ -82,6 +82,29 @@
     display: inline-block;
 }
 
+/* Multiple selection - every row carries its checkbox next to its icon, so what is picked reads at a glance */
+.tss-tree-selection-multiple .tss-tree-checkbox {
+    display: inline-block;
+}
+
+.tss-tree-selection-multiple .tss-tree-item-content.tss-selected .tss-tree-icon,
+.tss-tree-selection-multiple.tss-tree-shift-pressed .tss-tree-icon {
+    display: inline-block;
+}
+
+.tss-tree-selection-multiple .tss-tree-item-content.tss-selected .tss-tree-checkbox,
+.tss-tree-selection-multiple .tss-tree-item-content.tss-partially-selected .tss-tree-checkbox {
+    color: var(--tss-primary-background-color);
+}
+
+.tss-tree-selection-multiple .tss-tree-item.tss-tree-item-not-selectable > .tss-tree-item-content .tss-tree-checkbox {
+    visibility: hidden;
+}
+
+.tss-tree-selection-multiple .tss-tree-item-content.tss-partially-selected {
+    color: var(--tss-primary-background-color);
+}
+
 .tss-tree-icon {
     margin-right: 8px;
     font-size: 16px;


### PR DESCRIPTION
A `Tree` could hold one selected item: selecting a second unselected the first, and the only gesture that reached the selection at all was a shift-click or a click on the checkbox. That is not enough for a picker — a list of files someone chooses a subset of — which is what a tree is usually reached for.

## What changed

`Selectable(TreeSelectionMode)` now says how many items can be selected at once. `None` and `Single` are what the tree already did (`SelectionEnabled` is kept, as the shorthand for the two), and `Multiple` gives it the gestures of a list of search results, which is where the same choice is already made in an application:

- the checkbox of every row is on show, and picks that one row,
- **ctrl** — or **cmd**, which `OmniResult` does not yet read — clicking a row does the same without expanding it or running its `OnClick`,
- **shift**-clicking one picks everything between the last row picked and this one, unselecting what falls outside, over the rows actually on screen (so a collapsed folder counts as one row).

A plain click is deliberately left alone, so a tree can drive a details pane and carry a selection at the same time.

`CascadeSelection()` makes a folder's state its contents': selecting it selects everything inside, unselecting it unselects them, and a folder only part of which is picked draws itself half-selected (`SquareMinus`, reported as `IsPartiallySelected`). Folder states are recomputed deepest-first, so a tree built bottom-up and then added shows the right ones straight away.

`Item.Selectable(false)` marks a row that cannot be picked at all — a file with nothing to import, a heading — and it is then skipped by cascades, ranges and `SelectAll`, and shows no checkbox.

The tree-wide `OnSelectionChanged` hands over everything selected and fires once per gesture rather than once per row, so a handler that reads `SelectedItems` never sees a range half-applied.

## Files

- `Tesserae/src/Components/Tree.cs` — the `TreeSelectionMode` enum, the selection state machine (per-item apply, cascade down, ancestor recompute), the range walk and the anchor.
- `Tesserae/tps/assets/css/tss.tree.css` — the `Multiple` mode's always-visible checkbox, the half-selected state, and hiding the checkbox of a row that cannot be picked.
- `Tesserae.Tests/src/Samples/Lists/TreeSample.cs` — a "Multiple Selection, Cascading Into Folders" sample with a live count of what is picked, including one row that is `Selectable(false)`.
- `Tesserae/skills/references/tree.md` — the new members plus a "Selection gestures" section.

## Testing

`dotnet build` of both `Tesserae` and `Tesserae.Tests` is clean, and the new sample was driven in Chromium through Playwright, asserting on the DOM after each gesture: checkbox click (ancestors go half-selected), ctrl-click, shift-click range (replaces the selection), folder checkbox (cascades into every child), unchecking one child (folder returns to half-selected), a locked row refusing to be picked, a plain click leaving the selection alone, and a collapsed folder cascading through a range. No console errors.

The first consumer is the Curiosity Workspace definitions importer, whose file tree is built on exactly this (`curiosity-ai/mosaik#claude/config-import-tree-interface-t9adgo`); it was exercised end-to-end against a running workspace with this build packed locally.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RVrKDKHqGQi27fQsWH3kco)_