### PR TITLE
Switch OmniResult highlighting from .NET Regex to JavaScript RegExp

### DIFF
--- a/Tesserae/skills/references/omni-result.md
+++ b/Tesserae/skills/references/omni-result.md
@@ -47,9 +47,13 @@ stands for. Also `new OmniResult<T>(result, title)`. Bring factories into scope 
   case-insensitively. The marks and the badge share one pair of colors, from the `--tss-highlight-color`
   token (the same value as `--tss-link-color`, so `Theme.SetPrimary` moves both), and the excerpt
   itself is a quiet grey.
-- `.Highlight(Regex)` / `.Highlight(string pattern, bool ignoreCase = true)` — mark every match, e.g.
-  the pattern a search backend hands back. Matching runs against the text and each match is wrapped in
-  its own element, so text containing angle brackets renders them instead of obeying them.
+- `.Highlight(es5.RegExp)` / `.Highlight(string pattern, bool ignoreCase = true)` — mark every match,
+  e.g. the pattern a search backend hands back. The expression is the JavaScript one
+  (`Transpose.Core.es5.RegExp`), which is what a host highlighting a preview document alongside the row
+  already has, so one object serves both. It is taken for its pattern alone — the row scans with a
+  global copy of it — so sharing it across rows is safe, and it needs no `g` flag of its own. Matching
+  runs against the text and each match is wrapped in its own element, so text containing angle brackets
+  renders them instead of obeying them.
 
 **Icon tile**
 

--- a/Tesserae/src/Components/OmniResult.cs
+++ b/Tesserae/src/Components/OmniResult.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Text.RegularExpressions;
+using System.Text;
 using System.Threading.Tasks;
 using static Transpose.Core.dom;
 using Transpose.Core;
@@ -111,7 +111,7 @@ namespace Tesserae
         private string                       _title;
         private IComponent                   _titleComponent;
         private string                       _text;
-        private Regex                        _highlighter;
+        private es5.RegExp                   _highlighter;
         private OmniResultSelectionMode      _selectionMode = OmniResultSelectionMode.OnHoverBeforeIcon;
         private bool                         _selectionEnabled;
         private bool                         _textSelectable;
@@ -269,7 +269,7 @@ namespace Tesserae
 
         /// <summary>
         /// Gets or sets the excerpt shown under the title, or null when the result has none. Plain text: the
-        /// only markup it gets is the highlighting of <see cref="Highlight(Regex)"/>.
+        /// only markup it gets is the highlighting of <see cref="Highlight(es5.RegExp)"/>.
         /// </summary>
         public string Text
         {
@@ -336,7 +336,7 @@ namespace Tesserae
 
         /// <summary>
         /// Sets the title of the result. The title is ellipsized to one line, carries the full text as its
-        /// native tooltip, and has the terms of <see cref="Highlight(Regex)"/> marked in it.
+        /// native tooltip, and has the terms of <see cref="Highlight(es5.RegExp)"/> marked in it.
         /// </summary>
         public OmniResult<T> SetTitle(string title)
         {
@@ -354,7 +354,7 @@ namespace Tesserae
         /// text passed alongside it stays the row's <see cref="Title"/>, so the tooltip, the modal header and
         /// anything else reading the title still have something to say. Pass null to go back to plain text.
         /// <para>
-        /// A component title is drawn as it was given: <see cref="Highlight(Regex)"/> does not reach inside it.
+        /// A component title is drawn as it was given: <see cref="Highlight(es5.RegExp)"/> does not reach inside it.
         /// </para>
         /// </summary>
         public OmniResult<T> SetTitle(IComponent title, string text = null)
@@ -457,7 +457,7 @@ namespace Tesserae
         /// <summary>
         /// Sets the excerpt shown under the title. It is plain text, not a component: whatever the search
         /// returned as the matching passage, ellipsized to the two lines the row gives it, with the terms of
-        /// <see cref="Highlight(Regex)"/> marked in it. A null or empty value drops the line entirely.
+        /// <see cref="Highlight(es5.RegExp)"/> marked in it. A null or empty value drops the line entirely.
         /// </summary>
         public OmniResult<T> SetText(string text)
         {
@@ -551,10 +551,15 @@ namespace Tesserae
         /// Marks every match of the given expression in the title and the excerpt - the same pattern a search
         /// backend hands back for highlighting. Matching is done against the text itself and the matches are
         /// wrapped in their own elements, so neither is ever treated as markup.
+        /// <para>
+        /// The expression is taken for its pattern alone - the row scans with a global copy of it - so the same
+        /// object can be handed to every row of a result list, and to whatever else the host highlights, without
+        /// the scans stepping on each other through the shared <c>lastIndex</c>.
+        /// </para>
         /// </summary>
-        public OmniResult<T> Highlight(Regex highlighter)
+        public OmniResult<T> Highlight(es5.RegExp highlighter)
         {
-            _highlighter = highlighter;
+            _highlighter = GlobalCopyOf(highlighter);
 
             RenderTitle();
             RenderText();
@@ -569,27 +574,57 @@ namespace Tesserae
         {
             return Highlight(string.IsNullOrEmpty(pattern)
                 ? null
-                : new Regex(pattern, ignoreCase ? RegexOptions.IgnoreCase : RegexOptions.None));
+                : new es5.RegExp(pattern, ignoreCase ? "gi" : "g"));
         }
 
         /// <summary>
         /// Marks every occurrence of the given words in the excerpt, case-insensitively - the convenience
-        /// form of <see cref="Highlight(Regex)"/> for a host that has the query terms rather than a pattern.
+        /// form of <see cref="Highlight(es5.RegExp)"/> for a host that has the query terms rather than a pattern.
         /// </summary>
         public OmniResult<T> HighlightWords(params string[] words)
         {
-            if (words is null || words.Length == 0) return Highlight((Regex)null);
+            if (words is null || words.Length == 0) return Highlight((es5.RegExp)null);
 
             var escaped = new List<string>();
 
             foreach (var word in words)
             {
-                if (!string.IsNullOrWhiteSpace(word)) escaped.Add(Regex.Escape(word));
+                if (!string.IsNullOrWhiteSpace(word)) escaped.Add(EscapeForRegExp(word));
             }
 
-            if (escaped.Count == 0) return Highlight((Regex)null);
+            if (escaped.Count == 0) return Highlight((es5.RegExp)null);
 
-            return Highlight(new Regex(string.Join("|", escaped), RegexOptions.IgnoreCase));
+            return Highlight(new es5.RegExp(string.Join("|", escaped), "gi"));
+        }
+
+        // Backslashes every character JavaScript gives a meaning to inside a pattern, so a word the user typed
+        // matches itself. RegExp.escape does the same natively, but only on browsers from 2025 onwards.
+        private const string REGEXP_SPECIAL_CHARACTERS = @"\^$.|?*+()[]{}/";
+
+        private static string EscapeForRegExp(string word)
+        {
+            var escaped = new StringBuilder(word.Length + 8);
+
+            foreach (var c in word)
+            {
+                if (REGEXP_SPECIAL_CHARACTERS.IndexOf(c) >= 0) escaped.Append('\\');
+
+                escaped.Append(c);
+            }
+
+            return escaped.ToString();
+        }
+
+        // A scan walks the text with exec, which reads and writes lastIndex and only advances the search while
+        // the expression is global - so the row keeps a global copy of its own rather than the caller's object,
+        // which a host is free to hand to several rows or to keep for highlighting of its own.
+        private static es5.RegExp GlobalCopyOf(es5.RegExp highlighter)
+        {
+            if (highlighter is null) return null;
+
+            var flags = highlighter.flags;
+
+            return new es5.RegExp(highlighter.source, flags.Contains("g") ? flags : flags + "g");
         }
 
         /// <summary>
@@ -1871,22 +1906,36 @@ namespace Tesserae
             }
 
             var position = 0;
-            var matches  = _highlighter.Matches(text);
 
-            for (int i = 0; i < matches.Count; i++)
+            _highlighter.lastIndex = 0;
+
+            while (true)
             {
-                var match = matches[i];
+                var match = _highlighter.exec(text);
 
-                if (match.Length == 0) continue;
+                if (match is null) break;
 
-                if (match.Index > position)
+                var index = (int)match.index;
+                var value = match[0];
+
+                //A pattern that can match nothing would sit on the same index forever, so step past it.
+                if (string.IsNullOrEmpty(value))
                 {
-                    target.appendChild(document.createTextNode(text.Substring(position, match.Index - position)));
+                    _highlighter.lastIndex = index + 1;
+
+                    if (index >= text.Length) break;
+
+                    continue;
                 }
 
-                target.appendChild(Span(Att("tss-omniresult-highlight", text: match.Value)));
+                if (index > position)
+                {
+                    target.appendChild(document.createTextNode(text.Substring(position, index - position)));
+                }
 
-                position = match.Index + match.Length;
+                target.appendChild(Span(Att("tss-omniresult-highlight", text: value)));
+
+                position = index + value.Length;
             }
 
             if (position < text.Length)


### PR DESCRIPTION
## Summary

Migrates the `OmniResult` component's text highlighting system from .NET's `System.Text.RegularExpressions.Regex` to JavaScript's `es5.RegExp`, enabling seamless sharing of regex objects between the component and host code (e.g., search backends highlighting preview documents).

## Key Changes

- **API change**: `Highlight(Regex)` → `Highlight(es5.RegExp)` — the public method now accepts JavaScript regex objects instead of .NET regex objects
- **Global copy mechanism**: The component creates a global copy of the provided regex to avoid `lastIndex` conflicts when the same pattern is shared across multiple rows or other highlighting contexts
- **Pattern escaping**: Replaced `Regex.Escape()` with a custom `EscapeForRegExp()` method that escapes JavaScript regex special characters (since `RegExp.escape` is not yet widely supported)
- **Matching algorithm**: Rewrote `RenderHighlighted()` to use `RegExp.exec()` with manual `lastIndex` management instead of .NET's `Matches()` collection
- **Convenience overloads preserved**: `Highlight(string pattern, bool ignoreCase)` and `HighlightWords(params string[])` remain, now building `es5.RegExp` objects internally
- **Documentation**: Updated XML docs and the `omni-result.md` skill reference to explain the regex sharing pattern and the global copy behavior

## Implementation Details

- The `GlobalCopyOf()` helper ensures the regex has the `g` (global) flag, which is required for `exec()` to advance through matches via `lastIndex`
- Empty match handling prevents infinite loops on patterns that can match zero-width positions
- The component now works with the same regex objects that JavaScript code (search backends, preview highlighters) already uses, eliminating the need for pattern re-compilation or conversion

https://claude.ai/code/session_011Ui6ADcmexWLjTyq8o9aof