### PR TITLE
Draw an OmniResult's tile at the head of its title line

### DIFF
--- a/Tesserae.Tests/src/Samples/Search/OmniResultSample.cs
+++ b/Tesserae.Tests/src/Samples/Search/OmniResultSample.cs
@@ -74,6 +74,7 @@ namespace Tesserae.Tests.Samples
                 .FlatSection(VStack().WS().Children(NoPages()))
                 .FlatSection(VStack().WS().Children(TitleOnly()))
                 .FlatSection(VStack().WS().Children(Tiles()))
+                .FlatSection(VStack().WS().Children(TilesInHeader()))
                 .FlatSection(VStack().WS().Children(Identifiers()))
                 .FlatSection(VStack().WS().Children(Content()))
                 .FlatSection(VStack().WS().Children(Modals()))
@@ -160,6 +161,39 @@ namespace Tesserae.Tests.Samples
                     OmniResult(Hits[6], "brake-calibration-log.txt").SetIcon("TXT", "#94a3b8").SetSource("#0061d5", "Box").SetFooterEntries("A grey color stays grey in both themes"),
                     OmniResult(Hits[0], "curiosity-logo.svg").SetIcon(Image("./assets/img/curiosity-logo.svg")).SetSource("#0061d5", "Box").SetFooterEntries("SetIcon(IComponent) — a thumbnail covers the tile"),
                     OmniResult(Hits[0], "brake-sensor-reports").SetIcon(UIcons.Folder).SetSource("#0061d5", "Box").SetFooterEntries("No color: the tile falls back to the theme's own")));
+        }
+
+        // ---------- The tile in the header ----------
+
+        private IComponent TilesInHeader()
+        {
+            var quiet = VStack().WS().Children(
+                HeaderIconRow(Hits[1], "BRK-SEN-447 calibration procedure.pdf").SetId("JR-2214"),
+                HeaderIconRow(Hits[2], "Sensor drift analysis.xlsx"),
+                HeaderIconRow(Hits[4], "field-failures / 2024"));
+
+            var selectable = VStack().WS().Children(
+                Row(Hits[3], withText: true, withPages: false).Selectable(OmniResultSelectionMode.AlwaysBeforeHeaderIcon),
+                Row(Hits[5], withText: true, withPages: false).Selectable(OmniResultSelectionMode.AlwaysBeforeHeaderIcon)
+                    .SetIconBadge(Icon(UIcons.Star, UIconsWeight.Solid, color: "#f0c000"), OmniResultBadgeCorner.TopRight),
+                Row(Hits[6], withText: true, withPages: false).Selectable(OmniResultSelectionMode.AlwaysBeforeHeaderIcon));
+
+            return FeatureCard("The tile in the header", "Leading the title instead of the row",
+                "Two modes draw the tile small, at the start of the header line, before the identifier and the title - so the excerpt, the footer and the contribution bar start at the row's own left edge rather than indented past a 34px tile. HiddenBeforeHeaderIcon draws no checkbox at all, which is what a list that is never selected from wants: set it with SelectionMode(mode), which lays the row out without making it selectable. AlwaysBeforeHeaderIcon keeps a checkbox in its own column at the start of the row, always visible.",
+                TextBlock("OmniResultSelectionMode.HiddenBeforeHeaderIcon - no checkbox anywhere").Small().SemiBold().MB(4),
+                quiet,
+                TextBlock("OmniResultSelectionMode.AlwaysBeforeHeaderIcon - the checkbox is always visible").Small().SemiBold().MT(12).MB(4),
+                selectable,
+                TextBlock("A tile that spells the file type out rather than drawing a glyph shrinks with it, so \"XLSX\" is scaled rather than cropped. The starred row shows a corner badge pinned to the smaller tile.").Small().MT(8));
+        }
+
+        // A row laid out with its tile in the header and no checkbox at all - SelectionMode() sets the
+        // layout without making the row selectable.
+        private OmniResult<Hit> HeaderIconRow(Hit hit, string title)
+        {
+            return Row(hit, withText: true, withPages: false)
+                .SetTitle(title)
+                .SelectionMode(OmniResultSelectionMode.HiddenBeforeHeaderIcon);
         }
 
         // ---------- Identifiers ----------
@@ -399,7 +433,9 @@ namespace Tesserae.Tests.Samples
                 OmniResultSelectionMode.OnHoverBeforeIcon,
                 OmniResultSelectionMode.OnHoverOverIcon,
                 OmniResultSelectionMode.AlwaysBeforeIcon,
-                OmniResultSelectionMode.ReplacingIcon
+                OmniResultSelectionMode.ReplacingIcon,
+                OmniResultSelectionMode.AlwaysBeforeHeaderIcon,
+                OmniResultSelectionMode.HiddenBeforeHeaderIcon
             };
 
             var sections = VStack().WS();
@@ -429,8 +465,8 @@ namespace Tesserae.Tests.Samples
                 sections.Add(list);
             }
 
-            return FeatureCard("Selection", "Four places for the checkbox",
-                "Selectable(mode) makes a row selectable. The checkbox sits before the tile or over it, revealed on hover or always visible, or takes the tile's place entirely — and a selected row always shows its checkbox, whatever the mode. A corner badge marks the result rather than the tile, so it follows the checkbox where the checkbox stands in for the tile: the starred row in each group keeps its star over the checkbox. Ctrl-clicking a row toggles it too, and shift-clicking one asks for the range from the last row selected: a single card knows nothing about its siblings, so OnRangeSelectionRequested hands that to the host list, which selects them itself (that is what the rows below do, across all four groups).",
+            return FeatureCard("Selection", "Six places for the checkbox, and two for the tile",
+                "Selectable(mode) makes a row selectable. The checkbox sits before the tile or over it, revealed on hover or always visible, or takes the tile's place entirely — and a selected row always shows its checkbox, whatever the mode. A corner badge marks the result rather than the tile, so it follows the checkbox where the checkbox stands in for the tile: the starred row in each group keeps its star over the checkbox. The last two modes move the tile itself: it leads the header line, drawn small before the title, so the excerpt and the footer start at the row's own left edge instead of indented past a 34px tile — with the checkbox always visible beside it, or with no checkbox at all. Ctrl-clicking a row toggles it too, and shift-clicking one asks for the range from the last row selected: a single card knows nothing about its siblings, so OnRangeSelectionRequested hands that to the host list, which selects them itself (that is what the rows below do, across all six groups).",
                 sections,
                 _selectionState.MT(8),
                 HStack().Gap(8.px()).MT(8).Children(

--- a/Tesserae/skills/references/omni-result.md
+++ b/Tesserae/skills/references/omni-result.md
@@ -16,7 +16,15 @@ without a closure per row:
 ```
 
 Everything past the title is optional. Drop the excerpt, the preview, the footer, or all three, and
-the row tightens up — the same component covers a two-line picker row and a full result card.
+the row tightens up — the same component covers a two-line picker row and a full result card. The tile
+can also lead the header instead of standing in a column of its own, which pulls the excerpt and the
+footer back to the row's left edge:
+
+```
+[✓]  [PDF] JR-2214 › BRK-SEN-447 calibration.pdf   3 matches in text                  [pages]  [...]
+     Torque the mount to 12 Nm before starting brake sensor work. Full calibration steps …
+     ▪ Box · sample-files / pdfs · 2.4 MB · Pius Neuhaus · Apr 12, 2024
+```
 
 ## Create
 
@@ -80,6 +88,30 @@ stands for. Also `new OmniResult<T>(result, title)`. Bring factories into scope 
 Pass a literal color (`"#ef4444"`) rather than a CSS variable when you want the tint to track the
 theme: a `var(--…)` is resolved once, at the time it is set.
 
+**The tile in the header**
+
+Two of the selection modes move the tile out of its column beside the row and draw it small (22px) at
+the **start of the header line**, before the identifier and the title:
+
+- `AlwaysBeforeHeaderIcon` — with a checkbox in its own column at the start of the row, always visible.
+- `HiddenBeforeHeaderIcon` — with no checkbox at all, not even on a selected row. Set it through
+  `.SelectionMode(...)` on a row that isn't selectable; `.Selectable(...)` also accepts it, for a list
+  that owns the selection itself and wants the row background alone to say so.
+
+The excerpt, the footer and the contribution bar then start at the row's own left edge instead of being
+indented past a 34px tile, which is what a dense list — or one whose rows are mostly title — reads
+better as. Everything else is unchanged: a text tile ("XLSX") scales with the tile rather than being
+cropped, and the corner badges are scaled and tucked in with it. The copy the modal takes of the tile
+keeps the modal's own size.
+
+```csharp
+var row = OmniResult(hit, hit.Name)
+    .SetIcon("XLSX", "#16a34a")
+    .SetText(hit.Excerpt)
+    .SetFooterEntries(hit.Path, hit.Size)
+    .SelectionMode(OmniResultSelectionMode.HiddenBeforeHeaderIcon);   // laid out, not selectable
+```
+
 **Footer**
 
 The source leads the line and the metadata follows it, and all of it is `InlineLabel`s
@@ -109,9 +141,15 @@ The source leads the line and the metadata follows it, and all of it is `InlineL
 
 - `.Selectable(OmniResultSelectionMode mode = OnHoverBeforeIcon)` / `.NotSelectable()`.
   Modes: `OnHoverBeforeIcon`, `OnHoverOverIcon` (on the tile, which fades out under it),
-  `AlwaysBeforeIcon`, `ReplacingIcon` (no tile at all). A selected row always shows its checkbox,
-  whatever the mode, and the column is reserved either way so revealing it never shifts the row. In the
-  two modes where the checkbox stands in for the tile, the corner badges move onto it.
+  `AlwaysBeforeIcon`, `ReplacingIcon` (no tile at all), `AlwaysBeforeHeaderIcon` and
+  `HiddenBeforeHeaderIcon` (the two that move the tile into the header — see *The tile in the header*
+  below). A selected row always shows its checkbox, whatever the mode — except under
+  `HiddenBeforeHeaderIcon`, which draws none — and the column is reserved either way so revealing it
+  never shifts the row. In the two modes where the checkbox stands in for the tile, the corner badges
+  move onto it.
+- `.SelectionMode(OmniResultSelectionMode)` — sets the mode **without** making the row selectable,
+  which is how a list that is never selected from asks for `HiddenBeforeHeaderIcon`'s layout. On a row
+  `Selectable` already made selectable it just changes the mode.
 - `IsSelected` / `.Selected(bool = true)` / `IsSelectionEnabled`.
 - `.OnSelectionChanged(Action<OmniResult<T>, bool>)` — every change, from the user or from code.
 - `.OnRangeSelectionRequested(Action<OmniResult<T>>)` — shift-click. A row knows nothing about its

--- a/Tesserae/src/Components/OmniResult.cs
+++ b/Tesserae/src/Components/OmniResult.cs
@@ -25,8 +25,9 @@ namespace Tesserae
     }
 
     /// <summary>
-    /// Where the selection checkbox of an <see cref="OmniResult{T}"/> lives, and when it shows. A selected
-    /// result always shows its checkbox, whatever the mode.
+    /// Where the selection checkbox of an <see cref="OmniResult{T}"/> lives and when it shows, and with it
+    /// where the row draws its icon tile. A selected result always shows its checkbox, whatever the mode -
+    /// except under <see cref="OmniResultSelectionMode.HiddenBeforeHeaderIcon"/>, which draws none at all.
     /// </summary>
     public enum OmniResultSelectionMode
     {
@@ -38,7 +39,16 @@ namespace Tesserae
         AlwaysBeforeIcon,
         /// <summary>A checkbox in place of the icon tile, which is not drawn at all. Whatever
         /// <see cref="OmniResult{T}.SetIconBadge"/> pinned to the tile moves onto the checkbox.</summary>
-        ReplacingIcon
+        ReplacingIcon,
+        /// <summary>The tile leads the header instead of standing in a column of its own beside the whole
+        /// row - drawn small, before the identifier and the title, on the title's line - with a checkbox in
+        /// its own column at the start of the row, always visible.</summary>
+        AlwaysBeforeHeaderIcon,
+        /// <summary>The tile leads the header, as with <see cref="AlwaysBeforeHeaderIcon"/>, and no checkbox
+        /// is drawn at all - not even on a selected row. The layout of a list that is not selected from:
+        /// set it with <see cref="OmniResult{T}.SelectionMode(OmniResultSelectionMode)"/>, which lays the row
+        /// out without making it selectable.</summary>
+        HiddenBeforeHeaderIcon
     }
 
     /// <summary>
@@ -75,7 +85,10 @@ namespace Tesserae
     /// </para>
     /// <para>
     /// Rows are selectable (<see cref="Selectable(OmniResultSelectionMode)"/>) with a checkbox that can sit
-    /// beside or over the icon; commands are reached by right-click and, optionally, a [...] button
+    /// beside or over the icon - and the same mode decides whether the tile stands in a column of its own
+    /// beside the row or leads the header line, before the title
+    /// (<see cref="SelectionMode(OmniResultSelectionMode)"/> lays a row out that way without making it
+    /// selectable); commands are reached by right-click and, optionally, a [...] button
     /// (<see cref="OnContextMenu(Action{OmniResult{T}}, OmniResultCommandsMode)"/>), with room for a few
     /// inline commands before it (<see cref="InlineCommands(OmniResultCommandsVisibility, IComponent[])"/>).
     /// </para>
@@ -802,6 +815,12 @@ namespace Tesserae
         /// Makes the result selectable, with its checkbox shown as the given mode says. The checkbox toggles
         /// the selection on click; ctrl-clicking the row does the same, and shift-clicking it asks for a
         /// range (see <see cref="OnRangeSelectionRequested(Action{OmniResult{T}})"/>).
+        /// <para>
+        /// The mode also decides where the tile is drawn: the two <c>...BeforeHeaderIcon</c> modes move it
+        /// onto the header line, before the identifier and the title. Use
+        /// <see cref="SelectionMode(OmniResultSelectionMode)"/> to lay a row out that way without making it
+        /// selectable at all.
+        /// </para>
         /// </summary>
         public OmniResult<T> Selectable(OmniResultSelectionMode mode = OmniResultSelectionMode.OnHoverBeforeIcon)
         {
@@ -815,7 +834,30 @@ namespace Tesserae
         }
 
         /// <summary>
-        /// Takes the checkbox away again, unselecting the result if it was selected.
+        /// Sets where the checkbox goes and where the tile is drawn <em>without</em> making the row
+        /// selectable - what a list that is never selected from wants when it still wants one of the
+        /// layouts a mode carries, chiefly
+        /// <see cref="OmniResultSelectionMode.HiddenBeforeHeaderIcon"/>: the tile leading the header, and
+        /// no checkbox anywhere.
+        /// <para>
+        /// On a row that <see cref="Selectable(OmniResultSelectionMode)"/> already made selectable this
+        /// changes the mode and nothing else.
+        /// </para>
+        /// </summary>
+        public OmniResult<T> SelectionMode(OmniResultSelectionMode mode)
+        {
+            _selectionMode = mode;
+
+            if (_selectionEnabled) EnsureCheckBox();
+
+            ApplySelectionMode();
+
+            return this;
+        }
+
+        /// <summary>
+        /// Takes the checkbox away again, unselecting the result if it was selected. The layout the mode
+        /// asked for stays - a row laid out with the tile in its header keeps it.
         /// </summary>
         public OmniResult<T> NotSelectable()
         {
@@ -1874,6 +1916,13 @@ namespace Tesserae
                 "tss-omniresult-select-always-before",
                 "tss-omniresult-select-replacing");
 
+            //Where the tile is drawn is the mode's too, and unlike the checkbox it is drawn whether the row
+            //is selectable or not - which is what lets a list that is never selected from ask for the
+            //header layout through SelectionMode() alone.
+            InnerElement.UpdateClassIf(IsIconInHeader, "tss-omniresult-icon-in-header");
+
+            PlaceIconHolder();
+
             //The badges hang off whatever is drawn where the tile goes, which the mode - and whether the row
             //is selectable at all - decides.
             PlaceIconBadges();
@@ -1882,10 +1931,39 @@ namespace Tesserae
 
             switch (_selectionMode)
             {
-                case OmniResultSelectionMode.OnHoverBeforeIcon:  InnerElement.classList.add("tss-omniresult-select-hover-before"); break;
-                case OmniResultSelectionMode.OnHoverOverIcon:    InnerElement.classList.add("tss-omniresult-select-hover-over"); break;
-                case OmniResultSelectionMode.AlwaysBeforeIcon:   InnerElement.classList.add("tss-omniresult-select-always-before"); break;
-                case OmniResultSelectionMode.ReplacingIcon:      InnerElement.classList.add("tss-omniresult-select-replacing"); break;
+                case OmniResultSelectionMode.OnHoverBeforeIcon:      InnerElement.classList.add("tss-omniresult-select-hover-before"); break;
+                case OmniResultSelectionMode.OnHoverOverIcon:        InnerElement.classList.add("tss-omniresult-select-hover-over"); break;
+                case OmniResultSelectionMode.AlwaysBeforeIcon:       InnerElement.classList.add("tss-omniresult-select-always-before"); break;
+                case OmniResultSelectionMode.ReplacingIcon:          InnerElement.classList.add("tss-omniresult-select-replacing"); break;
+                case OmniResultSelectionMode.AlwaysBeforeHeaderIcon: InnerElement.classList.add("tss-omniresult-select-always-before"); break;
+                //HiddenBeforeHeaderIcon draws no checkbox, so it adds no class of its own - the column stays
+                //display:none, which is what it is without a mode at all.
+            }
+        }
+
+        /// <summary>
+        /// Whether the mode draws the tile at the start of the header rather than in a column of its own
+        /// beside the whole row. Unlike the checkbox, this holds whether the row is selectable or not.
+        /// </summary>
+        private bool IsIconInHeader => _selectionMode == OmniResultSelectionMode.AlwaysBeforeHeaderIcon
+                                    || _selectionMode == OmniResultSelectionMode.HiddenBeforeHeaderIcon;
+
+        //The tile is one element wherever it is drawn - moved rather than rebuilt - so whatever SetIcon,
+        //SetIconBadge and the modal's copy already put in it survives a change of mode.
+        private void PlaceIconHolder()
+        {
+            if (IsIconInHeader)
+            {
+                //First on the header line, before the identifier, the title and the badge.
+                if (_iconHolder.parentElement != _headerContainer || _headerContainer.firstChild != _iconHolder)
+                {
+                    _headerContainer.insertBefore(_iconHolder, _headerContainer.firstChild);
+                }
+            }
+            else if (_iconHolder.parentElement != InnerElement)
+            {
+                //Back to its own column, between the checkbox column and the text column.
+                InnerElement.insertBefore(_iconHolder, _mainContainer);
             }
         }
 

--- a/Tesserae/tps/assets/css/tss.omniresult.css
+++ b/Tesserae/tps/assets/css/tss.omniresult.css
@@ -214,6 +214,48 @@
 /* The tile itself is an IconTile (see tss.icontile.css): the row only adds this class so the rules above -
    and the peek overrides below - have something of its own to hang off. */
 
+/* Icon in the header ---------------------------------------------------------------------------- */
+
+/* AlwaysBeforeHeaderIcon / HiddenBeforeHeaderIcon: the tile leads the header line instead of standing in a
+   column of its own beside the whole row. The excerpt, the footer and the contribution bar then start at
+   the row's own left edge rather than indented past a tile, which is what a dense list of results - or one
+   whose rows are mostly title - reads better as. The tile is drawn at the title's line box (22px) so it
+   sits on the line rather than setting the line's height itself. */
+.tss-omniresult-icon-in-header .tss-omniresult-icon-holder {
+    align-self: center;
+}
+
+.tss-omniresult-icon-in-header .tss-omniresult-icon {
+    --tss-icontile-size: 22px;
+    --tss-icontile-radius: 6px;
+}
+
+/* The checkbox column is level with the header line, not with a 34px tile that is no longer there. */
+.tss-omniresult-icon-in-header .tss-omniresult-select {
+    height: 22px;
+}
+
+/* A corner badge is scaled with the tile it is pinned to, and tucked closer in: 4px out from a 34px tile
+   is a hint, 4px out from a 22px one is half the badge hanging in the air. */
+.tss-omniresult-icon-in-header .tss-omniresult-icon-badge {
+    font-size: 9px;
+}
+
+.tss-omniresult-icon-in-header .tss-omniresult-icon-badge img,
+.tss-omniresult-icon-in-header .tss-omniresult-icon-badge svg {
+    width: 11px;
+    height: 11px;
+    border-radius: 2px;
+}
+
+.tss-omniresult-icon-in-header .tss-omniresult-icon-badge-tl { left: -3px;  top: -3px; }
+.tss-omniresult-icon-in-header .tss-omniresult-icon-badge-tr { right: -3px; top: -3px; }
+.tss-omniresult-icon-in-header .tss-omniresult-icon-badge-bl { left: -3px;  bottom: -3px; }
+.tss-omniresult-icon-in-header .tss-omniresult-icon-badge-br { right: -3px; bottom: -3px; }
+
+/* The copy the modal takes of the tile keeps the modal's own size whatever the row did with it - the
+   sizing above hangs off the row, and the copy is not inside one. */
+
 /* Title, badge, excerpt --------------------------------------------------------------------------- */
 
 .tss-omniresult-main {


### PR DESCRIPTION
Two new OmniResultSelectionMode members move the icon tile out of the
column beside the whole row and draw it small, first on the header line,
before the identifier and the title: AlwaysBeforeHeaderIcon keeps a
checkbox in its own column at the start of the row, always visible, and
HiddenBeforeHeaderIcon draws none at all.

The excerpt, the footer and the contribution bar then start at the row's
own left edge instead of being indented past a 34px tile, which is what
a dense list - or one whose rows are mostly title - reads better as.

Where the tile is drawn is the mode's business now as much as where the
checkbox is, and unlike the checkbox it applies whether the row is
selectable or not - so SelectionMode(mode) sets the mode without making
the row selectable, which is how a list that is never selected from asks
for HiddenBeforeHeaderIcon's layout. The tile is moved rather than
rebuilt, so what SetIcon and SetIconBadge put in it survives a change of
mode; the badges are scaled and tucked in with the smaller tile, and the
copy the modal takes of it keeps the modal's own size.

Verified in the gallery with Playwright: the tile is the header's first
child at 22px, the checkbox column shows and toggles the row under
AlwaysBeforeHeaderIcon and is absent from the DOM under
HiddenBeforeHeaderIcon, and the rows the change does not touch measure
and render identically to the previous build.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013fWL48QWi4mTwciunZejkr