### PR TITLE
Add ShortcutGuide, the modal that lists an app's keyboard shortcuts

### DIFF
--- a/Tesserae.Tests/src/Samples/Commands/CommandPaletteSample.cs
+++ b/Tesserae.Tests/src/Samples/Commands/CommandPaletteSample.cs
@@ -28,6 +28,9 @@ namespace Tesserae.Tests.Samples
             {
                 Placeholder          = "Search files",
                 EnableGlobalShortcut = false,
+                //This one is opened by a button rather than a shortcut, so it is given the way out a pointer
+                //can see - see ShowCloseButton.
+                WillShowCloseButton  = true,
             };
 
             //The search takes as long as a server would, so the box's magnifier turns into a spinner while it
@@ -54,12 +57,15 @@ namespace Tesserae.Tests.Samples
                     Card(VStack().WS().Children(
                     TextBlock("Use the button below or press Cmd/Ctrl + K to open the palette.").Small().Secondary().PB(8),
                     openButton,
-                    TextBlock("Try navigating with arrow keys, Enter, Esc, and Backspace for nested items.").Small().Secondary().PT(12)
+                    TextBlock("Try navigating with arrow keys, Enter, Esc, and Backspace for nested items.").Small().Secondary().PT(12),
+                    Label("Show a close button beside the search box").Inline().AutoWidth().PT(8).SetContent(
+                        Toggle().OnChange((s, e) => palette.WillShowCloseButton = s.IsChecked).Checked(palette.WillShowCloseButton))
                )).SetTitle("Usage")))
                .FlatSection(Stack().Children(
                     Card(VStack().WS().Children(
                     TextBlock("SetResults puts rows of your own above the actions, and OnSearch refreshes them as the query changes — so a palette can answer a question rather than only list commands. The rows here are OmniResults, the same component a search page draws, and the last one is the way out to the full result list.").Small().Secondary().PB(8),
                     openSearchButton,
+                    TextBlock("This palette has no keyboard shortcut, so it carries a close button beside its search box — ShowCloseButton, or WillShowCloseButton on either palette above.").Small().Secondary().PT(8),
                     TextBlock("Type to filter, walk the rows with the arrow keys, and press Enter on one.").Small().Secondary().PT(12),
                     TextBlock("This search waits 700ms, like a server would: while it does, the search box's magnifier turns into a spinner and the rows of the previous query come down, since they are not an answer to this one. The palette does that on its own while an OnSearch call is in flight — a palette that fills its rows some other way says it with SetSearching(true).").Small().Secondary().PT(8)
                )).SetTitle("Searching, with results of your own")))

--- a/Tesserae.Tests/src/Samples/Overlays/ShortcutGuideSample.cs
+++ b/Tesserae.Tests/src/Samples/Overlays/ShortcutGuideSample.cs
@@ -1,0 +1,73 @@
+using Tesserae;
+using Tesserae.Tests;
+using static Transpose.Core.dom;
+using static Tesserae.Tests.Samples.SamplesHelper;
+using static Tesserae.UI;
+
+namespace Tesserae.Tests.Samples
+{
+    [SampleDetails(Group = SampleGroup.Overlays, Order = 100, Icon = UIcons.KeyboardFinger, Description = "The app's keyboard shortcuts, listed")]
+    public class ShortcutGuideSample : IComponent, ISample
+    {
+        private readonly IComponent _content;
+
+        public ShortcutGuideSample()
+        {
+            var container = Raw();
+            var lastFired = TextBlock("Nothing pressed yet").Small();
+
+            var guide = SampleGuide()
+               .Var(out var self)
+               .Section("Try it here")
+                   .Shortcut("Open this guide", "Ctrl", "/").OnPressed(() => self.Toggle())
+                   .Shortcut("Say hello",       "Ctrl", "Shift", "H").OnPressed(() => lastFired.Text = "Ctrl+Shift+H — hello!")
+                   .Shortcut("Clear",           "Escape").OnPressed(() => lastFired.Text = "Nothing pressed yet");
+
+            _content = SectionStack().Secondary()
+               .SampleTitle(typeof(ShortcutGuideSample), UIcons.KeyboardFinger, "A modal listing the app's keyboard shortcuts")
+               .FlatSection(Stack().Children(
+                    Card(VStack().WS().Children(
+                    TextBlock("ShortcutGuide is the \"keyboard shortcuts\" sheet an application opens from its help menu or with Ctrl+/. It lists shortcuts in titled sections — a description on the left, the keys on the right as KeyboardShortcut chips — and takes the same key names KeyboardShortcut.Matches tests, so a shortcut is declared once and what is listed cannot drift from what is bound."))).SetTitle("Overview")))
+               .FlatSection(Stack().Children(
+                    Card(VStack().WS().Children(
+                    TextBlock("Group shortcuts by where they apply (\"General\", \"In chats\") and describe what each one does, not what it is called in the code. Keep the list to the shortcuts a user can actually reach from the surface they are on. Give an entry an action with OnPressed and route the app's keydown through Handle to have the guide answer the presses it advertises; leave the action off for a key some other component already handles."))).SetTitle("Best Practices")))
+               .FlatSection(Stack().Children(
+                    Card(VStack().WS().Children(
+                    Button("Open Shortcut Guide").OnClick((s, e) => SampleGuide().Show()),
+                    Button("Open a narrow one").OnClick((s, e) => SampleGuide().W(360.px()).SetTitle("Shortcuts").Show()))).SetTitle("Usage"),
+                    Card(VStack().WS().Children(
+                    TextBlock("A guide whose entries carry actions can answer them too: this text box routes its keydown through Handle."),
+                    TextBox().SetPlaceholder("Click here, then press Ctrl+/, Ctrl+Shift+H or Escape").WS()
+                       .OnKeyDown((s, e) => { if (guide.Handle(e)) StopEvent(e); }),
+                    lastFired)).SetTitle("Handling the shortcuts")))
+               .FlatSection(Stack().Children(
+                    Card(VStack().WS().Children(
+                    Button("Show Guide Below").OnClick((s, e) => container.Content(SampleGuide().ShowEmbedded())),
+                    container)).SetTitle("Embedded Guide")))
+               .SeeAlso(typeof(KeyboardShortcutSample), typeof(CommandPaletteSample), typeof(ModalSample), typeof(TutorialModalSample), typeof(SidebarSample));
+        }
+
+        private static ShortcutGuide SampleGuide()
+        {
+            return ShortcutGuide()
+               .Section("General")
+                   .Shortcut("Quick chat or search", "Ctrl", "K")
+                   .Shortcut("Incognito chat",       "Ctrl", "Shift", "I")
+                   .Shortcut("Toggle sidebar",       "Ctrl", ".")
+                   .Shortcut("Keyboard shortcuts",   "Ctrl", "/")
+                   .Shortcut("Settings",             "Ctrl", "Shift", ",")
+               .Section("In chats")
+                   .Shortcut("Send message",         "Enter")
+                   .Shortcut("New line in message",  "Shift", "Enter")
+                   .Shortcut("Toggle thinking",      "Ctrl", "Shift", "E")
+                   .Shortcut("Open model menu",      "Ctrl", "Shift", ".")
+                   .Shortcut("Upload file",          "Ctrl", "U")
+                   .Shortcut("Stop the response",    "Escape");
+        }
+
+        public HTMLElement Render()
+        {
+            return _content.Render();
+        }
+    }
+}

--- a/Tesserae/skills/SKILL.md
+++ b/Tesserae/skills/SKILL.md
@@ -196,8 +196,8 @@ banner · live-progress · message · notification-center · progress-indicator 
 progress-modal · progress-ring · skeleton · spinner · tippy · toast
 
 **Overlays & Dialogs** — surfaces that float above the page
-dialog · float · layer · modal · modal-stack · panel · popover · tabbed-modal
-· teaching · tutorial-modal
+dialog · float · layer · modal · modal-stack · panel · popover · shortcut-guide
+· tabbed-modal · teaching · tutorial-modal
 
 **AI & Chat** — conversation, tool calls and their context
 ai-variants · chat · context-card · context-cards · plan · resource-card ·

--- a/Tesserae/skills/references/command-palette.md
+++ b/Tesserae/skills/references/command-palette.md
@@ -25,7 +25,23 @@ CommandPalette:
 - `.CurrentQuery` — what is typed in the search box right now, trimmed.
 - `.LightDismiss()` / `.NoLightDismiss()` / `.CanLightDismiss` — whether clicking beside the palette closes
   it, the way it does on a `Modal`. On by default. Escape closes it too, wherever the focus ended up.
+- `.ShowCloseButton()` / `.HideCloseButton()` / `.WillShowCloseButton` — a close button at the end of the
+  search row, beside the search box's own trigger button. **Off by default**, below.
 - `.SearchBox` / `.ConfigureSearchBox(Action&lt;OmniBox&gt;)` — the box itself, below.
+
+## The close button
+
+Off by default, because a palette normally has two ways out already: Escape, and a click beside it. Turn it
+on for the surfaces where neither is obvious — a touch screen, a palette opened from a button rather than a
+shortcut, or one shown with `NoLightDismiss` so there is nothing beside it to click.
+
+```csharp
+var palette = new CommandPalette(host, actions) { WillShowCloseButton = true };
+// or, in a chain: new CommandPalette(host, actions).ShowCloseButton()
+```
+
+It draws beside the search box's trigger button, matching it in size, and it *closes*: clicking it dismisses
+the palette even when the palette is a level down inside a nested action, where Escape would go back first.
 
 ## The search box is an OmniBox
 

--- a/Tesserae/skills/references/command-palette.md
+++ b/Tesserae/skills/references/command-palette.md
@@ -135,5 +135,6 @@ palette = new CommandPalette(ui, new[] { nav, home, help });
 
 - OmniResult — what a row of your own usually is — `omni-result.md`
 - Keyboard shortcut chips — `keyboard-shortcut.md`
+- ShortcutGuide — the modal listing every shortcut — `shortcut-guide.md`
 - Toast — `toast.md`
 - Full docs & API: `/tesserae/utilities/command-palette`

--- a/Tesserae/skills/references/keyboard-shortcut.md
+++ b/Tesserae/skills/references/keyboard-shortcut.md
@@ -70,6 +70,7 @@ var row = HStack().AlignItems(ItemAlign.Center).Gap(4.px()).Children(
 
 ## Related
 
+- ShortcutGuide (the modal listing every shortcut) — `shortcut-guide.md`
 - CommandPalette (actual Ctrl/Cmd-K launcher) — `command-palette.md`
 - Sidebar (`.AsSearchBox(...)`, `SidebarButton.SetKeyboardShortcut(...)`) — `sidebar.md`
 - Full docs & API: `/tesserae/utilities/keyboard-shortcut`

--- a/Tesserae/skills/references/modal.md
+++ b/Tesserae/skills/references/modal.md
@@ -46,6 +46,7 @@ modal.Show();
 - ModalStack — `modal-stack.md` (a deck of modals, when one opens another)
 - Dialog — `dialog.md` (prebuilt confirmation buttons)
 - Panel — `panel.md` (side drawer)
+- ShortcutGuide — `shortcut-guide.md` (a modal listing the app's keyboard shortcuts)
 - Float — `float.md`
 - PixelAvatar — `pixel-avatar.md` (a cat perched on the modal's top edge)
 - Full docs & API: `/tesserae/surfaces/modal`

--- a/Tesserae/skills/references/shortcut-guide.md
+++ b/Tesserae/skills/references/shortcut-guide.md
@@ -1,0 +1,84 @@
+---
+name: shortcut-guide
+description: A modal listing an application's keyboard shortcuts in titled sections, each row a description and its keys as chips, optionally answering the presses it lists. Use for the "keyboard shortcuts" sheet of a Tesserae (C#/Transpose) app.
+---
+
+# ShortcutGuide
+
+The "keyboard shortcuts" sheet an app opens from its help menu or with `Ctrl+/`. A
+`Modal` whose content is a list of sections; each row is a description on the left and
+the keys on the right, drawn by `KeyboardShortcut`. Because it takes the same key names
+`KeyboardShortcut.Matches` tests, a shortcut is declared once and what is listed cannot
+drift from what is bound.
+
+## Create
+
+`ShortcutGuide(string title = "Keyboard shortcuts")` — also via `UI.ShortcutGuide()`.
+Bring factories into scope with `using static Tesserae.UI;`.
+
+## Building the list
+
+- `.Section(string title)` — starts a section, e.g. `"General"`. Every shortcut added
+  after it is listed under it, until the next `.Section(...)`. Pass null or empty for an
+  untitled one.
+- `.Shortcut(string description, params string[] keys)` — a row. The keys are the names
+  `KeyboardShortcut` takes (`"Ctrl"`, `"Shift"`, `"Enter"`, `"Escape"`, `"ArrowUp"`, …),
+  so the modifiers show as ⌘/⇧ on macOS and Ctrl/Shift elsewhere. Calling it before any
+  `.Section(...)` opens an untitled section.
+- Describe what the shortcut *does* ("Quick chat or search"), not what the command is
+  called in the code, and group by where it applies.
+
+## Answering the shortcuts
+
+- `.OnPressed(Action)` — the action the shortcut added *last* runs. A row without one is
+  listed but not answered, which is right when the key belongs to some other component.
+- `.Handle(KeyboardEvent e)` — runs the first listed shortcut that `e` matches and
+  returns whether one did, so the caller stops the event only when the press was taken.
+  Call it from whatever keydown the app already has.
+
+```csharp
+window.addEventListener("keydown", ev =>
+{
+    if (guide.Handle(ev.As<KeyboardEvent>())) StopEvent(ev);
+});
+```
+
+## Showing it
+
+- `.Show()` / `.Hide(Action onHidden = null)` / `.Toggle()` — `Toggle` is what the
+  shortcut that opens the guide usually calls. `.IsVisible` reads the current state.
+- `.ShowEmbedded()` — returns a component to place in the page instead of floating it,
+  e.g. inside a settings or help page.
+- `.SetTitle(string)`, `.Width(UnitSize)` / `.W(...)` (560px by default),
+  `.LightDismiss()` (on by default) / `.NoLightDismiss()`, `.OnShow(...)` / `.OnHide(...)`.
+- It is a regular `IComponent`, and the sizing helpers apply to the modal itself, so
+  `.MaxHeight(80.vh())` and friends work as they do on `Modal`.
+
+## Example
+
+```csharp
+using static Tesserae.UI;
+
+var guide = ShortcutGuide()
+   .Var(out var self)                 // so a row can open the guide it is listed in
+   .Section("General")
+       .Shortcut("Quick chat or search", "Ctrl", "K").OnPressed(() => palette.Show())
+       .Shortcut("Toggle sidebar",       "Ctrl", ".").OnPressed(() => sidebar.Toggle())
+       .Shortcut("Keyboard shortcuts",   "Ctrl", "/").OnPressed(() => self.Toggle())
+   .Section("In chats")
+       .Shortcut("Send message",        "Enter")
+       .Shortcut("New line in message", "Shift", "Enter")
+       .Shortcut("Stop the response",   "Escape");
+```
+
+`.Var(out var self)` hands the guide to its own rows, which is how the `Ctrl+/` entry
+both advertises and performs the toggle. Rows for keys another component already owns
+(`Enter` in a chat box) are listed without an action.
+
+## Related
+
+- KeyboardShortcut (the key chips, and `Matches`) — `keyboard-shortcut.md`
+- Modal (the surface underneath) — `modal.md`
+- CommandPalette (the Ctrl/Cmd-K launcher a guide usually lists) — `command-palette.md`
+- Sidebar (`SidebarButton.SetKeyboardShortcut(...)`) — `sidebar.md`
+- Full docs & API: `/tesserae/surfaces/shortcut-guide`

--- a/Tesserae/src/Base/UI.Components.cs
+++ b/Tesserae/src/Base/UI.Components.cs
@@ -1558,6 +1558,11 @@ namespace Tesserae
         public static KeyboardShortcut KeyboardShortcut(params string[] keys) => new KeyboardShortcut(keys);
 
         /// <summary>
+        /// Creates a <see cref="Tesserae.ShortcutGuide"/> component.
+        /// </summary>
+        public static ShortcutGuide ShortcutGuide(string title = "Keyboard shortcuts") => new ShortcutGuide(title);
+
+        /// <summary>
         /// Creates a <see cref="Tesserae.NotificationCenter"/> component.
         /// </summary>
         public static NotificationCenter NotificationCenter() => new NotificationCenter();

--- a/Tesserae/src/Components/CommandPalette.cs
+++ b/Tesserae/src/Components/CommandPalette.cs
@@ -22,6 +22,7 @@ namespace Tesserae
         private readonly OmniBox _searchBox;
         private readonly HTMLDivElement _breadcrumbs;
         private readonly HTMLButtonElement _backButton;
+        private readonly HTMLButtonElement _closeButton;
         private readonly HTMLSpanElement _pathText;
         private readonly HTMLDivElement _results;
         private readonly HTMLDivElement _emptyState;
@@ -136,6 +137,36 @@ namespace Tesserae
         }
 
         /// <summary>
+        /// Whether a close button is drawn at the end of the search row, beside the search box's own trigger
+        /// button. Off by default - Escape closes the palette and a click beside it does too - so it is for
+        /// the surfaces where neither is obvious: a touch screen, a palette opened from a button rather than
+        /// a shortcut, or one shown with <see cref="NoLightDismiss"/> so there is nothing beside it to click.
+        /// <para>
+        /// Closing this way is closing, not going back: it dismisses the palette even from a level down
+        /// inside a nested action, where Escape goes back first.
+        /// </para>
+        /// </summary>
+        public bool WillShowCloseButton
+        {
+            get => _closeButton.style.display != "none";
+            set => _closeButton.style.display = value ? "" : "none";
+        }
+
+        /// <summary>Shows the close button at the end of the search row.</summary>
+        public CommandPalette ShowCloseButton()
+        {
+            WillShowCloseButton = true;
+            return this;
+        }
+
+        /// <summary>Hides the close button at the end of the search row (the default).</summary>
+        public CommandPalette HideCloseButton()
+        {
+            WillShowCloseButton = false;
+            return this;
+        }
+
+        /// <summary>
         /// The box the palette is typed into. It is a full <see cref="OmniBox"/>, so a host can give the
         /// palette the same snaps, value filters, history and suggestions its own search box has instead of
         /// the palette being a lesser search than the page it stands in for.
@@ -191,7 +222,21 @@ namespace Tesserae
             _pathText = Span(Att("tss-commandpalette-path tss-fontweight-semibold"));
             _breadcrumbs = Div(Att("tss-commandpalette-breadcrumbs"), _backButton, _pathText);
 
-            _searchContainer = Div(Att("tss-commandpalette-search-container"), _breadcrumbs, _searchBox.Render());
+            //Beside the search box's own trigger button, and off unless asked for: the palette is a keyboard
+            //surface where Escape is the way out, and a pointer has the backdrop. It earns its place where a
+            //pointer is all there is - a touch screen, or a palette embedded with no backdrop to click.
+            _closeButton = UI.Button(Att("tss-commandpalette-close", type: "button", title: "Close", ariaLabel: "Close"),
+                                     I(Att($"tss-commandpalette-close-icon {UIcons.CrossSmall.ToCssClass()}")));
+
+            _closeButton.addEventListener("click", e =>
+            {
+                StopEvent(e);
+                Hide();
+            });
+
+            _searchContainer = Div(Att("tss-commandpalette-search-container"), _breadcrumbs, _searchBox.Render(), _closeButton);
+            WillShowCloseButton = false;
+
             _results = Div(Att("tss-commandpalette-results", role: "listbox"));
             _emptyState = Div(Att("tss-commandpalette-empty", text: "No results"));
 

--- a/Tesserae/src/Components/ShortcutGuide.cs
+++ b/Tesserae/src/Components/ShortcutGuide.cs
@@ -1,0 +1,233 @@
+using System;
+using System.Collections.Generic;
+using static Transpose.Core.dom;
+using static Tesserae.UI;
+
+namespace Tesserae
+{
+    /// <summary>
+    /// A modal listing an application's keyboard shortcuts, grouped into titled sections, each row a
+    /// description on the left and the keys on the right as <see cref="KeyboardShortcut"/> chips.
+    /// <para>
+    /// A shortcut is declared here with the same key names <see cref="KeyboardShortcut.Matches"/> tests, so
+    /// a guide can also answer the presses it advertises: give an entry an action with
+    /// <see cref="OnPressed"/> and call <see cref="Handle"/> from the application's keydown handler.
+    /// </para>
+    /// </summary>
+    [Transpose.Name("tss.ShortcutGuide")]
+    public sealed class ShortcutGuide : IComponent, ISpecialCaseStyling
+    {
+        private readonly Modal       _modal;
+        private readonly TextBlock   _title;
+        private readonly HTMLElement _sections;
+        private readonly List<Entry> _entries = new List<Entry>();
+
+        private HTMLElement _currentSection;
+
+        /// <summary>
+        /// Gets the styling container for the guide, so the sizing helpers reach the modal itself.
+        /// </summary>
+        public HTMLElement StylingContainer => _modal.StylingContainer;
+
+        /// <summary>
+        /// Gets whether a sizing helper applied to this component should tag it so a wrapper-building container hoists the style onto the wrapper.
+        /// </summary>
+        public bool PropagateStylesToWrapper => _modal.PropagateStylesToWrapper;
+
+        /// <summary>
+        /// Initializes a new instance of this class.
+        /// </summary>
+        /// <param name="title">The modal's title.</param>
+        public ShortcutGuide(string title = "Keyboard shortcuts")
+        {
+            _title    = TextBlock(title).Large().SemiBold();
+            _sections = Div(Att("tss-shortcut-guide"));
+
+            _modal = Modal(_title)
+               .LightDismiss()
+               .Content(Raw(_sections));
+
+            Width(560.px());
+        }
+
+        /// <summary>
+        /// Starts a new section. Every shortcut added after this call is listed under it, until the next
+        /// <see cref="Section"/>.
+        /// </summary>
+        /// <param name="title">The section's title, e.g. "General". Pass null or empty for an untitled section.</param>
+        public ShortcutGuide Section(string title)
+        {
+            _currentSection = Div(Att("tss-shortcut-guide-section"));
+
+            if (!string.IsNullOrWhiteSpace(title))
+            {
+                _currentSection.appendChild(Div(Att("tss-shortcut-guide-section-title", text: title)));
+            }
+
+            _sections.appendChild(_currentSection);
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a shortcut to the current section, creating an untitled one if <see cref="Section"/> has not
+        /// been called yet.
+        /// </summary>
+        /// <param name="description">What the shortcut does, e.g. "Quick chat or search".</param>
+        /// <param name="keys">The keys, in the names <see cref="KeyboardShortcut"/> takes, e.g. "Ctrl", "K".</param>
+        public ShortcutGuide Shortcut(string description, params string[] keys)
+        {
+            if (_currentSection is null) Section(null);
+
+            var row = Div(Att("tss-shortcut-guide-row"), Div(Att("tss-shortcut-guide-description", text: description)));
+            row.appendChild(new KeyboardShortcut(keys).Render());
+            _currentSection.appendChild(row);
+
+            _entries.Add(new Entry(keys));
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the action the last added shortcut runs when <see cref="Handle"/> sees it pressed. A shortcut
+        /// without one is listed but not answered - which is right when whatever owns the key already
+        /// handles it.
+        /// </summary>
+        public ShortcutGuide OnPressed(Action action)
+        {
+            if (_entries.Count == 0) throw new InvalidOperationException("Call Shortcut(...) before OnPressed(...) - the action belongs to the shortcut added last.");
+
+            _entries[_entries.Count - 1].Action = action;
+            return this;
+        }
+
+        /// <summary>
+        /// Runs the action of the first listed shortcut that <paramref name="e"/> matches, and answers whether
+        /// one did - so a caller can stop the event only when the press was taken.
+        /// </summary>
+        public bool Handle(KeyboardEvent e)
+        {
+            foreach (var entry in _entries)
+            {
+                if (entry.Action is null) continue;
+                if (!KeyboardShortcut.Matches(e, entry.Keys)) continue;
+
+                entry.Action();
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Sets the title of the component.
+        /// </summary>
+        public ShortcutGuide SetTitle(string title)
+        {
+            _title.Text = title;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the width of the component.
+        /// </summary>
+        public ShortcutGuide Width(UnitSize width)
+        {
+            _modal.Width(width);
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the width of the component.
+        /// </summary>
+        public ShortcutGuide W(UnitSize width) => Width(width);
+
+        /// <summary>
+        /// Enables light-dismiss behaviour (clicking outside the guide closes it). It is on by default.
+        /// </summary>
+        public ShortcutGuide LightDismiss()
+        {
+            _modal.LightDismiss();
+            return this;
+        }
+
+        /// <summary>
+        /// Removes / disables the light dismiss on the component.
+        /// </summary>
+        public ShortcutGuide NoLightDismiss()
+        {
+            _modal.NoLightDismiss();
+            return this;
+        }
+
+        /// <summary>
+        /// Registers a callback invoked when the guide is shown.
+        /// </summary>
+        public ShortcutGuide OnShow(Modal.OnShowHandler onShow)
+        {
+            _modal.OnShow(onShow);
+            return this;
+        }
+
+        /// <summary>
+        /// Registers a callback invoked when the guide is hidden.
+        /// </summary>
+        public ShortcutGuide OnHide(Modal.OnHideHandler onHide)
+        {
+            _modal.OnHide(onHide);
+            return this;
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the guide is currently shown.
+        /// </summary>
+        public bool IsVisible => _modal.IsVisible;
+
+        /// <summary>
+        /// Shows the component.
+        /// </summary>
+        public ShortcutGuide Show()
+        {
+            _modal.Show();
+            return this;
+        }
+
+        /// <summary>
+        /// Hides the component.
+        /// </summary>
+        public ShortcutGuide Hide(Action onHidden = null)
+        {
+            _modal.Hide(onHidden);
+            return this;
+        }
+
+        /// <summary>
+        /// Shows the guide if it is hidden and hides it if it is shown, which is what the shortcut that opens
+        /// it usually does.
+        /// </summary>
+        public ShortcutGuide Toggle()
+        {
+            if (IsVisible) return Hide();
+            return Show();
+        }
+
+        /// <summary>
+        /// Returns the guide as a component to place in the page, instead of showing it as a modal layer.
+        /// </summary>
+        public IComponent ShowEmbedded() => _modal.ShowEmbedded();
+
+        /// <summary>
+        /// Renders the component's root HTML element.
+        /// </summary>
+        public HTMLElement Render() => _modal.Render();
+
+        private sealed class Entry
+        {
+            public Entry(string[] keys)
+            {
+                Keys = keys;
+            }
+
+            public readonly string[] Keys;
+            public          Action   Action;
+        }
+    }
+}

--- a/Tesserae/tps/assets/css/tss.commandpalette.css
+++ b/Tesserae/tps/assets/css/tss.commandpalette.css
@@ -72,6 +72,36 @@
     font-size: 12px;
 }
 
+/* The close button, off unless the palette is asked for one - see WillShowCloseButton. It sits after the
+   search box, so it lines up with that box's own trigger button rather than floating over the row. */
+.tss-commandpalette-close {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    /* The box and the glyph of the search box's own trigger button, which it stands beside: a pair of
+       buttons the same size reads as one cluster, one 28px and one 36px reads as an afterthought. */
+    width: 36px;
+    height: 36px;
+    flex-shrink: 0;
+    border: none;
+    border-radius: 6px;
+    background: transparent;
+    color: var(--tss-secondary-foreground-color);
+    cursor: pointer;
+    padding: 0;
+}
+
+    .tss-commandpalette-close:hover {
+        background: var(--tss-default-background-hover-color);
+        color: var(--tss-default-foreground-color);
+    }
+
+.tss-commandpalette-close-icon {
+    /* cross-small at 16px paints the same weight as the magnifier at 12px: the plain cross glyph fills far
+       more of its em box, so matching the font sizes would not have matched what is drawn. */
+    font-size: 16px;
+}
+
 .tss-commandpalette-path {
     color: var(--tss-secondary-foreground-color);
     user-select: none;

--- a/Tesserae/tps/assets/css/tss.kbd.css
+++ b/Tesserae/tps/assets/css/tss.kbd.css
@@ -36,3 +36,48 @@
     padding: 0 1px;
     user-select: none;
 }
+
+/* ShortcutGuide - the modal that lists an app's shortcuts, one row per shortcut, drawn with the
+   key chips above. */
+.tss-shortcut-guide {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    /* No side padding: the rows line up with the modal's title, which is what the eye follows down. */
+    padding: 4px 0 16px 0;
+}
+
+.tss-shortcut-guide-section:not(:first-child) {
+    margin-top: 20px;
+}
+
+.tss-shortcut-guide-section-title {
+    font-family: var(--tss-sansserif-font-family);
+    font-size: var(--tss-font-size-smallplus);
+    font-weight: var(--tss-font-weight-semibold);
+    line-height: 1.4;
+    color: var(--tss-default-foreground-color);
+    padding-bottom: 4px;
+}
+
+.tss-shortcut-guide-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    min-height: 34px;
+    padding: 4px 0;
+    /* A rule under every row but the last one of its section, so the sections read as blocks. */
+    border-bottom: 1px solid var(--tss-default-separator-color);
+}
+
+    .tss-shortcut-guide-row:last-child {
+        border-bottom: none;
+    }
+
+.tss-shortcut-guide-description {
+    font-family: var(--tss-sansserif-font-family);
+    font-size: var(--tss-font-size-small);
+    color: var(--tss-default-foreground-color);
+    overflow-wrap: anywhere;
+}


### PR DESCRIPTION
The "keyboard shortcuts" sheet an app opens from its help menu or with Ctrl+/:
a Modal whose content is titled sections of rows, each a description on the
left and its keys on the right as KeyboardShortcut chips.

It takes the same key names KeyboardShortcut.Matches tests, which is what lets
it answer the presses it advertises rather than only listing them: give an entry
an action with OnPressed and route the app's keydown through Handle, and the
shortcut is declared once - so what is shown cannot drift from what is bound.
A row for a key some other component already owns is listed without an action.

The name is not KeyboardHelpModal: a component named after the surface it
happens to use says nothing about what it holds, and this one is the guide to
the app's shortcuts whether it floats (Show) or sits in a help page
(ShowEmbedded) - the same reason Dialog and CommandPalette are not called
modals either.

The stylesheet only adds .tss-shortcut-guide* selectors to tss.kbd.css, next to
the key chips it draws, so nothing that renders today changes.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GN7WJBpWySyVvwkUTSeC9h