### PR TITLE
Fix the blank page the gallery showed at a mobile viewport

### DIFF
--- a/Tesserae.Tests/src/App.cs
+++ b/Tesserae.Tests/src/App.cs
@@ -58,14 +58,6 @@ namespace Tesserae.Tests
             // land somewhere else in the list than the person who sent it saw.
             var sidebar = Sidebar();
 
-            // On mobile we use navbar mode: horizontal bar + full-screen sliding drawer.
-            // This is evaluated once at startup; the CSS (tss-mobile class) handles visual switches
-            // for subsequent resize events.
-            if (Theme.IsMobileMode)
-            {
-                sidebar.AsNavbar();
-            }
-
             sidebar.AddHeader(new SidebarText("header", "Tesserae", "TSS", textSize: TextSize.XLarge, textWeight: TextWeight.Bold));
 
             var searchBox = new SidebarSearchBox("search", "Search...");
@@ -93,18 +85,16 @@ namespace Tesserae.Tests
                 ? (IComponent)VStack().S().ScrollY().Children(new LandingPage(samples.Values).WS())
                 : VStack().S().ScrollY().Children((await page.ContentGenerator()).WS().MinHeight(100.percent())));
 
-            // On mobile the sidebar is a fixed top navbar, so the layout is vertical (sidebar then content).
-            // On desktop the layout is horizontal (sidebar left, content right).
-            Stack pageContent;
-
-            if (Theme.IsMobileMode)
-            {
-                pageContent = VStack().Class("tss-page-layout").S().Children(sidebar.WS(), contentArea.WS().H(1).Grow());
-            }
-            else
-            {
-                pageContent = HStack().Class("tss-page-layout").S().Children(sidebar.HS(), contentArea.HS().W(1).Grow());
-            }
+            // The shell is built once and re-pointed by ApplyLayoutMode below, which runs at startup
+            // and again on every mobile-mode change: on mobile the sidebar is a fixed top navbar and
+            // the layout is a column (navbar above content); on desktop it is a row (sidebar left,
+            // content right). Deciding it only at startup left the C# layout and the stylesheet
+            // disagreeing after a resize - the row's content still carried the width:1px+grow that
+            // claims leftover space along a row, which in a column is simply a one-pixel-wide page.
+            //
+            // The sidebar itself is never given an inline width: .tss-sidebar's own 250px is what
+            // sizes it on desktop, and .tss-navbar overrides both axes on mobile.
+            var pageContent = HStack().Class("tss-page-layout").S().Children(sidebar.HS(), contentArea);
 
             MountToBody(pageContent);
 
@@ -115,13 +105,42 @@ namespace Tesserae.Tests
 
             var openClose = new SidebarCommand(UIcons.AngleLeft).Tooltip("Close Sidebar");
 
-            // In mobile/navbar mode the drawer always starts closed (hamburger opens it).
-            // In desktop mode, restore the user's last open/closed preference from localStorage.
-            if (!Theme.IsMobileMode)
+            // Points the shell at the layout the current mode calls for. Called once below and then
+            // on every OnMobileModeChanged, so narrowing or widening the window switches the whole
+            // shell rather than leaving a row layout for the mobile stylesheet to reshape.
+            void ApplyLayoutMode(bool isMobile)
             {
-                var sidebarOpenState = bool.TryParse(localStorage.getItem(_sidebarOpenStateKey), out var v) ? v : true;
-                sidebar.Closed(!sidebarOpenState);
+                sidebar.AsNavbar(isMobile);
+
+                if (isMobile)
+                {
+                    // Column: the navbar is fixed at the top and the content fills what is left. The
+                    // 1px height is the flex basis the grow expands from, so it has to be on the axis
+                    // the column measures - and the width has to be restated, since the row layout
+                    // left width:1px behind on what is now the cross axis.
+                    pageContent.Vertical();
+                    contentArea.WS().H(1).Grow();
+
+                    // AsNavbar already closed the drawer; keep the affordance's icon saying so.
+                    openClose.SetIcon(UIcons.AngleRight).Tooltip("Open Sidebar");
+                }
+                else
+                {
+                    pageContent.Horizontal();
+                    contentArea.HS().W(1).Grow();
+
+                    // Back on desktop, the sidebar is a rail again, so restore the user's own
+                    // open/closed preference rather than leaving it collapsed by the drawer.
+                    var sidebarOpenState = bool.TryParse(localStorage.getItem(_sidebarOpenStateKey), out var v) ? v : true;
+                    sidebar.Closed(!sidebarOpenState);
+
+                    openClose.SetIcon(sidebarOpenState ? UIcons.AngleLeft : UIcons.AngleRight)
+                       .Tooltip(sidebarOpenState ? "Close Sidebar" : "Open Sidebar");
+                }
             }
+
+            ApplyLayoutMode(Theme.IsMobileMode);
+            Theme.OnMobileModeChanged += () => ApplyLayoutMode(Theme.IsMobileMode);
 
             openClose.OnClick(() =>
             {

--- a/Tesserae/skills/references/navbar.md
+++ b/Tesserae/skills/references/navbar.md
@@ -15,6 +15,8 @@ in a drawer).
 - `Nav()` — an empty nav tree; add links with `.Links(...)`.
 - `new NavLink(string text)` / `new NavLink(IComponent content)` — a node.
 - `Sidebar().AsNavbar()` — top-bar navigation populated with `SidebarButton`/`SidebarSeparator` items.
+  `.AsNavbar(false)` puts it back to a vertical sidebar, and `.IsNavbar` reports which it is,
+  so one sidebar can follow `Theme.OnMobileModeChanged` instead of being fixed at startup.
 
 Bring the factories into scope with `using static Tesserae.UI;`.
 
@@ -34,6 +36,7 @@ NavLink:
 - `.Icon` (icon class), `.Text` / `.SetText(...)`.
 
 Sidebar-as-navbar: `.AddHeader(item)`, `.AddContent(item)`, `.AddFooter(item)`.
+See *Responsive* in the Sidebar reference for switching between the two forms on a resize.
 
 ## Example
 

--- a/Tesserae/skills/references/sidebar.md
+++ b/Tesserae/skills/references/sidebar.md
@@ -25,7 +25,9 @@ Bring factories into scope with `using static Tesserae.UI;`.
 - `.Closed(bool = true)` / `.Toggle()` / `.IsClosed` — collapse to icon rail.
 - `.ShiftTo(childSidebar)` / `.ShiftBack()` / `.IsShifted` — slide into a nested
   sidebar (see below).
-- `.AsNavbar()` — render horizontally as a top bar with a hamburger drawer.
+- `.AsNavbar(bool = true)` / `.IsNavbar` — render horizontally as a top bar with a
+  hamburger drawer, or (passing `false`) back as a vertical sidebar. Both directions
+  work, so an app can switch on a window resize — see *Responsive* below.
 - `.Secondary()` — use the secondary background colour.
 - `.Sortable(bool)` — enable/disable drag reordering.
 - `.Search(term)` — filter searchable middle items.
@@ -207,6 +209,40 @@ Only one depth level is supported: a child sidebar can't shift again. The child
 is rendered inside the hosting sidebar and follows its open/closed state, so
 `.Toggle()` on the main sidebar collapses both. Shifting is ignored in
 `.AsNavbar()` mode.
+
+## Responsive: sidebar on desktop, navbar on mobile
+
+`Theme.EnableMobileDetection()` adds and removes the `tss-mobile` class as the
+viewport crosses a breakpoint, and the mobile stylesheet turns a `.tss-page-layout`
+shell into a column with the navbar pinned to the top. Follow
+`Theme.OnMobileModeChanged` and switch the whole shell, rather than picking a layout
+once at startup — the stylesheet reshapes what is on the page either way, so a row
+built for desktop is still a row in C# when the CSS starts drawing it as a column:
+
+```csharp
+Theme.EnableMobileDetection(breakpoint: 768);
+
+var sidebar = Sidebar();
+var content = VStack().S().ScrollY().Children(/* ... */);
+
+// The sidebar gets no inline width: .tss-sidebar sizes it on desktop and the
+// navbar rules override both axes on mobile.
+var shell = HStack().Class("tss-page-layout").S().Children(sidebar.HS(), content);
+
+void ApplyLayoutMode(bool isMobile)
+{
+    sidebar.AsNavbar(isMobile);
+
+    // The 1px is the flex basis the grow expands from, so it has to sit on the axis
+    // the container measures — and the other axis has to be restated, or the value
+    // left over from the previous mode becomes a real size on the cross axis.
+    if (isMobile) { shell.Vertical();   content.WS().H(1).Grow(); }
+    else          { shell.Horizontal(); content.HS().W(1).Grow(); }
+}
+
+ApplyLayoutMode(Theme.IsMobileMode);
+Theme.OnMobileModeChanged += () => ApplyLayoutMode(Theme.IsMobileMode);
+```
 
 ```csharp
 var sidebar = Sidebar();

--- a/Tesserae/src/Components/Sidebar/Sidebar.cs
+++ b/Tesserae/src/Components/Sidebar/Sidebar.cs
@@ -150,27 +150,69 @@ namespace Tesserae
         }
 
         /// <summary>
-        /// Configures the sidebar to render as a navbar.
+        /// Gets whether the sidebar is currently rendering as a navbar.
         /// </summary>
+        public bool IsNavbar => _isNavbar;
+
+        /// <summary>
+        /// Configures the sidebar to render as a navbar - a horizontal bar with a hamburger that opens
+        /// the items in a sliding drawer - or back to an ordinary vertical sidebar.
+        /// </summary>
+        /// <remarks>
+        /// Both directions are supported so an app can follow <see cref="UI.Theme.OnMobileModeChanged"/>
+        /// and switch on a window resize, rather than deciding once at startup and rendering a layout
+        /// the stylesheet then reshapes underneath it.
+        /// </remarks>
+        /// <param name="isNavbar">Whether to render as a navbar.</param>
         /// <returns>The current instance.</returns>
-        public Sidebar AsNavbar()
+        public Sidebar AsNavbar(bool isNavbar = true)
         {
-            _isNavbar = true;
-            _sidebar.Horizontal();
-            _sidebar.Class("tss-navbar");
-            _closed.Value = true;
+            if (_isNavbar == isNavbar) return this;
 
-            // Apply the closed class synchronously so CSS states are correct before first paint.
-            _sidebar.Class("tss-navbar-closed");
+            _isNavbar = isNavbar;
 
-            // Create a backdrop element appended to the body. On mobile it dims the background
-            // when the drawer is open and closes the sidebar on click.
-            if (_mobileBackdrop is null)
+            if (isNavbar)
             {
-                _mobileBackdrop           = (HTMLDivElement)document.createElement("div");
-                _mobileBackdrop.className = "tss-mobile-backdrop";
-                _mobileBackdrop.addEventListener("click", (Event e) => { _closed.Value = true; });
-                document.body.appendChild(_mobileBackdrop);
+                _sidebar.Horizontal();
+                _sidebar.Class("tss-navbar");
+
+                // The drawer always starts closed: on a phone it covers the page, so opening it
+                // unasked would hide whatever the user came for.
+                _closed.Value = true;
+
+                // Apply the closed class synchronously so CSS states are correct before first paint,
+                // and drop the one the vertical sidebar uses so only one of the two is ever on.
+                _sidebar.RemoveClass("tss-sidebar-closed");
+                _sidebar.Class("tss-navbar-closed");
+
+                // Create a backdrop element appended to the body. On mobile it dims the background
+                // when the drawer is open and closes the sidebar on click.
+                if (_mobileBackdrop is null)
+                {
+                    _mobileBackdrop           = (HTMLDivElement)document.createElement("div");
+                    _mobileBackdrop.className = "tss-mobile-backdrop";
+                    _mobileBackdrop.addEventListener("click", (Event e) => { _closed.Value = true; });
+                    document.body.appendChild(_mobileBackdrop);
+                }
+            }
+            else
+            {
+                _sidebar.Vertical();
+                _sidebar.RemoveClass("tss-navbar");
+                _sidebar.RemoveClass("tss-navbar-closed");
+
+                if (_closed.Value)
+                {
+                    _sidebar.Class("tss-sidebar-closed");
+                }
+
+                // The backdrop only ever belongs to a drawer, and it is a full-viewport click target,
+                // so it goes away with the drawer rather than lingering over the page.
+                if (_mobileBackdrop is object)
+                {
+                    _mobileBackdrop.remove();
+                    _mobileBackdrop = null;
+                }
             }
 
             Refresh();

--- a/Tesserae/tps/assets/css/tss.mobile.css
+++ b/Tesserae/tps/assets/css/tss.mobile.css
@@ -22,9 +22,21 @@ body.tss-mobile .tss-navbar {
     padding: 0 12px !important;
 }
 
-/* Push the page content area down below the fixed navbar */
+/* Push the page content area down below the fixed navbar, and make it own the full
+   width of the column.
+
+   The width matters as much as the offset: an app that built its shell as a row
+   (sidebar | content) gives the content `width: 1px` plus `flex-grow`, which is how a
+   flex item claims the leftover main axis. Flipping the direction to column above turns
+   width into the *cross* axis, so that 1px stops being a growable basis and becomes the
+   content's actual width — a page one pixel wide, which reads as a blank white screen.
+   Restating the sizing for the new axis keeps a layout built for either mode readable. */
 body.tss-mobile .tss-page-layout > .tss-stack-item:last-child {
     margin-top: 52px;
+    width: 100% !important;
+    height: auto !important;
+    min-width: 0 !important;
+    flex: 1 1 auto !important;
 }
 
 /* Full-screen drawer: always in DOM for animation, positioned fixed */


### PR DESCRIPTION
Narrowing the window to a phone width left the sample gallery a white screen. `App.cs` chose its shell once at startup - a row of sidebar-then-content on desktop, a column of navbar-then-content on mobile - but `EnableMobileDetection` keeps toggling the `tss-mobile` class on every resize, so after a resize the stylesheet was reshaping a layout built for the other mode.

The content area in the desktop row carries `width: 1px` plus `flex-grow`, which is how a flex item claims the leftover main axis. `tss.mobile.css` flips the shell to `flex-direction: column`, and width is then the *cross* axis: the 1px stops being a growable basis and becomes the content's real width. A page one pixel wide reads as blank. The sidebar was gone too, since a sidebar that is not a navbar is `display: none` on mobile - so even the navigation was missing.

Three changes:

- `Sidebar.AsNavbar` takes a bool and can go back to a vertical sidebar, adding `IsNavbar` to report which it is. Leaving navbar mode drops the navbar classes and removes the backdrop, which is a full-viewport click target and has no business outliving the drawer. Entering it also clears `tss-sidebar-closed`, so only one of the two closed-state classes is ever on.

- The gallery builds its shell once and applies the mode from one place, at startup and on every `OnMobileModeChanged`: it switches the sidebar in and out of navbar mode, flips the stack's orientation, and restates the content area's sizing for the axis that is now the main one. Coming back to desktop restores the user's own sidebar open/closed preference instead of leaving it collapsed by the drawer.

- `tss.mobile.css` restates width and flex on the page-layout content area, so any app whose shell is a row - not just this gallery - stays readable when the mobile rules turn it into a column.

Verified in Chromium: fresh loads from 320px to 1440px and resizes in both directions across the 768px breakpoint all render content and reach the samples through the drawer, and `textdiff-samples.js` reports the desktop gallery unchanged (132/135 samples identical; the three others are the known clock-derived and spinner-animation noise).


Claude-Session: https://claude.ai/code/session_01SkCcvGVqSE1BNNHF299hZB