### PR TITLE
Replace the gallery's placeholder home with a component landing page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,8 +197,14 @@ sample picks its category on its attribute, and `Order` places it inside that
 category — the list runs from the most fundamental member outwards, in steps of 10:
 
 ```csharp
-[SampleDetails(Group = SampleGroup.Inputs, Order = 10, Icon = UIcons.InputText)]
+[SampleDetails(Group = SampleGroup.Inputs, Order = 10, Icon = UIcons.InputText, Description = "Single-line text input, with icons and prefixes")]
 ```
+
+`Description` is what the landing page prints under the component's name, so it is
+required on every sample: one line saying what the *component* is for, not what the
+sample page shows. It is drawn on a single ellipsized line about 310px wide, which
+is room for roughly fifty characters — anything longer is only reachable through the
+card's tooltip.
 
 Two conventions keep it navigable: the file lives in
 `Tesserae.Tests/src/Samples/<Constant>/` (the folder is named after the *constant* —
@@ -207,6 +213,12 @@ within the gallery, since the sidebar is read by glyph as much as by label. The 
 categories are used by the `tesserae` skill's reference index and by the
 `documentation` repo under `tesserae/`; a component that moves category has to move
 in all three.
+
+The gallery's home page, [`Tesserae.Tests/src/LandingPage.cs`](Tesserae.Tests/src/LandingPage.cs),
+draws that same list as a grid of `ContextCard`s under a header per category, in
+`SampleGroup.InDisplayOrder` — so it needs nothing done to it when a sample is added,
+beyond the attribute above. A category added to `SampleGroup` should get a colour in
+the landing page's `GroupColors`, which is indexed by `SampleGroup.DisplayIndex`.
 
 ## Layout system
 

--- a/Tesserae.Tests/src/App.cs
+++ b/Tesserae.Tests/src/App.cs
@@ -14,7 +14,6 @@ namespace Tesserae.Tests
 {
     internal static class App
     {
-        private const string _sidebarOrderKey     = "tss-sample-sidebar-order";
         private const string _sidebarOpenStateKey = "tss-sample-sidebar-open-close";
 
         private static void Main()
@@ -53,7 +52,11 @@ namespace Tesserae.Tests
                 }
             });
 
-            var sidebar = Sidebar(sortable: true);
+            // Not sortable: the sidebar's order is the one SampleGroup.InDisplayOrder and each
+            // sample's Order declare, and it is the same order the landing page reads top to bottom.
+            // Dragging an entry out of it made the two disagree, and made a shared link to a sample
+            // land somewhere else in the list than the person who sent it saw.
+            var sidebar = Sidebar();
 
             // On mobile we use navbar mode: horizontal bar + full-screen sliding drawer.
             // This is evaluated once at startup; the CSS (tss-mobile class) handles visual switches
@@ -63,36 +66,31 @@ namespace Tesserae.Tests
                 sidebar.AsNavbar();
             }
 
-            var sortingTimeout = 0d;
-
-            sidebar.OnSortingChanged(itemOrder =>
-            {
-                window.clearTimeout(sortingTimeout);
-
-                sortingTimeout = window.setTimeout(_ =>
-                {
-                    var itemOrderObject = new { };
-
-                    foreach (var item in itemOrder)
-                    {
-                        itemOrderObject[item.Key] = item.Value;
-                    }
-                    var sorting = new { itemOrder = itemOrderObject };
-
-                    localStorage.setItem(_sidebarOrderKey, es5.JSON.stringify(sorting));
-                    console.log("saved sorting", sorting);
-                }, 1000);
-            });
-
-
             sidebar.AddHeader(new SidebarText("header", "Tesserae", "TSS", textSize: TextSize.XLarge, textWeight: TextWeight.Bold));
 
             var searchBox = new SidebarSearchBox("search", "Search...");
             searchBox.OnSearch((term) => sidebar.Search(term));
             sidebar.AddHeader(searchBox);
 
+            //Important: Reflection will only properly work here if reflection metadata is emitted inline with the javascript, instead of in a separate .meta.js file
+            //           i.e. in the tps.json file, we need:      "reflection": { "disabled": false, "target":  "inline" },
+
+            // Built before the content area, because the landing page it shows when no sample is
+            // selected is the same list, drawn as cards.
+            var samples = typeof(ISample).Assembly.GetTypes().Where(t => typeof(ISample).IsAssignableFrom(t) && !t.IsInterface)
+               .Select(sampleType =>
+               {
+                   var sg = sampleType.GetCustomAttributes(typeof(SampleDetailsAttribute), true).FirstOrDefault() as SampleDetailsAttribute;
+                   var group = sg is object ? sg.Group : "Others";
+                   int order = sg is object ? sg.Order : 0;
+                   UIcons icon = sg is object ? sg.Icon : UIcons.Circle;
+                   string description = sg is object ? sg.Description : null;
+                   return new Sample(sampleType.Name, Sample.FormatSampleName(sampleType), group, order, icon, description, async () => await Activator.CreateInstanceAsync(sampleType) as IComponent);
+               })
+               .ToDictionary(s => s.Name, s => s);
+
             var contentArea = Defer(currentPage, async page => page is null
-                ? (IComponent)CenteredCardWithBackground(Message("Welcome to Tesserae", "Select a component to see more details").Icon(UIcons.Search))
+                ? (IComponent)VStack().S().ScrollY().Children(new LandingPage(samples.Values).WS())
                 : VStack().S().ScrollY().Children((await page.ContentGenerator()).WS().MinHeight(100.percent())));
 
             // On mobile the sidebar is a fixed top navbar, so the layout is vertical (sidebar then content).
@@ -109,20 +107,6 @@ namespace Tesserae.Tests
             }
 
             MountToBody(pageContent);
-
-            //Important: Reflection will only properly work here if reflection metadata is emitted inline with the javascript, instead of in a separate .meta.js file
-            //           i.e. in the tps.json file, we need:      "reflection": { "disabled": false, "target":  "inline" },
-
-            var samples = typeof(ISample).Assembly.GetTypes().Where(t => typeof(ISample).IsAssignableFrom(t) && !t.IsInterface)
-               .Select(sampleType =>
-               {
-                   var sg = sampleType.GetCustomAttributes(typeof(SampleDetailsAttribute), true).FirstOrDefault() as SampleDetailsAttribute;
-                   var group = sg is object ? sg.Group : "Others";
-                   int order = sg is object ? sg.Order : 0;
-                   UIcons icon = sg is object ? sg.Icon : UIcons.Circle;
-                   return new Sample(sampleType.Name, Sample.FormatSampleName(sampleType), group, order, icon, async () => await Activator.CreateInstanceAsync(sampleType) as IComponent);
-               })
-               .ToDictionary(s => s.Name, s => s);
 
             sidebar.AddHeader(new SidebarButton("SOURCE_CODE", Emoji.House, "Source Code", new SidebarCommand(UIcons.ArrowUpRightFromSquare).Tooltip("Open repository on GitHub")
                    .OnClick(() => window.open("https://github.com/curiosity-ai/tesserae", "_blank")))
@@ -211,26 +195,6 @@ namespace Tesserae.Tests
                 }
             }
 
-
-            var sidebarOrderJson = localStorage.getItem(_sidebarOrderKey);
-
-            if (sidebarOrderJson is object)
-            {
-                var sidebarOrderObj = es5.JSON.parse(sidebarOrderJson);
-                console.log("loaded sorting", sidebarOrderObj);
-
-
-                var itemOrderObj = sidebarOrderObj["itemOrder"].As<object>();
-                if (itemOrderObj is null) return;
-                var itemOrder = new Dictionary<string, string[]>();
-
-                foreach (var identifier in GetOwnPropertyNames(itemOrderObj))
-                {
-                    itemOrder[identifier] = itemOrderObj[identifier].As<string[]>();
-
-                }
-                sidebar.LoadSorting(itemOrder);
-            }
 
             // One handler covers every way out of a sample: the browser's back/forward buttons,
             // Router.Navigate, and the sidebar's Router.Push. (Closing or reloading the browser tab

--- a/Tesserae.Tests/src/LandingPage.cs
+++ b/Tesserae.Tests/src/LandingPage.cs
@@ -1,0 +1,126 @@
+using System.Collections.Generic;
+using System.Linq;
+using Transpose.Core;
+using Tesserae.Tests.Samples;
+using static Transpose.Core.dom;
+using static Tesserae.UI;
+
+namespace Tesserae.Tests
+{
+    /// <summary>
+    /// The gallery's home page — what you get before a sample is picked, and what the "home" route
+    /// returns to. It draws the same list the sidebar does, in the same order
+    /// (<see cref="SampleGroup.InDisplayOrder"/>), but as a grid of <see cref="ContextCard"/>s under
+    /// a header per category, so the whole toolkit can be read at a glance instead of scrolled
+    /// through one item at a time.
+    /// <para>
+    /// A card carries the sample's icon, its name and the one-line
+    /// <see cref="SampleDetailsAttribute.Description"/> declared on the sample, and navigates to it
+    /// on click — through <see cref="Router"/>, so the sidebar selection follows along exactly as if
+    /// the sidebar entry had been clicked.
+    /// </para>
+    /// </summary>
+    internal sealed class LandingPage : IComponent
+    {
+        // The sub-label is one ellipsized line, so a card needs a width it can say something in. The
+        // cards sit in an auto-filled grid rather than a wrapping row, so a row is filled edge to edge
+        // whatever the window is: as many equal columns as fit at this width, each taking a share of
+        // what is left over.
+        private static readonly UnitSize CardColumns = new UnitSize("repeat(auto-fill, minmax(310px, 1fr))");
+
+        // One colour per category, in the order SampleGroup.InDisplayOrder lists them, so a card's
+        // tile still says which group it belongs to once its header has scrolled away. A category
+        // past the end of this list falls back to the theme's primary colour.
+        private static readonly string[] GroupColors =
+        {
+            Theme.Colors.Blue600,    // Layout
+            Theme.Colors.Teal600,    // Text & Content
+            Theme.Colors.Purple600,  // Buttons & Commands
+            Theme.Colors.Green600,   // Inputs
+            Theme.Colors.Orange600,  // Date & Time
+            Theme.Colors.Lime600,    // Forms & Validation
+            Theme.Colors.Magenta600, // Navigation
+            Theme.Colors.Blue500,    // Lists & Data
+            Theme.Colors.Teal500,    // Search
+            Theme.Colors.Purple500,  // Charts & Visualization
+            Theme.Colors.Yellow600,  // Feedback & Status
+            Theme.Colors.Red600,     // Overlays & Dialogs
+            Theme.Colors.Magenta500, // AI & Chat
+            Theme.Colors.Orange500,  // Media & Graphics
+            Theme.Colors.Green500,   // Theming & Icons
+            Theme.Colors.Neutral600, // Utilities & Behaviors
+        };
+
+        private readonly IComponent _content;
+
+        public LandingPage(IEnumerable<Sample> samples)
+        {
+            // Same grouping and ordering as the sidebar in App.cs, so the two read as one list.
+            var groups = samples
+               .GroupBy(s => s.Group)
+               .OrderBy(g => SampleGroup.DisplayIndex(g.Key))
+               .ThenBy(g => g.Key)
+               .ToArray();
+
+            var page = VStack().WS().Gap(32.px()).Padding(32.px());
+
+            page.Add(Header(groups.Sum(g => g.Count()), groups.Length));
+
+            foreach (var group in groups)
+            {
+                page.Add(Section(group.Key, group.OrderBy(s => s.Order).ThenBy(s => s.Name.ToLower())));
+            }
+
+            _content = page;
+        }
+
+        public HTMLElement Render() => _content.Render();
+
+        private static IComponent Header(int componentCount, int groupCount) =>
+            VStack().WS().Gap(6.px()).Children(
+                TextBlock("Tesserae").XLarge().Bold(),
+                TextBlock($"{componentCount} components in {groupCount} categories. Pick one to see it running, alongside the code that draws it.")
+                   .Medium().Foreground(Theme.Colors.Neutral600),
+                HStack().Gap(8.px()).PT(12).Children(
+                    Button("Documentation").SetIcon(UIcons.Books).Primary()
+                       .OnClick(() => window.open("https://docs.curiosity.ai/tesserae/", "_blank")),
+                    Button("Source code").SetIcon(UIcons.ArrowUpRightFromSquare)
+                       .OnClick(() => window.open("https://github.com/curiosity-ai/tesserae", "_blank"))));
+
+        private static IComponent Section(string group, IEnumerable<Sample> samples)
+        {
+            var color = GroupColors[SampleGroup.DisplayIndex(group) % GroupColors.Length];
+            var cards = Grid(CardColumns).WS().Gap(12.px());
+
+            foreach (var sample in samples)
+            {
+                cards.Add(SampleCard(sample, color));
+            }
+
+            return VStack().WS().Gap(12.px()).Children(GroupHeader(group, color), cards);
+        }
+
+        // The category name, with a rule running out to the end of the row so the groups stay legible
+        // once the page is a few hundred cards long.
+        private static IComponent GroupHeader(string group, string color) =>
+            HStack().WS().AlignItems(ItemAlign.Center).Gap(12.px()).Children(
+                TextBlock(group).Large().SemiBold(),
+                Raw(Div(Att(styles: s =>
+                {
+                    s.height     = "1px";
+                    s.background = $"color-mix(in srgb, {color} 45%, transparent)";
+                }))).Grow());
+
+        private static ContextCard SampleCard(Sample sample, string color) =>
+            ContextCard(sample.Name, sample.Icon)
+               .SetSubLabel(sample.Description)
+               .IconTint(color)
+               .WithChevron()
+               // A ContextCard sizes itself to its content, and a grid item only stretches to its
+               // track when its own width is auto - so the card is told to fill the column.
+               .WS()
+               // The sub-label is cut to one line, so the full text stays reachable on hover.
+               .Tooltip(string.IsNullOrEmpty(sample.Description) ? sample.Name : sample.Description)
+               .OnClick((_, __) => Router.Navigate($"#/view/{sample.Name}"));
+    }
+}

--- a/Tesserae.Tests/src/Samples/AI/AIVariantsSample.cs
+++ b/Tesserae.Tests/src/Samples/AI/AIVariantsSample.cs
@@ -4,7 +4,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.AI, Order = 10, Icon = UIcons.Sparkles)]
+    [SampleDetails(Group = SampleGroup.AI, Order = 10, Icon = UIcons.Sparkles, Description = "The purple-to-blue tint for anything a model made")]
     public class AIVariantsSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/AI/ChatSample.cs
+++ b/Tesserae.Tests/src/Samples/AI/ChatSample.cs
@@ -6,7 +6,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.AI, Order = 20, Icon = UIcons.CommentAlt)]
+    [SampleDetails(Group = SampleGroup.AI, Order = 20, Icon = UIcons.CommentAlt, Description = "A chat transcript with messages and a composer")]
     public class ChatSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/AI/ContextCardSample.cs
+++ b/Tesserae.Tests/src/Samples/AI/ContextCardSample.cs
@@ -4,7 +4,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.AI, Order = 30, Icon = UIcons.Clip)]
+    [SampleDetails(Group = SampleGroup.AI, Order = 30, Icon = UIcons.Clip, Description = "Cards for the files and data attached to a chat")]
     public class ContextCardSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/AI/PlanSample.cs
+++ b/Tesserae.Tests/src/Samples/AI/PlanSample.cs
@@ -7,7 +7,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.AI, Order = 50, Icon = UIcons.ClipboardListCheck)]
+    [SampleDetails(Group = SampleGroup.AI, Order = 50, Icon = UIcons.ClipboardListCheck, Description = "A model's plan, step by step, as it runs")]
     public class PlanSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/AI/ResourceCardSample.cs
+++ b/Tesserae.Tests/src/Samples/AI/ResourceCardSample.cs
@@ -6,7 +6,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.AI, Order = 60, Icon = UIcons.IdBadge)]
+    [SampleDetails(Group = SampleGroup.AI, Order = 60, Icon = UIcons.IdBadge, Description = "A rich summary card for a document or source")]
     public class ResourceCardSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/AI/ToolCallSample.cs
+++ b/Tesserae.Tests/src/Samples/AI/ToolCallSample.cs
@@ -4,7 +4,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.AI, Order = 40, Icon = UIcons.Tools)]
+    [SampleDetails(Group = SampleGroup.AI, Order = 40, Icon = UIcons.Tools, Description = "Inline tool-call indicators and a summary popup")]
     public class ToolCallSample : IComponent, ISample
     {
         // Handed over compact on purpose: ToolCallInspect re-indents JSON as it is set.

--- a/Tesserae.Tests/src/Samples/Charts/ChartsSample.cs
+++ b/Tesserae.Tests/src/Samples/Charts/ChartsSample.cs
@@ -5,7 +5,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Charts, Order = 10, Icon = UIcons.ChartMixed)]
+    [SampleDetails(Group = SampleGroup.Charts, Order = 10, Icon = UIcons.ChartMixed, Description = "Lightweight, dependency-free SVG charts")]
     public class ChartsSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Charts/ContributionBarSample.cs
+++ b/Tesserae.Tests/src/Samples/Charts/ContributionBarSample.cs
@@ -4,7 +4,7 @@ using static Transpose.Core.dom;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Charts, Order = 40, Icon = UIcons.ChartSimpleHorizontal)]
+    [SampleDetails(Group = SampleGroup.Charts, Order = 40, Icon = UIcons.ChartSimpleHorizontal, Description = "A stacked bar of how weighted parts add up")]
     public class ContributionBarSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Charts/DiagramSample.cs
+++ b/Tesserae.Tests/src/Samples/Charts/DiagramSample.cs
@@ -4,7 +4,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Charts, Order = 60, Icon = UIcons.Workflow)]
+    [SampleDetails(Group = SampleGroup.Charts, Order = 60, Icon = UIcons.Workflow, Description = "Draggable nodes with auto-computed arrows")]
     public class DiagramSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Charts/MetricSample.cs
+++ b/Tesserae.Tests/src/Samples/Charts/MetricSample.cs
@@ -4,7 +4,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Charts, Order = 30, Icon = UIcons.ChartSimple)]
+    [SampleDetails(Group = SampleGroup.Charts, Order = 30, Icon = UIcons.ChartSimple, Description = "One number, with its trend and its delta")]
     public class MetricSample : IComponent, ISample
     {
         private readonly IComponent content;

--- a/Tesserae.Tests/src/Samples/Charts/NodeViewSample.cs
+++ b/Tesserae.Tests/src/Samples/Charts/NodeViewSample.cs
@@ -6,7 +6,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Charts, Order = 70, Icon = UIcons.Network)]
+    [SampleDetails(Group = SampleGroup.Charts, Order = 70, Icon = UIcons.Network, Description = "An interactive node-graph editor")]
     public class NodeViewSample : IComponent, ISample
     {
         private readonly IComponent content;

--- a/Tesserae.Tests/src/Samples/Charts/SparklineSample.cs
+++ b/Tesserae.Tests/src/Samples/Charts/SparklineSample.cs
@@ -4,7 +4,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Charts, Order = 20, Icon = UIcons.ChartLineUp)]
+    [SampleDetails(Group = SampleGroup.Charts, Order = 20, Icon = UIcons.ChartLineUp, Description = "A compact inline trend chart")]
     public class SparklineSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Charts/UptimeSample.cs
+++ b/Tesserae.Tests/src/Samples/Charts/UptimeSample.cs
@@ -5,7 +5,7 @@ using static Tesserae.UI;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Charts, Order = 50, Icon = UIcons.HeartRate)]
+    [SampleDetails(Group = SampleGroup.Charts, Order = 50, Icon = UIcons.HeartRate, Description = "Status history as bars or a month calendar")]
     public class UptimeSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Commands/ActionButtonSample.cs
+++ b/Tesserae.Tests/src/Samples/Commands/ActionButtonSample.cs
@@ -6,7 +6,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Commands, Order = 20, Icon = UIcons.CursorFingerClick)]
+    [SampleDetails(Group = SampleGroup.Commands, Order = 20, Icon = UIcons.CursorFingerClick, Description = "A borderless button for inline actions")]
     public class ActionButtonSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Commands/ButtonSample.cs
+++ b/Tesserae.Tests/src/Samples/Commands/ButtonSample.cs
@@ -6,7 +6,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Commands, Order = 10, Icon = UIcons.Cursor)]
+    [SampleDetails(Group = SampleGroup.Commands, Order = 10, Icon = UIcons.Cursor, Description = "The control that triggers an action")]
     public class ButtonSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Commands/CommandBarSample.cs
+++ b/Tesserae.Tests/src/Samples/Commands/CommandBarSample.cs
@@ -4,7 +4,7 @@ using static Transpose.Core.dom;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Commands, Order = 40, Icon = UIcons.ToolBox)]
+    [SampleDetails(Group = SampleGroup.Commands, Order = 40, Icon = UIcons.ToolBox, Description = "A toolbar housing commands and overflow")]
     public class CommandBarSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Commands/CommandPaletteSample.cs
+++ b/Tesserae.Tests/src/Samples/Commands/CommandPaletteSample.cs
@@ -8,7 +8,7 @@ using static Transpose.Core.dom;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Commands, Order = 80, Icon = UIcons.Command)]
+    [SampleDetails(Group = SampleGroup.Commands, Order = 80, Icon = UIcons.Command, Description = "A Ctrl+K palette for searching commands")]
     public class CommandPaletteSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Commands/ContextMenuSample.cs
+++ b/Tesserae.Tests/src/Samples/Commands/ContextMenuSample.cs
@@ -4,7 +4,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Commands, Order = 70, Icon = UIcons.AppsAdd)]
+    [SampleDetails(Group = SampleGroup.Commands, Order = 70, Icon = UIcons.AppsAdd, Description = "A menu opened at the pointer on right-click")]
     public class ContextMenuSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Commands/IconToggleSample.cs
+++ b/Tesserae.Tests/src/Samples/Commands/IconToggleSample.cs
@@ -5,7 +5,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Commands, Order = 30, Icon = UIcons.LayoutFluid)]
+    [SampleDetails(Group = SampleGroup.Commands, Order = 30, Icon = UIcons.LayoutFluid, Description = "Icon buttons where exactly one is selected")]
     public class IconToggleSample : IComponent, ISample
     {
         public enum ViewMode { List, Grid, Table }

--- a/Tesserae.Tests/src/Samples/Commands/MenuSample.cs
+++ b/Tesserae.Tests/src/Samples/Commands/MenuSample.cs
@@ -4,7 +4,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Commands, Order = 60, Icon = UIcons.MenuBurger)]
+    [SampleDetails(Group = SampleGroup.Commands, Order = 60, Icon = UIcons.MenuBurger, Description = "A dropdown menu with nested submenus")]
     public class MenuSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Commands/OverflowSetSample.cs
+++ b/Tesserae.Tests/src/Samples/Commands/OverflowSetSample.cs
@@ -5,7 +5,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Commands, Order = 50, Icon = UIcons.MenuDots)]
+    [SampleDetails(Group = SampleGroup.Commands, Order = 50, Icon = UIcons.MenuDots, Description = "A row that folds what doesn't fit into a menu")]
     public class OverflowSetSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/DateTime/CronEditorSample.cs
+++ b/Tesserae.Tests/src/Samples/DateTime/CronEditorSample.cs
@@ -6,7 +6,7 @@ using static Tesserae.UI;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.DateTime, Order = 80, Icon = UIcons.AlarmClock)]
+    [SampleDetails(Group = SampleGroup.DateTime, Order = 80, Icon = UIcons.AlarmClock, Description = "Build a cron expression without the syntax")]
     public sealed class CronEditorSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/DateTime/DatePickerSample.cs
+++ b/Tesserae.Tests/src/Samples/DateTime/DatePickerSample.cs
@@ -5,7 +5,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.DateTime, Order = 10, Icon = UIcons.Calendar)]
+    [SampleDetails(Group = SampleGroup.DateTime, Order = 10, Icon = UIcons.Calendar, Description = "A calendar dropdown for picking one date")]
     public class DatePickerSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/DateTime/DateRangePickerSample.cs
+++ b/Tesserae.Tests/src/Samples/DateTime/DateRangePickerSample.cs
@@ -5,7 +5,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.DateTime, Order = 20, Icon = UIcons.CalendarLines)]
+    [SampleDetails(Group = SampleGroup.DateTime, Order = 20, Icon = UIcons.CalendarLines, Description = "Pick a contiguous range of dates")]
     public class DateRangePickerSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/DateTime/DateTimePickerSample.cs
+++ b/Tesserae.Tests/src/Samples/DateTime/DateTimePickerSample.cs
@@ -5,7 +5,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.DateTime, Order = 30, Icon = UIcons.CalendarClock)]
+    [SampleDetails(Group = SampleGroup.DateTime, Order = 30, Icon = UIcons.CalendarClock, Description = "A date and a time of day in one control")]
     public class DateTimePickerSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/DateTime/MonthPickerSample.cs
+++ b/Tesserae.Tests/src/Samples/DateTime/MonthPickerSample.cs
@@ -5,7 +5,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.DateTime, Order = 50, Icon = UIcons.CalendarDay)]
+    [SampleDetails(Group = SampleGroup.DateTime, Order = 50, Icon = UIcons.CalendarDay, Description = "Pick a year and a month")]
     public class MonthPickerSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/DateTime/TimeHistogramPickerSample.cs
+++ b/Tesserae.Tests/src/Samples/DateTime/TimeHistogramPickerSample.cs
@@ -6,7 +6,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.DateTime, Order = 70, Icon = UIcons.ChartHistogram)]
+    [SampleDetails(Group = SampleGroup.DateTime, Order = 70, Icon = UIcons.ChartHistogram, Description = "Brush a time range over a histogram")]
     public class TimeHistogramPickerSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/DateTime/TimePickerSample.cs
+++ b/Tesserae.Tests/src/Samples/DateTime/TimePickerSample.cs
@@ -5,7 +5,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.DateTime, Order = 40, Icon = UIcons.Clock)]
+    [SampleDetails(Group = SampleGroup.DateTime, Order = 40, Icon = UIcons.Clock, Description = "Pick a time of day")]
     public class TimePickerSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/DateTime/WeekPickerSample.cs
+++ b/Tesserae.Tests/src/Samples/DateTime/WeekPickerSample.cs
@@ -5,7 +5,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.DateTime, Order = 60, Icon = UIcons.CalendarWeek)]
+    [SampleDetails(Group = SampleGroup.DateTime, Order = 60, Icon = UIcons.CalendarWeek, Description = "Pick an ISO week number")]
     public class WeekPickerSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Feedback/BannerSample.cs
+++ b/Tesserae.Tests/src/Samples/Feedback/BannerSample.cs
@@ -4,7 +4,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Feedback, Order = 20, Icon = UIcons.Megaphone)]
+    [SampleDetails(Group = SampleGroup.Feedback, Order = 20, Icon = UIcons.Megaphone, Description = "A notice strip with an action and a dismiss")]
     public class BannerSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Feedback/MessageSample.cs
+++ b/Tesserae.Tests/src/Samples/Feedback/MessageSample.cs
@@ -5,7 +5,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Feedback, Order = 10, Icon = UIcons.Comment)]
+    [SampleDetails(Group = SampleGroup.Feedback, Order = 10, Icon = UIcons.Comment, Description = "Inline info, success, warning and error notes")]
     public class MessageSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Feedback/NotificationCenterSample.cs
+++ b/Tesserae.Tests/src/Samples/Feedback/NotificationCenterSample.cs
@@ -6,7 +6,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Feedback, Order = 40, Icon = UIcons.Bell)]
+    [SampleDetails(Group = SampleGroup.Feedback, Order = 40, Icon = UIcons.Bell, Description = "A bell opening a panel of notifications")]
     public class NotificationCenterSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Feedback/ProgressIndicatorSample.cs
+++ b/Tesserae.Tests/src/Samples/Feedback/ProgressIndicatorSample.cs
@@ -7,7 +7,7 @@ using Tesserae.Tests;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Feedback, Order = 70, Icon = UIcons.BarsProgress)]
+    [SampleDetails(Group = SampleGroup.Feedback, Order = 70, Icon = UIcons.BarsProgress, Description = "Determinate and indeterminate progress bars")]
     public class ProgressIndicatorSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Feedback/ProgressModalSample.cs
+++ b/Tesserae.Tests/src/Samples/Feedback/ProgressModalSample.cs
@@ -9,7 +9,7 @@ using Tesserae.Tests;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Feedback, Order = 90, Icon = UIcons.WindowMaximize)]
+    [SampleDetails(Group = SampleGroup.Feedback, Order = 90, Icon = UIcons.WindowMaximize, Description = "A modal that blocks while work runs")]
     public class ProgressModalSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Feedback/ProgressRingSample.cs
+++ b/Tesserae.Tests/src/Samples/Feedback/ProgressRingSample.cs
@@ -6,7 +6,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Feedback, Order = 80, Icon = UIcons.ChartPieAlt)]
+    [SampleDetails(Group = SampleGroup.Feedback, Order = 80, Icon = UIcons.ChartPieAlt, Description = "A circular progress indicator")]
     public class ProgressRingSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Feedback/SkeletonSample.cs
+++ b/Tesserae.Tests/src/Samples/Feedback/SkeletonSample.cs
@@ -4,7 +4,7 @@ using static Transpose.Core.dom;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Feedback, Order = 100, Icon = UIcons.RectanglesMixed)]
+    [SampleDetails(Group = SampleGroup.Feedback, Order = 100, Icon = UIcons.RectanglesMixed, Description = "Placeholder shapes while content loads")]
     public class SkeletonSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Feedback/SpinnerSample.cs
+++ b/Tesserae.Tests/src/Samples/Feedback/SpinnerSample.cs
@@ -7,7 +7,7 @@ using Tesserae.Tests;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Feedback, Order = 60, Icon = UIcons.Spinner)]
+    [SampleDetails(Group = SampleGroup.Feedback, Order = 60, Icon = UIcons.Spinner, Description = "A loading spinner with an optional label")]
     public class SpinnerSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Feedback/TippySample.cs
+++ b/Tesserae.Tests/src/Samples/Feedback/TippySample.cs
@@ -6,7 +6,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Feedback, Order = 50, Icon = UIcons.CommentInfo)]
+    [SampleDetails(Group = SampleGroup.Feedback, Order = 50, Icon = UIcons.CommentInfo, Description = "Tooltips and popovers on any component")]
     public class TippySample : IComponent, ISample
     {
         private readonly IComponent content;

--- a/Tesserae.Tests/src/Samples/Feedback/ToastSample.cs
+++ b/Tesserae.Tests/src/Samples/Feedback/ToastSample.cs
@@ -6,7 +6,7 @@ using Tesserae.Tests;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Feedback, Order = 30, Icon = UIcons.BreadSlice)]
+    [SampleDetails(Group = SampleGroup.Feedback, Order = 30, Icon = UIcons.BreadSlice, Description = "Transient notifications in a screen corner")]
     public class ToastSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Forms/PropertyGridSample.cs
+++ b/Tesserae.Tests/src/Samples/Forms/PropertyGridSample.cs
@@ -5,7 +5,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Forms, Order = 10, Icon = UIcons.ListCheck)]
+    [SampleDetails(Group = SampleGroup.Forms, Order = 10, Icon = UIcons.ListCheck, Description = "A two-way-bound editor built from an object")]
     public class PropertyGridSample : IComponent, ISample
     {
         public enum AccountTier { Free, Pro, Enterprise }

--- a/Tesserae.Tests/src/Samples/Forms/QuestionnaireSample.cs
+++ b/Tesserae.Tests/src/Samples/Forms/QuestionnaireSample.cs
@@ -4,7 +4,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Forms, Order = 20, Icon = UIcons.CommentQuestion)]
+    [SampleDetails(Group = SampleGroup.Forms, Order = 20, Icon = UIcons.CommentQuestion, Description = "Inline questions and answer options for chats")]
     public class QuestionnaireSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Forms/SaveButtonSample.cs
+++ b/Tesserae.Tests/src/Samples/Forms/SaveButtonSample.cs
@@ -6,7 +6,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Forms, Order = 40, Icon = UIcons.Disk)]
+    [SampleDetails(Group = SampleGroup.Forms, Order = 40, Icon = UIcons.Disk, Description = "A button that shows saving and saved state")]
     public class SaveButtonSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Forms/SavingToastSample.cs
+++ b/Tesserae.Tests/src/Samples/Forms/SavingToastSample.cs
@@ -6,7 +6,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Forms, Order = 50, Icon = UIcons.CloudUpload)]
+    [SampleDetails(Group = SampleGroup.Forms, Order = 50, Icon = UIcons.CloudUpload, Description = "A toast that tracks a save in progress")]
     public class SavingToastSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Forms/UnsavedChangesGuardSample.cs
+++ b/Tesserae.Tests/src/Samples/Forms/UnsavedChangesGuardSample.cs
@@ -4,7 +4,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Forms, Order = 60, Icon = UIcons.Exclamation)]
+    [SampleDetails(Group = SampleGroup.Forms, Order = 60, Icon = UIcons.Exclamation, Description = "Warn before losing an editor's unsaved changes")]
     public class UnsavedChangesGuardSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Forms/ValidatorSample.cs
+++ b/Tesserae.Tests/src/Samples/Forms/ValidatorSample.cs
@@ -5,7 +5,7 @@ using static Tesserae.UI;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Forms, Order = 30, Icon = UIcons.Check)]
+    [SampleDetails(Group = SampleGroup.Forms, Order = 30, Icon = UIcons.Check, Description = "Validation rules across a whole form")]
     public class ValidatorSample : IComponent, ISample
     {
         private readonly IComponent content;

--- a/Tesserae.Tests/src/Samples/Inputs/AnnotatedTextEditorSample.cs
+++ b/Tesserae.Tests/src/Samples/Inputs/AnnotatedTextEditorSample.cs
@@ -8,7 +8,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Inputs, Order = 40, Icon = UIcons.Highlighter)]
+    [SampleDetails(Group = SampleGroup.Inputs, Order = 40, Icon = UIcons.Highlighter, Description = "Text editing with inline annotations")]
     public class AnnotatedTextEditorSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Inputs/CheckBoxSample.cs
+++ b/Tesserae.Tests/src/Samples/Inputs/CheckBoxSample.cs
@@ -5,7 +5,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Inputs, Order = 50, Icon = UIcons.Checkbox)]
+    [SampleDetails(Group = SampleGroup.Inputs, Order = 50, Icon = UIcons.Checkbox, Description = "Checkboxes, including the indeterminate state")]
     public class CheckBoxSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Inputs/ChoiceGroupSample.cs
+++ b/Tesserae.Tests/src/Samples/Inputs/ChoiceGroupSample.cs
@@ -5,7 +5,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Inputs, Order = 70, Icon = UIcons.RadioButton)]
+    [SampleDetails(Group = SampleGroup.Inputs, Order = 70, Icon = UIcons.RadioButton, Description = "Radio buttons for one choice out of several")]
     public class ChoiceGroupSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Inputs/ColorPickerSample.cs
+++ b/Tesserae.Tests/src/Samples/Inputs/ColorPickerSample.cs
@@ -4,7 +4,7 @@ using static Tesserae.UI;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Inputs, Order = 150, Icon = UIcons.Palette)]
+    [SampleDetails(Group = SampleGroup.Inputs, Order = 150, Icon = UIcons.Palette, Description = "Pick a color from a wheel or a field")]
     public class ColorPickerSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Inputs/DropdownSample.cs
+++ b/Tesserae.Tests/src/Samples/Inputs/DropdownSample.cs
@@ -7,7 +7,7 @@ using static Tesserae.UI;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Inputs, Order = 80, Icon = UIcons.CaretSquareDown)]
+    [SampleDetails(Group = SampleGroup.Inputs, Order = 80, Icon = UIcons.CaretSquareDown, Description = "Single and multi-select dropdowns")]
     public sealed class DropdownSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Inputs/EditableLabelSample.cs
+++ b/Tesserae.Tests/src/Samples/Inputs/EditableLabelSample.cs
@@ -5,7 +5,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Inputs, Order = 30, Icon = UIcons.Edit)]
+    [SampleDetails(Group = SampleGroup.Inputs, Order = 30, Icon = UIcons.Edit, Description = "Text that turns into an input when clicked")]
     public class EditableLabelSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Inputs/FileSelectorAndDropAreaSample.cs
+++ b/Tesserae.Tests/src/Samples/Inputs/FileSelectorAndDropAreaSample.cs
@@ -5,7 +5,7 @@ using static Tesserae.UI;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Inputs, Order = 170, Icon = UIcons.Upload)]
+    [SampleDetails(Group = SampleGroup.Inputs, Order = 170, Icon = UIcons.Upload, Description = "File picking and drag-and-drop uploads")]
     public class FileSelectorAndDropAreaSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Inputs/GridPickerSample.cs
+++ b/Tesserae.Tests/src/Samples/Inputs/GridPickerSample.cs
@@ -6,7 +6,7 @@ using static Tesserae.UI;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Inputs, Order = 160, Icon = UIcons.TableLayout)]
+    [SampleDetails(Group = SampleGroup.Inputs, Order = 160, Icon = UIcons.TableLayout, Description = "Drag to select states across a grid")]
     public class GridPickerSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Inputs/NumberPickerSample.cs
+++ b/Tesserae.Tests/src/Samples/Inputs/NumberPickerSample.cs
@@ -5,7 +5,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Inputs, Order = 110, Icon = UIcons.InputNumeric)]
+    [SampleDetails(Group = SampleGroup.Inputs, Order = 110, Icon = UIcons.InputNumeric, Description = "A number input with steppers and bounds")]
     public class NumberPickerSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Inputs/PickerSample.cs
+++ b/Tesserae.Tests/src/Samples/Inputs/PickerSample.cs
@@ -7,7 +7,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Inputs, Order = 90, Icon = UIcons.BarsFilter)]
+    [SampleDetails(Group = SampleGroup.Inputs, Order = 90, Icon = UIcons.BarsFilter, Description = "Type to search and pick many items")]
     public class PickerSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Inputs/RatingSample.cs
+++ b/Tesserae.Tests/src/Samples/Inputs/RatingSample.cs
@@ -5,7 +5,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Inputs, Order = 140, Icon = UIcons.Star)]
+    [SampleDetails(Group = SampleGroup.Inputs, Order = 140, Icon = UIcons.Star, Description = "Star ratings, read-only or editable")]
     public class RatingSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Inputs/SliderSample.cs
+++ b/Tesserae.Tests/src/Samples/Inputs/SliderSample.cs
@@ -5,7 +5,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Inputs, Order = 120, Icon = UIcons.SettingsSliders)]
+    [SampleDetails(Group = SampleGroup.Inputs, Order = 120, Icon = UIcons.SettingsSliders, Description = "Drag a value along a continuous range")]
     public class SliderSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Inputs/StepsSliderSample.cs
+++ b/Tesserae.Tests/src/Samples/Inputs/StepsSliderSample.cs
@@ -5,7 +5,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Inputs, Order = 130, Icon = UIcons.SlidersHSquare)]
+    [SampleDetails(Group = SampleGroup.Inputs, Order = 130, Icon = UIcons.SlidersHSquare, Description = "A slider that snaps to named steps")]
     public class StepsSliderSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Inputs/TagsInputSample.cs
+++ b/Tesserae.Tests/src/Samples/Inputs/TagsInputSample.cs
@@ -4,7 +4,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Inputs, Order = 100, Icon = UIcons.Tags)]
+    [SampleDetails(Group = SampleGroup.Inputs, Order = 100, Icon = UIcons.Tags, Description = "A multi-value chip and tag input")]
     public class TagsInputSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Inputs/TextAreaSample.cs
+++ b/Tesserae.Tests/src/Samples/Inputs/TextAreaSample.cs
@@ -5,7 +5,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Inputs, Order = 20, Icon = UIcons.AlignJustify)]
+    [SampleDetails(Group = SampleGroup.Inputs, Order = 20, Icon = UIcons.AlignJustify, Description = "Multi-line text input")]
     public class TextAreaSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Inputs/TextBoxSample.cs
+++ b/Tesserae.Tests/src/Samples/Inputs/TextBoxSample.cs
@@ -5,7 +5,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Inputs, Order = 10, Icon = UIcons.InputText)]
+    [SampleDetails(Group = SampleGroup.Inputs, Order = 10, Icon = UIcons.InputText, Description = "Single-line text input, with icons and prefixes")]
     public class TextBoxSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Inputs/ToggleSample.cs
+++ b/Tesserae.Tests/src/Samples/Inputs/ToggleSample.cs
@@ -5,7 +5,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Inputs, Order = 60, Icon = UIcons.ToggleOn)]
+    [SampleDetails(Group = SampleGroup.Inputs, Order = 60, Icon = UIcons.ToggleOn, Description = "An on/off switch")]
     public class ToggleSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Layout/AccordionSample.cs
+++ b/Tesserae.Tests/src/Samples/Layout/AccordionSample.cs
@@ -4,7 +4,7 @@ using static Transpose.Core.dom;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Layout, Order = 70, Icon = UIcons.Accordion)]
+    [SampleDetails(Group = SampleGroup.Layout, Order = 70, Icon = UIcons.Accordion, Description = "Sections that expand and collapse")]
     public class AccordionSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Layout/CardSample.cs
+++ b/Tesserae.Tests/src/Samples/Layout/CardSample.cs
@@ -6,7 +6,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Layout, Order = 60, Icon = UIcons.AddressCard)]
+    [SampleDetails(Group = SampleGroup.Layout, Order = 60, Icon = UIcons.AddressCard, Description = "A bordered surface with a title and a footer")]
     public class CardSample : IComponent, ISample
     {
         private IComponent _content;

--- a/Tesserae.Tests/src/Samples/Layout/GridSample.cs
+++ b/Tesserae.Tests/src/Samples/Layout/GridSample.cs
@@ -6,7 +6,7 @@ using static Tesserae.UI;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Layout, Order = 20, Icon = UIcons.Grid)]
+    [SampleDetails(Group = SampleGroup.Layout, Order = 20, Icon = UIcons.Grid, Description = "CSS Grid with explicit rows and columns")]
     public class GridSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Layout/HorizontalSeparatorSample.cs
+++ b/Tesserae.Tests/src/Samples/Layout/HorizontalSeparatorSample.cs
@@ -5,7 +5,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Layout, Order = 90, Icon = UIcons.HorizontalRule)]
+    [SampleDetails(Group = SampleGroup.Layout, Order = 90, Icon = UIcons.HorizontalRule, Description = "A rule, with optional text in the middle")]
     public class HorizontalSeparatorSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Layout/HorizontalSplitViewSample.cs
+++ b/Tesserae.Tests/src/Samples/Layout/HorizontalSplitViewSample.cs
@@ -5,7 +5,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Layout, Order = 40, Icon = UIcons.SplitScreen)]
+    [SampleDetails(Group = SampleGroup.Layout, Order = 40, Icon = UIcons.SplitScreen, Description = "Two resizable panes, top and bottom")]
     public class HorizontalSplitViewSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Layout/MasonrySample.cs
+++ b/Tesserae.Tests/src/Samples/Layout/MasonrySample.cs
@@ -7,7 +7,7 @@ using System.Linq;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Layout, Order = 80, Icon = UIcons.GridDividers)]
+    [SampleDetails(Group = SampleGroup.Layout, Order = 80, Icon = UIcons.GridDividers, Description = "Pinterest-style variable-height columns")]
     public class MasonrySample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Layout/SectionStackSample.cs
+++ b/Tesserae.Tests/src/Samples/Layout/SectionStackSample.cs
@@ -7,7 +7,7 @@ using Tesserae.Tests;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Layout, Order = 50, Icon = UIcons.BorderAll)]
+    [SampleDetails(Group = SampleGroup.Layout, Order = 50, Icon = UIcons.BorderAll, Description = "A page of titled, animated sections")]
     public class SectionStackSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Layout/SplitViewSample.cs
+++ b/Tesserae.Tests/src/Samples/Layout/SplitViewSample.cs
@@ -5,7 +5,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Layout, Order = 30, Icon = UIcons.TableColumns)]
+    [SampleDetails(Group = SampleGroup.Layout, Order = 30, Icon = UIcons.TableColumns, Description = "Two resizable panes, left and right")]
     public class SplitViewSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Layout/StackSample.cs
+++ b/Tesserae.Tests/src/Samples/Layout/StackSample.cs
@@ -7,7 +7,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Layout, Order = 10, Icon = UIcons.ObjectsColumn)]
+    [SampleDetails(Group = SampleGroup.Layout, Order = 10, Icon = UIcons.ObjectsColumn, Description = "The flexbox workhorse: rows and columns")]
     public class StackSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Lists/DetailsGridSample.cs
+++ b/Tesserae.Tests/src/Samples/Lists/DetailsGridSample.cs
@@ -4,7 +4,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Lists, Order = 30, Icon = UIcons.Table)]
+    [SampleDetails(Group = SampleGroup.Lists, Order = 30, Icon = UIcons.Table, Description = "A bordered table of label and value rows")]
     public class DetailsGridSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Lists/DetailsListSample.cs
+++ b/Tesserae.Tests/src/Samples/Lists/DetailsListSample.cs
@@ -9,7 +9,7 @@ using static Tesserae.UI;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Lists, Order = 20, Icon = UIcons.TableRows)]
+    [SampleDetails(Group = SampleGroup.Lists, Order = 20, Icon = UIcons.TableRows, Description = "A sortable, groupable table of records")]
     public class DetailsListSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Lists/InfiniteScrollingListSample.cs
+++ b/Tesserae.Tests/src/Samples/Lists/InfiniteScrollingListSample.cs
@@ -8,7 +8,7 @@ using static Transpose.Core.dom;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Lists, Order = 50, Icon = UIcons.Infinity)]
+    [SampleDetails(Group = SampleGroup.Lists, Order = 50, Icon = UIcons.Infinity, Description = "A list that loads more as you scroll")]
     public class InfiniteScrollingListSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Lists/ItemsListSample.cs
+++ b/Tesserae.Tests/src/Samples/Lists/ItemsListSample.cs
@@ -7,7 +7,7 @@ using static Transpose.Core.dom;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Lists, Order = 10, Icon = UIcons.List)]
+    [SampleDetails(Group = SampleGroup.Lists, Order = 10, Icon = UIcons.List, Description = "A simple list or grid of any components")]
     public class ItemsListSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Lists/KeyedObservableStackSample.cs
+++ b/Tesserae.Tests/src/Samples/Lists/KeyedObservableStackSample.cs
@@ -9,7 +9,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Lists, Order = 60, Icon = UIcons.RotateRight)]
+    [SampleDetails(Group = SampleGroup.Lists, Order = 60, Icon = UIcons.RotateRight, Description = "A stack that follows keyed observable data")]
     public class KeyedObservableStackSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Lists/TaskBoardSample.cs
+++ b/Tesserae.Tests/src/Samples/Lists/TaskBoardSample.cs
@@ -5,7 +5,7 @@ using static Transpose.Core.dom;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Lists, Order = 90, Icon = UIcons.Dashboard)]
+    [SampleDetails(Group = SampleGroup.Lists, Order = 90, Icon = UIcons.Dashboard, Description = "Kanban columns with draggable cards")]
     public class TaskBoardSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Lists/TimelineSample.cs
+++ b/Tesserae.Tests/src/Samples/Lists/TimelineSample.cs
@@ -8,7 +8,7 @@ using static Transpose.Core.dom;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Lists, Order = 80, Icon = UIcons.TimePast)]
+    [SampleDetails(Group = SampleGroup.Lists, Order = 80, Icon = UIcons.TimePast, Description = "Events down a vertical timeline")]
     public class TimelineSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Lists/TreeSample.cs
+++ b/Tesserae.Tests/src/Samples/Lists/TreeSample.cs
@@ -7,7 +7,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Lists, Order = 70, Icon = UIcons.FolderTree)]
+    [SampleDetails(Group = SampleGroup.Lists, Order = 70, Icon = UIcons.FolderTree, Description = "An expandable hierarchical list")]
     public class TreeSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Lists/VirtualizedListSample.cs
+++ b/Tesserae.Tests/src/Samples/Lists/VirtualizedListSample.cs
@@ -7,7 +7,7 @@ using static Transpose.Core.dom;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Lists, Order = 40, Icon = UIcons.Scroll)]
+    [SampleDetails(Group = SampleGroup.Lists, Order = 40, Icon = UIcons.Scroll, Description = "Thousands of rows, only the visible ones drawn")]
     public class VirtualizedListSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Media/AvatarSample.cs
+++ b/Tesserae.Tests/src/Samples/Media/AvatarSample.cs
@@ -4,7 +4,7 @@ using static Transpose.Core.dom;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Media, Order = 10, Icon = UIcons.User)]
+    [SampleDetails(Group = SampleGroup.Media, Order = 10, Icon = UIcons.User, Description = "A user, as initials, an image or presence")]
     public class AvatarSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Media/CarouselSample.cs
+++ b/Tesserae.Tests/src/Samples/Media/CarouselSample.cs
@@ -4,7 +4,7 @@ using static Transpose.Core.dom;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Media, Order = 30, Icon = UIcons.Images)]
+    [SampleDetails(Group = SampleGroup.Media, Order = 30, Icon = UIcons.Images, Description = "A slideshow cycling through its slides")]
     public class CarouselSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Media/PagesStackSample.cs
+++ b/Tesserae.Tests/src/Samples/Media/PagesStackSample.cs
@@ -4,7 +4,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Media, Order = 40, Icon = UIcons.Copy)]
+    [SampleDetails(Group = SampleGroup.Media, Order = 40, Icon = UIcons.Copy, Description = "A fanning stack of page thumbnails")]
     public class PagesStackSample : IComponent, ISample
     {
         private static readonly string[] Thumbnails =

--- a/Tesserae.Tests/src/Samples/Media/PixelAvatarSample.cs
+++ b/Tesserae.Tests/src/Samples/Media/PixelAvatarSample.cs
@@ -4,7 +4,7 @@ using static Transpose.Core.dom;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Media, Order = 20, Icon = UIcons.Cat)]
+    [SampleDetails(Group = SampleGroup.Media, Order = 20, Icon = UIcons.Cat, Description = "An animated avatar built one pixel at a time")]
     public class PixelAvatarSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Media/SandboxSample.cs
+++ b/Tesserae.Tests/src/Samples/Media/SandboxSample.cs
@@ -7,7 +7,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Media, Order = 50, Icon = UIcons.Shield)]
+    [SampleDetails(Group = SampleGroup.Media, Order = 50, Icon = UIcons.Shield, Description = "A locked-down iframe for untrusted HTML")]
     public class SandboxSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Navigation/BreadcrumbSample.cs
+++ b/Tesserae.Tests/src/Samples/Navigation/BreadcrumbSample.cs
@@ -5,7 +5,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Navigation, Order = 100, Icon = UIcons.Route)]
+    [SampleDetails(Group = SampleGroup.Navigation, Order = 100, Icon = UIcons.Route, Description = "Where you are, with links back up")]
     public class BreadcrumbSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Navigation/CardPivotSample.cs
+++ b/Tesserae.Tests/src/Samples/Navigation/CardPivotSample.cs
@@ -4,7 +4,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Navigation, Order = 80, Icon = UIcons.CreditCard)]
+    [SampleDetails(Group = SampleGroup.Navigation, Order = 80, Icon = UIcons.CreditCard, Description = "Tabs drawn as selectable cards")]
     public class CardPivotSample : IComponent, ISample
     {
         private readonly IComponent content;

--- a/Tesserae.Tests/src/Samples/Navigation/NavbarSample.cs
+++ b/Tesserae.Tests/src/Samples/Navigation/NavbarSample.cs
@@ -6,7 +6,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Navigation, Order = 40, Icon = UIcons.BarsStaggered)]
+    [SampleDetails(Group = SampleGroup.Navigation, Order = 40, Icon = UIcons.BarsStaggered, Description = "A top navigation bar with menus")]
     public class NavbarSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Navigation/PaginationSample.cs
+++ b/Tesserae.Tests/src/Samples/Navigation/PaginationSample.cs
@@ -4,7 +4,7 @@ using static Transpose.Core.dom;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Navigation, Order = 120, Icon = UIcons.Duplicate)]
+    [SampleDetails(Group = SampleGroup.Navigation, Order = 120, Icon = UIcons.Duplicate, Description = "Page through a set of results")]
     public class PaginationSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Navigation/PivotSample.cs
+++ b/Tesserae.Tests/src/Samples/Navigation/PivotSample.cs
@@ -7,7 +7,7 @@ using System.Linq;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Navigation, Order = 60, Icon = UIcons.TablePivot)]
+    [SampleDetails(Group = SampleGroup.Navigation, Order = 60, Icon = UIcons.TablePivot, Description = "Tabs with lazily rendered pages")]
     public class PivotSample : IComponent, ISample
     {
         private readonly IComponent content;

--- a/Tesserae.Tests/src/Samples/Navigation/PivotSelectorSample.cs
+++ b/Tesserae.Tests/src/Samples/Navigation/PivotSelectorSample.cs
@@ -7,7 +7,7 @@ using System.Linq;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Navigation, Order = 90, Icon = UIcons.DropdownBar)]
+    [SampleDetails(Group = SampleGroup.Navigation, Order = 90, Icon = UIcons.DropdownBar, Description = "Pivot pages switched from a dropdown")]
     public class PivotSelectorSample : IComponent, ISample
     {
         private readonly IComponent content;

--- a/Tesserae.Tests/src/Samples/Navigation/SegmentedPivotSample.cs
+++ b/Tesserae.Tests/src/Samples/Navigation/SegmentedPivotSample.cs
@@ -4,7 +4,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Navigation, Order = 70, Icon = UIcons.Columns3)]
+    [SampleDetails(Group = SampleGroup.Navigation, Order = 70, Icon = UIcons.Columns3, Description = "Pivot pages as a segmented pill control")]
     public class SegmentedPivotSample : IComponent, ISample
     {
         private readonly IComponent content;

--- a/Tesserae.Tests/src/Samples/Navigation/SidebarSample.cs
+++ b/Tesserae.Tests/src/Samples/Navigation/SidebarSample.cs
@@ -8,7 +8,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Navigation, Order = 10, Icon = UIcons.Sidebar)]
+    [SampleDetails(Group = SampleGroup.Navigation, Order = 10, Icon = UIcons.Sidebar, Description = "The app shell's collapsible side navigation")]
     public class SidebarSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Navigation/SidebarSeparatorSample.cs
+++ b/Tesserae.Tests/src/Samples/Navigation/SidebarSeparatorSample.cs
@@ -5,7 +5,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Navigation, Order = 20, Icon = UIcons.GripLines)]
+    [SampleDetails(Group = SampleGroup.Navigation, Order = 20, Icon = UIcons.GripLines, Description = "Group headers inside a sidebar")]
     public class SidebarSeparatorSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Navigation/SidebarShiftSample.cs
+++ b/Tesserae.Tests/src/Samples/Navigation/SidebarShiftSample.cs
@@ -6,7 +6,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Navigation, Order = 30, Icon = UIcons.AngleRight)]
+    [SampleDetails(Group = SampleGroup.Navigation, Order = 30, Icon = UIcons.AngleRight, Description = "Sliding a sidebar into a nested one")]
     public class SidebarShiftSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Navigation/SidenavSample.cs
+++ b/Tesserae.Tests/src/Samples/Navigation/SidenavSample.cs
@@ -6,7 +6,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Navigation, Order = 50, Icon = UIcons.Apps)]
+    [SampleDetails(Group = SampleGroup.Navigation, Order = 50, Icon = UIcons.Apps, Description = "A narrow icon-only navigation rail")]
     public class SidenavSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Navigation/StepperSample.cs
+++ b/Tesserae.Tests/src/Samples/Navigation/StepperSample.cs
@@ -4,7 +4,7 @@ using static Transpose.Core.dom;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Navigation, Order = 130, Icon = UIcons.ArrowProgress)]
+    [SampleDetails(Group = SampleGroup.Navigation, Order = 130, Icon = UIcons.ArrowProgress, Description = "A numbered, step-by-step wizard")]
     public class StepperSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Navigation/TextBreadcrumbsSample.cs
+++ b/Tesserae.Tests/src/Samples/Navigation/TextBreadcrumbsSample.cs
@@ -4,7 +4,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Navigation, Order = 110, Icon = UIcons.AngleDoubleRight)]
+    [SampleDetails(Group = SampleGroup.Navigation, Order = 110, Icon = UIcons.AngleDoubleRight, Description = "Breadcrumbs as plain inline text")]
     public class TextBreadcrumbsSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Overlays/DialogSample.cs
+++ b/Tesserae.Tests/src/Samples/Overlays/DialogSample.cs
@@ -7,7 +7,7 @@ using Tesserae.Tests;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Overlays, Order = 10, Icon = UIcons.WindowMinimize)]
+    [SampleDetails(Group = SampleGroup.Overlays, Order = 10, Icon = UIcons.WindowMinimize, Description = "Confirm, prompt and message dialogs")]
     public class DialogSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Overlays/FloatSample.cs
+++ b/Tesserae.Tests/src/Samples/Overlays/FloatSample.cs
@@ -6,7 +6,7 @@ using Tesserae.Tests;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Overlays, Order = 60, Icon = UIcons.GameBoardAlt)]
+    [SampleDetails(Group = SampleGroup.Overlays, Order = 60, Icon = UIcons.GameBoardAlt, Description = "Content pinned to a corner of its parent")]
     public class FloatSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Overlays/LayerSample.cs
+++ b/Tesserae.Tests/src/Samples/Overlays/LayerSample.cs
@@ -6,7 +6,7 @@ using static Tesserae.UI;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Overlays, Order = 70, Icon = UIcons.Layers)]
+    [SampleDetails(Group = SampleGroup.Overlays, Order = 70, Icon = UIcons.Layers, Description = "Render above everything, outside the tree")]
     public class LayerSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Overlays/ModalSample.cs
+++ b/Tesserae.Tests/src/Samples/Overlays/ModalSample.cs
@@ -6,7 +6,7 @@ using static Tesserae.UI;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Overlays, Order = 20, Icon = UIcons.WindowRestore)]
+    [SampleDetails(Group = SampleGroup.Overlays, Order = 20, Icon = UIcons.WindowRestore, Description = "A modal window over the whole page")]
     public class ModalSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Overlays/PanelSample.cs
+++ b/Tesserae.Tests/src/Samples/Overlays/PanelSample.cs
@@ -7,7 +7,7 @@ using Panel = Tesserae.Panel;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Overlays, Order = 40, Icon = UIcons.Drawer)]
+    [SampleDetails(Group = SampleGroup.Overlays, Order = 40, Icon = UIcons.Drawer, Description = "A panel sliding in from an edge")]
     public class PanelSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Overlays/PopoverSample.cs
+++ b/Tesserae.Tests/src/Samples/Overlays/PopoverSample.cs
@@ -4,7 +4,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Overlays, Order = 50, Icon = UIcons.CommentAltDots)]
+    [SampleDetails(Group = SampleGroup.Overlays, Order = 50, Icon = UIcons.CommentAltDots, Description = "An overlay anchored to a component")]
     public class PopoverSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Overlays/TabbedModalSample.cs
+++ b/Tesserae.Tests/src/Samples/Overlays/TabbedModalSample.cs
@@ -7,7 +7,7 @@ using System.Linq;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Overlays, Order = 30, Icon = UIcons.Browser)]
+    [SampleDetails(Group = SampleGroup.Overlays, Order = 30, Icon = UIcons.Browser, Description = "A modal with tabs down its side")]
     public class TabbedModalSample : IComponent, ISample
     {
         private readonly IComponent content;

--- a/Tesserae.Tests/src/Samples/Overlays/TeachingSample.cs
+++ b/Tesserae.Tests/src/Samples/Overlays/TeachingSample.cs
@@ -5,7 +5,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Overlays, Order = 80, Icon = UIcons.ShoePrints)]
+    [SampleDetails(Group = SampleGroup.Overlays, Order = 80, Icon = UIcons.ShoePrints, Description = "A walkthrough highlighting the UI in turn")]
     public class TeachingSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Overlays/TutorialModalSample.cs
+++ b/Tesserae.Tests/src/Samples/Overlays/TutorialModalSample.cs
@@ -6,7 +6,7 @@ using static Tesserae.UI;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Overlays, Order = 90, Icon = UIcons.GraduationCap)]
+    [SampleDetails(Group = SampleGroup.Overlays, Order = 90, Icon = UIcons.GraduationCap, Description = "A guided, multi-step tutorial modal")]
     public class TutorialModalSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Sample.cs
+++ b/Tesserae.Tests/src/Samples/Sample.cs
@@ -10,15 +10,20 @@ namespace Tesserae.Tests
         public string           Group            { get; }
         public int              Order            { get; }
         public UIcons           Icon             { get; }
+
+        /// <summary>What the component is for, in one short line, from <see cref="SampleDetailsAttribute.Description"/>.</summary>
+        public string           Description      { get; }
+
         public Func<System.Threading.Tasks.Task<IComponent>> ContentGenerator { get; }
 
-        public Sample(string type, string name, string group, int order, UIcons icon, Func<System.Threading.Tasks.Task<IComponent>> contentGenerator)
+        public Sample(string type, string name, string group, int order, UIcons icon, string description, Func<System.Threading.Tasks.Task<IComponent>> contentGenerator)
         {
             Type             = type;
             Name             = name;
             Group            = group;
             Order            = order;
             Icon             = icon;
+            Description      = description;
             ContentGenerator = contentGenerator;
         }
 

--- a/Tesserae.Tests/src/Samples/SampleGroupAttribute.cs
+++ b/Tesserae.Tests/src/Samples/SampleGroupAttribute.cs
@@ -8,5 +8,12 @@ namespace Tesserae.Tests
         public string Group { get; set; }
         public int    Order { get; set; }
         public UIcons Icon  { get; set; }
+
+        /// <summary>
+        /// One line saying what the component is for. The landing page shows it under the sample's
+        /// name, on a single ellipsized line, so it has to stay short — about 50 characters — and
+        /// read as a description of the component rather than of the sample page.
+        /// </summary>
+        public string Description { get; set; }
     }
 }

--- a/Tesserae.Tests/src/Samples/Search/OmniBoxSample.cs
+++ b/Tesserae.Tests/src/Samples/Search/OmniBoxSample.cs
@@ -8,7 +8,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Search, Order = 40, Icon = UIcons.SearchBar)]
+    [SampleDetails(Group = SampleGroup.Search, Order = 40, Icon = UIcons.SearchBar, Description = "One input for both search and chat")]
     public class OmniBoxSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Search/OmniResultSample.cs
+++ b/Tesserae.Tests/src/Samples/Search/OmniResultSample.cs
@@ -8,7 +8,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Search, Order = 50, Icon = UIcons.Document)]
+    [SampleDetails(Group = SampleGroup.Search, Order = 50, Icon = UIcons.Document, Description = "Search-result rows with highlighted excerpts")]
     public class OmniResultSample : IComponent, ISample
     {
         // What the sample searched for, and so what the excerpts highlight.
@@ -178,8 +178,8 @@ namespace Tesserae.Tests.Samples
                     .SetIconBadge(Icon(UIcons.Star, UIconsWeight.Solid, color: "#f0c000"), OmniResultBadgeCorner.TopRight),
                 Row(Hits[6], withText: true, withPages: false).Selectable(OmniResultSelectionMode.AlwaysBeforeHeaderIcon));
 
-            /r/A tile that spells its type out is a label on this line rather than a square, so the type name
-            //is not limited to the three or four letters that fit a square: it grows with the text.
+            // A tile that spells its type out is a label on this line rather than a square, so the type name
+            // is not limited to the three or four letters that fit a square: it grows with the text.
             var spelledOut = VStack().WS().Children(
                 HeaderIconRow(Hits[1], "Q3 line review.pptx").SetIcon("PPTX", "#f97316"),
                 HeaderIconRow(Hits[2], "sensor-events-2024-03.parquet").SetIcon("PARQUET", "#8b5cf6"),

--- a/Tesserae.Tests/src/Samples/Search/SearchBoxSample.cs
+++ b/Tesserae.Tests/src/Samples/Search/SearchBoxSample.cs
@@ -5,7 +5,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Search, Order = 10, Icon = UIcons.Search)]
+    [SampleDetails(Group = SampleGroup.Search, Order = 10, Icon = UIcons.Search, Description = "A search input, with clear and debounce")]
     public class SearchBoxSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Search/SearchableGroupedListSample.cs
+++ b/Tesserae.Tests/src/Samples/Search/SearchableGroupedListSample.cs
@@ -7,7 +7,7 @@ using static Transpose.Core.dom;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Search, Order = 30, Icon = UIcons.Filter)]
+    [SampleDetails(Group = SampleGroup.Search, Order = 30, Icon = UIcons.Filter, Description = "A grouped list filtered as you type")]
     public class SearchableGroupedListSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Search/SearchableListSample.cs
+++ b/Tesserae.Tests/src/Samples/Search/SearchableListSample.cs
@@ -7,7 +7,7 @@ using static Transpose.Core.dom;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Search, Order = 20, Icon = UIcons.SearchAlt)]
+    [SampleDetails(Group = SampleGroup.Search, Order = 20, Icon = UIcons.SearchAlt, Description = "A list filtered as you type")]
     public class SearchableListSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Text/BadgeSample.cs
+++ b/Tesserae.Tests/src/Samples/Text/BadgeSample.cs
@@ -4,7 +4,7 @@ using static Transpose.Core.dom;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Text, Order = 50, Icon = UIcons.Sticker)]
+    [SampleDetails(Group = SampleGroup.Text, Order = 50, Icon = UIcons.Sticker, Description = "Small pills for status, tags and counts")]
     public class BadgeSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Text/CodeDiffSample.cs
+++ b/Tesserae.Tests/src/Samples/Text/CodeDiffSample.cs
@@ -4,7 +4,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Text, Order = 70, Icon = UIcons.CodeCompare)]
+    [SampleDetails(Group = SampleGroup.Text, Order = 70, Icon = UIcons.CodeCompare, Description = "Unified diffs, rendered with diff2html")]
     public class CodeDiffSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Text/InlineLabelSample.cs
+++ b/Tesserae.Tests/src/Samples/Text/InlineLabelSample.cs
@@ -5,7 +5,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Text, Order = 30, Icon = UIcons.Bookmark)]
+    [SampleDetails(Group = SampleGroup.Text, Order = 30, Icon = UIcons.Bookmark, Description = "One small fact, drawn inline or as a chip")]
     public class InlineLabelSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Text/KeyboardShortcutSample.cs
+++ b/Tesserae.Tests/src/Samples/Text/KeyboardShortcutSample.cs
@@ -5,7 +5,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Text, Order = 80, Icon = UIcons.Keyboard)]
+    [SampleDetails(Group = SampleGroup.Text, Order = 80, Icon = UIcons.Keyboard, Description = "Keyboard shortcuts as styled key chips")]
     public class KeyboardShortcutSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Text/LabelSample.cs
+++ b/Tesserae.Tests/src/Samples/Text/LabelSample.cs
@@ -5,7 +5,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Text, Order = 20, Icon = UIcons.Label)]
+    [SampleDetails(Group = SampleGroup.Text, Order = 20, Icon = UIcons.Label, Description = "A label for a field, with a required mark")]
     public class LabelSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Text/ListItemTextSample.cs
+++ b/Tesserae.Tests/src/Samples/Text/ListItemTextSample.cs
@@ -5,7 +5,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Text, Order = 40, Icon = UIcons.AlignLeft)]
+    [SampleDetails(Group = SampleGroup.Text, Order = 40, Icon = UIcons.AlignLeft, Description = "A title and subtitle for a list row")]
     public class ListItemTextSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Text/MarkdownBlockSample.cs
+++ b/Tesserae.Tests/src/Samples/Text/MarkdownBlockSample.cs
@@ -4,7 +4,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Text, Order = 60, Icon = UIcons.Paragraph)]
+    [SampleDetails(Group = SampleGroup.Text, Order = 60, Icon = UIcons.Paragraph, Description = "Markdown rendered as sanitized HTML")]
     public class MarkdownBlockSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Text/TextBlockSample.cs
+++ b/Tesserae.Tests/src/Samples/Text/TextBlockSample.cs
@@ -5,7 +5,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Text, Order = 10, Icon = UIcons.Text)]
+    [SampleDetails(Group = SampleGroup.Text, Order = 10, Icon = UIcons.Text, Description = "Text in every size, weight and tone")]
     public class TextBlockSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Theming/ColorPaletteSample.cs
+++ b/Tesserae.Tests/src/Samples/Theming/ColorPaletteSample.cs
@@ -5,7 +5,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Theming, Order = 40, Icon = UIcons.PaintBucket)]
+    [SampleDetails(Group = SampleGroup.Theming, Order = 40, Icon = UIcons.PaintBucket, Description = "A grid of named colour swatches")]
     public class ColorPaletteSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Theming/ColorsSample.cs
+++ b/Tesserae.Tests/src/Samples/Theming/ColorsSample.cs
@@ -8,7 +8,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Theming, Order = 10, Icon = UIcons.Swatchbook)]
+    [SampleDetails(Group = SampleGroup.Theming, Order = 10, Icon = UIcons.Swatchbook, Description = "Every named colour in the theme")]
     public class ColorsSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Theming/EmojiSample.cs
+++ b/Tesserae.Tests/src/Samples/Theming/EmojiSample.cs
@@ -8,7 +8,7 @@ using Tesserae.Tests;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Theming, Order = 70, Icon = UIcons.Smile)]
+    [SampleDetails(Group = SampleGroup.Theming, Order = 70, Icon = UIcons.Smile, Description = "The bundled emoji set")]
     public class EmojiSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Theming/GradientsSample.cs
+++ b/Tesserae.Tests/src/Samples/Theming/GradientsSample.cs
@@ -8,7 +8,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Theming, Order = 50, Icon = UIcons.Rainbow)]
+    [SampleDetails(Group = SampleGroup.Theming, Order = 50, Icon = UIcons.Rainbow, Description = "Ready-made background gradients")]
     public class GradientsSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Theming/ThemeBuilderSample.cs
+++ b/Tesserae.Tests/src/Samples/Theming/ThemeBuilderSample.cs
@@ -4,7 +4,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Theming, Order = 30, Icon = UIcons.PaintBrush)]
+    [SampleDetails(Group = SampleGroup.Theming, Order = 30, Icon = UIcons.PaintBrush, Description = "Build a custom theme with one fluent call")]
     public class ThemeBuilderSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Theming/ThemeColorsSample.cs
+++ b/Tesserae.Tests/src/Samples/Theming/ThemeColorsSample.cs
@@ -7,7 +7,7 @@ using Tesserae.Tests;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Theming, Order = 20, Icon = UIcons.Brightness)]
+    [SampleDetails(Group = SampleGroup.Theming, Order = 20, Icon = UIcons.Brightness, Description = "The colour roles a theme is built from")]
     public class ThemeColorsSample : IComponent, ISample
     {
         private IComponent _content;

--- a/Tesserae.Tests/src/Samples/Theming/UIconsSample.cs
+++ b/Tesserae.Tests/src/Samples/Theming/UIconsSample.cs
@@ -8,7 +8,7 @@ using Tesserae.Tests;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Theming, Order = 60, Icon = UIcons.IconStar)]
+    [SampleDetails(Group = SampleGroup.Theming, Order = 60, Icon = UIcons.IconStar, Description = "The bundled icon set, in all nine weights")]
     public class UIconsSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Utilities/BindingSample.cs
+++ b/Tesserae.Tests/src/Samples/Utilities/BindingSample.cs
@@ -7,7 +7,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Utilities, Order = 10, Icon = UIcons.Link)]
+    [SampleDetails(Group = SampleGroup.Utilities, Order = 10, Icon = UIcons.Link, Description = "Two-way binding against an observable")]
     public class BindingSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Utilities/DeferSample.cs
+++ b/Tesserae.Tests/src/Samples/Utilities/DeferSample.cs
@@ -6,7 +6,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Utilities, Order = 20, Icon = UIcons.Hourglass)]
+    [SampleDetails(Group = SampleGroup.Utilities, Order = 20, Icon = UIcons.Hourglass, Description = "Render a component once its data arrives")]
     public class DeferSample : IComponent, ISample
     {
         private readonly IComponent content;

--- a/Tesserae.Tests/src/Samples/Utilities/DeferWithProgressSample.cs
+++ b/Tesserae.Tests/src/Samples/Utilities/DeferWithProgressSample.cs
@@ -6,7 +6,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Utilities, Order = 30, Icon = UIcons.HourglassEnd)]
+    [SampleDetails(Group = SampleGroup.Utilities, Order = 30, Icon = UIcons.HourglassEnd, Description = "Defer, with progress while it loads")]
     public class DeferWithProgressSample : IComponent, ISample
     {
         private readonly IComponent content;

--- a/Tesserae.Tests/src/Samples/Utilities/DeltaComponentSample.cs
+++ b/Tesserae.Tests/src/Samples/Utilities/DeltaComponentSample.cs
@@ -7,7 +7,7 @@ using System.Linq;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Utilities, Order = 40, Icon = UIcons.Refresh)]
+    [SampleDetails(Group = SampleGroup.Utilities, Order = 40, Icon = UIcons.Refresh, Description = "Patch the DOM instead of re-rendering it")]
     public class DeltaComponentSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Utilities/GesturesSample.cs
+++ b/Tesserae.Tests/src/Samples/Utilities/GesturesSample.cs
@@ -5,7 +5,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Utilities, Order = 50, Icon = UIcons.CursorFinger)]
+    [SampleDetails(Group = SampleGroup.Utilities, Order = 50, Icon = UIcons.CursorFinger, Description = "Tap, swipe, pinch and long-press recognizers")]
     public class GesturesSample : IComponent, ISample
     {
         private readonly IComponent _content;

--- a/Tesserae.Tests/src/Samples/Utilities/SanitizeHTMLSample.cs
+++ b/Tesserae.Tests/src/Samples/Utilities/SanitizeHTMLSample.cs
@@ -4,7 +4,7 @@ using static Tesserae.Tests.Samples.SamplesHelper;
 
 namespace Tesserae.Tests.Samples
 {
-    [SampleDetails(Group = SampleGroup.Utilities, Order = 60, Icon = UIcons.ShieldCheck)]
+    [SampleDetails(Group = SampleGroup.Utilities, Order = 60, Icon = UIcons.ShieldCheck, Description = "Sanitize untrusted HTML with DOMPurify")]
     public class SanitizeHTMLSample : IComponent, ISample
     {
         private readonly IComponent _content;


### PR DESCRIPTION
The home page was a single card saying "Select a component to see more
details" — the whole toolkit was only readable through the sidebar, one
entry at a time, with nothing saying what any of it was for.

It is now the same list the sidebar draws, in the same order, as a grid of
ContextCards under a header per category: icon, name, and a one-line
description of what the component is for. A card navigates through Router,
so the sidebar selection follows exactly as if its entry had been clicked.

The description is new metadata on [SampleDetails], so it lives with the
sample rather than in a table the landing page would have to keep in sync;
all 133 samples carry one. The cards sit in an auto-filled grid rather than
a wrapping row, so every row is filled edge to edge at any window width, and
each category's tile colour keeps the grouping legible once its header has
scrolled away.

The sidebar is no longer sortable, and the code that saved and restored a
dragged order goes with it: the declared order is the one the landing page
reads top to bottom, and dragging an entry out of it made the two disagree.

Also fixes a typo committed in #353 that left OmniResultSample.cs unable to
compile (/r/A for // A).