### PR TITLE
Let the highlight color be set on its own, apart from the primary

### DIFF
--- a/Tesserae.Tests/src/Samples/Theming/ThemeBuilderSample.cs
+++ b/Tesserae.Tests/src/Samples/Theming/ThemeBuilderSample.cs
@@ -16,15 +16,16 @@ namespace Tesserae.Tests.Samples
                .FlatSection(Stack().Children(
                     Card(VStack().WS().Children(
                     TextBlock("UI.Theme.Build() exposes every color CSS variable the toolkit understands, in one fluent API. Each setter takes a light value and a dark value, and Apply() injects a single <style> element that overrides the defaults from tss.common.css."),
-                    TextBlock("Use this when you need to fully re-brand the toolkit. For lightweight tweaks (just the primary color, or just the background) the existing UI.Theme.SetPrimary / SetBackground helpers are sharper tools."),
+                    TextBlock("Use this when you need to fully re-brand the toolkit. For lightweight tweaks (just the primary color, just the background, or just the highlight) the existing UI.Theme.SetPrimary / SetBackground / SetHighlight helpers are sharper tools."),
                     TextBlock("Call UI.Theme.ResetBuild() to drop the injected theme and return to the defaults."))).SetTitle("Overview")))
                .FlatSection(Stack().Children(
                     Card(VStack().WS().Children(
                     SampleSubTitle("Try a few presets"),
                     HStack().Children(
                         Button("Ocean").OnClick(() => Theme.Build()
-                            .Primary(Color.FromString("#0078d4"), Color.FromString("#2899f5"))
-                            .Link   (Color.FromString("#0078d4"), Color.FromString("#55b3fb"))
+                            .Primary  (Color.FromString("#0078d4"), Color.FromString("#2899f5"))
+                            .Link     (Color.FromString("#0078d4"), Color.FromString("#55b3fb"))
+                            .Highlight(Color.FromString("#0078d4"), Color.FromString("#55b3fb"))
                             .DefaultBackground       (Color.FromString("#eaf3fb"), Color.FromString("#0b1320"))
                             .DefaultBackgroundHover  (Color.FromString("#d6e6f4"), Color.FromString("#101d33"))
                             .DefaultBackgroundActive (Color.FromString("#c4dbef"), Color.FromString("#162644"))
@@ -32,8 +33,9 @@ namespace Tesserae.Tests.Samples
                             .DefaultBorder           (Color.FromString("#bcd6ea"), Color.FromString("#1f3252"))
                             .Apply()).MR(8),
                         Button("Forest").OnClick(() => Theme.Build()
-                            .Primary(Color.FromString("#16a34a"), Color.FromString("#22c55e"))
-                            .Link   (Color.FromString("#15803d"), Color.FromString("#22c55e"))
+                            .Primary  (Color.FromString("#16a34a"), Color.FromString("#22c55e"))
+                            .Link     (Color.FromString("#15803d"), Color.FromString("#22c55e"))
+                            .Highlight(Color.FromString("#15803d"), Color.FromString("#22c55e"))
                             .DefaultBackground       (Color.FromString("#eaf7ee"), Color.FromString("#08160d"))
                             .DefaultBackgroundHover  (Color.FromString("#d4ebda"), Color.FromString("#0f2418"))
                             .DefaultBackgroundActive (Color.FromString("#bbdec5"), Color.FromString("#173324"))
@@ -41,8 +43,9 @@ namespace Tesserae.Tests.Samples
                             .DefaultBorder           (Color.FromString("#bdddc7"), Color.FromString("#1d3a25"))
                             .Apply()).MR(8),
                         Button("Sunset").OnClick(() => Theme.Build()
-                            .Primary(Color.FromString("#ea580c"), Color.FromString("#fb923c"))
-                            .Link   (Color.FromString("#c2410c"), Color.FromString("#fb923c"))
+                            .Primary  (Color.FromString("#ea580c"), Color.FromString("#fb923c"))
+                            .Link     (Color.FromString("#c2410c"), Color.FromString("#fb923c"))
+                            .Highlight(Color.FromString("#c2410c"), Color.FromString("#fb923c"))
                             .DefaultBackground       (Color.FromString("#fff2e3"), Color.FromString("#1c1209"))
                             .DefaultBackgroundHover  (Color.FromString("#fbe4cb"), Color.FromString("#2a1c10"))
                             .DefaultBackgroundActive (Color.FromString("#f6d2ad"), Color.FromString("#3a2716"))
@@ -50,8 +53,9 @@ namespace Tesserae.Tests.Samples
                             .DefaultBorder           (Color.FromString("#f1cba0"), Color.FromString("#3b271a"))
                             .Apply()).MR(8),
                         Button("Grape").OnClick(() => Theme.Build()
-                            .Primary(Color.FromString("#7c3aed"), Color.FromString("#a78bfa"))
-                            .Link   (Color.FromString("#6d28d9"), Color.FromString("#c4b5fd"))
+                            .Primary  (Color.FromString("#7c3aed"), Color.FromString("#a78bfa"))
+                            .Link     (Color.FromString("#6d28d9"), Color.FromString("#c4b5fd"))
+                            .Highlight(Color.FromString("#6d28d9"), Color.FromString("#c4b5fd"))
                             .DefaultBackground       (Color.FromString("#f3edff"), Color.FromString("#14091f"))
                             .DefaultBackgroundHover  (Color.FromString("#e6daff"), Color.FromString("#1e1230"))
                             .DefaultBackgroundActive (Color.FromString("#d6c4ff"), Color.FromString("#2c1d44"))
@@ -71,7 +75,8 @@ namespace Tesserae.Tests.Samples
                             Button("Default")
                         ).MT(8),
                         Label("A textbox").SetContent(TextBox()).MT(8),
-                        Label("A link").SetContent(Button("Visit curiosity.ai", href: "https://curiosity.ai").Class("tss-btn-link")).MT(8))
+                        Label("A link").SetContent(Button("Visit curiosity.ai", href: "https://curiosity.ai").Class("tss-btn-link")).MT(8),
+                        Label("Highlighted text").SetContent(TextBlock("what matched").SemiBold().Foreground(Theme.Default.Highlight)).MT(8))
                     )
                 )).SetTitle("Usage")))
                .SeeAlso(typeof(ThemeColorsSample), typeof(ColorsSample), typeof(ColorPaletteSample), typeof(GradientsSample), typeof(ColorPickerSample));

--- a/Tesserae.Tests/src/Samples/Theming/ThemeColorsSample.cs
+++ b/Tesserae.Tests/src/Samples/Theming/ThemeColorsSample.cs
@@ -82,13 +82,18 @@ namespace Tesserae.Tests.Samples
             var backgroundLight = new SettableObservable<Color>();
             var primaryDark     = new SettableObservable<Color>();
             var backgroundDark  = new SettableObservable<Color>();
+            var highlightLight  = new SettableObservable<Color>();
+            var highlightDark   = new SettableObservable<Color>();
 
-            var combined = new CombinedObservable<Color, Color, Color, Color>(primaryLight, primaryDark, backgroundLight, backgroundDark);
+            var combined          = new CombinedObservable<Color, Color, Color, Color>(primaryLight, primaryDark, backgroundLight, backgroundDark);
+            var combinedHighlight = new CombinedObservable<Color, Color>(highlightLight, highlightDark);
 
             var cpPrimaryLight    = ColorPicker().OnInput((cp, ev) => primaryLight.Value = cp.Color);
             var cpPrimaryDark     = ColorPicker().OnInput((cp, ev) => primaryDark.Value = cp.Color);
             var cpBackgroundLight = ColorPicker().OnInput((cp, ev) => backgroundLight.Value = cp.Color);
             var cpBackgroundDark  = ColorPicker().OnInput((cp, ev) => backgroundDark.Value = cp.Color);
+            var cpHighlightLight  = ColorPicker().OnInput((cp, ev) => highlightLight.Value = cp.Color);
+            var cpHighlightDark   = ColorPicker().OnInput((cp, ev) => highlightDark.Value = cp.Color);
 
             Theme.Light();
 
@@ -97,6 +102,7 @@ namespace Tesserae.Tests.Samples
 
                 primaryLight.Value    = Color.FromString(Color.EvalVar(Theme.Primary.Background));
                 backgroundLight.Value = Color.FromString(Color.EvalVar(Theme.Default.Background));
+                highlightLight.Value  = Color.FromString(Color.EvalVar(Theme.Default.Highlight));
 
                 Theme.Dark();
 
@@ -104,6 +110,7 @@ namespace Tesserae.Tests.Samples
                 {
                     primaryDark.Value    = Color.FromString(Color.EvalVar(Theme.Primary.Background));
                     backgroundDark.Value = Color.FromString(Color.EvalVar(Theme.Default.Background));
+                    highlightDark.Value  = Color.FromString(Color.EvalVar(Theme.Default.Highlight));
                     Theme.IsLight        = currentTheme;
 
 
@@ -111,12 +118,16 @@ namespace Tesserae.Tests.Samples
                     cpPrimaryDark.Color     = primaryDark.Value;
                     cpBackgroundLight.Color = backgroundLight.Value;
                     cpBackgroundDark.Color  = backgroundDark.Value;
+                    cpHighlightLight.Color  = highlightLight.Value;
+                    cpHighlightDark.Color   = highlightDark.Value;
 
                     combined.ObserveFutureChanges(v =>
                     {
                         Theme.SetPrimary(v.first, v.second);
                         Theme.SetBackground(v.third, v.forth);
                     });
+
+                    combinedHighlight.ObserveFutureChanges(v => Theme.SetHighlight(v.first, v.second));
 
                 }, 1);
             }, 1);
@@ -155,7 +166,11 @@ namespace Tesserae.Tests.Samples
                         Label("Primary Light").Inline().SetContent(cpPrimaryLight),
                         Label("Primary Dark").Inline().SetContent(cpPrimaryDark),
                         Label("Background Light").Inline().SetContent(cpBackgroundLight),
-                        Label("Background Dark").Inline().SetContent(cpBackgroundDark)
+                        Label("Background Dark").Inline().SetContent(cpBackgroundDark),
+                        Label("Highlight Light").Inline().SetContent(cpHighlightLight),
+                        Label("Highlight Dark").Inline().SetContent(cpHighlightDark),
+                        TextBlock("The highlight color follows the primary one until Theme.SetHighlight is called - the two pickers above call it, and Theme.ResetHighlight puts the following back. This is what marked search terms are drawn in:").MT(8),
+                        TextBlock("highlighted").SemiBold().Foreground(Theme.Default.Highlight)
                     )).SetTitle("Usage")))
                .SeeAlso(typeof(ColorsSample), typeof(ThemeBuilderSample), typeof(ColorPaletteSample), typeof(GradientsSample));
         }

--- a/Tesserae/skills/references/colors.md
+++ b/Tesserae/skills/references/colors.md
@@ -37,10 +37,12 @@ var badge = Badge("New")
 
 - `Theme.SetPrimary(Color light, Color dark)` — regenerate primary CSS vars for both modes.
 - `Theme.SetBackground(Color light, Color dark)` — same for background.
+- `Theme.SetHighlight(Color light, Color dark)` — same for the highlight color, which otherwise follows the primary.
 
 ```csharp
 Theme.SetPrimary(Color.FromString("#0063B1"), Color.FromString("#2899F5"));
 Theme.SetBackground(Color.FromString("#FFFFFF"), Color.FromString("#1B1A19"));
+Theme.SetHighlight(Color.FromString("#B45309"), Color.FromString("#FBBF24"));
 ```
 
 ## Working with Color

--- a/Tesserae/skills/references/omni-result.md
+++ b/Tesserae/skills/references/omni-result.md
@@ -45,7 +45,7 @@ stands for. Also `new OmniResult<T>(result, title)`. Bring factories into scope 
   than cutting it off. Null un-caps it.
 - `.HighlightWords(params string[])` — mark those words in the **title and the excerpt**,
   case-insensitively. The marks and the badge share one pair of colors, from the `--tss-highlight-color`
-  token (the same value as `--tss-link-color`, so `Theme.SetPrimary` moves both), and the excerpt
+  token (which follows the primary color unless `Theme.SetHighlight` gives it one of its own), and the excerpt
   itself is a quiet grey.
 - `.Highlight(es5.RegExp)` / `.Highlight(string pattern, bool ignoreCase = true)` — mark every match,
   e.g. the pattern a search backend hands back. The expression is the JavaScript one

--- a/Tesserae/skills/references/theme-colors.md
+++ b/Tesserae/skills/references/theme-colors.md
@@ -15,11 +15,16 @@ description: The static `Theme` class for switching light/dark mode and overridi
   colors derived from it: `--tss-link-color` (links, `Badge().Info()`) and `--tss-highlight-color`
   (marked search terms, see `omni-result.md`).
 - `Theme.SetBackground(Color light, Color dark)` — set background for both modes.
+- `Theme.SetHighlight(Color light, Color dark)` — set the highlight color (`--tss-highlight-color`)
+  for both modes, so marked text stops following the primary color. What is set here wins over
+  `SetPrimary` whatever order the two are called in.
+- `Theme.ResetHighlight()` — drop an explicit highlight color and go back to following the primary.
 
 ## Properties
 
 - `Theme.IsLight` / `Theme.IsDark` — current mode (bool).
 - `Theme.Default`, `Theme.Primary`, `Theme.Secondary`, `Theme.Danger`, `Theme.Success` — color accessors exposing `.Background`, `.Foreground`, `.Border`, etc.
+- `Theme.Default.Highlight` — the highlight color as a CSS variable reference, for drawing your own marked text with it.
 - `Theme.Fonts.SansSerif` / `Theme.Fonts.Monospace` — the two font stacks the toolkit draws with, as CSS variable references. See `styling.md`.
 - `Theme.OnThemeChanged` — event raised on mode change.
 
@@ -39,6 +44,9 @@ Stack().Children(
 // Runtime recolor
 Theme.SetPrimary(Color.FromString("blue"), Color.FromString("lightblue"));
 Theme.SetBackground(Color.FromString("white"), Color.FromString("#333"));
+
+// The highlight follows the primary color unless you say otherwise
+Theme.SetHighlight(Color.FromString("#b45309"), Color.FromString("#fbbf24"));
 ```
 
 ## Related

--- a/Tesserae/src/Base/UI.Theme.cs
+++ b/Tesserae/src/Base/UI.Theme.cs
@@ -13,6 +13,7 @@ namespace Tesserae
         {
             private static HTMLStyleElement _primaryStyleElement;
             private static HTMLStyleElement _backgroundStyleElement;
+            private static HTMLStyleElement _highlightStyleElement;
 
             /// <summary>
             /// Raised when on theme changed occurs.
@@ -347,6 +348,67 @@ namespace Tesserae
 
                 var head = document.getElementsByTagName("head")[0];
                 head.appendChild(_primaryStyleElement);
+
+                //This also writes the highlight color, so move an explicit one back to the end of the head to keep it winning
+                if (_highlightStyleElement is object)
+                {
+                    head.appendChild(_highlightStyleElement);
+                }
+            }
+
+            /// <summary>
+            /// Sets the highlight color for both light and dark modes - the color marked text is drawn in
+            /// (the terms an OmniResult marks in an excerpt, and the badge naming what matched).
+            /// </summary>
+            /// <remarks>
+            /// The highlight color otherwise follows the primary color, which is what
+            /// <see cref="SetPrimary"/> writes it as. Call this when the two should differ - a brand color
+            /// that reads badly as a mark on top of the page background, say. The color set here wins over
+            /// the primary-derived one whatever order the two are called in, until <see cref="ResetHighlight"/>
+            /// puts it back.
+            /// </remarks>
+            /// <param name="highlightLight">The color used in light mode.</param>
+            /// <param name="highlightDark">The color used in dark mode (when the body carries tss-dark-mode).</param>
+            public static void SetHighlight(Color highlightLight, Color highlightDark)
+            {
+                if (_highlightStyleElement is object)
+                {
+                    _highlightStyleElement.remove();
+                    _highlightStyleElement = null;
+                }
+
+                var sb = new StringBuilder();
+                sb.AppendLine(":root {");
+                sb.Append("  --tss-highlight-color-root: ").Append(highlightLight.ToRGBvar()).AppendLine(";");
+
+                //We need to redefine the variable again here otherwise the value won't change as it's derived twice from variables
+                sb.AppendLine("  --tss-highlight-color: rgb(var(--tss-highlight-color-root ));");
+                sb.AppendLine("}");
+
+                sb.AppendLine(".tss-dark-mode {");
+                sb.Append("  --tss-highlight-color-root: ").Append(highlightDark.ToRGBvar()).AppendLine(";");
+                sb.AppendLine("  --tss-highlight-color: rgb(var(--tss-highlight-color-root ));");
+                sb.AppendLine("}");
+
+                _highlightStyleElement      = (HTMLStyleElement)document.createElement("style");
+                _highlightStyleElement.type = "text/css";
+                _highlightStyleElement.appendChild(document.createTextNode(sb.ToString()));
+
+                var head = document.getElementsByTagName("head")[0];
+                head.appendChild(_highlightStyleElement);
+            }
+
+            /// <summary>
+            /// Drops an explicit highlight color installed by <see cref="SetHighlight"/>, so the highlight
+            /// goes back to following the primary color (or the tss.common.css default when no primary was set).
+            /// </summary>
+            public static void ResetHighlight()
+            {
+                if (_highlightStyleElement is object)
+                {
+                    _highlightStyleElement.remove();
+                    _highlightStyleElement = null;
+                }
             }
 
             //Variables from tesserae.common.css
@@ -413,6 +475,12 @@ namespace Tesserae
                 /// CSS variable reference for the default surface card shadow style.
                 /// </summary>
                 public const string CardShadow     = "var(--tss-card-shadow, 0 0.3px 0.9px 0 rgba(0,0,0,0.108))";
+                /// <summary>
+                /// CSS variable reference for the color marked text is drawn in (the terms an OmniResult
+                /// marks in an excerpt, and the badge naming what matched). Set it with
+                /// <see cref="SetHighlight"/>.
+                /// </summary>
+                public const string Highlight      = "var(--tss-highlight-color)";
             }
 
             public static class Sidebar

--- a/Tesserae/src/Base/UI.ThemeBuilder.cs
+++ b/Tesserae/src/Base/UI.ThemeBuilder.cs
@@ -83,7 +83,12 @@ namespace Tesserae
 
                 // ---------- Primary (the brand color used for primary buttons, focus rings, links) ----------
 
-                /// <summary>Sets the primary brand color (primary button background, focus ring, link color).</summary>
+                /// <summary>
+                /// Sets the primary brand color (primary button background, focus ring), along with the two
+                /// colors derived from it: the link color and the highlight color. Chain
+                /// <see cref="Link"/> or <see cref="Highlight"/> <em>after</em> this call to give either
+                /// one a color of its own.
+                /// </summary>
                 public ThemeBuilder Primary(Color light, Color dark)
                 {
                     Set("primary-background-color",        light, dark);
@@ -92,6 +97,7 @@ namespace Tesserae
                     Set("primary-border-color",            light, dark);
                     Set("primary-shadow-color",            light, dark);
                     Set("link-color",                      light, dark);
+                    Set("highlight-color",                 light, dark);
                     return this;
                 }
 
@@ -221,6 +227,14 @@ namespace Tesserae
 
                 /// <summary>Sets the color used for hyperlinks.</summary>
                 public ThemeBuilder Link(Color light, Color dark) => Set("link-color", light, dark);
+
+                // ---------- Highlight ----------
+
+                /// <summary>
+                /// Sets the color marked text is drawn in - the terms an OmniResult marks in an excerpt,
+                /// and the badge naming what matched. Defaults to following the primary color.
+                /// </summary>
+                public ThemeBuilder Highlight(Color light, Color dark) => Set("highlight-color", light, dark);
 
                 // ---------- Tooltip ----------
 

--- a/docs/COLORS.md
+++ b/docs/COLORS.md
@@ -35,6 +35,14 @@ Theme.SetBackground(Color.FromString("#FFFFFF"), Color.FromString("#1B1A19"));
 
 `SetPrimary` and `SetBackground` generate CSS variables for both light and dark themes at runtime.
 
+The highlight color — what marked text is drawn in — follows the primary color. To give it one of its
+own, call `SetHighlight`; it wins over `SetPrimary` whatever order the two are called in, and
+`ResetHighlight()` puts the following back:
+
+```csharp
+Theme.SetHighlight(Color.FromString("#B45309"), Color.FromString("#FBBF24"));
+```
+
 ## Working with Color
 
 The `Color` helper supports parsing from hex/rgba strings and constructing from ARGB components:


### PR DESCRIPTION
The highlight color - what marked text is drawn in, the terms an OmniResult
marks in an excerpt and the badge naming what matched - was only ever writable
as a side effect of SetPrimary, so a brand color that reads badly as a mark on
top of the page background could not be separated from the one the buttons use.

Theme.SetHighlight(light, dark) installs it as a sheet of its own, and
ResetHighlight() drops it back to following the primary. SetPrimary still writes
the derived value, but now moves an explicit highlight back to the end of the
head afterwards, so the two work in either order. ThemeBuilder gains the
matching .Highlight(), and its .Primary() now seeds highlight-color the way
SetPrimary does (chain .Highlight() after it to override).

Theme.Default.Highlight exposes the variable for a host drawing its own marks.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NNsWTwk1tewLqymiBnYfg4