### PR TITLE
Stop a caller's padding from breaking CheckBox, Choice and Toggle

### DIFF
--- a/Tesserae/skills/references/choice-group.md
+++ b/Tesserae/skills/references/choice-group.md
@@ -29,6 +29,8 @@ Choice:
 - `.Selected()` / `.SelectedIf(bool)` — initial selection.
 - `.Disabled(bool = true)` — disable a single option.
 - `.OnSelected(Action<Choice>)` — per-option callback.
+- Text formatting — `.Tiny()` … `.Mega()`, `.SemiBold()` / `.Bold()`: a `Choice` is an
+  `ITextFormating`, and the radio scales with the label.
 
 ## Example
 

--- a/Tesserae/skills/references/creating-a-component.md
+++ b/Tesserae/skills/references/creating-a-component.md
@@ -107,6 +107,14 @@ own clicks (a raw `element.onclick`) should make the same check first with
   the wrap-and-transfer protocol — see `Stack.CopyStylesDefinedWithExtension`.
   A component can opt out of wrapping by implementing `ISpecialCaseStyling` and
   exposing a `StylingContainer`.
+- **Don't spend `padding` on the element `Render()` returns.** `.P()` / `.PL()` and
+  friends write an inline padding onto exactly that element, and an inline value beats
+  any stylesheet, so a caller asking for room around your component silently deletes
+  whatever inner offset the padding was holding. Put the component's own spacing on a
+  child instead — a `margin` between the parts, or padding on an inner element — and the
+  two compose: the caller's padding moves the whole control, your margin keeps its
+  pieces apart. `CheckBox`, `ChoiceGroup.Choice` and `Toggle` lay their mark and their
+  text out side by side in a flex row for this reason.
 - To accept children, implement `IContainer<T, TChild>` and wrap each child with
   the stack-item protocol; most custom components instead *compose* existing
   components (return a `Stack().Children(...)`).

--- a/Tesserae/src/Components/CheckBox.cs
+++ b/Tesserae/src/Components/CheckBox.cs
@@ -10,6 +10,7 @@ namespace Tesserae
     public class CheckBox : ComponentBase<CheckBox, HTMLInputElement>, IBindableComponent<bool>, IRoundedStyle, ITextFormating
     {
         private readonly HTMLSpanElement          _checkSpan;
+        private readonly HTMLSpanElement          _textSpan;
         private readonly HTMLLabelElement         _label;
         private readonly SettableObservable<bool> _observable;
 
@@ -20,7 +21,8 @@ namespace Tesserae
         {
             InnerElement = CheckBox(Att("tss-checkbox"));
             _checkSpan   = Span(Att("tss-checkbox-mark"));
-            _label = UI.Label(Att("tss-checkbox-container tss-default-component-margin tss-fontcolor-default tss-fontsize-small tss-fontweight-regular", text: text), InnerElement, _checkSpan);
+            _textSpan    = Span(Att("tss-checkbox-text", text: text));
+            _label       = UI.Label(Att("tss-checkbox-container tss-default-component-margin tss-fontcolor-default tss-fontsize-small tss-fontweight-regular"), InnerElement, _checkSpan, _textSpan);
 
             AttachClick();
             AttachChange();
@@ -40,8 +42,8 @@ namespace Tesserae
         /// </summary>
         public string Text
         {
-            get => _label.innerText;
-            set => _label.innerText = value;
+            get => _textSpan.innerText;
+            set => _textSpan.innerText = value;
         }
 
         /// <summary>

--- a/Tesserae/src/Components/ChoiceGroup.cs
+++ b/Tesserae/src/Components/ChoiceGroup.cs
@@ -186,6 +186,7 @@ namespace Tesserae
             private event ComponentEventHandler<Choice> SelectedItem;
 
             private readonly HTMLSpanElement  _radioSpan;
+            private readonly HTMLSpanElement  _textSpan;
             private readonly HTMLLabelElement _label;
             /// <summary>
             /// Initializes a new instance of this class.
@@ -194,7 +195,8 @@ namespace Tesserae
             {
                 InnerElement = RadioButton(Att("tss-option"));
                 _radioSpan   = Span(Att("tss-option-mark"));
-                _label       = Label(Att("tss-option-container tss-default-component-margin tss-fontcolor-default tss-fontsize-small tss-fontweight-regular", text: text), InnerElement, _radioSpan);
+                _textSpan    = Span(Att("tss-option-text", text: text));
+                _label       = Label(Att("tss-option-container tss-default-component-margin tss-fontcolor-default tss-fontsize-small tss-fontweight-regular"), InnerElement, _radioSpan, _textSpan);
                 AttachClick();
                 AttachChange();
                 AttachFocus();
@@ -248,8 +250,8 @@ namespace Tesserae
             /// </summary>
             public string Text
             {
-                get { return _label.innerText; }
-                set { _label.innerText = value; }
+                get { return _textSpan.innerText; }
+                set { _textSpan.innerText = value; }
             }
 
             /// <summary>

--- a/Tesserae/src/Components/Toggle.cs
+++ b/Tesserae/src/Components/Toggle.cs
@@ -11,6 +11,7 @@ namespace Tesserae
     {
         private readonly HTMLElement              _checkElement;
         private readonly HTMLElement              _onOffSpan;
+        private readonly HTMLElement              _textSpan;
         private readonly HTMLElement              _container;
         private readonly IComponent               _offText;
         private readonly IComponent               _onText;
@@ -28,8 +29,11 @@ namespace Tesserae
             InnerElement  = CheckBox(Att("tss-checkbox"));
             InnerElement.setAttribute("role", "switch");
             _checkElement = Div(Att("tss-toggle-mark"));
-            _onOffSpan = Div(Att("tss-toggle-text"), _offText.Render());
-            _container = Div(Att("tss-toggle-container tss-default-component-margin tss-fontcolor-default tss-fontsize-small tss-fontweight-regular"), InnerElement, _checkElement, _onOffSpan);
+            _onOffSpan    = Div(Att("tss-toggle-text"), _offText.Render());
+            _textSpan     = Div(Att("tss-toggle-text"));
+            _container    = Div(Att("tss-toggle-container tss-default-component-margin tss-fontcolor-default tss-fontsize-small tss-fontweight-regular"), InnerElement, _checkElement, _onOffSpan, _textSpan);
+
+            _textSpan.style.display = "none";
 
             _observable = new SettableObservable<bool>();
 
@@ -53,13 +57,14 @@ namespace Tesserae
         /// </summary>
         public string Text
         {
-            get => _container.innerText;
+            get => _textSpan.innerText;
             set
             {
-                _container.innerText = value;
+                _textSpan.innerText = value;
+                var hasOwnText      = !string.IsNullOrEmpty(value);
 
-                if (string.IsNullOrEmpty(value)) _onOffSpan.style.display = "";
-                else _onOffSpan.style.display                             = "none";
+                _onOffSpan.style.display = hasOwnText ? "none" : "";
+                _textSpan.style.display  = hasOwnText ? ""     : "none";
             }
         }
 

--- a/Tesserae/tps/assets/css/tss.checkbox.css
+++ b/Tesserae/tps/assets/css/tss.checkbox.css
@@ -5,8 +5,7 @@
     color: var(--tss-default-foreground-color);
     -webkit-user-select: none;
     user-select: none;
-    padding-left: 25px;
-    display: block;
+    display: flex;
     height: 21px;
 }
 
@@ -18,16 +17,28 @@
         width: 0;
     }
 
+    /* The mark is a flow item with the text beside it, not an overlay sitting in a padding well the
+       container reserves: a caller's .PL(n) writes an inline padding-left that wins over any padding
+       declared here, which used to drop the text on top of the mark. A margin between the two is
+       untouched by it, so the whole control just moves over. */
     .tss-checkbox-container .tss-checkbox-mark {
-        position: absolute;
-        top: 0;
-        left: 0;
+        position: relative;
+        flex: 0 0 auto;
         height: 20px;
         width: 20px;
         border-radius: var(--tss-border-radius-sm);
         background-color: var(--tss-default-background-color);
         border: 1px solid var(--tss-default-foreground-color);
         transition: all 0.15s ease-in-out;
+    }
+
+    .tss-checkbox-container .tss-checkbox-text {
+        min-width: 0;
+        margin-left: 5px;
+    }
+
+    .tss-checkbox-container .tss-checkbox-text:empty {
+        display: none;
     }
 
     .tss-checkbox-container:hover input ~ .tss-checkbox-mark:after {
@@ -77,47 +88,38 @@
 
     .tss-checkbox-container.tss-fontsize-mega {
         height: calc(9px + var(--tss-font-size-mega));
-        padding-left: calc(13px + var(--tss-font-size-mega));
     }
 
     .tss-checkbox-container.tss-fontsize-xxlarge {
         height: calc(9px + var(--tss-font-size-xxlarge));
-        padding-left: calc(13px + var(--tss-font-size-xxlarge));
     }
 
     .tss-checkbox-container.tss-fontsize-xlarge {
         height: calc(9px + var(--tss-font-size-xlarge));
-        padding-left: calc(13px + var(--tss-font-size-xlarge));
     }
 
     .tss-checkbox-container.tss-fontsize-large {
         height: calc(9px + var(--tss-font-size-large));
-        padding-left: calc(13px + var(--tss-font-size-large));
     }
 
     .tss-checkbox-container.tss-fontsize-mediumplus {
         height: calc(9px + var(--tss-font-size-mediumplus));
-        padding-left: calc(13px + var(--tss-font-size-mediumplus));
     }
 
     .tss-checkbox-container.tss-fontsize-medium {
         height: calc(9px + var(--tss-font-size-medium));
-        padding-left: calc(13px + var(--tss-font-size-medium));
     }
 
     .tss-checkbox-container.tss-fontsize-smallplus {
         height: calc(9px + var(--tss-font-size-smallplus));
-        padding-left: calc(13px + var(--tss-font-size-smallplus));
     }
 
     .tss-checkbox-container.tss-fontsize-xsmall {
         height: calc(9px + var(--tss-font-size-xsmall));
-        padding-left: calc(13px + var(--tss-font-size-xsmall));
     }
 
     .tss-checkbox-container.tss-fontsize-tiny {
         height: calc(9px + var(--tss-font-size-tiny));
-        padding-left: calc(13px + var(--tss-font-size-tiny));
     }
 
 

--- a/Tesserae/tps/assets/css/tss.choice.css
+++ b/Tesserae/tps/assets/css/tss.choice.css
@@ -15,8 +15,7 @@
     font-weight: var(--tss-font-weight-regular);
     -webkit-user-select: none;
     user-select: none;
-    padding-left: 28px;
-    display: block;
+    display: flex;
     text-align: left;
 }
 
@@ -28,14 +27,29 @@
         width: 0;
     }
 
+    /* The mark is a flow item with the text beside it, not an overlay sitting in a padding well the
+       container reserves: a caller's .PL(n) writes an inline padding-left that wins over any padding
+       declared here, which used to drop the text on top of the mark. A margin between the two is
+       untouched by it, so the whole control just moves over. `top` still only nudges the mark
+       optically, since a relatively positioned box keeps the space it was laid out in. */
     .tss-option-container .tss-option-mark {
-        position: absolute;
+        position: relative;
+        flex: 0 0 auto;
         top: 2px;
-        left: 1px;
+        margin-left: 1px;
         height: 18px;
         width: 18px;
         border-radius: 50%;
         border: 1px solid var(--tss-default-foreground-color);
+    }
+
+    .tss-option-container .tss-option-text {
+        min-width: 0;
+        margin-left: 9px;
+    }
+
+    .tss-option-container .tss-option-text:empty {
+        display: none;
     }
 
     .tss-option-container:hover input ~ .tss-option-mark:after {
@@ -89,47 +103,38 @@
 
 .tss-option-container.tss-fontsize-mega {
     height: calc(9px + var(--tss-font-size-mega));
-    padding-left: calc(13px + var(--tss-font-size-mega));
 }
 
 .tss-option-container.tss-fontsize-xxlarge {
     height: calc(9px + var(--tss-font-size-xxlarge));
-    padding-left: calc(13px + var(--tss-font-size-xxlarge));
 }
 
 .tss-option-container.tss-fontsize-xlarge {
     height: calc(9px + var(--tss-font-size-xlarge));
-    padding-left: calc(13px + var(--tss-font-size-xlarge));
 }
 
 .tss-option-container.tss-fontsize-large {
     height: calc(9px + var(--tss-font-size-large));
-    padding-left: calc(13px + var(--tss-font-size-large));
 }
 
 .tss-option-container.tss-fontsize-mediumplus {
     height: calc(9px + var(--tss-font-size-mediumplus));
-    padding-left: calc(13px + var(--tss-font-size-mediumplus));
 }
 
 .tss-option-container.tss-fontsize-medium {
     height: calc(9px + var(--tss-font-size-medium));
-    padding-left: calc(13px + var(--tss-font-size-medium));
 }
 
 .tss-option-container.tss-fontsize-smallplus {
     height: calc(9px + var(--tss-font-size-smallplus));
-    padding-left: calc(13px + var(--tss-font-size-smallplus));
 }
 
 .tss-option-container.tss-fontsize-xsmall {
     height: calc(9px + var(--tss-font-size-xsmall));
-    padding-left: calc(13px + var(--tss-font-size-xsmall));
 }
 
 .tss-option-container.tss-fontsize-tiny {
     height: calc(9px + var(--tss-font-size-tiny));
-    padding-left: calc(13px + var(--tss-font-size-tiny));
 }
 
 

--- a/Tesserae/tps/assets/css/tss.choice.css
+++ b/Tesserae/tps/assets/css/tss.choice.css
@@ -7,15 +7,17 @@
         margin-right: 12px;
     }
 
+/* No font-size / font-weight here: the container already carries the tss-fontsize-* and
+   tss-fontweight-* class the ITextFormating helpers swap, and a same-specificity rule declared
+   later in the bundle silently beat them - so .Mega() grew the radio and left the label at 13px. */
 .tss-option-container {
     position: relative;
     cursor: pointer;
     color: var(--tss-default-foreground-color);
-    font-size: var(--tss-font-size-small);
-    font-weight: var(--tss-font-weight-regular);
     -webkit-user-select: none;
     user-select: none;
     display: flex;
+    align-items: center;
     text-align: left;
 }
 
@@ -30,12 +32,10 @@
     /* The mark is a flow item with the text beside it, not an overlay sitting in a padding well the
        container reserves: a caller's .PL(n) writes an inline padding-left that wins over any padding
        declared here, which used to drop the text on top of the mark. A margin between the two is
-       untouched by it, so the whole control just moves over. `top` still only nudges the mark
-       optically, since a relatively positioned box keeps the space it was laid out in. */
+       untouched by it, so the whole control just moves over. */
     .tss-option-container .tss-option-mark {
         position: relative;
         flex: 0 0 auto;
-        top: 2px;
         margin-left: 1px;
         height: 18px;
         width: 18px;

--- a/Tesserae/tps/assets/css/tss.omniresult.css
+++ b/Tesserae/tps/assets/css/tss.omniresult.css
@@ -1,4 +1,4 @@
-/* OmniResult — a search-result row: icon tile, title + badge, excerpt, footer, pages rail, commands. */
+﻿/* OmniResult — a search-result row: icon tile, title + badge, excerpt, footer, pages rail, commands. */
 
 /* A row is something you click, not something you read a sentence out of: dragging across a list of
    results should never leave half an excerpt highlighted. The modal is where a result is read, so its
@@ -66,7 +66,6 @@
 
 .tss-omniresult-select .tss-checkbox-container {
     margin: 0;
-    padding-left: 20px;
     width: 20px;
     height: 20px;
 }

--- a/Tesserae/tps/assets/css/tss.toggle.css
+++ b/Tesserae/tps/assets/css/tss.toggle.css
@@ -7,17 +7,26 @@
     font-weight: var(--tss-font-weight-semibold);
     -webkit-user-select: none;
     user-select: none;
-    padding-left: 45px;
-    display: inline-block;
+    display: inline-flex;
     height:20px;
 }
 
+    /* The gap to the switch is a margin here, not padding on the container: a caller's .PL(n) writes
+       an inline padding-left that wins over any padding declared here, which used to drop the text on
+       top of the switch. It also replaces the per-size padding-left compensation the text used to
+       carry, since the text now simply follows however wide the switch grew. */
     .tss-toggle-container .tss-toggle-text {
         font-weight: var(--tss-font-weight-regular);
         text-overflow: ellipsis;
         overflow: hidden;
         white-space: nowrap;
+        min-width: 0;
         min-height: 21px;
+        margin-left: 3px;
+    }
+
+    .tss-toggle-container .tss-toggle-text:empty {
+        display: none;
     }
 
     .tss-toggle-container .tss-checkbox {
@@ -29,9 +38,8 @@
     }
 
     .tss-toggle-container .tss-toggle-mark {
-        position: absolute;
-        top: 0;
-        left: 0;
+        position: relative;
+        flex: 0 0 auto;
         display: inline-block;
         height: 20px;
         width: 40px;
@@ -92,11 +100,8 @@
             border-color: var(--tss-disabled-foreground-color);
         }
 
-
-
     .tss-toggle-container.tss-fontsize-tiny {
         height: calc(10px + var(--tss-font-size-tiny));
-        padding-left:36px;
     }
 
         .tss-toggle-container.tss-fontsize-tiny .tss-toggle-mark {
@@ -111,10 +116,6 @@
                 height: calc(var(--tss-font-size-tiny));
                 width: calc(var(--tss-font-size-tiny));
             }
-
-        .tss-toggle-container.tss-fontsize-tiny .tss-toggle-text {
-            padding-left: 0px;
-        }
 
     .tss-toggle-container.tss-fontsize-smallplus {
         height: calc(10px + var(--tss-font-size-smallplus));
@@ -133,10 +134,6 @@
                 width: calc(var(--tss-font-size-smallplus));
             }
 
-        .tss-toggle-container.tss-fontsize-smallplus .tss-toggle-text {
-            padding-left: 8px;
-        }
-
     .tss-toggle-container.tss-fontsize-medium {
         height: calc(10px + var(--tss-font-size-medium));
     }
@@ -153,11 +150,6 @@
                 height: calc(var(--tss-font-size-medium));
                 width: calc(var(--tss-font-size-medium));
             }
-
-        .tss-toggle-container.tss-fontsize-medium .tss-toggle-text {
-            padding-left: 14px;
-        }
-
 
     .tss-toggle-container.tss-fontsize-large {
         height: calc(10px + var(--tss-font-size-large));
@@ -176,10 +168,6 @@
                 width: calc(var(--tss-font-size-large));
             }
 
-        .tss-toggle-container.tss-fontsize-large .tss-toggle-text {
-            padding-left: 14px;
-        }
-
     .tss-toggle-container.tss-fontsize-xlarge {
         height: calc(10px + var(--tss-font-size-xlarge));
     }
@@ -196,10 +184,6 @@
                 height: calc(var(--tss-font-size-xlarge));
                 width: calc(var(--tss-font-size-xlarge));
             }
-
-        .tss-toggle-container.tss-fontsize-xlarge .tss-toggle-text {
-            padding-left: 20px;
-        }
 
     .tss-toggle-container.tss-fontsize-xxlarge {
         height: calc(10px + var(--tss-font-size-xxlarge));
@@ -218,11 +202,6 @@
                 width: calc(var(--tss-font-size-xxlarge));
             }
 
-        .tss-toggle-container.tss-fontsize-xxlarge .tss-toggle-text {
-            padding-left: 24px;
-        }
-
-
     .tss-toggle-container.tss-fontsize-mega {
         height: calc(10px + var(--tss-font-size-mega));
     }
@@ -239,9 +218,5 @@
                 height: calc(var(--tss-font-size-mega));
                 width: calc(var(--tss-font-size-mega));
             }
-
-        .tss-toggle-container.tss-fontsize-mega .tss-toggle-text {
-            padding-left: 34px;
-        }
 
 /* IconToggle lives in tss.icontoggle.css */


### PR DESCRIPTION
`.P()` / `.PL()` and friends write an **inline** padding onto the element a component renders, and an inline value beats the stylesheet. Three controls spent that same property on their own internals — the container reserved a well with `padding-left` and the mark was absolutely positioned inside it — so `CheckBox("…").PL(16)` replaced the 25px well with 16px and dropped the label on top of the checkbox.

Reported from Curiosity Workspace's profiling view, where `CheckBox("Collect rundown").PL(16)` renders the label over the box.

## The breakage

Measured on the sample gallery, with an inline `padding-left: 16px` applied to every control:

| | container padding | overlapping rows |
|---|---|---|
| `.tss-checkbox-container` | 25px | 6 / 6 |
| `.tss-option-container` | 28px | 6 / 6 |
| `.tss-toggle-container` | 45px | 5 / 6 |

## The fix

Each control now lays its mark and its text out **side by side in a flex row**, with the gap as a `margin` on the text (`.tss-checkbox-text` / `.tss-option-text`, and Toggle's existing `.tss-toggle-text`). Nothing on the container claims `padding` any more, so a caller's padding moves the whole control and the mark keeps its distance from the label.

Same measurement after: **0 overlaps**, and the un-padded geometry is unchanged — mark and text land on the same pixels as before.

## Two bugs fixed on the way

**`Text` destroyed the control.** It assigned `innerText` on the container, wiping the input and the mark out of the DOM. `Toggle().SetText("With Label")` rendered a bare label with no switch at all in the gallery; giving the text its own element fixes it.

**A `Choice` label never scaled.** `.tss-option-container` declared `font-size: var(--tss-font-size-small)` itself — the same specificity as the `.tss-fontsize-*` class the container already carries, and `tss.choice.css` is bundled after `tss.common.css`, so the container's own rule won. `Choice("Mega").Mega()` computed **13px at every size** while the circle grew 18px → 49px, which is what read as a centring bug. `font-weight` was pinned the same way, so `.Bold()` on a `Choice` silently did nothing. Dropping both, plus `align-items: center`, lines mark and label up at every size:

| | before | after |
|---|---|---|
| default (13px) | −1.9px | 0 |
| tiny → mega | −1.0px | 0 |
| `Small` beside `Medium`/`Large` in a horizontal group | **+5.5px** | 0 |

`CheckBox` never had those declarations, which is why it scaled correctly all along.

## Deliberate consequences

- The per-size `padding-left` compensation is gone (9 rules in checkbox/choice, 8 in toggle). It existed because the container's well was a constant while the mark grew with the font size; the text now simply follows however wide the mark got. Gaps in the sized variants normalise — a radio's is 3px wider, a toggle's up to 6px tighter.
- A toggle in an inline context sits in a line box **1px** taller: the switch is a flow item now, and the line accounts for its real 22px height. Five ways of clawing that pixel back were tried; each moved the switch instead.
- `Choice(…).Bold()` renders bold now.

## Verification

`Tesserae.Bench`, gallery vs gallery:

- padding change — 118 of 132 samples text-identical; the rest are the variant-gap and label-scaling changes above (Pivot's clock drift aside)
- centring change — 130 of 132 identical, the one diff being Choice Group's ten label runs growing (`dx=0`, `dw=18`, `dh=5` on "Medium"): labels scaling, nothing moving sideways
- `all-samples.js` gate: 131 / 132, the exception being Sandbox's documented console noise

## Not changed

Two places carry the same padding-well pattern and were left alone: `.tss-omniresult`'s hover-over checkbox overlay (anchored at `left: 14px; top: 12px` to match the row's padding) and `.tss-pixelavatar-*`'s `--tss-pxav-reserve`, which is documented as deliberate and has no wrapper to move a margin onto in the adopted-modal case. `.tss-toggle-container` keeps its font pin — it only bites the `SetText` label, and unpicking it also means unpicking `.tss-toggle-text { font-weight: regular }`.

The rule is written into `references/creating-a-component.md` so the next component doesn't repeat it: don't spend `padding` on the element `Render()` returns.


---
_Generated by [Claude Code](https://claude.ai/code/session_016hQuxYHFzBRBiLQcie7Xgb)_