### PR TITLE
Draw an OmniResult's tile at the head of its title line

### DIFF
--- a/Tesserae.Tests/src/Samples/Search/OmniResultSample.cs
+++ b/Tesserae.Tests/src/Samples/Search/OmniResultSample.cs
@@ -74,6 +74,7 @@ namespace Tesserae.Tests.Samples
                 .FlatSection(VStack().WS().Children(NoPages()))
                 .FlatSection(VStack().WS().Children(TitleOnly()))
                 .FlatSection(VStack().WS().Children(Tiles()))
+                .FlatSection(VStack().WS().Children(TilesInHeader()))
                 .FlatSection(VStack().WS().Children(Identifiers()))
                 .FlatSection(VStack().WS().Children(Content()))
                 .FlatSection(VStack().WS().Children(Modals()))
@@ -160,6 +161,39 @@ namespace Tesserae.Tests.Samples
                     OmniResult(Hits[6], "brake-calibration-log.txt").SetIcon("TXT", "#94a3b8").SetSource("#0061d5", "Box").SetFooterEntries("A grey color stays grey in both themes"),
                     OmniResult(Hits[0], "curiosity-logo.svg").SetIcon(Image("./assets/img/curiosity-logo.svg")).SetSource("#0061d5", "Box").SetFooterEntries("SetIcon(IComponent) — a thumbnail covers the tile"),
                     OmniResult(Hits[0], "brake-sensor-reports").SetIcon(UIcons.Folder).SetSource("#0061d5", "Box").SetFooterEntries("No color: the tile falls back to the theme's own")));
+        }
+
+        // ---------- The tile in the header ----------
+
+        private IComponent TilesInHeader()
+        {
+            var quiet = VStack().WS().Children(
+                HeaderIconRow(Hits[1], "BRK-SEN-447 calibration procedure.pdf").SetId("JR-2214"),
+                HeaderIconRow(Hits[2], "Sensor drift analysis.xlsx"),
+                HeaderIconRow(Hits[4], "field-failures / 2024"));
+
+            var selectable = VStack().WS().Children(
+                Row(Hits[3], withText: true, withPages: false).Selectable(OmniResultSelectionMode.AlwaysBeforeHeaderIcon),
+                Row(Hits[5], withText: true, withPages: false).Selectable(OmniResultSelectionMode.AlwaysBeforeHeaderIcon)
+                    .SetIconBadge(Icon(UIcons.Star, UIconsWeight.Solid, color: "#f0c000"), OmniResultBadgeCorner.TopRight),
+                Row(Hits[6], withText: true, withPages: false).Selectable(OmniResultSelectionMode.AlwaysBeforeHeaderIcon));
+
+            return FeatureCard("The tile in the header", "Leading the title instead of the row",
+                "Two modes draw the tile small, at the start of the header line, before the identifier and the title - so the excerpt, the footer and the contribution bar start at the row's own left edge rather than indented past a 34px tile. HiddenBeforeHeaderIcon draws no checkbox at all, which is what a list that is never selected from wants: set it with SelectionMode(mode), which lays the row out without making it selectable. AlwaysBeforeHeaderIcon keeps a checkbox in its own column at the start of the row, always visible.",
+                TextBlock("OmniResultSelectionMode.HiddenBeforeHeaderIcon - no checkbox anywhere").Small().SemiBold().MB(4),
+                quiet,
+                TextBlock("OmniResultSelectionMode.AlwaysBeforeHeaderIcon - the checkbox is always visible").Small().SemiBold().MT(12).MB(4),
+                selectable,
+                TextBlock("A tile that spells the file type out rather than drawing a glyph shrinks with it, so \"XLSX\" is scaled rather than cropped. The starred row shows a corner badge pinned to the smaller tile.").Small().MT(8));
+        }
+
+        // A row laid out with its tile in the header and no checkbox at all - SelectionMode() sets the
+        // layout without making the row selectable.
+        private OmniResult<Hit> HeaderIconRow(Hit hit, string title)
+        {
+            return Row(hit, withText: true, withPages: false)
+                .SetTitle(title)
+                .SelectionMode(OmniResultSelectionMode.HiddenBeforeHeaderIcon);
         }
 
         // ---------- Identifiers ----------
@@ -399,7 +433,9 @@ namespace Tesserae.Tests.Samples
                 OmniResultSelectionMode.OnHoverBeforeIcon,
                 OmniResultSelectionMode.OnHoverOverIcon,
                 OmniResultSelectionMode.AlwaysBeforeIcon,
-                OmniResultSelectionMode.ReplacingIcon
+                OmniResultSelectionMode.ReplacingIcon,
+                OmniResultSelectionMode.AlwaysBeforeHeaderIcon,
+                OmniResultSelectionMode.HiddenBeforeHeaderIcon
             };
 
             var sections = VStack().WS();
@@ -429,8 +465,8 @@ namespace Tesserae.Tests.Samples
                 sections.Add(list);
             }
 
-            return FeatureCard("Selection", "Four places for the checkbox",
-                "Selectable(mode) makes a row selectable. The checkbox sits before the tile or over it, revealed on hover or always visible, or takes the tile's place entirely — and a selected row always shows its checkbox, whatever the mode. A corner badge marks the result rather than the tile, so it follows the checkbox where the checkbox stands in for the tile: the starred row in each group keeps its star over the checkbox. Ctrl-clicking a row toggles it too, and shift-clicking one asks for the range from the last row selected: a single card knows nothing about its siblings, so OnRangeSelectionRequested hands that to the host list, which selects them itself (that is what the rows below do, across all four groups).",
+            return FeatureCard("Selection", "Six places for the checkbox, and two for the tile",
+                "Selectable(mode) makes a row selectable. The checkbox sits before the tile or over it, revealed on hover or always visible, or takes the tile's place entirely — and a selected row always shows its checkbox, whatever the mode. A corner badge marks the result rather than the tile, so it follows the checkbox where the checkbox stands in for the tile: the starred row in each group keeps its star over the checkbox. The last two modes move the tile itself: it leads the header line, drawn small before the title, so the excerpt and the footer start at the row's own left edge instead of indented past a 34px tile — with the checkbox always visible beside it, or with no checkbox at all. Ctrl-clicking a row toggles it too, and shift-clicking one asks for the range from the last row selected: a single card knows nothing about its siblings, so OnRangeSelectionRequested hands that to the host list, which selects them itself (that is what the rows below do, across all six groups).",
                 sections,
                 _selectionState.MT(8),
                 HStack().Gap(8.px()).MT(8).Children(

--- a/Tesserae.Tests/src/Samples/Search/OmniResultSample.cs
+++ b/Tesserae.Tests/src/Samples/Search/OmniResultSample.cs
@@ -29,6 +29,10 @@ namespace Tesserae.Tests.Samples
         // "Modals" section: the rows are kept so stepping and stacking can reach them by index.
         private readonly List<OmniResult<Hit>> _modalRows = new List<OmniResult<Hit>>();
 
+        // The two rows that open with the tile on the modal's title line - outside the chain above, so
+        // stepping through it is unaffected by them.
+        private readonly List<OmniResult<Hit>> _inTitleModalRows = new List<OmniResult<Hit>>();
+
         private static readonly Hit[] Hits =
         {
             new Hit("brake-sensor-reports", null, UIcons.Folder, "#6366f1", "Name match",
@@ -263,10 +267,55 @@ namespace Tesserae.Tests.Samples
                 rows.Add(row);
             }
 
+            _inTitleModalRows.Add(InTitleModalRow(Hits[1], "BRK-SEN-447 calibration procedure.pdf", null, null));
+            _inTitleModalRows.Add(InTitleModalRow(Hits[2], "sensor-events-2024-03.parquet", "PARQUET", "#8b5cf6"));
+
+            var inTitleRows = VStack().WS();
+
+            foreach (var row in _inTitleModalRows)
+            {
+                inTitleRows.Add(row);
+            }
+
             return FeatureCard("Opening as a modal", "The row carries its own full view",
                 "SetModalContent gives the row the full view of the thing it stands for, and ToModal builds a Modal showing it: the row's identifier, chevron and title for its header - plus the tile and the source line when ModalKeepsIcon and ModalKeepsFooter ask for them - a standard set of commands at the end of that header, and the keyboard shortcuts it answers along its bottom edge. The Func overload builds the content on open, so a list of a thousand rows pays for none of them until one is asked for.",
                 rows,
-                TextBlock("The header's commands are whatever the row was configured for: OpenInSource adds the named button (and hangs the rest off the arrow beside it), ModalNavigation adds the arrows and \"2 of 3\" between them, ModalCommands adds [...], and the full-screen and close buttons are always there. Open one and try Esc, the arrow keys, Ctrl+Enter and Shift+Enter. \"Open a related result\" inside pushes a second sheet onto the stack - go three deep and the ones behind peek out above it; click one to go back to it, or the backdrop to dismiss the chain.").Small().MT(8));
+                TextBlock("The header's commands are whatever the row was configured for: OpenInSource adds the named button (and hangs the rest off the arrow beside it), ModalNavigation adds the arrows and \"2 of 3\" between them, ModalCommands adds [...], and the full-screen and close buttons are always there. Open one and try Esc, the arrow keys, Ctrl+Enter and Shift+Enter. \"Open a related result\" inside pushes a second sheet onto the stack - go three deep and the ones behind peek out above it; click one to go back to it, or the backdrop to dismiss the chain.").Small().MT(8),
+                SampleSubTitle("The tile on the modal's title line").MT(16),
+                TextBlock("ModalKeepsIconInTitle is ModalKeepsIcon's other placement: the tile is drawn small, on the title's own line, before the identifier and the title - the way the two header-icon modes draw it in the row - so the source line under the title starts where the tile does rather than being indented past it, and a row laid out that way opens as the same row enlarged. A tile that spells its type out grows with its text there too. Open these two and compare their headers with the three above.").MB(8),
+                inTitleRows);
+        }
+
+        // The same modal as above, minus the navigation chain, on a row laid out with its tile in the
+        // header - and opening with the tile on the modal's title line to match.
+        private OmniResult<Hit> InTitleModalRow(Hit hit, string title, string iconText, string iconColor)
+        {
+            var row = Row(hit, withText: true, withPages: false)
+                .SetTitle(title)
+                .SetId("JR-2214")
+                .SelectionMode(OmniResultSelectionMode.HiddenBeforeHeaderIcon)
+                .SetModalContent(r => Task.FromResult<IComponent>(InTitleModalBody(r)))
+                .ModalSize(60.vw(), 60.vh())
+                .ModalKeepsIconInTitle()
+                .ModalKeepsFooter()
+                .OpenInSource("Open in Box", inNewTab => Toast().Information(inNewTab ? $"Opening \"{title}\" in a new tab" : $"Opening \"{title}\" in Box"), UIcons.ArrowUpRightFromSquare);
+
+            if (iconText is object) row.SetIcon(iconText, iconColor);
+
+            return row.OnClick((r, _) => ModalStack.Push($"in-title-{title}", r.Title, r.ToModal()));
+        }
+
+        private IComponent InTitleModalBody(OmniResult<Hit> result)
+        {
+            var metadata = result.Result.Metadata;
+
+            return VStack().WS().P(16).Children(
+                DetailsGrid()
+                    .Row("Location", metadata.Length > 0 ? metadata[0] : null)
+                    .Row("Size",     metadata.Length > 1 ? metadata[1] : null)
+                    .Row("Owner",    metadata.Length > 2 ? metadata[2] : null)
+                    .Row("Modified", metadata.Length > 3 ? metadata[3] : null),
+                TextBlock(result.Result.Text).MT(16));
         }
 
         private OmniResult<Hit> ModalRow(Hit hit, int index)

--- a/Tesserae.Tests/src/Samples/Search/OmniResultSample.cs
+++ b/Tesserae.Tests/src/Samples/Search/OmniResultSample.cs
@@ -178,13 +178,26 @@ namespace Tesserae.Tests.Samples
                     .SetIconBadge(Icon(UIcons.Star, UIconsWeight.Solid, color: "#f0c000"), OmniResultBadgeCorner.TopRight),
                 Row(Hits[6], withText: true, withPages: false).Selectable(OmniResultSelectionMode.AlwaysBeforeHeaderIcon));
 
+            //A tile that spells its type out is a label on this line rather than a square, so the type name
+            //is not limited to the three or four letters that fit a square: it grows with the text.
+            var spelledOut = VStack().WS().Children(
+                HeaderIconRow(Hits[1], "Q3 line review.pptx").SetIcon("PPTX", "#f97316"),
+                HeaderIconRow(Hits[2], "sensor-events-2024-03.parquet").SetIcon("PARQUET", "#8b5cf6"),
+                HeaderIconRow(Hits[3], "Calibration runbook.markdown").SetIcon("MARKDOWN", "#0ea5e9"),
+                Row(Hits[6], withText: true, withPages: false).SetTitle("line-4-sensor-events.jsonlines").SetIcon("JSONLINES", "#0d9488")
+                    .Selectable(OmniResultSelectionMode.AlwaysBeforeHeaderIcon),
+                Row(Hits[5], withText: true, withPages: false).SetTitle("Bismuth supplier notice.spreadsheetml").SetIcon("SPREADSHEETML", "#16a34a")
+                    .Selectable(OmniResultSelectionMode.AlwaysBeforeHeaderIcon));
+
             return FeatureCard("The tile in the header", "Leading the title instead of the row",
                 "Two modes draw the tile small, at the start of the header line, before the identifier and the title - so the excerpt, the footer and the contribution bar start at the row's own left edge rather than indented past a 34px tile. HiddenBeforeHeaderIcon draws no checkbox at all, which is what a list that is never selected from wants: set it with SelectionMode(mode), which lays the row out without making it selectable. AlwaysBeforeHeaderIcon keeps a checkbox in its own column at the start of the row, always visible.",
                 TextBlock("OmniResultSelectionMode.HiddenBeforeHeaderIcon - no checkbox anywhere").Small().SemiBold().MB(4),
                 quiet,
                 TextBlock("OmniResultSelectionMode.AlwaysBeforeHeaderIcon - the checkbox is always visible").Small().SemiBold().MT(12).MB(4),
                 selectable,
-                TextBlock("A tile that spells the file type out rather than drawing a glyph shrinks with it, so \"XLSX\" is scaled rather than cropped. The starred row shows a corner badge pinned to the smaller tile.").Small().MT(8));
+                TextBlock("A tile that spells the file type out rather than drawing a glyph").Small().SemiBold().MT(12).MB(4),
+                spelledOut,
+                TextBlock("On the header line the tile sits beside words rather than in a column of its own, so a text tile is a label there instead of a square: it keeps the title's height and grows sideways with its text, so nothing has to reach for a smaller TextSize to make a long type name fit. The square tile is the floor, so a three- or four-letter type still comes out about as square as the glyph tiles beside it. The starred row above shows a corner badge pinned to the smaller tile.").Small().MT(8));
         }
 
         // A row laid out with its tile in the header and no checkbox at all - SelectionMode() sets the

--- a/Tesserae/skills/references/omni-result.md
+++ b/Tesserae/skills/references/omni-result.md
@@ -16,7 +16,15 @@ without a closure per row:
 ```
 
 Everything past the title is optional. Drop the excerpt, the preview, the footer, or all three, and
-the row tightens up — the same component covers a two-line picker row and a full result card.
+the row tightens up — the same component covers a two-line picker row and a full result card. The tile
+can also lead the header instead of standing in a column of its own, which pulls the excerpt and the
+footer back to the row's left edge:
+
+```
+[✓]  [PDF] JR-2214 › BRK-SEN-447 calibration.pdf   3 matches in text                  [pages]  [...]
+     Torque the mount to 12 Nm before starting brake sensor work. Full calibration steps …
+     ▪ Box · sample-files / pdfs · 2.4 MB · Pius Neuhaus · Apr 12, 2024
+```
 
 ## Create
 
@@ -80,6 +88,30 @@ stands for. Also `new OmniResult<T>(result, title)`. Bring factories into scope 
 Pass a literal color (`"#ef4444"`) rather than a CSS variable when you want the tint to track the
 theme: a `var(--…)` is resolved once, at the time it is set.
 
+**The tile in the header**
+
+Two of the selection modes move the tile out of its column beside the row and draw it small (22px) at
+the **start of the header line**, before the identifier and the title:
+
+- `AlwaysBeforeHeaderIcon` — with a checkbox in its own column at the start of the row, always visible.
+- `HiddenBeforeHeaderIcon` — with no checkbox at all, not even on a selected row. Set it through
+  `.SelectionMode(...)` on a row that isn't selectable; `.Selectable(...)` also accepts it, for a list
+  that owns the selection itself and wants the row background alone to say so.
+
+The excerpt, the footer and the contribution bar then start at the row's own left edge instead of being
+indented past a 34px tile, which is what a dense list — or one whose rows are mostly title — reads
+better as. Everything else is unchanged: a text tile ("XLSX") scales with the tile rather than being
+cropped, and the corner badges are scaled and tucked in with it. The copy the modal takes of the tile
+keeps the modal's own size.
+
+```csharp
+var row = OmniResult(hit, hit.Name)
+    .SetIcon("XLSX", "#16a34a")
+    .SetText(hit.Excerpt)
+    .SetFooterEntries(hit.Path, hit.Size)
+    .SelectionMode(OmniResultSelectionMode.HiddenBeforeHeaderIcon);   // laid out, not selectable
+```
+
 **Footer**
 
 The source leads the line and the metadata follows it, and all of it is `InlineLabel`s
@@ -109,9 +141,15 @@ The source leads the line and the metadata follows it, and all of it is `InlineL
 
 - `.Selectable(OmniResultSelectionMode mode = OnHoverBeforeIcon)` / `.NotSelectable()`.
   Modes: `OnHoverBeforeIcon`, `OnHoverOverIcon` (on the tile, which fades out under it),
-  `AlwaysBeforeIcon`, `ReplacingIcon` (no tile at all). A selected row always shows its checkbox,
-  whatever the mode, and the column is reserved either way so revealing it never shifts the row. In the
-  two modes where the checkbox stands in for the tile, the corner badges move onto it.
+  `AlwaysBeforeIcon`, `ReplacingIcon` (no tile at all), `AlwaysBeforeHeaderIcon` and
+  `HiddenBeforeHeaderIcon` (the two that move the tile into the header — see *The tile in the header*
+  below). A selected row always shows its checkbox, whatever the mode — except under
+  `HiddenBeforeHeaderIcon`, which draws none — and the column is reserved either way so revealing it
+  never shifts the row. In the two modes where the checkbox stands in for the tile, the corner badges
+  move onto it.
+- `.SelectionMode(OmniResultSelectionMode)` — sets the mode **without** making the row selectable,
+  which is how a list that is never selected from asks for `HiddenBeforeHeaderIcon`'s layout. On a row
+  `Selectable` already made selectable it just changes the mode.
 - `IsSelected` / `.Selected(bool = true)` / `IsSelectionEnabled`.
 - `.OnSelectionChanged(Action<OmniResult<T>, bool>)` — every change, from the user or from code.
 - `.OnRangeSelectionRequested(Action<OmniResult<T>>)` — shift-click. A row knows nothing about its

--- a/Tesserae/skills/references/omni-result.md
+++ b/Tesserae/skills/references/omni-result.md
@@ -100,13 +100,18 @@ the **start of the header line**, before the identifier and the title:
 
 The excerpt, the footer and the contribution bar then start at the row's own left edge instead of being
 indented past a 34px tile, which is what a dense list — or one whose rows are mostly title — reads
-better as. Everything else is unchanged: a text tile ("XLSX") scales with the tile rather than being
-cropped, and the corner badges are scaled and tucked in with it. The copy the modal takes of the tile
-keeps the modal's own size.
+better as. The corner badges are scaled and tucked in with the smaller tile, and the copy the modal
+takes of it keeps the modal's own size.
+
+A tile that spells the file type out is a **label** on this line rather than a square: it keeps the
+title's height and grows sideways with its text, so `SetIcon("SPREADSHEETML", …)` is drawn in full and
+nothing has to reach for a smaller `TextSize` to make a long type name fit. The square tile is the
+floor, so "PDF" or "XLSX" still comes out about as square as the glyph tiles beside it. In every other
+mode — where the tile stands in a column of its own — it is a square as before.
 
 ```csharp
 var row = OmniResult(hit, hit.Name)
-    .SetIcon("XLSX", "#16a34a")
+    .SetIcon("PARQUET", "#8b5cf6")                                   // grows with its text here
     .SetText(hit.Excerpt)
     .SetFooterEntries(hit.Path, hit.Size)
     .SelectionMode(OmniResultSelectionMode.HiddenBeforeHeaderIcon);   // laid out, not selectable

--- a/Tesserae/skills/references/omni-result.md
+++ b/Tesserae/skills/references/omni-result.md
@@ -109,6 +109,9 @@ nothing has to reach for a smaller `TextSize` to make a long type name fit. The 
 floor, so "PDF" or "XLSX" still comes out about as square as the glyph tiles beside it. In every other
 mode — where the tile stands in a column of its own — it is a square as before.
 
+A row laid out this way usually wants `.ModalKeepsIconInTitle()` rather than `.ModalKeepsIcon()`, so
+that opening it reads as the same row enlarged — see *Opening as a modal* below.
+
 ```csharp
 var row = OmniResult(hit, hit.Name)
     .SetIcon("PARQUET", "#8b5cf6")                                   // grows with its text here
@@ -207,9 +210,15 @@ and the detail are one object rather than two that have to be kept in step.
   Null makes the row modal-less again.
 - `HasModalContent` — whether it has any, so "this result has no preview" is one check.
 - `.ModalSize(UnitSize width, UnitSize height)` — the size it opens at. `Auto` by default.
-- `.ModalKeepsIcon(bool = true)` — keeps the icon tile in the modal's header, before the identifier
+- `.ModalKeepsIcon(bool = true)` — keeps the icon tile in the modal's header, beside the identifier
   and the title, so an opened result still shows what kind of thing it is. Everything the tile
   carries comes with it: the glyph or thumbnail, its tint, and any corner badges. Off by default.
+- `.ModalKeepsIconInTitle(bool = true)` — the other placement: the tile is drawn small, **on the
+  title's own line**, before the identifier and the title, exactly as the two header-icon modes draw
+  it in the row (a text tile grows with its text there too). The source line under the title then
+  starts where the tile does rather than being indented past it, so a row laid out with its tile in
+  the header opens as the same row enlarged. Off by default; whichever of the two was called last is
+  the placement that holds, and the row's own layout doesn't decide the modal's.
 - `.ModalKeepsFooter(bool = true)` — keeps the footer (the source and the metadata beside it) as a
   second line under the title, so where a result came from is still said once it is open. Off by
   default.
@@ -240,6 +249,14 @@ full-screen, so a modal never offers something the host didn't wire up:
         ▪ Box · sample-files / pdfs · 2.4 MB · Pius Neuhaus · Apr 12, 2024
         …
         Esc Close   ← → Navigate results   Ctrl+↵ Open in source   Shift+↵ Open in a new tab
+```
+
+With `ModalKeepsIconInTitle` instead, the tile is on the title's line and the source line under it is
+not indented:
+
+```
+[PDF] JR-2214 › BRK-SEN-447 calibration.pdf     [Open in Box ▾]  ‹ 2 of 7 ›  [...]  [⤢]  [✕]
+▪ Box · sample-files / pdfs · 2.4 MB · Pius Neuhaus · Apr 12, 2024
 ```
 
 - `.OpenInSource(string name, Action<bool> onOpen, UIcons? icon = null)` — the named button that opens
@@ -334,7 +351,7 @@ foreach (var hit in results)
         .InlineCommands(Button(UIcons.Download).Tooltip("Download").OnClick(() => Download(hit)))
         .SetModalContent(async r => await BuildFullViewAsync(r.Result))                  // opens as a modal
         .ModalSize(80.vw(), 80.vh())
-        .ModalKeepsIcon()                                                                // tile in the header
+        .ModalKeepsIcon()                                                                // tile beside the header
         .ModalKeepsFooter();                                                             // source line under the title
 
     list.Add(row);

--- a/Tesserae/src/Components/OmniResult.cs
+++ b/Tesserae/src/Components/OmniResult.cs
@@ -41,7 +41,8 @@ namespace Tesserae
         /// <see cref="OmniResult{T}.SetIconBadge"/> pinned to the tile moves onto the checkbox.</summary>
         ReplacingIcon,
         /// <summary>The tile leads the header instead of standing in a column of its own beside the whole
-        /// row - drawn small, before the identifier and the title, on the title's line - with a checkbox in
+        /// row - drawn small, before the identifier and the title, on the title's line, and growing sideways
+        /// with its text where it spells a file type out rather than drawing a glyph - with a checkbox in
         /// its own column at the start of the row, always visible.</summary>
         AlwaysBeforeHeaderIcon,
         /// <summary>The tile leads the header, as with <see cref="AlwaysBeforeHeaderIcon"/>, and no checkbox
@@ -417,6 +418,13 @@ namespace Tesserae
         /// no glyph says it as plainly - in the given color, over a paler wash of that same color. It is drawn
         /// at the size the tile is sized for unless <paramref name="size"/> asks for another one - text longer
         /// than the three or four letters a type name usually is wants <see cref="TextSize.Tiny"/>.
+        /// <para>
+        /// In the two modes that draw the tile on the header line
+        /// (<see cref="OmniResultSelectionMode.AlwaysBeforeHeaderIcon"/> and
+        /// <see cref="OmniResultSelectionMode.HiddenBeforeHeaderIcon"/>) the tile is a label rather than a
+        /// square: it grows sideways with its text, so a long type name is drawn in full at the ordinary
+        /// size and needs no <paramref name="size"/> of its own.
+        /// </para>
         /// </summary>
         public OmniResult<T> SetIcon(string text, string color = null, TextSize? size = null)
         {

--- a/Tesserae/src/Components/OmniResult.cs
+++ b/Tesserae/src/Components/OmniResult.cs
@@ -145,6 +145,7 @@ namespace Tesserae
         private UnitSize                              _modalWidth     = UnitSize.Auto();
         private UnitSize                              _modalHeight    = UnitSize.Auto();
         private bool                                  _modalKeepsIcon;
+        private bool                                  _modalIconInTitle;
         private bool                                  _modalKeepsFooter;
 
         private HTMLElement            _footerStandIn;
@@ -1291,14 +1292,42 @@ namespace Tesserae
         }
 
         /// <summary>
-        /// Keeps the icon tile in the modal's header, before the identifier and the title - so an opened
+        /// Keeps the icon tile in the modal's header, beside the identifier and the title - so an opened
         /// result still shows what kind of thing it is, and the row and the modal read as one thing rather
         /// than two. Whatever the tile carries comes with it: the glyph or the thumbnail, the color it is
         /// tinted with, and any corner badges. Off by default.
+        /// <para>
+        /// The tile stands beside the whole header block, level with the title and the source line under it,
+        /// at the size the row draws it. <see cref="ModalKeepsIconInTitle(bool)"/> is the other placement.
+        /// </para>
         /// </summary>
         public OmniResult<T> ModalKeepsIcon(bool value = true)
         {
             _modalKeepsIcon = value;
+
+            //Each of the two says where the tile goes as well as that it is kept, so whichever was asked
+            //for last is the one that holds.
+            if (value) _modalIconInTitle = false;
+
+            return this;
+        }
+
+        /// <summary>
+        /// Keeps the icon tile in the modal's header the way
+        /// <see cref="OmniResultSelectionMode.AlwaysBeforeHeaderIcon"/> and
+        /// <see cref="OmniResultSelectionMode.HiddenBeforeHeaderIcon"/> draw it in the row: small, on the
+        /// title's own line, before the identifier and the title, and growing sideways with its text where
+        /// it spells a file type out. Off by default.
+        /// <para>
+        /// This is what a row laid out with its tile in the header wants, so that opening it reads as the
+        /// same row enlarged: the source line under the title then starts where the tile does rather than
+        /// being indented past it. Whatever the tile carries comes with it, corner badges included.
+        /// </para>
+        /// </summary>
+        public OmniResult<T> ModalKeepsIconInTitle(bool value = true)
+        {
+            _modalKeepsIcon   = value;
+            _modalIconInTitle = value;
 
             return this;
         }
@@ -1581,12 +1610,19 @@ namespace Tesserae
 
         /// <summary>
         /// The header <see cref="ToModal"/> uses by default: the identifier and the title, drawn the way the
-        /// row draws them, plus whatever <see cref="ModalKeepsIcon"/> and <see cref="ModalKeepsFooter"/>
-        /// asked to keep. Useful to a caller building its own header around it.
+        /// row draws them, plus whatever <see cref="ModalKeepsIcon"/>,
+        /// <see cref="ModalKeepsIconInTitle"/> and <see cref="ModalKeepsFooter"/> asked to keep. Useful to a
+        /// caller building its own header around it.
         /// </summary>
         public IComponent ModalTitle()
         {
             var titleRow = Div(Att("tss-omniresult-modal-title"));
+
+            //The tile leads the title's line under ModalKeepsIconInTitle, and stands beside the whole header
+            //block under ModalKeepsIcon - so the copy is made once here and appended to whichever it is.
+            var icon = _modalKeepsIcon ? CopyOfIcon() : null;
+
+            if (icon is object && _modalIconInTitle) titleRow.appendChild(icon);
 
             if (!string.IsNullOrEmpty(_id))
             {
@@ -1607,7 +1643,7 @@ namespace Tesserae
 
             var header = Div(Att("tss-omniresult-modal-header"));
 
-            if (_modalKeepsIcon) header.appendChild(CopyOfIcon());
+            if (icon is object && !_modalIconInTitle) header.appendChild(icon);
 
             header.appendChild(main);
 
@@ -1654,6 +1690,11 @@ namespace Tesserae
             var copy = _iconHolder.cloneNode(true).As<HTMLElement>();
 
             copy.classList.add("tss-omniresult-modal-icon");
+
+            //The clone carries whatever the row's own placement put on the holder, and the modal's placement
+            //is its own choice: a row laid out with a 34px tile can still open with a small one on the title
+            //line, and one laid out with a small tile can still open with the tile beside the header.
+            copy.UpdateClassIf(_modalIconInTitle, "tss-omniresult-icon-inline");
 
             //The modal draws the tile even where the row replaced it with the checkbox, so the badges that
             //moved onto the checkbox are copied back onto it.
@@ -1928,6 +1969,10 @@ namespace Tesserae
             //is selectable or not - which is what lets a list that is never selected from ask for the
             //header layout through SelectionMode() alone.
             InnerElement.UpdateClassIf(IsIconInHeader, "tss-omniresult-icon-in-header");
+
+            //How the tile itself is drawn hangs off the holder rather than off the row, so the copy the
+            //modal takes of it is drawn the same way wherever it ends up - see CopyOfIcon.
+            _iconHolder.UpdateClassIf(IsIconInHeader, "tss-omniresult-icon-inline");
 
             PlaceIconHolder();
 

--- a/Tesserae/src/Components/OmniResult.cs
+++ b/Tesserae/src/Components/OmniResult.cs
@@ -25,8 +25,9 @@ namespace Tesserae
     }
 
     /// <summary>
-    /// Where the selection checkbox of an <see cref="OmniResult{T}"/> lives, and when it shows. A selected
-    /// result always shows its checkbox, whatever the mode.
+    /// Where the selection checkbox of an <see cref="OmniResult{T}"/> lives and when it shows, and with it
+    /// where the row draws its icon tile. A selected result always shows its checkbox, whatever the mode -
+    /// except under <see cref="OmniResultSelectionMode.HiddenBeforeHeaderIcon"/>, which draws none at all.
     /// </summary>
     public enum OmniResultSelectionMode
     {
@@ -38,7 +39,16 @@ namespace Tesserae
         AlwaysBeforeIcon,
         /// <summary>A checkbox in place of the icon tile, which is not drawn at all. Whatever
         /// <see cref="OmniResult{T}.SetIconBadge"/> pinned to the tile moves onto the checkbox.</summary>
-        ReplacingIcon
+        ReplacingIcon,
+        /// <summary>The tile leads the header instead of standing in a column of its own beside the whole
+        /// row - drawn small, before the identifier and the title, on the title's line - with a checkbox in
+        /// its own column at the start of the row, always visible.</summary>
+        AlwaysBeforeHeaderIcon,
+        /// <summary>The tile leads the header, as with <see cref="AlwaysBeforeHeaderIcon"/>, and no checkbox
+        /// is drawn at all - not even on a selected row. The layout of a list that is not selected from:
+        /// set it with <see cref="OmniResult{T}.SelectionMode(OmniResultSelectionMode)"/>, which lays the row
+        /// out without making it selectable.</summary>
+        HiddenBeforeHeaderIcon
     }
 
     /// <summary>
@@ -75,7 +85,10 @@ namespace Tesserae
     /// </para>
     /// <para>
     /// Rows are selectable (<see cref="Selectable(OmniResultSelectionMode)"/>) with a checkbox that can sit
-    /// beside or over the icon; commands are reached by right-click and, optionally, a [...] button
+    /// beside or over the icon - and the same mode decides whether the tile stands in a column of its own
+    /// beside the row or leads the header line, before the title
+    /// (<see cref="SelectionMode(OmniResultSelectionMode)"/> lays a row out that way without making it
+    /// selectable); commands are reached by right-click and, optionally, a [...] button
     /// (<see cref="OnContextMenu(Action{OmniResult{T}}, OmniResultCommandsMode)"/>), with room for a few
     /// inline commands before it (<see cref="InlineCommands(OmniResultCommandsVisibility, IComponent[])"/>).
     /// </para>
@@ -802,6 +815,12 @@ namespace Tesserae
         /// Makes the result selectable, with its checkbox shown as the given mode says. The checkbox toggles
         /// the selection on click; ctrl-clicking the row does the same, and shift-clicking it asks for a
         /// range (see <see cref="OnRangeSelectionRequested(Action{OmniResult{T}})"/>).
+        /// <para>
+        /// The mode also decides where the tile is drawn: the two <c>...BeforeHeaderIcon</c> modes move it
+        /// onto the header line, before the identifier and the title. Use
+        /// <see cref="SelectionMode(OmniResultSelectionMode)"/> to lay a row out that way without making it
+        /// selectable at all.
+        /// </para>
         /// </summary>
         public OmniResult<T> Selectable(OmniResultSelectionMode mode = OmniResultSelectionMode.OnHoverBeforeIcon)
         {
@@ -815,7 +834,30 @@ namespace Tesserae
         }
 
         /// <summary>
-        /// Takes the checkbox away again, unselecting the result if it was selected.
+        /// Sets where the checkbox goes and where the tile is drawn <em>without</em> making the row
+        /// selectable - what a list that is never selected from wants when it still wants one of the
+        /// layouts a mode carries, chiefly
+        /// <see cref="OmniResultSelectionMode.HiddenBeforeHeaderIcon"/>: the tile leading the header, and
+        /// no checkbox anywhere.
+        /// <para>
+        /// On a row that <see cref="Selectable(OmniResultSelectionMode)"/> already made selectable this
+        /// changes the mode and nothing else.
+        /// </para>
+        /// </summary>
+        public OmniResult<T> SelectionMode(OmniResultSelectionMode mode)
+        {
+            _selectionMode = mode;
+
+            if (_selectionEnabled) EnsureCheckBox();
+
+            ApplySelectionMode();
+
+            return this;
+        }
+
+        /// <summary>
+        /// Takes the checkbox away again, unselecting the result if it was selected. The layout the mode
+        /// asked for stays - a row laid out with the tile in its header keeps it.
         /// </summary>
         public OmniResult<T> NotSelectable()
         {
@@ -1874,6 +1916,13 @@ namespace Tesserae
                 "tss-omniresult-select-always-before",
                 "tss-omniresult-select-replacing");
 
+            //Where the tile is drawn is the mode's too, and unlike the checkbox it is drawn whether the row
+            //is selectable or not - which is what lets a list that is never selected from ask for the
+            //header layout through SelectionMode() alone.
+            InnerElement.UpdateClassIf(IsIconInHeader, "tss-omniresult-icon-in-header");
+
+            PlaceIconHolder();
+
             //The badges hang off whatever is drawn where the tile goes, which the mode - and whether the row
             //is selectable at all - decides.
             PlaceIconBadges();
@@ -1882,10 +1931,39 @@ namespace Tesserae
 
             switch (_selectionMode)
             {
-                case OmniResultSelectionMode.OnHoverBeforeIcon:  InnerElement.classList.add("tss-omniresult-select-hover-before"); break;
-                case OmniResultSelectionMode.OnHoverOverIcon:    InnerElement.classList.add("tss-omniresult-select-hover-over"); break;
-                case OmniResultSelectionMode.AlwaysBeforeIcon:   InnerElement.classList.add("tss-omniresult-select-always-before"); break;
-                case OmniResultSelectionMode.ReplacingIcon:      InnerElement.classList.add("tss-omniresult-select-replacing"); break;
+                case OmniResultSelectionMode.OnHoverBeforeIcon:      InnerElement.classList.add("tss-omniresult-select-hover-before"); break;
+                case OmniResultSelectionMode.OnHoverOverIcon:        InnerElement.classList.add("tss-omniresult-select-hover-over"); break;
+                case OmniResultSelectionMode.AlwaysBeforeIcon:       InnerElement.classList.add("tss-omniresult-select-always-before"); break;
+                case OmniResultSelectionMode.ReplacingIcon:          InnerElement.classList.add("tss-omniresult-select-replacing"); break;
+                case OmniResultSelectionMode.AlwaysBeforeHeaderIcon: InnerElement.classList.add("tss-omniresult-select-always-before"); break;
+                //HiddenBeforeHeaderIcon draws no checkbox, so it adds no class of its own - the column stays
+                //display:none, which is what it is without a mode at all.
+            }
+        }
+
+        /// <summary>
+        /// Whether the mode draws the tile at the start of the header rather than in a column of its own
+        /// beside the whole row. Unlike the checkbox, this holds whether the row is selectable or not.
+        /// </summary>
+        private bool IsIconInHeader => _selectionMode == OmniResultSelectionMode.AlwaysBeforeHeaderIcon
+                                    || _selectionMode == OmniResultSelectionMode.HiddenBeforeHeaderIcon;
+
+        //The tile is one element wherever it is drawn - moved rather than rebuilt - so whatever SetIcon,
+        //SetIconBadge and the modal's copy already put in it survives a change of mode.
+        private void PlaceIconHolder()
+        {
+            if (IsIconInHeader)
+            {
+                //First on the header line, before the identifier, the title and the badge.
+                if (_iconHolder.parentElement != _headerContainer || _headerContainer.firstChild != _iconHolder)
+                {
+                    _headerContainer.insertBefore(_iconHolder, _headerContainer.firstChild);
+                }
+            }
+            else if (_iconHolder.parentElement != InnerElement)
+            {
+                //Back to its own column, between the checkbox column and the text column.
+                InnerElement.insertBefore(_iconHolder, _mainContainer);
             }
         }
 

--- a/Tesserae/tps/assets/css/tss.omniresult.css
+++ b/Tesserae/tps/assets/css/tss.omniresult.css
@@ -214,28 +214,32 @@
 /* The tile itself is an IconTile (see tss.icontile.css): the row only adds this class so the rules above -
    and the peek overrides below - have something of its own to hang off. */
 
-/* Icon in the header ---------------------------------------------------------------------------- */
+/* The tile drawn inline ------------------------------------------------------------------------- */
 
-/* AlwaysBeforeHeaderIcon / HiddenBeforeHeaderIcon: the tile leads the header line instead of standing in a
-   column of its own beside the whole row. The excerpt, the footer and the contribution bar then start at
-   the row's own left edge rather than indented past a tile, which is what a dense list of results - or one
-   whose rows are mostly title - reads better as. The tile is drawn at the title's line box (22px) so it
-   sits on the line rather than setting the line's height itself. */
-.tss-omniresult-icon-in-header .tss-omniresult-icon-holder {
+/* AlwaysBeforeHeaderIcon / HiddenBeforeHeaderIcon draw the tile on the header line instead of standing it
+   in a column of its own beside the whole row, and ModalKeepsIconInTitle does the same on the modal's
+   title line. The excerpt, the footer and the contribution bar then start at the row's own left edge
+   rather than indented past a 34px tile, which is what a dense list - or one whose rows are mostly title -
+   reads better as. The tile is drawn at the title's line box (22px) so it sits on the line rather than
+   setting the line's height itself.
+
+   All of this hangs off the holder rather than off the row, so the copy the modal takes of the tile is
+   drawn the same way there - see OmniResult.CopyOfIcon. */
+.tss-omniresult-icon-inline {
     align-self: center;
 }
 
-.tss-omniresult-icon-in-header .tss-omniresult-icon {
+.tss-omniresult-icon-inline .tss-omniresult-icon {
     --tss-icontile-size: 22px;
     --tss-icontile-radius: 6px;
 }
 
-/* A tile that spells the file type out is a label here, not a square: on the header line it sits beside
-   words, so it grows sideways with its text instead of squeezing "PARQUET" into the width of "PDF" - and
-   nothing has to reach for a smaller TextSize to make a long type name fit. The height stays the title's
-   line box, and the square tile is the floor, so a three- or four-letter type - the common case - still
-   comes out about as square as the glyph tiles it is listed among. */
-.tss-omniresult-icon-in-header .tss-omniresult-icon:has(> .tss-icontile-text) {
+/* A tile that spells the file type out is a label here, not a square: on this line it sits beside words,
+   so it grows sideways with its text instead of squeezing "PARQUET" into the width of "PDF" - and nothing
+   has to reach for a smaller TextSize to make a long type name fit. The height stays the title's line box,
+   and the square tile is the floor, so a three- or four-letter type - the common case - still comes out
+   about as square as the glyph tiles it is listed among. */
+.tss-omniresult-icon-inline .tss-omniresult-icon:has(> .tss-icontile-text) {
     width: auto;
     min-width: var(--tss-icontile-size);
     padding: 0 4px;
@@ -243,35 +247,33 @@
 
 /* Its text is the one thing in the tile that must not be clipped, and it no longer has to be: the tile
    grew to hold it. */
-.tss-omniresult-icon-in-header .tss-omniresult-icon > .tss-icontile-text {
+.tss-omniresult-icon-inline .tss-omniresult-icon > .tss-icontile-text {
     white-space: nowrap;
-}
-
-/* The checkbox column is level with the header line, not with a 34px tile that is no longer there. */
-.tss-omniresult-icon-in-header .tss-omniresult-select {
-    height: 22px;
 }
 
 /* A corner badge is scaled with the tile it is pinned to, and tucked closer in: 4px out from a 34px tile
    is a hint, 4px out from a 22px one is half the badge hanging in the air. */
-.tss-omniresult-icon-in-header .tss-omniresult-icon-badge {
+.tss-omniresult-icon-inline .tss-omniresult-icon-badge {
     font-size: 9px;
 }
 
-.tss-omniresult-icon-in-header .tss-omniresult-icon-badge img,
-.tss-omniresult-icon-in-header .tss-omniresult-icon-badge svg {
+.tss-omniresult-icon-inline .tss-omniresult-icon-badge img,
+.tss-omniresult-icon-inline .tss-omniresult-icon-badge svg {
     width: 11px;
     height: 11px;
     border-radius: 2px;
 }
 
-.tss-omniresult-icon-in-header .tss-omniresult-icon-badge-tl { left: -3px;  top: -3px; }
-.tss-omniresult-icon-in-header .tss-omniresult-icon-badge-tr { right: -3px; top: -3px; }
-.tss-omniresult-icon-in-header .tss-omniresult-icon-badge-bl { left: -3px;  bottom: -3px; }
-.tss-omniresult-icon-in-header .tss-omniresult-icon-badge-br { right: -3px; bottom: -3px; }
+.tss-omniresult-icon-inline .tss-omniresult-icon-badge-tl { left: -3px;  top: -3px; }
+.tss-omniresult-icon-inline .tss-omniresult-icon-badge-tr { right: -3px; top: -3px; }
+.tss-omniresult-icon-inline .tss-omniresult-icon-badge-bl { left: -3px;  bottom: -3px; }
+.tss-omniresult-icon-inline .tss-omniresult-icon-badge-br { right: -3px; bottom: -3px; }
 
-/* The copy the modal takes of the tile keeps the modal's own size whatever the row did with it - the
-   sizing above hangs off the row, and the copy is not inside one. */
+/* The one thing that is the row's rather than the tile's: with no 34px tile in the row, the checkbox
+   column is level with the header line instead. */
+.tss-omniresult-icon-in-header .tss-omniresult-select {
+    height: 22px;
+}
 
 /* Title, badge, excerpt --------------------------------------------------------------------------- */
 
@@ -784,11 +786,12 @@
     gap: 8px;
 }
 
+/* Through the tile's own variables rather than its width and height, so a tile that grows with its text
+   (ModalKeepsIconInTitle) shrinks here as well without having its type name cropped to a square. */
 .tss-modalstack-peek .tss-omniresult-modal-icon .tss-omniresult-icon {
-    width: 24px;
-    height: 24px;
-    border-radius: 6px;
-    font-size: 11px;
+    --tss-icontile-size: 24px;
+    --tss-icontile-radius: 6px;
+    --tss-icontile-glyph-size: 11px;
 }
 
 /* A tile that spells its file type out has to shrink with the tile, or "DOCX" is cropped rather than

--- a/Tesserae/tps/assets/css/tss.omniresult.css
+++ b/Tesserae/tps/assets/css/tss.omniresult.css
@@ -230,6 +230,23 @@
     --tss-icontile-radius: 6px;
 }
 
+/* A tile that spells the file type out is a label here, not a square: on the header line it sits beside
+   words, so it grows sideways with its text instead of squeezing "PARQUET" into the width of "PDF" - and
+   nothing has to reach for a smaller TextSize to make a long type name fit. The height stays the title's
+   line box, and the square tile is the floor, so a three- or four-letter type - the common case - still
+   comes out about as square as the glyph tiles it is listed among. */
+.tss-omniresult-icon-in-header .tss-omniresult-icon:has(> .tss-icontile-text) {
+    width: auto;
+    min-width: var(--tss-icontile-size);
+    padding: 0 4px;
+}
+
+/* Its text is the one thing in the tile that must not be clipped, and it no longer has to be: the tile
+   grew to hold it. */
+.tss-omniresult-icon-in-header .tss-omniresult-icon > .tss-icontile-text {
+    white-space: nowrap;
+}
+
 /* The checkbox column is level with the header line, not with a 34px tile that is no longer there. */
 .tss-omniresult-icon-in-header .tss-omniresult-select {
     height: 22px;

--- a/Tesserae/tps/assets/css/tss.omniresult.css
+++ b/Tesserae/tps/assets/css/tss.omniresult.css
@@ -214,6 +214,48 @@
 /* The tile itself is an IconTile (see tss.icontile.css): the row only adds this class so the rules above -
    and the peek overrides below - have something of its own to hang off. */
 
+/* Icon in the header ---------------------------------------------------------------------------- */
+
+/* AlwaysBeforeHeaderIcon / HiddenBeforeHeaderIcon: the tile leads the header line instead of standing in a
+   column of its own beside the whole row. The excerpt, the footer and the contribution bar then start at
+   the row's own left edge rather than indented past a tile, which is what a dense list of results - or one
+   whose rows are mostly title - reads better as. The tile is drawn at the title's line box (22px) so it
+   sits on the line rather than setting the line's height itself. */
+.tss-omniresult-icon-in-header .tss-omniresult-icon-holder {
+    align-self: center;
+}
+
+.tss-omniresult-icon-in-header .tss-omniresult-icon {
+    --tss-icontile-size: 22px;
+    --tss-icontile-radius: 6px;
+}
+
+/* The checkbox column is level with the header line, not with a 34px tile that is no longer there. */
+.tss-omniresult-icon-in-header .tss-omniresult-select {
+    height: 22px;
+}
+
+/* A corner badge is scaled with the tile it is pinned to, and tucked closer in: 4px out from a 34px tile
+   is a hint, 4px out from a 22px one is half the badge hanging in the air. */
+.tss-omniresult-icon-in-header .tss-omniresult-icon-badge {
+    font-size: 9px;
+}
+
+.tss-omniresult-icon-in-header .tss-omniresult-icon-badge img,
+.tss-omniresult-icon-in-header .tss-omniresult-icon-badge svg {
+    width: 11px;
+    height: 11px;
+    border-radius: 2px;
+}
+
+.tss-omniresult-icon-in-header .tss-omniresult-icon-badge-tl { left: -3px;  top: -3px; }
+.tss-omniresult-icon-in-header .tss-omniresult-icon-badge-tr { right: -3px; top: -3px; }
+.tss-omniresult-icon-in-header .tss-omniresult-icon-badge-bl { left: -3px;  bottom: -3px; }
+.tss-omniresult-icon-in-header .tss-omniresult-icon-badge-br { right: -3px; bottom: -3px; }
+
+/* The copy the modal takes of the tile keeps the modal's own size whatever the row did with it - the
+   sizing above hangs off the row, and the copy is not inside one. */
+
 /* Title, badge, excerpt --------------------------------------------------------------------------- */
 
 .tss-omniresult-main {


### PR DESCRIPTION
Two new `OmniResultSelectionMode` members draw the icon tile on the header line instead of standing it in a column beside the whole row, plus the modal placement that matches them.

## The two modes

| | checkbox | tile |
|---|---|---|
| `AlwaysBeforeHeaderIcon` | its own column at the start of the row, always visible | first on the header line, before the identifier and the title |
| `HiddenBeforeHeaderIcon` | none at all, not even on a selected row | same |

The excerpt, the footer and the contribution bar then start at the row's own left edge (14px) instead of being indented past a 34px tile (60px) — which is what a dense list, or one whose rows are mostly title, reads better as.

Where the tile is drawn is the mode's business now as much as where the checkbox is, and unlike the checkbox it applies whether the row is selectable or not. So there is a new entry point:

```csharp
public OmniResult<T> SelectionMode(OmniResultSelectionMode mode)
```

It sets the mode **without** making the row selectable — how a list that is never selected from asks for `HiddenBeforeHeaderIcon`'s layout. `Selectable(mode)` still takes both new modes for a list that does select. The tile is *moved* rather than rebuilt, so whatever `SetIcon` and `SetIconBadge` put in it survives a change of mode.

## A text tile grows with its text

On the header line the tile sits beside words, so one that spells a file type out is a label there rather than a square: it keeps the title's line height and grows sideways. `SetIcon("SPREADSHEETML", …)` is drawn in full at the ordinary size, and nothing has to reach for a smaller `TextSize` to make a long type name fit. The square tile stays the floor, so a three- or four-letter type still comes out about as square as the glyph tiles it is listed among.

Measured in the gallery: glyph 22.0, `PDF` 23.8, `XLSX` 28.7, `PARQUET` 46.1, `MARKDOWN` 56.6, `SPREADSHEETML` 78.8 — all at a constant 22px tall. A tile holding a glyph, an image or any other component is untouched, and so is every mode that draws the tile in a column of its own.

## `ModalKeepsIconInTitle`

`ModalKeepsIcon` stands the tile beside the whole header block, at the 34px the row draws it. That is the wrong shape for a row laid out with its tile in the header: opening it moved the tile off the title's line and indented the source line past it.

`ModalKeepsIconInTitle` is the other placement — the tile leads the title's own line, small, growing with its text. Each method says where the tile goes as well as that it is kept, so whichever was called last holds, and the row's own layout does not decide the modal's.

| | tile | source-line indent |
|---|---|---|
| `ModalKeepsIcon` | 34 × 34, beside the header | 46px |
| `ModalKeepsIconInTitle`, glyph | 23.8 × 22, first on the title line | 0px |
| `ModalKeepsIconInTitle`, `PARQUET` | 46.1 × 22 | 0px |

How the tile is drawn now hangs off the holder (`tss-omniresult-icon-inline`) rather than off the row, which is what lets the copy the modal takes of it be drawn either way from one set of rules. The peeked-sheet shrink is expressed through the tile's own variables for the same reason — as fixed width and height it would have cropped a grown tile's type name back to a square. It resolves to the 24px square, 6px radius and 11px glyph it did before.

## Verification

Driven in the gallery with Playwright, on the Debug build:

- The tile is the header's first child at 22px in every in-header row; the checkbox column shows and toggles the row under `AlwaysBeforeHeaderIcon` and is absent from the DOM under `HiddenBeforeHeaderIcon` (ctrl-click does nothing there).
- A peeked sheet measures 24 × 24 / 6px / 11px / 6.5px, exactly as before; the inline one peeks at 39.3 × 24 with its text uncropped.
- **No regression on untouched rows.** Built the branch point and the change and compared the gallery: the "The full row" and "Icon tiles" cards are byte-identical PNGs, and every element's rect inside the "Identifiers" card measures identically to the hundredth of a pixel between the two builds (its text antialiases differently only because the new card sits above it in the page). All 68 rows in the other modes still measure 34 × 34.
- No page errors in either theme.

## Also in this change

- Gallery: a new "The tile in the header" card (three groups — no checkbox, always-visible checkbox, and long type names), two rows in "Opening as a modal" demonstrating `ModalKeepsIconInTitle`, and the "Selection" card now shows all six modes.
- `Tesserae/skills/references/omni-result.md` updated alongside, per the skill-sync rule in `CLAUDE.md`.

Not done: the matching page in the `documentation` repo under `tesserae/` needs the same two sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013fWL48QWi4mTwciunZejkr

---
_Generated by [Claude Code](https://claude.ai/code/session_013fWL48QWi4mTwciunZejkr)_