### PR TITLE
Keep an OmniResult's corner badge on the checkbox that covers its tile

### DIFF
--- a/Tesserae.Tests/src/Samples/Search/OmniResultSample.cs
+++ b/Tesserae.Tests/src/Samples/Search/OmniResultSample.cs
@@ -417,6 +417,10 @@ namespace Tesserae.Tests.Samples
                         .OnSelectionChanged((r, isSelected) => ReportSelection())
                         .OnRangeSelectionRequested(r => SelectRangeTo(r));
 
+                    //The first row of each group is badged, so what a corner badge does when the checkbox
+                    //takes the tile's place is visible in every mode.
+                    if (i == 0) row.SetIconBadge(Icon(UIcons.Star, UIconsWeight.Solid, color: "#f0c000"), OmniResultBadgeCorner.TopRight);
+
                     _selectable.Add(row);
                     list.Add(row);
                 }
@@ -426,7 +430,7 @@ namespace Tesserae.Tests.Samples
             }
 
             return FeatureCard("Selection", "Four places for the checkbox",
-                "Selectable(mode) makes a row selectable. The checkbox sits before the tile or over it, revealed on hover or always visible, or takes the tile's place entirely — and a selected row always shows its checkbox, whatever the mode. Ctrl-clicking a row toggles it too, and shift-clicking one asks for the range from the last row selected: a single card knows nothing about its siblings, so OnRangeSelectionRequested hands that to the host list, which selects them itself (that is what the rows below do, across all four groups).",
+                "Selectable(mode) makes a row selectable. The checkbox sits before the tile or over it, revealed on hover or always visible, or takes the tile's place entirely — and a selected row always shows its checkbox, whatever the mode. A corner badge marks the result rather than the tile, so it follows the checkbox where the checkbox stands in for the tile: the starred row in each group keeps its star over the checkbox. Ctrl-clicking a row toggles it too, and shift-clicking one asks for the range from the last row selected: a single card knows nothing about its siblings, so OnRangeSelectionRequested hands that to the host list, which selects them itself (that is what the rows below do, across all four groups).",
                 sections,
                 _selectionState.MT(8),
                 HStack().Gap(8.px()).MT(8).Children(

--- a/Tesserae/skills/references/omni-result.md
+++ b/Tesserae/skills/references/omni-result.md
@@ -73,6 +73,10 @@ stands for. Also `new OmniResult<T>(result, title)`. Bring factories into scope 
   corner of the tile, drawn outside its clipping: where the result came from, that it is pinned.
   Corners: `TopLeft`, `TopRight`, `BottomLeft`, `BottomRight`. Null clears that corner.
 
+  A badge marks the result, not the tile, so it follows whatever stands in the tile's place: under
+  `OnHoverOverIcon` it tucks into the checkbox's corners while the checkbox is showing, and under
+  `ReplacingIcon` — where there is no tile — it is drawn on the checkbox itself.
+
 Pass a literal color (`"#ef4444"`) rather than a CSS variable when you want the tint to track the
 theme: a `var(--…)` is resolved once, at the time it is set.
 
@@ -106,7 +110,8 @@ The source leads the line and the metadata follows it, and all of it is `InlineL
 - `.Selectable(OmniResultSelectionMode mode = OnHoverBeforeIcon)` / `.NotSelectable()`.
   Modes: `OnHoverBeforeIcon`, `OnHoverOverIcon` (on the tile, which fades out under it),
   `AlwaysBeforeIcon`, `ReplacingIcon` (no tile at all). A selected row always shows its checkbox,
-  whatever the mode, and the column is reserved either way so revealing it never shifts the row.
+  whatever the mode, and the column is reserved either way so revealing it never shifts the row. In the
+  two modes where the checkbox stands in for the tile, the corner badges move onto it.
 - `IsSelected` / `.Selected(bool = true)` / `IsSelectionEnabled`.
 - `.OnSelectionChanged(Action<OmniResult<T>, bool>)` — every change, from the user or from code.
 - `.OnRangeSelectionRequested(Action<OmniResult<T>>)` — shift-click. A row knows nothing about its

--- a/Tesserae/src/Components/OmniResult.cs
+++ b/Tesserae/src/Components/OmniResult.cs
@@ -36,7 +36,8 @@ namespace Tesserae
         OnHoverOverIcon,
         /// <summary>A checkbox in its own column before the icon, always visible.</summary>
         AlwaysBeforeIcon,
-        /// <summary>A checkbox in place of the icon tile, which is not drawn at all.</summary>
+        /// <summary>A checkbox in place of the icon tile, which is not drawn at all. Whatever
+        /// <see cref="OmniResult{T}.SetIconBadge"/> pinned to the tile moves onto the checkbox.</summary>
         ReplacingIcon
     }
 
@@ -104,6 +105,7 @@ namespace Tesserae
         private readonly Dictionary<string, HTMLElement> _iconBadges = new Dictionary<string, HTMLElement>();
 
         private CheckBox          _checkBox;
+        private HTMLElement       _checkBoxHolder;
         private ContributionBar   _contribution;
         private HTMLButtonElement _menuButton;
         private PagesStack        _pages;
@@ -516,6 +518,12 @@ namespace Tesserae
         /// <summary>
         /// Pins a badge to a corner of the icon tile - where a result came from, that it is pinned - drawn
         /// over the tile's corner and outside its clipping. Pass null to clear that corner.
+        /// <para>
+        /// A badge marks the result, not the tile, so it follows whatever stands in the tile's place: with
+        /// <see cref="OmniResultSelectionMode.OnHoverOverIcon"/> it tucks into the checkbox's corners while
+        /// the checkbox is showing, and with <see cref="OmniResultSelectionMode.ReplacingIcon"/> it is drawn
+        /// on the checkbox, there being no tile to sit on.
+        /// </para>
         /// </summary>
         public OmniResult<T> SetIconBadge(IComponent badge, OmniResultBadgeCorner corner = OmniResultBadgeCorner.BottomRight)
         {
@@ -523,7 +531,7 @@ namespace Tesserae
 
             if (_iconBadges.TryGetValue(cornerClass, out var stale))
             {
-                _iconHolder.removeChild(stale);
+                stale.parentElement?.removeChild(stale);
                 _iconBadges.Remove(cornerClass);
             }
 
@@ -531,10 +539,35 @@ namespace Tesserae
 
             var holder = Div(Att("tss-omniresult-icon-badge " + cornerClass), badge.Render());
 
-            _iconHolder.appendChild(holder);
+            IconBadgeHost.appendChild(holder);
             _iconBadges[cornerClass] = holder;
 
             return this;
+        }
+
+        /// <summary>
+        /// What the corner badges hang off: the tile, or the checkbox when the checkbox is drawn in its place.
+        /// </summary>
+        private HTMLElement IconBadgeHost
+        {
+            get
+            {
+                var onCheckBox = _selectionEnabled
+                              && _selectionMode == OmniResultSelectionMode.ReplacingIcon
+                              && _checkBoxHolder is object;
+
+                return onCheckBox ? _checkBoxHolder : _iconHolder;
+            }
+        }
+
+        private void PlaceIconBadges()
+        {
+            var host = IconBadgeHost;
+
+            foreach (var badge in _iconBadges.Values)
+            {
+                if (badge.parentElement != host) host.appendChild(badge);
+            }
         }
 
         private static string CornerClass(OmniResultBadgeCorner corner)
@@ -1572,6 +1605,16 @@ namespace Tesserae
 
             copy.classList.add("tss-omniresult-modal-icon");
 
+            //The modal draws the tile even where the row replaced it with the checkbox, so the badges that
+            //moved onto the checkbox are copied back onto it.
+            if (IconBadgeHost != _iconHolder)
+            {
+                foreach (var badge in _iconBadges.Values)
+                {
+                    copy.appendChild(badge.cloneNode(true).As<HTMLElement>());
+                }
+            }
+
             return copy;
         }
 
@@ -1806,7 +1849,11 @@ namespace Tesserae
 
             _checkBox.OnChange((cb, _) => IsSelected = cb.IsChecked);
 
-            _selectContainer.appendChild(_checkBox.Render());
+            //The checkbox sits in a box of its own so a corner badge drawn on it has the checkbox to hang
+            //off rather than the column, which is as tall as the row's first line.
+            _checkBoxHolder = Div(Att("tss-omniresult-select-box"), _checkBox.Render());
+
+            _selectContainer.appendChild(_checkBoxHolder);
         }
 
         private void ApplySelectionMode()
@@ -1826,6 +1873,10 @@ namespace Tesserae
                 "tss-omniresult-select-hover-over",
                 "tss-omniresult-select-always-before",
                 "tss-omniresult-select-replacing");
+
+            //The badges hang off whatever is drawn where the tile goes, which the mode - and whether the row
+            //is selectable at all - decides.
+            PlaceIconBadges();
 
             if (!_selectionEnabled) return;
 

--- a/Tesserae/tps/assets/css/tss.omniresult.css
+++ b/Tesserae/tps/assets/css/tss.omniresult.css
@@ -64,6 +64,17 @@
     height: 34px;
 }
 
+/* The checkbox's own 20px box: what a corner badge drawn on the checkbox hangs off, so it tucks into the
+   checkbox's corner rather than the column's, which is as tall as the row's first line. */
+.tss-omniresult-select-box {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 20px;
+    height: 20px;
+}
+
 .tss-omniresult-select .tss-checkbox-container {
     margin: 0;
     width: 20px;
@@ -123,7 +134,43 @@
     opacity: 0;
 }
 
-/* Replacing the icon: no tile at all. */
+/* A corner badge stays on while the tile fades - it says something about the result, not about the tile -
+   so it moves onto the checkbox that took the tile's place. The checkbox is 20px centred in the 34px tile,
+   which is 7px in from each edge, and a badge sits 4px out from the corner it is pinned to: 7 - 4 = 3. */
+.tss-omniresult-select-hover-over:hover .tss-omniresult-icon-badge-tl,
+.tss-omniresult-select-hover-over.tss-omniresult-active .tss-omniresult-icon-badge-tl,
+.tss-omniresult-select-hover-over:focus-within .tss-omniresult-icon-badge-tl,
+.tss-omniresult-select-hover-over.tss-omniresult-selected .tss-omniresult-icon-badge-tl {
+    left: 3px;
+    top: 3px;
+}
+
+.tss-omniresult-select-hover-over:hover .tss-omniresult-icon-badge-tr,
+.tss-omniresult-select-hover-over.tss-omniresult-active .tss-omniresult-icon-badge-tr,
+.tss-omniresult-select-hover-over:focus-within .tss-omniresult-icon-badge-tr,
+.tss-omniresult-select-hover-over.tss-omniresult-selected .tss-omniresult-icon-badge-tr {
+    right: 3px;
+    top: 3px;
+}
+
+.tss-omniresult-select-hover-over:hover .tss-omniresult-icon-badge-bl,
+.tss-omniresult-select-hover-over.tss-omniresult-active .tss-omniresult-icon-badge-bl,
+.tss-omniresult-select-hover-over:focus-within .tss-omniresult-icon-badge-bl,
+.tss-omniresult-select-hover-over.tss-omniresult-selected .tss-omniresult-icon-badge-bl {
+    left: 3px;
+    bottom: 3px;
+}
+
+.tss-omniresult-select-hover-over:hover .tss-omniresult-icon-badge-br,
+.tss-omniresult-select-hover-over.tss-omniresult-active .tss-omniresult-icon-badge-br,
+.tss-omniresult-select-hover-over:focus-within .tss-omniresult-icon-badge-br,
+.tss-omniresult-select-hover-over.tss-omniresult-selected .tss-omniresult-icon-badge-br {
+    right: 3px;
+    bottom: 3px;
+}
+
+/* Replacing the icon: no tile at all, so the badges are drawn on the checkbox itself (the row moves them
+   there - see OmniResult.PlaceIconBadges) and hang off its corners the way they hang off the tile's. */
 .tss-omniresult-select-replacing .tss-omniresult-icon-holder {
     display: none;
 }
@@ -138,14 +185,17 @@
     line-height: 0;
 }
 
+/* A badge marks the result rather than the tile, so it is drawn above the checkbox (z-index 2) that
+   covers the tile, and moves with it - see the corner offsets under "Selection" above. */
 .tss-omniresult-icon-badge {
     position: absolute;
     display: flex;
     align-items: center;
     justify-content: center;
-    z-index: 1;
+    z-index: 3;
     line-height: 0;
     pointer-events: none;
+    transition: top 120ms ease-in-out, right 120ms ease-in-out, bottom 120ms ease-in-out, left 120ms ease-in-out;
 }
 
 .tss-omniresult-icon-badge img,


### PR DESCRIPTION
A corner badge set with `SetIconBadge` says something about the **result** — where it came from, that it is a favorite — not about the tile it happens to be drawn on. Today the selection checkbox either covers it (`OnHoverOverIcon`) or takes the whole tile away with it (`ReplacingIcon`, which hides the icon holder the badges live in). It now follows whatever stands in the tile's place.

**`OnHoverOverIcon`** — the badge is drawn above the checkbox (z-index 3 over the checkbox's 2) and tucks into its corners while it shows. The checkbox is 20px centred in the 34px tile, so 7px in from each edge, and a badge sits 4px out from the corner it is pinned to: the offset is `7 - 4 = 3px`. It slides there over the same 120ms the checkbox fades in.

**`ReplacingIcon`** — there is no tile at all, so the badges move onto the checkbox itself (`PlaceIconBadges`, called from `ApplySelectionMode` so `NotSelectable()` brings them back). The checkbox gained a 20px box of its own to hang off — `.tss-omniresult-select-box` — because the column it sits in is as tall as the row's first line, which is not the corner a badge means. The modal still draws them on its own copy of the tile.

The before-the-icon modes are unchanged: the tile is still there, and the badge stays on it.

### Sample

The first row of each group in the Selection section of the OmniResult sample now carries a star, so what a badge does in each of the four modes is visible in the gallery. Verified in the browser: on the tile in the two "before" modes, on the checkbox's top-right corner in the other two.

---
_Generated by [Claude Code](https://claude.ai/code/session_015JaNfC7VM5K2Mc87DtkWbe)_