### PR TITLE
Clarify component wiring, sizing helpers, and reference links

### DIFF
--- a/Tesserae/skills/SKILL.md
+++ b/Tesserae/skills/SKILL.md
@@ -42,6 +42,14 @@ private static void Main()
 - **Compose**: containers take children via `.Children(...)` or `.Add(...)`.
 - **Mount**: `MountToBody` / `MountCenteredToBody` attach the root to the DOM.
 
+> **Reaching a nested type.** `using static Tesserae.UI;` imports a factory *method* for
+> almost every component, and a method hides a same-named type. So inside your own
+> namespace `Float.Position.TopLeft`, `Dialog.Response.Yes`, `OmniBox.Config`,
+> `SaveButton.State`, `Teaching.StepType` and friends do not compile
+> (`CS0119: … is a method, which is not valid in the given context`) — qualify them:
+> `Tesserae.Float.Position.TopLeft`. The same applies to statics such as
+> `Tesserae.KeyboardShortcut.Matches(...)` and `Tesserae.Icon.Transform(...)`.
+
 ## Layout: Stack and Grid
 
 `Stack` and `Grid` are the two workhorse containers. Most layouts are nested
@@ -71,7 +79,7 @@ Key `Stack` methods: `Horizontal()` / `Vertical()` (and `…Reverse()`),
 ```csharp
 Grid()
     .Columns(200.px(), 1.fr())    // two columns: fixed sidebar + flexible body
-    .Rows(auto, 1.fr())
+    .Rows(new[] { UnitSize.Auto(), 1.fr() })
     .Gap(12.px())
     .AlignItemsCenter();
 ```
@@ -99,7 +107,8 @@ not per-component members). Call them before adding the component to a container
 | Self-alignment | `.AlignStart()`, `.AlignCenter()`, `.AlignEnd()`, `.AlignStretch()`, `.JustifyStart/Center/End()` |
 
 Sizes are `UnitSize` values from numeric helpers: `100.px()`, `50.percent()`,
-`1.em()`, `1.fr()`.
+`1.fr()`, `100.vw()`, `100.vh()` — plus `UnitSize.Auto()`, `UnitSize.FitContent()`
+and raw `new UnitSize("calc(100% - 32px)")` for anything else.
 
 > **Container-level vs. item-level alignment.** `AlignItemsCenter()` is a method on
 > `Stack`/`Grid` that centers *all* children. `.AlignCenter()` is an extension on a
@@ -145,6 +154,8 @@ references. Open the reference for whatever you are working with. The full set:
   `references/theme-colors.md`, `references/iconography.md`,
   `references/accessibility.md`, `references/project-setup.md`,
   `references/routing.md`.
+- `references/observables.md` — the reactive state containers `Defer` and the
+  collection components read from.
 - `references/creating-a-component.md` — build your own `IComponent`.
 - `references/javascript-interop.md` — call JS/browser APIs from C# via Transpose.
 - `references/wrap-a-javascript-library.md` — wrap a third-party JS library.

--- a/Tesserae/skills/SKILL.md
+++ b/Tesserae/skills/SKILL.md
@@ -165,8 +165,8 @@ accordion · background-area · card · expander · grid · horizontal-separator
 horizontal-split-view · masonry · section-stack · split-view · stack
 
 **Text & Content** — text, labels and rich content blocks
-badge · icon-tile · inline-label · keyboard-shortcut · label · markdown-block
-· section-title · text-block
+badge · code-diff · icon-tile · inline-label · keyboard-shortcut · label ·
+list-item-text · markdown-block · section-title · text-block
 
 **Buttons & Commands** — things the user clicks to do something
 action-button · button · command-bar · command-palette · context-menu ·
@@ -183,7 +183,8 @@ cron-editor · date-picker · date-range-picker · date-time-picker ·
 month-picker · time-histogram-picker · time-picker · week-picker
 
 **Forms & Validation** — binding a form to data, validating and saving it
-property-grid · save-button · saving-toast · unsaved-changes-guard · validator
+property-grid · questionnaire · save-button · saving-toast ·
+unsaved-changes-guard · validator
 
 **Navigation** — moving between pages, sections and tabs
 breadcrumb · card-pivot · inline-pagination · navbar · pagination · pivot ·
@@ -192,15 +193,15 @@ stepper · text-breadcrumbs
 
 **Lists & Data** — rendering a collection of items
 details-grid · details-list · infinite-scrolling-list · items-list ·
-observable-stack · sortable-stack · task-board · timeline · tree ·
-virtualized-list
+keyed-observable-stack · observable-stack · sortable-stack · task-board ·
+timeline · tree · virtualized-list
 
 **Search** — search inputs and their result surfaces
 omni-box · omni-result · search-box · searchable-grouped-list ·
 searchable-list
 
 **Charts & Visualization** — numbers and relationships, drawn
-charts · contribution-bar · metric · node-view · sparkline · uptime
+charts · contribution-bar · diagram · metric · node-view · sparkline · uptime
 
 **Feedback & Status** — progress, notifications and empty states
 banner · live-progress · message · notification-center · progress-indicator ·
@@ -218,7 +219,7 @@ tool-agent-selector · tool-call
 avatar · carousel · image · pages-stack · pixel-avatar · sandbox
 
 **Theming & Icons** — colours, gradients, icons and emoji
-color-palette · emoji · gradients · icon · uicons
+color-palette · emoji · gradients · icon · theme-builder · uicons
 
 **Utilities & Behaviors** — helpers that render little or nothing on their own
 defer · defer-with-progress · delta-component · gestures · visibility-sensor

--- a/Tesserae/skills/references/accessibility.md
+++ b/Tesserae/skills/references/accessibility.md
@@ -64,5 +64,5 @@ var toast = Message("Success!")
 
 ## Related
 
-- Button — `.button.md`
+- Button — `button.md`
 - Full docs & API: `/tesserae/get-started/accessibility`

--- a/Tesserae/skills/references/banner.md
+++ b/Tesserae/skills/references/banner.md
@@ -74,11 +74,11 @@ Toast().TopFull().Banner().Show(
 
 ## Shown as a toast
 
-`Toast().Show(banner)` hooks the banner's dismiss button to the toast's own hiding,
-chained *after* whatever `OnDismiss` handler you already set — so the `[x]` closes
-the toast and your handler still runs. Whether there is a button at all follows the
-toast's settings: an edge-to-edge banner follows its `showHideButton`, an ordinary
-toast shows one unless `NoDismiss()` said it cannot be dismissed at all.
+`Toast().Show(banner)` chains the banner's `[x]` to the toast's own hiding, *after*
+whatever `OnDismiss` handler you set — so it closes the toast and your handler still
+runs. Whether there is a button at all follows the toast: an edge-to-edge banner
+follows its `showHideButton`, an ordinary one shows a button unless `NoDismiss()`
+said it cannot be dismissed at all (`toast.md`).
 
 ## Related
 

--- a/Tesserae/skills/references/charts.md
+++ b/Tesserae/skills/references/charts.md
@@ -139,4 +139,5 @@ var live = AreaChart()
 ## Related
 
 - Sparkline — `/tesserae/components/sparkline`
+- Diagram — relationships rather than numbers — `diagram.md`
 - Full docs & API: `/tesserae/components/charts`

--- a/Tesserae/skills/references/chat.md
+++ b/Tesserae/skills/references/chat.md
@@ -99,6 +99,7 @@ queuedStack.Add(queued);                              // a VStack below the Chat
 - Pixel-art cats as chat avatars — `pixel-avatar.md`
 
 - Avatar — `avatar.md`
+- Questionnaire — an inline question a turn can ask — `questionnaire.md`
 - ContextCard (the attachment row above the composer) — `context-card.md`
 - ContextCards — a group of those behind one summary pill, or a compact row of pills for the sources a
   reply cites (usable with `WithReferences`) — `context-cards.md`

--- a/Tesserae/skills/references/choice-group.md
+++ b/Tesserae/skills/references/choice-group.md
@@ -50,4 +50,5 @@ group.AsObservable().Observe(choice => Toast().Information(choice?.Text));
 ## Related
 
 - CheckBox (multi-select) — `check-box.md`
+- Questionnaire — the one-shot, inline form for a chat — `questionnaire.md`
 - Full docs & API: `/tesserae/components/choice-group`

--- a/Tesserae/skills/references/code-diff.md
+++ b/Tesserae/skills/references/code-diff.md
@@ -1,0 +1,76 @@
+---
+name: code-diff
+description: Renders a unified diff (the output of git diff) as a coloured line-by-line or side-by-side view, with optional file list and syntax highlighting. Use when showing what changed between two versions of a file in a Tesserae (C#/Transpose) app.
+---
+
+# CodeDiff
+
+`CodeDiff` renders unified-diff text — what `git diff` prints — as the familiar
+red/green view, either line-by-line or side-by-side. It wraps
+[diff2html](https://github.com/rtfpessoa/diff2html); the slim UI bundle and its CSS ship
+with Tesserae, so there is nothing to preload.
+
+Setting any of its properties re-draws (debounced), which is what makes it usable as a
+live preview of a diff being edited or streamed in.
+
+## Create
+
+`UI.CodeDiff(string diff = "", CodeDiff.Format format = Format.LineByLine)`.
+Bring factories into scope with `using static Tesserae.UI;`.
+
+`Format` and `Matching` are nested types, so under `using static Tesserae.UI;` they need
+qualifying — `Tesserae.CodeDiff.Format.SideBySide` — because the `CodeDiff(...)` factory
+method hides the type of the same name (see the note in `SKILL.md`).
+
+## Key configuration
+
+All of these are properties, and each one re-draws:
+
+- `.DiffText` — the unified diff to render.
+- `.OutputFormat` — `Format.LineByLine` (default) or `Format.SideBySide`.
+- `.LineMatching` — how the two sides are paired up: `Matching.None`, `Matching.Lines`
+  (the default) or `Matching.Words`.
+- `.DrawFileList` — a summary list of the files in the diff, above it. Off by default.
+- `.HighlightCode` — asks diff2html to syntax-highlight after drawing. It calls
+  `hljs` (highlight.js), which Tesserae does **not** bundle: load it yourself, or this is
+  a no-op.
+
+Long lines scroll horizontally by default. Add the `tss-codediff-wrap` class
+(`.Class("tss-codediff-wrap")`) to wrap them inside the pane instead.
+
+## Example
+
+```csharp
+using static Tesserae.UI;
+
+const string patch = @"diff --git a/sample.js b/sample.js
+--- a/sample.js
++++ b/sample.js
+@@ -1,3 +1,4 @@
+-function greet(name) {
+-    console.log('Hello, ' + name);
++function greet(name, greeting) {
++    greeting = greeting || 'Hello';
++    console.log(greeting + ', ' + name + '!');
+ }
+";
+
+var diff = CodeDiff(patch).WS();
+
+// Editing the text re-draws the view.
+var editor = TextArea(patch).WS().H(220).OnInput((ta, _) => diff.DiffText = ta.Text);
+
+var sideBySide = Toggle("Side by side").OnChange((s, _) =>
+    diff.OutputFormat = s.IsChecked
+        ? Tesserae.CodeDiff.Format.SideBySide
+        : Tesserae.CodeDiff.Format.LineByLine);
+
+var ui = VStack().WS().Children(editor, sideBySide, diff);
+```
+
+## Related
+
+- MarkdownBlock — rendered prose rather than a diff — `markdown-block.md`
+- TextArea — the editor a diff is usually produced from — `text-area.md`
+- Sandbox — for HTML you did not produce — `sandbox.md`
+- Full docs & API: `/tesserae/components/code-diff`

--- a/Tesserae/skills/references/colors.md
+++ b/Tesserae/skills/references/colors.md
@@ -57,6 +57,7 @@ Theme.SetHighlight(Color.FromString("#B45309"), Color.FromString("#FBBF24"));
 ## Related
 
 - Theme switching detail — `theme-colors.md`
+- ThemeBuilder — set every colour variable at once — `theme-builder.md`
 - Gradients — `gradients.md`
 - ColorPalette picker — `color-palette.md`
 - Full docs & API: `/tesserae/utilities/colors`, `/tesserae/get-started/colors`

--- a/Tesserae/skills/references/context-card.md
+++ b/Tesserae/skills/references/context-card.md
@@ -118,7 +118,7 @@ doc.OnContextMenu(() => new[]
 var shot = ContextCard("screenshot.png", UIcons.FileImage).SetSubLabel("Image").SetImage(url);
 var page = ContextCard("tesserae.dev/components", UIcons.Globe).SetSubLabel("Web page").Compact();
 
-var composer = VStack().WS().Children(attached, OmniBox());
+var composer = VStack().WS().Children(attached, OmniBox(new OmniBox.Config(OmniBox.Mode.Chat)));
 ```
 
 An `OmniBox` in chat mode hosts the row itself, inside the box below the input — that is the usual

--- a/Tesserae/skills/references/context-cards.md
+++ b/Tesserae/skills/references/context-cards.md
@@ -55,7 +55,7 @@ var sources = ContextCards(
     ContextCard("Incident 482 postmortem", UIcons.FileInvoice).SetSubLabel("docs/postmortem-482.md").MonospaceSubLabel().SetBadge("Wiki").IconTint("#3b82f6"),
     ContextCard("events.request_log", UIcons.Database).SetSubLabel("warehouse · 2.1M rows").MonospaceSubLabel().SetBadge("Snowflake").IconTint("#10b981"))
    .SetSummary("3 sources for this answer")
-   .OnToggle(g => Console.WriteLine(g.IsExpanded));
+   .OnToggle(g => console.log(g.IsExpanded));
 
 // Compact: a dense row that ends in "+N more".
 var attached = ContextCards().Compact().MaxVisible(3);

--- a/Tesserae/skills/references/core-concepts.md
+++ b/Tesserae/skills/references/core-concepts.md
@@ -79,7 +79,7 @@ List, Observable Stack) over rebuilding subtrees.
 
 ## Related
 
-- Styling — `.styling.md`
-- Layout & Alignment — `.layout-alignment.md`
-- Routing — `.routing.md`
+- Styling — `styling.md`
+- Layout & Alignment — `layout-alignment.md`
+- Routing — `routing.md`
 - Full docs & API: `/tesserae/core-concepts`

--- a/Tesserae/skills/references/creating-a-component.md
+++ b/Tesserae/skills/references/creating-a-component.md
@@ -93,20 +93,31 @@ own clicks (a raw `element.onclick`) should make the same check first with
 `UI.IsModifiedLinkClick(element, mouseEvent)`, and return without calling
 `StopEvent` when it is true — the open is the anchor's own default action.
 
-## Wiring it into the toolkit (the repo convention)
+## Wiring it up
 
-1. Add the class under `Tesserae/src/Components/`.
-2. Add a factory in `Tesserae/src/Base/UI.Components.cs`:
-   `public static MyBadge MyBadge(string text) => new MyBadge(text);`
-3. Add fluent helpers/extensions in `Tesserae/src/Extensions/` if needed.
-4. Add a sample in `Tesserae.Tests/`.
+In your own app a component is just a class — `new MyBadge("…")` is enough. If you want it
+to read like the built-ins, add a static factory of your own beside it:
+
+```csharp
+public static class MyUI
+{
+    public static MyBadge MyBadge(string text) => new MyBadge(text);
+}
+```
+
+and bring it into scope with `using static MyApp.MyUI;` next to `using static Tesserae.UI;`.
+(Contributing the component to the toolkit itself instead? The class goes under
+`Tesserae/src/Components/`, the factory in `Tesserae/src/Base/UI.Components.cs`, fluent
+helpers in `Tesserae/src/Extensions/`, and a sample in `Tesserae.Tests/`.)
 
 ## Sizing, containers, mounting
 
-- Sizing helpers (`.W()`, `.WS()`, `.Grow()`, …) work on any `IComponent` via
-  the wrap-and-transfer protocol — see `Stack.CopyStylesDefinedWithExtension`.
-  A component can opt out of wrapping by implementing `ISpecialCaseStyling` and
-  exposing a `StylingContainer`.
+- Sizing helpers (`.W()`, `.WS()`, `.Grow()`, …) work on any `IComponent`: they write the
+  CSS onto the element `Render()` returns, which is the flex/grid item a `Stack` or `Grid`
+  measures. (`Masonry` and `SectionStack` build a wrapper for their items and move the
+  properties onto it.) A component that sizes a container of its own implements
+  `ISpecialCaseStyling` and exposes a `StylingContainer`, and the helpers write there
+  instead.
 - **Don't spend `padding` on the element `Render()` returns.** `.P()` / `.PL()` and
   friends write an inline padding onto exactly that element, and an inline value beats
   any stylesheet, so a caller asking for room around your component silently deletes
@@ -125,5 +136,5 @@ own clicks (a raw `element.onclick`) should make the same check first with
 
 - `javascript-interop` — call JS from C# when you need browser APIs in `Render()`.
 - `wrap-a-javascript-library` — back a component with an existing JS library.
-- Layout/sizing internals — see the toolkit `CLAUDE.md` "Layout system" section.
+- Layout/sizing — `icomponent.md`, `stack.md`, `grid.md`.
 - Docs: `/tesserae/extending/creating-a-component`

--- a/Tesserae/skills/references/custom-styles.md
+++ b/Tesserae/skills/references/custom-styles.md
@@ -53,5 +53,5 @@ Matching stylesheet:
 
 ## Related
 
-- Styling — `.styling.md`
+- Styling — `styling.md`
 - Full docs & API: `/tesserae/get-started/custom-styles`

--- a/Tesserae/skills/references/date-range-picker.md
+++ b/Tesserae/skills/references/date-range-picker.md
@@ -29,7 +29,7 @@ var range = DateRangePicker(DateTime.Today, DateTime.Today.AddDays(7));
 range.OnChange(r =>
 {
     if (r.From is DateTime f && r.To is DateTime t)
-        Console.WriteLine($"{f:d} to {t:d}");
+        console.log($"{f:d} to {t:d}");
 });
 ```
 

--- a/Tesserae/skills/references/diagram.md
+++ b/Tesserae/skills/references/diagram.md
@@ -1,0 +1,92 @@
+---
+name: diagram
+description: A flow-chart surface of draggable pill-shaped nodes with arrows computed automatically between connected ones, drawn on a pannable dotted-grid canvas. Use to show a pipeline, a graph of bindings or any node-and-arrow flow in a Tesserae (C#/Transpose) app.
+---
+
+# Diagram
+
+`Diagram` draws a flow chart: pill-shaped nodes with an optional icon and label, and
+arrows between the ones you connect. You declare the *flow* — the layout is computed
+from node sizes and connectivity, arranging the nodes in layers that follow the arrows.
+
+The background is a pannable dotted grid; the arrows live on a canvas behind the nodes
+and are redrawn as the user pans, drags a node, or the container resizes (via a
+`ResizeObserver`).
+
+For an editable node graph with typed inputs and outputs, use `NodeView` instead
+(`node-view.md`); for a static two-axis layout, use `Grid`.
+
+## Create
+
+`UI.Diagram()` — the surface. `UI.DiagramNode(string text = "")` — one node.
+Bring factories into scope with `using static Tesserae.UI;`.
+
+Give it a height (`.H(300.px())`); it fills the width it is given.
+
+## Key configuration
+
+Diagram:
+
+- `.Connect(Node from, Node to)` — draw an arrow between the two, adding either to the
+  diagram if it isn't there yet. This is the usual way to build one: the nodes come along
+  with the connections.
+- `.Nodes(params Node[])` / `.Add(Node)` / `.Remove(Node)` / `.Clear()` — manage nodes
+  directly, for a node that stands on its own.
+- `.AutoArrange()` — recompute the layout for **every** node, including ones the user
+  dragged or you pinned with `.At(...)`, and re-centre the view.
+- `.DotSpacing(int pixels)` (24 by default, floors at 4) / `.NoDots()` — the background grid.
+- `.NotDraggable()` — stop the background from panning. Nodes stay draggable.
+
+Node:
+
+- `.SetText(string)` / `.Text` — the label. A node with no text renders as a circle, which
+  is what a junction point wants.
+- `.SetIcon(UIcons icon, string color = "", TextSize size = Small, UIconsWeight weight = Regular)`
+  / `.SetIcon(Emoji, TextSize)` / `.SetImage(string url)` / `.ClearIcon()` — the mark before
+  the label.
+- `.Default()` / `.Primary()` / `.Secondary()` / `.Success()` / `.Danger()` — the same tones
+  a `Button` has.
+- `.Color(string background, string foreground = "", string borderColor = "")` — anything the
+  tones don't cover; `background` takes a gradient as happily as a colour.
+- `.At(double x, double y)` — pin the node at that position, so the automatic layout leaves
+  it alone. Dragging a node pins it the same way.
+- `.OnClick(...)` / `.OnContextMenu(...)` — both take `Action` or a `(node, mouseEvent)`
+  handler. A click is not raised after a drag, so moving a node never also activates it.
+- `.Background` / `.Foreground` — CSS colours of the node itself.
+
+## Example
+
+```csharp
+using static Tesserae.UI;
+
+var source = DiagramNode("Source").SetIcon(UIcons.CloudDownloadAlt);
+var parse  = DiagramNode("Parse").SetIcon(UIcons.FileCode).Secondary();
+var enrich = DiagramNode("Enrich").SetIcon(UIcons.Sparkles).Primary();
+var index  = DiagramNode("Search index").SetIcon(UIcons.Search).Success();
+var graph  = DiagramNode("Graph").SetIcon(UIcons.ChartNetwork).Danger();
+
+// An icon-only node draws as a circle - a junction rather than a step.
+var fanIn  = DiagramNode().SetIcon(UIcons.Bolt, color: "white")
+                          .Color("linear-gradient(135deg, #6a11cb, #2575fc)", "white", "transparent");
+
+var pipeline = Diagram()
+    .Connect(source, parse)
+    .Connect(parse,  enrich)
+    .Connect(enrich, index)
+    .Connect(enrich, graph)
+    .Connect(fanIn,  parse)
+    .WS().H(420.px());
+
+// Pinned, and answering clicks.
+var entry = DiagramNode("Entry point").SetIcon(UIcons.CursorFinger).Primary()
+    .At(260, 40)
+    .OnClick(() => Toast().Information("Entry point"));
+```
+
+## Related
+
+- NodeView — an editable node graph with typed interfaces — `node-view.md`
+- Tree — hierarchy rather than flow — `tree.md`
+- Plan — a task list with progress, when the steps are sequential — `plan.md`
+- Grid — for a layout rather than a graph — `grid.md`
+- Full docs & API: `/tesserae/components/diagram`

--- a/Tesserae/skills/references/expander.md
+++ b/Tesserae/skills/references/expander.md
@@ -35,7 +35,7 @@ var expander = Expander(
         TextBlock("Hidden until expanded."),
         CheckBox("Enable telemetry")
     ).Padding(8.px())
-).OnExpand(e => Console.WriteLine("opened"));
+).OnExpand(e => console.log("opened"));
 ```
 
 ## Related

--- a/Tesserae/skills/references/gestures.md
+++ b/Tesserae/skills/references/gestures.md
@@ -26,8 +26,8 @@ Each takes either `Action<GestureState>` or a parameterless `Action`:
 
 ```csharp
 someComponent
-    .OnTapped(s => Console.WriteLine($"tap at {s.X},{s.Y}"))
-    .OnDoubleTapped(() => Console.WriteLine("double-tap"))
+    .OnTapped(s => console.log($"tap at {s.X},{s.Y}"))
+    .OnDoubleTapped(() => console.log("double-tap"))
     .OnLongPress(s => ShowMenu(s.X, s.Y));
 
 draggable.OnPan(s =>

--- a/Tesserae/skills/references/grid-picker.md
+++ b/Tesserae/skills/references/grid-picker.md
@@ -38,7 +38,7 @@ Action<Button, int, int> format = (btn, state, prev) =>
     btn.SetText(state == 0 ? "Off" : "On");
 
 var picker = GridPicker(columns, rows, states: 2, initialStates: initial, formatState: format)
-    .OnChange((s, _) => Console.WriteLine("changed"));
+    .OnChange((s, _) => console.log("changed"));
 ```
 
 ## Related

--- a/Tesserae/skills/references/horizontal-split-view.md
+++ b/Tesserae/skills/references/horizontal-split-view.md
@@ -11,9 +11,10 @@ left/right split, use `SplitView`.)
 
 ## Create
 
-`HorizontalSplitView(UnitSize splitterSize = null)` — returns a
-`HorizontalSplitView` (splitter defaults to 8px). Bring factories into scope
-with `using static Tesserae.UI;`.
+`HorizontalSplitView()` — returns a `HorizontalSplitView` (splitter defaults to
+8px). For another splitter size construct it directly:
+`new HorizontalSplitView(4.px())`. Bring factories into scope with
+`using static Tesserae.UI;`.
 
 ## Key configuration
 

--- a/Tesserae/skills/references/icomponent.md
+++ b/Tesserae/skills/references/icomponent.md
@@ -30,8 +30,8 @@ using static Tesserae.UI;
 Call them before adding the component to a container. In a `Stack` or `Grid` they
 write straight onto the component's own element, which is the item the container
 measures; `Masonry` and `SectionStack` build a real wrapper for their item and the
-markers are transferred onto it. See `tesserae-overview` and the repo `CLAUDE.md`
-"Layout system".
+markers are transferred onto it. See `stack.md`, `grid.md` and
+`layout-alignment.md`.
 
 ## Sizing — `IComponentExtensions.cs`
 
@@ -48,8 +48,9 @@ markers are transferred onto it. See `tesserae-overview` and the repo `CLAUDE.md
 | `.Grow(int = 1)` | `flex-grow` (inside a `Stack`) |
 | `.Shrink()` / `.NoShrink()` | `flex-shrink` `1` / `0` |
 
-`UnitSize` comes from helpers like `100.px()`, `50.percent()`, `1.em()`,
-`2.fr()` (see `styling`).
+`UnitSize` comes from helpers like `100.px()`, `50.percent()`, `2.fr()`,
+`100.vw()`, `100.vh()` — plus `UnitSize.Auto()` / `UnitSize.FitContent()` and raw
+`new UnitSize("1em")` (see `styling`).
 
 ## Spacing — `IComponentExtensions.cs`
 
@@ -161,4 +162,4 @@ var row = HStack().Children(
 - `creating-a-component` — implementing `IComponent` yourself.
 - `styling`, `layout-alignment`, `accessibility`, `gestures`, `observables`,
   `tippy`, `validator` — deeper dives on each extension group.
-- `tesserae-overview` — the wrap-and-transfer protocol and layout cheat-sheet.
+- `SKILL.md` — the sizing/spacing cheat-sheet and how a child becomes a stack item.

--- a/Tesserae/skills/references/iconography.md
+++ b/Tesserae/skills/references/iconography.md
@@ -45,6 +45,6 @@ var faRocket = Icon(UIconHelper.AsUIcon("fa-solid fa-rocket"));
 
 ## Related
 
-- Button — `.button.md`
-- Project Setup — `.project-setup.md`
+- Button — `button.md`
+- Project Setup — `project-setup.md`
 - Full docs & API: `/tesserae/get-started/iconography`

--- a/Tesserae/skills/references/inline-label.md
+++ b/Tesserae/skills/references/inline-label.md
@@ -79,9 +79,6 @@ row.SetFooterEntries(
   either way, so a link is middle-clickable and shows its address in the status bar. A label with both
   an href and an `OnClick` runs the handler on a plain click, but leaves ctrl/cmd-click, shift-click and
   middle-click to the browser, which opens the address in a new tab or a new window.
-- `.IsEmpty` — whether there is neither text nor mark in it. A label that is empty and not still loading
-  also carries the `tss-inlinelabel-empty` class, which is how a container leaves out what stands for it —
-  an `OmniResult` footer hides the entry, and its separating dot with it — without looking inside.
 
 Whatever the mark is it takes one box — 14px on the compact button, 12px in a footer — and the text
 ellipsizes rather than wrapping, so a long path gives way to whatever it shares the line with. What a

--- a/Tesserae/skills/references/items-list.md
+++ b/Tesserae/skills/references/items-list.md
@@ -42,4 +42,5 @@ var list = ItemsList(items, 100.percent())   // single column → stack
 
 - VirtualizedList — `virtualized-list.md` (large datasets)
 - SearchableList — `searchable-list.md`
+- ListItemText — the title + subtitle block a row is usually made of — `list-item-text.md`
 - Full docs & API: `/tesserae/collections/items-list`

--- a/Tesserae/skills/references/javascript-interop.md
+++ b/Tesserae/skills/references/javascript-interop.md
@@ -85,9 +85,11 @@ used, through the Transpose runtime's loader:
 ```csharp
 using Transpose;
 
-await Require.RequireAsync("assets/js/chart.min.js");                  // classic script
-await Require.RequireAsync("assets/css/chart.css", "assets/js/chart.js"); // in order: css, then js
-await Require.RequireAsync(RequireKind.Module, "./viewer.js");         // a module that keeps a .js name
+// Qualify it: `Tesserae.Require` (the forwarding shim below) is also in scope in a
+// Tesserae app, so the bare name `Require` is ambiguous.
+await Transpose.Require.RequireAsync("assets/js/chart.min.js");                  // classic script
+await Transpose.Require.RequireAsync("assets/css/chart.css", "assets/js/chart.js"); // in order: css, then js
+await Transpose.Require.RequireAsync(RequireKind.Module, "./viewer.js");         // a module that keeps a .js name
 ```
 
 It picks the element from the URL (`.css` → a stylesheet link, `.mjs` → a module, anything else →
@@ -108,7 +110,8 @@ to exactly this.
 - A Debug build and a Release build link different variants of a bundle (`x.js` vs `x.min.js`);
   any external script you call must be bundled so the global exists at runtime — see
   `wrap-a-javascript-library` — and fetched through `Require.RequireAsync`, which resolves the
-  variant difference for you.
+  variant difference for you (spelled `Transpose.Require.RequireAsync`, to keep it apart from
+  `Tesserae.Require`).
 
 ## Related
 

--- a/Tesserae/skills/references/keyed-observable-stack.md
+++ b/Tesserae/skills/references/keyed-observable-stack.md
@@ -1,0 +1,99 @@
+---
+name: keyed-observable-stack
+description: A Stack driven by an observable list of keyed components that reconciles against the live DOM - matching rows by their Identifier, re-rendering one only when its ContentHash changes, and moving the rest. Use for a server-driven or streaming list that reorders in a Tesserae (C#/Transpose) app.
+---
+
+# KeyedObservableStack
+
+`KeyedObservableStack` renders an `ObservableList<IComponentWithID>` and, on every change,
+reconciles the DOM instead of rebuilding it: rows are matched by their string
+`Identifier`, a matched row is re-rendered only when its `ContentHash` changed, surviving
+rows are moved into the new order, dropped rows are removed and new ones inserted. Changes
+are debounced by default.
+
+Arbitrary reorders are the point: shuffling the middle of the list moves the existing
+elements rather than rebuilding the span, so scroll position, focus and any DOM state in
+the untouched rows survive.
+
+**Which of the two observable stacks?**
+
+| | `KeyedObservableStack` | `ObservableStack<T>` (`observable-stack.md`) |
+|---|---|---|
+| Item | an `IComponentWithID` — its own component | any `T`, rendered by a factory you pass |
+| Matched by | the `Identifier` string | reference identity |
+| Re-render | when `ContentHash` changes | never — a row refreshes itself |
+| Reorder | any permutation | diffs a common prefix/suffix, so an interior reorder rebuilds that span |
+
+Reach for this one when the items *are* rendered components carrying a stable key and a
+cheap content hash; for data objects with self-managing rows, `ObservableStack<T>` is the
+lighter fit.
+
+## Create
+
+`new KeyedObservableStack(ObservableList<IComponentWithID> items, Stack.Orientation orientation = Vertical, bool debounce = true)`
+— construct directly (there is no `UI.` factory). Pass `debounce: false` when every change
+must land in the same frame.
+
+Each item implements `IComponentWithID`, which is `IComponent` plus two strings:
+
+```csharp
+public interface IComponentWithID : IComponent
+{
+    string Identifier  { get; }   // stable per item, and unique in the list
+    string ContentHash { get; }   // changes exactly when the rendered content would
+}
+```
+
+`Identifier` is what survives a reorder; `ContentHash` is what decides a re-render. A hash
+that never changes leaves a stale row on screen; one that changes every time throws away
+the win.
+
+## Key configuration
+
+- `.Horizontal()` / `.Vertical()` / `.HorizontalReverse()` / `.VerticalReverse()` — orientation
+  (also `.StackOrientation`).
+- `.AlignItems(ItemAlign)` / `.AlignItemsCenter()` / `.AlignContent(...)` /
+  `.JustifyContent(ItemJustify)` / `.JustifyItems(...)` — alignment.
+- `.Wrap()` / `.NoWrap()`, `.Inline()`, `.OverflowHidden()`, `.NoDefaultMargin()`,
+  `.Relative()` — the same layout tweaks a `Stack` takes.
+- `.Clear()` — empty the rendered stack.
+- `.OnMouseOver(...)` / `.OnMouseOut(...)`, `.Background` / `.Margin` / `.Padding`.
+- Mutating the `ObservableList` is what drives it: `.Add`, `.RemoveAt`, `.ReplaceAll`, …
+
+## Example
+
+```csharp
+using static Tesserae.UI;
+
+public class Row : IComponentWithID
+{
+    public Row(string id, string name) { Id = id; Name = name; }
+
+    public string Id   { get; }
+    public string Name { get; set; }
+
+    public string Identifier  => Id;                                  // survives reordering
+    public string ContentHash => Id + "|" + Name;                     // re-render trigger
+
+    public HTMLElement Render() =>
+        Card(HStack().WS().AlignItemsCenter().Children(
+            TextBlock(Name).SemiBold().Grow(),
+            TextBlock(Id).Small())).Render();
+}
+
+var items = new ObservableList<IComponentWithID>();
+items.ReplaceAll(new IComponentWithID[] { new Row("1", "Alpha"), new Row("2", "Beta") });
+
+var stack = new KeyedObservableStack(items);
+
+// Reordering moves the existing elements; only a row whose hash changed is re-rendered.
+items.ReplaceAll(items.Value.Reverse().ToArray());
+```
+
+## Related
+
+- ObservableStack — the reference-identity sibling — `observable-stack.md`
+- Observables — `ObservableList<T>` and friends — `observables.md`
+- Stack — the container this renders as — `stack.md`
+- Chat — the streaming transcript this shape suits — `chat.md`
+- Full docs & API: `/tesserae/collections/keyed-observable-stack`

--- a/Tesserae/skills/references/layout-alignment.md
+++ b/Tesserae/skills/references/layout-alignment.md
@@ -60,6 +60,6 @@ grid.Add(Card(TextBlock("B").TextCenter()).WS().GridColumn(1, 3)); // span both 
 
 ## Related
 
-- Styling (UnitSize, shorthands) — `.styling.md`
-- Core Concepts — `.core-concepts.md`
+- Styling (UnitSize, shorthands) — `styling.md`
+- Core Concepts — `core-concepts.md`
 - Full docs & API: `/tesserae/get-started/layout-alignment`

--- a/Tesserae/skills/references/list-item-text.md
+++ b/Tesserae/skills/references/list-item-text.md
@@ -1,0 +1,61 @@
+---
+name: list-item-text
+description: A two-line list row - a bold title with a lighter subtitle under it, and an optional icon in a rounded, tinted square. Use for settings entries, notification rows and any list row that needs one line of context under its heading in a Tesserae (C#/Transpose) app.
+---
+
+# ListItemText
+
+`ListItemText` is the small two-line block a list row is usually made of: a title in
+semibold with a quieter second line under it, and optionally a leading icon inside a
+rounded square.
+
+It renders text and nothing else — no border, no hover, no click. Put it inside whatever
+is doing the listing (`Card`, `ItemsList`, `DetailsList`, a `Stack`) and let that own the
+row's behaviour.
+
+## Create
+
+`UI.ListItemText(string title, string subtitle = null)` — a null or empty subtitle leaves
+the second line out and the row draws as one line. Bring factories into scope with
+`using static Tesserae.UI;`.
+
+## Key configuration
+
+- `.SetTitle(string)` / `.Title` — the bold first line.
+- `.SetSubtitle(string)` / `.Subtitle` — the quieter second line. Setting it to null or
+  empty hides it.
+- `.SetIcon(UIcons icon, UIconsWeight weight = Regular, TextSize size = Medium)` — a
+  leading glyph in a rounded square. Calling it again swaps the glyph.
+- `.IconForeground(string color)` / `.IconBackground(string color)` — the glyph and the
+  square behind it. Both are no-ops until an icon is set, and both take any CSS colour, so
+  the theme's own variables are the tidy way to say "this row is a warning".
+
+## Example
+
+```csharp
+using static Tesserae.UI;
+
+var rows = VStack().WS().Children(
+    ListItemText("Project roadmap", "Last edited 3 hours ago by Alex"),
+
+    ListItemText("General settings", "Theme, language and notifications")
+        .SetIcon(UIcons.Settings),
+
+    ListItemText("Backup completed", "All files synced successfully")
+        .SetIcon(UIcons.Check)
+        .IconForeground("var(--tss-success-foreground-color)")
+        .IconBackground("var(--tss-success-background-color)"),
+
+    ListItemText("Storage almost full", "Free up space to keep syncing")
+        .SetIcon(UIcons.TriangleWarning)
+        .IconForeground("var(--tss-danger-foreground-color)")
+        .IconBackground("var(--tss-danger-background-color)"));
+```
+
+## Related
+
+- OmniResult — the full search-result row, with an icon tile, excerpt and commands — `omni-result.md`
+- ContextCard — the compact card for one attached piece of context — `context-card.md`
+- ItemsList / DetailsList — what usually holds a column of these — `items-list.md`, `details-list.md`
+- TextBlock — one line of text on its own — `text-block.md`
+- Full docs & API: `/tesserae/components/list-item-text`

--- a/Tesserae/skills/references/live-progress.md
+++ b/Tesserae/skills/references/live-progress.md
@@ -102,8 +102,8 @@ still opens full width underneath.
 
 ## Related
 
-- ToolCall / ToolsUsed — `.tool-call.md`
-- Chat — `.chat.md`
-- ProgressIndicator (determinate bar) — `.progress-indicator.md`
-- Observables — `.observables.md`
+- ToolCall / ToolsUsed — `tool-call.md`
+- Chat — `chat.md`
+- ProgressIndicator (determinate bar) — `progress-indicator.md`
+- Observables — `observables.md`
 - Full docs & API: `/tesserae/components/live-progress`

--- a/Tesserae/skills/references/markdown-block.md
+++ b/Tesserae/skills/references/markdown-block.md
@@ -68,6 +68,7 @@ md.Text = "Updated **content**.";
 
 ## Related
 
+- CodeDiff — a unified diff rather than prose — `code-diff.md`
 - TextBlock — `/tesserae/components/text-block`
 - AnnotatedTextEditor — `/tesserae/components/annotated-text-editor`
 - Full docs & API: `/tesserae/components/markdown-block`

--- a/Tesserae/skills/references/menu.md
+++ b/Tesserae/skills/references/menu.md
@@ -49,7 +49,8 @@ var menu = Menu().Items(
         MenuItem("CSV").OnClick(() => ExportCsv())))
 );
 
-var trigger = Button("File").OnClick(b => menu.ShowFor(b));
+Button trigger = null;
+trigger = Button("File").OnClick(() => menu.ShowFor(trigger));
 ```
 
 ## Related

--- a/Tesserae/skills/references/modal-stack.md
+++ b/Tesserae/skills/references/modal-stack.md
@@ -49,16 +49,17 @@ still works: `Hide()` pops it, and its show/hide handlers run as they would have
 ```csharp
 using static Tesserae.UI;
 
-void OpenPreview(Document document, bool steppingThroughResults)
+void OpenPreview(SearchHit doc, bool steppingThroughResults)   // `document`/`Document` are the DOM's
 {
-    var modal = BuildPreviewModal(document);   // any Modal; OmniResult<T>.ToModal() is the usual one
+    var modal = BuildPreviewModal(doc);   // any Modal; OmniResult<T>.ToModal() is the usual one
 
-    if (steppingThroughResults) ModalStack.Replace(document.Id, document.Title, modal);
-    else                        ModalStack.Push(document.Id, document.Title, modal);
+    if (steppingThroughResults) ModalStack.Replace(doc.Id, doc.Title, modal);
+    else                        ModalStack.Push(doc.Id, doc.Title, modal);
 }
 
 // Keep the URL naming the whole chain, so a refresh reopens it.
-ModalStack.Changed += () => Route.Set("open", string.Join(",", ModalStack.Entries.Select(e => e.Key)));
+ModalStack.Changed += () => Router.ReplaceQueryParameters(
+    p => p.With("open", string.Join(",", ModalStack.Entries.Select(e => e.Key))));
 ```
 
 ## Related
@@ -66,4 +67,5 @@ ModalStack.Changed += () => Route.Set("open", string.Join(",", ModalStack.Entrie
 - Modal — the surface a sheet is — `modal.md`
 - OmniResult — `ToModal()` builds the sheet a search result opens into — `omni-result.md`
 - Layer — the overlay infrastructure underneath — `layer.md`
+- Routing — keeping the URL in step with the chain — `routing.md`
 - Full docs & API: `/tesserae/components/modal-stack`

--- a/Tesserae/skills/references/node-view.md
+++ b/Tesserae/skills/references/node-view.md
@@ -40,5 +40,6 @@ nodeView.OnChange(nv => console.log(nv.GetJsonState(true)));
 
 ## Related
 
+- Diagram — a read-mostly flow chart, laid out for you — `diagram.md`
 - SplitView (common layout for an editor + JSON pane) — `/tesserae/layout/split-view`
 - Full docs & API: `/tesserae/utilities/node-view`

--- a/Tesserae/skills/references/node-view.md
+++ b/Tesserae/skills/references/node-view.md
@@ -17,7 +17,7 @@ A visual node-based editor. Define node types with typed input/output interfaces
 - `.DefineDynamicNode(typeName, buildBase, (inputs, outputs, ib) => …)` — outputs/inputs recomputed from current values.
 - `.Register<T>()` — register a node type implementing `INodeView` (`IDynamicNodeView` for dynamic).
 - `.OnChange(Action<NodeView>)` — fires (debounced) on graph edits.
-- `.GetState()` / `.GetJsonState(bool formatted = false)` / `.SetState(json or NodeViewGraphState)` — persistence.
+- `.GetState()` / `.GetJsonState(bool formated = false)` / `.SetState(json or NodeViewGraphState)` — persistence.
 - `NodeView.State()` — a `StateBuilder` to construct graphs programmatically.
 
 Interface builders (`NodeView.Interfaces`): `TextInterface`, `TextInputInterface`, `IntegerInterface`, `NumberInterface`, `CheckboxInterface`, `SelectInterface`, `SliderInterface`, `ButtonInterface`.

--- a/Tesserae/skills/references/number-picker.md
+++ b/Tesserae/skills/references/number-picker.md
@@ -42,3 +42,4 @@ var form = Stack().Children(
 - TextBox — `/tesserae/components/text-box`
 - Slider — `/tesserae/components/slider`
 - Full docs & API: `/tesserae/components/number-picker`
+- Full docs & API: `/tesserae/components/number-picker`

--- a/Tesserae/skills/references/observable-stack.md
+++ b/Tesserae/skills/references/observable-stack.md
@@ -18,11 +18,19 @@ newly-inserted item. Bring factories into scope with `using static Tesserae.UI;`
 
 ## Key configuration
 
-- Mutate the backing `ObservableList<T>` (`.Add`, `.RemoveAt`, `.ReplaceAll`, …) to reconcile.
-- `.Horizontal()` / `.Vertical()` / `.HorizontalReverse()` / `.VerticalReverse()` — orientation.
-- `.AlignItems(ItemAlign)` / `.AlignItemsCenter()` / `.JustifyContent(ItemJustify)` — flex alignment.
-- `.Wrap()` / `.NoWrap()`, `.NoDefaultMargin()`, `.OverflowHidden()` — layout tweaks.
-- `.WS()` / `.Clear()` — stretch width / remove all rows.
+`ObservableStack<T>` itself is a plain `IComponent`: what it renders is the host `Stack`, and
+that is where the layout is configured. Everything else is driven by the list.
+
+- Mutate the backing `ObservableList<T>` (`.Add`, `.RemoveAt`, `.ReplaceAll`, `.Clear`, …) to
+  reconcile the rows.
+- Pass a configured host to the constructor for orientation and alignment —
+  `new ObservableStack<T>(items, render, HStack().Wrap().AlignItemsCenter())` — or keep a
+  reference to it and configure it later. `Stack`'s own methods (`.Horizontal()` /
+  `.Vertical()`, `.AlignItems(ItemAlign)`, `.JustifyContent(ItemJustify)`, `.Wrap()` /
+  `.NoWrap()`, `.NoDefaultMargin()`, `.OverflowHidden()`, `.Clear()`) live there, not on the
+  `ObservableStack`.
+- The generic `IComponent` helpers (`.WS()`, `.Grow()`, `.MaxHeight(...)`, …) do apply to the
+  `ObservableStack` itself, as they do to any component.
 
 ## Example
 

--- a/Tesserae/skills/references/observable-stack.md
+++ b/Tesserae/skills/references/observable-stack.md
@@ -54,5 +54,6 @@ return stack.Render();
 
 - Stack — `stack.md`
 - Observables — `observables.md`
+- KeyedObservableStack — the keyed sibling, for rows that reorder — `keyed-observable-stack.md`
 - SortableStack — `sortable-stack.md`
 - Full docs & API: `/tesserae/collections/observable-stack`

--- a/Tesserae/skills/references/observables.md
+++ b/Tesserae/skills/references/observables.md
@@ -53,5 +53,6 @@ return Stack().Children(output, addButton).Render();
 ## Related
 
 - ObservableStack — `observable-stack.md` (renders an `ObservableList`)
+- KeyedObservableStack — the keyed, reorder-friendly variant — `keyed-observable-stack.md`
 - Defer — `/tesserae/utilities/defer`
 - Full docs & API: `/tesserae/collections/observables`

--- a/Tesserae/skills/references/omni-box.md
+++ b/Tesserae/skills/references/omni-box.md
@@ -112,8 +112,8 @@ var config = new OmniBox.Config(OmniBox.Mode.SearchAndChat)
 };
 
 var omni = new OmniBox(config)
-    .OnSearch((s, q) => Console.WriteLine($"Search: {q.Tokens.Count} tokens"))
-    .OnChat((s, m) => Console.WriteLine("Chat sent"));
+    .OnSearch((s, q) => console.log($"Search: {q.Tokens.Count} tokens"))
+    .OnChat((s, m) => console.log("Chat sent"));
 ```
 
 A pill-shaped search box with a result count and an "Ask AI" action:

--- a/Tesserae/skills/references/omni-result.md
+++ b/Tesserae/skills/references/omni-result.md
@@ -15,9 +15,9 @@ without a closure per row:
             ▪ Box · sample-files / pdfs · 2.4 MB · Pius Neuhaus · Apr 12, 2024
 ```
 
-Everything past the title is optional. Drop the excerpt, the preview, the footer, or all three, and
+Everything past the title is optional: drop the excerpt, the preview, the footer, or all three, and
 the row tightens up — the same component covers a two-line picker row and a full result card. The tile
-can also lead the header instead of standing in a column of its own, which pulls the excerpt and the
+can also lead the header rather than standing in a column of its own, which pulls the excerpt and the
 footer back to the row's left edge:
 
 ```
@@ -151,7 +151,7 @@ The source leads the line and the metadata follows it, and all of it is `InlineL
   Modes: `OnHoverBeforeIcon`, `OnHoverOverIcon` (on the tile, which fades out under it),
   `AlwaysBeforeIcon`, `ReplacingIcon` (no tile at all), `AlwaysBeforeHeaderIcon` and
   `HiddenBeforeHeaderIcon` (the two that move the tile into the header — see *The tile in the header*
-  below). A selected row always shows its checkbox, whatever the mode — except under
+  above). A selected row always shows its checkbox, whatever the mode — except under
   `HiddenBeforeHeaderIcon`, which draws none — and the column is reserved either way so revealing it
   never shifts the row. In the two modes where the checkbox stands in for the tile, the corner badges
   move onto it.
@@ -222,11 +222,8 @@ and the detail are one object rather than two that have to be kept in step.
 - `.ModalKeepsFooter(bool = true)` — keeps the footer (the source and the metadata beside it) as a
   second line under the title, so where a result came from is still said once it is open. Off by
   default.
-- `.SetModalHeader(Func<OmniResult<T>, IComponent>)` — replaces the default header (the same
-  identifier, chevron and title the row shows, plus whatever the two options above kept) with one
-  built from the result — for a header that also carries commands or status beside the title. Null
-  goes back to the default.
-- `.ModalTitle()` — that default header on its own, to build around.
+- `.SetModalHeader(...)` / `.ModalTitle()` — replace or reuse the default header; see *The modal's
+  chrome* below.
 
 The tile is **copied** into the header, so opening a result never takes it out of the row behind it.
 The footer is the row's **own** line, moved into the header with a copy left in the row's place and

--- a/Tesserae/skills/references/overflow-set.md
+++ b/Tesserae/skills/references/overflow-set.md
@@ -32,11 +32,11 @@ var message = TextBlock();
 
 var bar = OverflowSet()
     .Items(
-        Button("Folder 1").Link().OnClick((s, e) => message.Text("Folder 1")),
-        Button("Folder 2").Link().OnClick((s, e) => message.Text("Folder 2")).Disabled(),
-        Button("Folder 3").Link().OnClick((s, e) => message.Text("Folder 3")),
-        Button("Folder 4").Link().OnClick((s, e) => message.Text("Folder 4")),
-        Button("Folder 5").Link().OnClick((s, e) => message.Text("Folder 5")))
+        Button("Folder 1").Class("tss-btn-link").OnClick((s, e) => message.Text("Folder 1")),
+        Button("Folder 2").Class("tss-btn-link").OnClick((s, e) => message.Text("Folder 2")).Disabled(),
+        Button("Folder 3").Class("tss-btn-link").OnClick((s, e) => message.Text("Folder 3")),
+        Button("Folder 4").Class("tss-btn-link").OnClick((s, e) => message.Text("Folder 4")),
+        Button("Folder 5").Class("tss-btn-link").OnClick((s, e) => message.Text("Folder 5")))
     .Small();
 ```
 

--- a/Tesserae/skills/references/picker.md
+++ b/Tesserae/skills/references/picker.md
@@ -43,5 +43,5 @@ var picker = Picker<TagItem>(maximumAllowedSelections: 3, suggestionsTitleText: 
 
 ## Related
 
-- Dropdown — `.dropdown.md`
+- Dropdown — `dropdown.md`
 - Full docs & API: `/tesserae/components/picker`

--- a/Tesserae/skills/references/pixel-avatar.md
+++ b/Tesserae/skills/references/pixel-avatar.md
@@ -30,23 +30,21 @@ internal static class SpriteKey { internal const byte Value = 42; }
 var cat = PixelAvatar(SpriteKey.Value, PixelAvatarDesign.Orange);
 ```
 
-This is obfuscation, not security. A key the browser has to see is readable by anyone who looks;
+This is obfuscation, not security: a key the browser has to see is readable by anyone who looks, and
 it only keeps the artwork out of casual sight in the shipped JavaScript. Every entry point that
-builds an avatar for you takes the same key: `UI.PixelAvatarBadge`, the `ChatMessage` design
-overload, and `WithPixelAvatar(key, design, anchor)`. The ones handed an avatar you already
-built do not.
+*builds* an avatar takes the same key — `UI.PixelAvatarBadge`, the `ChatMessage` design overload,
+`WithPixelAvatar(key, design, anchor)` — while the ones handed an avatar you already built do not, and
+`PixelAvatarSprites.Get` throws until some avatar has supplied it.
 
-`PixelAvatarSprites.Get` throws until some avatar has supplied the key.
-
-The animation timer only runs while the avatar is mounted, so an avatar inside a hidden
-tab or a removed subtree costs nothing.
+The animation timer only runs while the avatar is mounted, so one inside a hidden tab or a removed
+subtree costs nothing.
 
 ## Key configuration
 
 - `.PixelSize(int)` — CSS pixels per sprite pixel; default `PixelAvatar.DefaultPixelSize` (4), giving a 40x32 avatar. `RenderedWidth` / `RenderedHeight` report the result.
 - `.Facing(PixelAvatarFacing)` — `Right` (the artwork's own direction) or `Left` to mirror it, instantly. `FacingValue` reads it back.
 - `.Turn(PixelAvatarFacing, int durationMs = PixelAvatar.DefaultTurnDurationMs)` / `.TurnAround(...)` — change direction by pivoting the sprite about its vertical axis under a perspective scaled to the avatar's own width, so it reads as the cat physically turning rather than its pixels swapping sides. Turning to the direction it already faces does nothing.
-- `.Speed(double)` — playback multiplier; values above 1 play faster.
+- `.Speed(double)` — playback multiplier; values above 1 play faster. It scales the resting holds below along with the frames.
 - `.Play(PixelAvatarAnimation)` — restart on a new animation. `.Pause()` / `.Resume()` / `.IsPaused`, and `.GoToFrame(int)` to hold a specific frame.
 - `.SetDesign(PixelAvatarDesign)` — swap the coat. See **Custom palettes** below for the ways to supply your own colors.
 - `.Outline(bool = true)` — a hairline halo in the theme's contrasting color, **on by default**. Several palettes contain pure white (`White`, `SpottedGrey`, `SpottedOrange`) and several near-black (`Black`, `Tuxedo`, `Siamese`), so without it those designs disappear against one theme or the other. `.OutlineColor(string)` overrides the color, which defaults to translucent black in light mode and translucent white in dark mode.
@@ -100,7 +98,6 @@ jittered by ±20% on use, so nothing the cat does lands on a stopwatch:
 - `.RestDelay(minMs, maxMs)` — overrides how long each resting pose holds its first frame. Zero for both restores the built-in 5–10s.
 - `.SleepAfter(ms)` — resting time before it sleeps, jittered on use. `PixelAvatar.DefaultSleepAfterMs` is 60000; pass zero to keep it awake indefinitely.
 - `.Wake()` — restarts the sleep countdown, and plays the wake-up performance if the cat was actually out.
-- `.Speed(x)` — scales every frame duration and rest hold together.
 
 ## Clicking the cat
 

--- a/Tesserae/skills/references/plan.md
+++ b/Tesserae/skills/references/plan.md
@@ -41,5 +41,5 @@ var plan = Plan("Database Migration")
 
 ## Related
 
-- ProgressIndicator — `.progress-indicator.md`
+- ProgressIndicator — `progress-indicator.md`
 - Full docs & API: `/tesserae/components/plan`

--- a/Tesserae/skills/references/popover.md
+++ b/Tesserae/skills/references/popover.md
@@ -38,10 +38,11 @@ var popover = Popover()
     .Placement(TooltipPlacement.BottomStart)
     .Arrow();
 
-var anchor = Button("Show popover").OnClick(b => popover.ShowFor(b));
+Button anchor = null;
+anchor = Button("Show popover").OnClick(() => popover.ShowFor(anchor));
 ```
 
 ## Related
 
-- Menu — `.menu.md`
+- Menu — `menu.md`
 - Full docs & API: `/tesserae/components/popover`

--- a/Tesserae/skills/references/progress-indicator.md
+++ b/Tesserae/skills/references/progress-indicator.md
@@ -35,6 +35,6 @@ Stack().Children(
 
 ## Related
 
-- ProgressRing — `.progress-ring.md`
+- ProgressRing — `progress-ring.md`
 - AI variants — the `.AI()` variant — `ai-variants.md`
 - Full docs & API: `/tesserae/components/progress-indicator`

--- a/Tesserae/skills/references/progress-ring.md
+++ b/Tesserae/skills/references/progress-ring.md
@@ -33,5 +33,5 @@ HStack().Gap(24.px()).AlignItems(ItemAlign.End).Children(
 
 ## Related
 
-- ProgressIndicator — `.progress-indicator.md`
+- ProgressIndicator — `progress-indicator.md`
 - Full docs & API: `/tesserae/components/progress-ring`

--- a/Tesserae/skills/references/project-setup.md
+++ b/Tesserae/skills/references/project-setup.md
@@ -77,6 +77,6 @@ Place assets under an `assets/` folder in the output directory (e.g. `tps/assets
 
 ## Related
 
-- Core Concepts — `.core-concepts.md`
-- Routing — `.routing.md`
+- Core Concepts — `core-concepts.md`
+- Routing — `routing.md`
 - Full docs: `/tesserae/get-started/project-setup`

--- a/Tesserae/skills/references/questionnaire.md
+++ b/Tesserae/skills/references/questionnaire.md
@@ -1,0 +1,56 @@
+---
+name: questionnaire
+description: An inline question with a row of answer buttons that locks itself once one is picked, showing the question with the chosen answer highlighted. Use when an assistant or a flow has to ask one thing mid-conversation in a Tesserae (C#/Transpose) app.
+---
+
+# Questionnaire
+
+`Questionnaire` asks one question inline and offers its answers as buttons. The moment an
+answer is picked — by the user, or by you — it switches to its **answered** mode: the
+question stays, the chosen answer is highlighted and the buttons stop taking input, so a
+transcript shows what was asked and what was decided.
+
+That one-shot shape is what makes it a chat component rather than a form control. For a
+question that stays editable use `ChoiceGroup` (`choice-group.md`).
+
+## Create
+
+`UI.Questionnaire(string question, params string[] options)` or
+`UI.Questionnaire(string question, IEnumerable<string> options = null)`.
+Bring factories into scope with `using static Tesserae.UI;`.
+
+## Key configuration
+
+- `.OnAnswered(Action<Questionnaire>)` — the user picked an option; read `.Answer` in the
+  handler. **Not** raised by `SetAnswer`, so restoring a known answer never looks like the
+  user answering again.
+- `.SetAnswer(string)` — put it in answered mode with that option chosen, for an answer
+  that came back from the server or a reloaded transcript.
+- `.ClearAnswer()` — drop the answer and re-enable the buttons.
+- `.AddOption(string)` / `.AddOptions(IEnumerable<string>)` — add options after
+  construction.
+- `.SetQuestion(string)` — change the question.
+- `.Question` / `.Answer` (null until answered) / `.IsAnswered` — read state.
+
+## Example
+
+```csharp
+using static Tesserae.UI;
+
+var confirm = Questionnaire("Do you want to delete this file?", "Yes", "No", "Show me the diff first")
+    .OnAnswered(q => console.log("Answered: " + q.Answer));
+
+// A turn being replayed from history arrives already answered.
+var replayed = Questionnaire("Which framework should we use?", "React", "Vue", "Svelte", "Solid")
+    .SetAnswer("Svelte");
+
+chat.Add(ChatMessage(confirm).LeftAligned().MaxWidth());
+```
+
+## Related
+
+- ChoiceGroup — the form control, when the answer stays changeable — `choice-group.md`
+- Chat — the transcript this usually sits in — `chat.md`
+- Dialog — when the question should block the page instead — `dialog.md`
+- Rating — a score rather than a choice — `rating.md`
+- Full docs & API: `/tesserae/components/questionnaire`

--- a/Tesserae/skills/references/resource-card.md
+++ b/Tesserae/skills/references/resource-card.md
@@ -20,7 +20,7 @@ Each setter takes a `string` (wrapped in a styled `TextBlock`) or an `IComponent
 - `.SetTitle(string | IComponent)` / `.SetSubtitle(string | IComponent)`.
 - `.SetTags(params IComponent[])` — small inline tags, e.g. `Badge("...")`.
 - `.SetDescription(string | IComponent)` / `.SetDate(string | IComponent)`.
-- `.SetFooter(IComponent)` — left-aligned footer content (e.g. a link).
+- `.SetFooter(IComponent)` — left-aligned footer content (e.g. a link: `Button(text, href).Class("tss-btn-link")`).
 - `.SetFooterCommands(params IComponent[])` — right-aligned footer actions (e.g. buttons).
 - `.BackgroundColor(string)` / `.Border(color, size = null)` — card chrome.
 
@@ -36,13 +36,13 @@ var card = ResourceCard()
     .SetTags(Badge("Text-to-Image"))
     .SetDescription("ByteDance's image creation model.")
     .SetDate("Apr 8, 2026")
-    .SetFooter(Link("https://example.com/terms", "Terms"))
+    .SetFooter(Button("Terms", href: "https://example.com/terms").Class("tss-btn-link"))
     .SetFooterCommands(Button("Copy ID").SetIcon(UIcons.Copy).NoBorder().NoBackground());
 ```
 
 ## Related
 
-- Card — `.card.md`
-- ContextCard (the compact chat-attachment variant) — `.context-card.md`
+- Card — `card.md`
+- ContextCard (the compact chat-attachment variant) — `context-card.md`
 - OmniResult (the search-result row, with highlighting and a page preview) — `omni-result.md`
 - Full docs & API: `/tesserae/components/resource-card`

--- a/Tesserae/skills/references/routing.md
+++ b/Tesserae/skills/references/routing.md
@@ -105,6 +105,6 @@ private static void Show(IComponent page) { Content.Clear(); Content.Add(page); 
 
 ## Related
 
-- Core Concepts (observables, Defer) — `.core-concepts.md`
+- Core Concepts (observables, Defer) — `core-concepts.md`
 - UnsavedChangesGuard (blocks navigation while an editor is dirty, via `OnBeforeNavigate`) — `unsaved-changes-guard.md`
 - Full docs & API: `/tesserae/get-started/routing`

--- a/Tesserae/skills/references/save-button.md
+++ b/Tesserae/skills/references/save-button.md
@@ -42,6 +42,6 @@ saveButton = new SaveButton()
 
 ## Related
 
-- Button — `.button.md`
-- SavingToast — `.saving-toast.md`
+- Button — `button.md`
+- SavingToast — `saving-toast.md`
 - Full docs & API: `/tesserae/components/save-button`

--- a/Tesserae/skills/references/saving-toast.md
+++ b/Tesserae/skills/references/saving-toast.md
@@ -40,5 +40,5 @@ await SaveAsync().WithSavingToast(savedMessage: "Saved!");
 
 ## Related
 
-- SaveButton — `.save-button.md`
+- SaveButton — `save-button.md`
 - Full docs & API: `/tesserae/components/saving-toast` and `/tesserae/utilities/saving-toast`

--- a/Tesserae/skills/references/search-box.md
+++ b/Tesserae/skills/references/search-box.md
@@ -39,5 +39,5 @@ var search = SearchBox("Search")
 
 ## Related
 
-- TextBox — `.text-box.md`
+- TextBox — `text-box.md`
 - Full docs & API: `/tesserae/components/search-box`

--- a/Tesserae/skills/references/sidebar.md
+++ b/Tesserae/skills/references/sidebar.md
@@ -82,18 +82,18 @@ the open button carries the chip; the closed rail has room for the glyph and
 nothing else. A collapsed button holds no shortcut either, because there is
 nothing on screen for the key to press.
 
-`.AsSearchBox(keys)` shows the same chip *without* binding the key, because the
-palette or page it opens is what owns that key — and answers it from inside a text
-field too, where a button's shortcut steps aside. Pass no keys and call
-`.SetKeyboardShortcut(...)` when the button itself should answer.
+`.AsSearchBox(keys)` shows the same chip *without* binding the key: the palette or
+page it opens owns that key, and answers it from inside a text field too, where a
+button's shortcut steps aside. Pass no keys and call `.SetKeyboardShortcut(...)`
+when the button itself should answer.
 
 `.ShortcutOnlyOnHover()` — on both `SidebarButton` and `SidebarSearchBox` — keeps
-the chip out of sight until the pointer is on the row, or something inside it has
-focus, so a row reached by tabbing shows its key too. For a rail where most rows
-carry a key: all the chips at once read as a column of noise beside the labels,
-while one chip on the row being pointed at is still how the key gets discovered.
-The binding is untouched, and the room the chip takes stays reserved, so no label
-re-flows as it fades in. Pass `false` for the default, a chip that is always there.
+the chip out of sight until the pointer is on the row or something inside it has
+focus, so a row reached by tabbing shows its key too. It is for a rail where most
+rows carry one: all the chips at once read as a column of noise, while the chip on
+the row being pointed at still gets the key discovered. The binding is untouched
+and the chip's room stays reserved, so no label re-flows as it fades in. Pass
+`false` for the default, a chip that is always there.
 
 ```csharp
 sidebar.AddContent(new SidebarButton("home", UIcons.Home, "Home")

--- a/Tesserae/skills/references/sortable-stack.md
+++ b/Tesserae/skills/references/sortable-stack.md
@@ -35,7 +35,7 @@ sortable.Add("beta",  Card(TextBlock("Beta")).WS().MB(4.px()));
 sortable.Add("gamma", Card(TextBlock("Gamma")).WS().MB(4.px()));
 
 sortable.OnSortingChanged(order =>
-    Console.WriteLine(string.Join(", ", order))); // e.g. "beta, alpha, gamma"
+    console.log(string.Join(", ", order))); // e.g. "beta, alpha, gamma"
 
 return sortable.Render();
 ```

--- a/Tesserae/skills/references/styling.md
+++ b/Tesserae/skills/references/styling.md
@@ -81,6 +81,6 @@ var button = Button("Download").Style(s => s.borderRadius = "12px");
 
 ## Related
 
-- Custom Styles (CSS classes) — `.custom-styles.md`
-- Layout & Alignment — `.layout-alignment.md`
+- Custom Styles (CSS classes) — `custom-styles.md`
+- Layout & Alignment — `layout-alignment.md`
 - Full docs & API: `/tesserae/get-started/styling`

--- a/Tesserae/skills/references/text-block.md
+++ b/Tesserae/skills/references/text-block.md
@@ -19,7 +19,7 @@ Sizes and weights come from `ITextFormating` fluent helpers:
 - `.Tiny()` / `.Small()` / `.Medium()` / `.Large()` / `.XLarge()` — text size.
 - `.Regular()` / `.SemiBold()` / `.Bold()` — text weight.
 - `.NoWrap()` — disable wrapping (sets `CanWrap = false`).
-- `.Primary()` / `.Secondary()` / `.Success()` / `.Danger()` / `.Invalid()` — colour variant.
+- `.Primary()` / `.Secondary()` / `.Success()` / `.Danger()` — colour variant.
 - `.Title(string)` — tooltip (hover) text.
 - `.AI()` — paints the words with the purple-to-blue AI gradient. For **short** strings: a title, a heading over generated output, a one-line summary.
 - `.AISurface()` — generated prose: the theme's own text colour on a faint tinted panel with an accent edge, for a paragraph a gradient would make unreadable. See `ai-variants.md`.
@@ -46,6 +46,6 @@ var note = TextBlock("The quick brown fox.", selectable: true)
 
 ## Related
 
-- Label — `.label.md`
+- Label — `label.md`
 - AI variants — the `.AI()` / `.AISurface()` variant — `ai-variants.md`
 - Full docs & API: `/tesserae/components/text-block`

--- a/Tesserae/skills/references/text-block.md
+++ b/Tesserae/skills/references/text-block.md
@@ -47,5 +47,6 @@ var note = TextBlock("The quick brown fox.", selectable: true)
 ## Related
 
 - Label — `label.md`
+- ListItemText — a title with a subtitle under it — `list-item-text.md`
 - AI variants — the `.AI()` / `.AISurface()` variant — `ai-variants.md`
 - Full docs & API: `/tesserae/components/text-block`

--- a/Tesserae/skills/references/text-box.md
+++ b/Tesserae/skills/references/text-box.md
@@ -43,5 +43,5 @@ var stack = Stack().Children(
 
 ## Related
 
-- Label — `.label.md`
+- Label — `label.md`
 - Full docs & API: `/tesserae/components/text-box`

--- a/Tesserae/skills/references/text-breadcrumbs.md
+++ b/Tesserae/skills/references/text-breadcrumbs.md
@@ -44,5 +44,5 @@ var ui = Stack().Children(message, breadcrumbs);
 
 ## Related
 
-- Stack — `.stack.md`
+- Stack — `stack.md`
 - Full docs & API: `/tesserae/components/text-breadcrumbs`

--- a/Tesserae/skills/references/theme-builder.md
+++ b/Tesserae/skills/references/theme-builder.md
@@ -1,0 +1,87 @@
+---
+name: theme-builder
+description: A fluent builder for every colour CSS variable the toolkit exposes, set independently for light and dark mode and applied as one stylesheet. Use to brand an app, match an existing design system, or ship a per-tenant palette in a Tesserae (C#/Transpose) app.
+---
+
+# ThemeBuilder
+
+`Theme.Build()` hands you a builder for the whole palette: every colour variable the
+toolkit reads, each taking a **light** value and a **dark** value, applied in one go as a
+single `<style>` element.
+
+Use it when you are theming the product. For a one-off change — the primary colour, the
+page background — `Theme.SetPrimary(...)` / `Theme.SetBackground(...)` /
+`Theme.SetHighlight(...)` (`theme-colors.md`) are the smaller tools, and they leave the
+rest of the palette alone.
+
+## Create
+
+`Theme.Build()` — returns a `ThemeBuilder`. Chain setters, finish with `.Apply()`.
+`Theme.ResetBuild()` drops the applied theme and goes back to the defaults in
+`tss.common.css`. Bring factories into scope with `using static Tesserae.UI;`.
+
+Anything you don't set keeps its default, so a theme is only as long as the parts you
+actually want to change. The dark value applies while the document carries `.tss-dark-mode`
+(what `Theme.Dark()` / `Theme.Light()` toggle), the light one otherwise — so one `Apply()`
+themes both modes, and switching mode afterwards needs nothing further.
+
+## Key configuration
+
+Each setter takes `(Color light, Color dark)`:
+
+- **Surface** — `.DefaultBackground`, `.DefaultBackgroundHover`, `.DefaultBackgroundActive`,
+  `.DefaultForeground`, `.DefaultForegroundHover`, `.DefaultForegroundActive`,
+  `.DefaultBorder`, `.DarkBorder`, `.DefaultSeparator`, `.InvalidBorder`.
+- **Primary** — `.Primary(light, dark)` sets the background, its hover/active shades, the
+  border and the shadow together; `.PrimaryBackground`, `.PrimaryBackgroundHover`,
+  `.PrimaryBackgroundActive`, `.PrimaryBorder`, `.PrimaryForeground`,
+  `.PrimaryForegroundHover`, `.PrimaryForegroundActive`, `.PrimaryShadow` set the pieces.
+- **Tones** — `.Danger(light, dark)` and `.Success(light, dark)` (same all-at-once shape as
+  `Primary`), plus their `…Background`/`…BackgroundHover`/`…BackgroundActive`/`…Border`/
+  `…Foreground`/`…ForegroundHover`/`…ForegroundActive` parts, and
+  `.WarningBackground` / `.WarningForeground`.
+- **Chrome** — `.SecondaryBackground`, `.SecondaryForeground`, `.SidebarBackground`,
+  `.SidebarForeground`, `.DisabledBackground`, `.DisabledForeground`,
+  `.TooltipBackground`, `.TooltipForeground`.
+- **Accents** — `.Link` (links, `Badge().Info()`), `.Highlight` (marked search terms, see
+  `omni-result.md`), `.Slider`, `.SliderActive`, `.SliderDisabled`, `.ProgressBackground`.
+- `.SetVariable(string name, Color light, Color dark)` — the escape hatch, for a variable
+  the typed setters don't cover. Give the name **without** the `--tss-` prefix
+  (`"my-accent-color"`).
+
+Finishing:
+
+- `.Apply()` — render the palette into a `<style>` in the document head. A theme applied
+  earlier is removed first, so calls are idempotent, and `Theme.OnThemeChanged` is raised.
+- `.ToCss()` — the generated CSS without attaching it: for a preview, for server-side
+  rendering, or to persist a tenant's theme and re-apply it on load.
+- `Theme.ResetBuild()` — remove the applied theme entirely.
+
+## Example
+
+```csharp
+using static Tesserae.UI;
+
+Theme.Build()
+    .Primary  (Color.FromString("#0078d4"), Color.FromString("#2899f5"))
+    .Link     (Color.FromString("#0078d4"), Color.FromString("#55b3fb"))
+    .Highlight(Color.FromString("#0078d4"), Color.FromString("#55b3fb"))
+    .DefaultBackground      (Color.FromString("#eaf3fb"), Color.FromString("#0b1320"))
+    .DefaultBackgroundHover (Color.FromString("#d6e6f4"), Color.FromString("#101d33"))
+    .DefaultForeground      (Color.FromString("#0b3559"), Color.FromString("#e6f1fb"))
+    .DefaultBorder          (Color.FromString("#bcd6ea"), Color.FromString("#1f3252"))
+    .Apply();
+
+// Keep it: the CSS is a string, so a tenant's palette can be stored and re-applied.
+var css = Theme.Build().Primary(Color.FromString("#16a34a"), Color.FromString("#22c55e")).ToCss();
+
+Theme.ResetBuild();   // back to the shipped defaults
+```
+
+## Related
+
+- Theme colours — light/dark switching and the focused setters — `theme-colors.md`
+- Colors — the palette constants and the `Color` helper — `colors.md`
+- Gradients — `gradients.md`
+- Custom styles — your own CSS classes on top — `custom-styles.md`
+- Full docs & API: `/tesserae/utilities/theme-builder`

--- a/Tesserae/skills/references/theme-colors.md
+++ b/Tesserae/skills/references/theme-colors.md
@@ -51,6 +51,7 @@ Theme.SetHighlight(Color.FromString("#b45309"), Color.FromString("#fbbf24"));
 
 ## Related
 
+- ThemeBuilder — the whole palette in one fluent call — `theme-builder.md`
 - Colors (palette constants + Color helper) — `colors.md`
 - Gradients — `gradients.md`
 - Full docs & API: `/tesserae/utilities/theme-colors`

--- a/Tesserae/skills/references/time-histogram-picker.md
+++ b/Tesserae/skills/references/time-histogram-picker.md
@@ -35,10 +35,10 @@ var values = new[] { DateTime.Now.AddMinutes(-15), DateTime.Now.AddMinutes(30), 
 var picker = TimeHistogramPicker(values, 12)
     .WithCustomTimeRender(d => d.ToString("MMM d, HH:mm"))
     .OnRangeChanged((from, to, count) =>
-        Console.WriteLine($"{from:g} - {to:g} ({count} values)"));
+        console.log($"{from:g} - {to:g} ({count} values)"));
 ```
 
 ## Related
 
-- Date Picker — `.date-picker.md`
+- Date Picker — `date-picker.md`
 - Full docs & API: `/tesserae/components/time-histogram-picker`

--- a/Tesserae/skills/references/time-picker.md
+++ b/Tesserae/skills/references/time-picker.md
@@ -36,6 +36,6 @@ var component = Stack().Children(
 
 ## Related
 
-- Date Picker — `.date-picker.md`
-- Date Time Picker — `.date-time-picker.md`
+- Date Picker — `date-picker.md`
+- Date Time Picker — `date-time-picker.md`
 - Full docs & API: `/tesserae/components/time-picker`

--- a/Tesserae/skills/references/tippy.md
+++ b/Tesserae/skills/references/tippy.md
@@ -11,10 +11,11 @@ Tooltips for components, via the `.Tooltip()` extension on `IComponent`. Content
 
 `.Tooltip(...)` (extension on `IComponent`), two overloads:
 
-- `.Tooltip(string text, TooltipAnimation animation = Fade, TooltipPlacement placement = Top, int delay = 0, int duration = 200, bool interactive = false)`
-- `.Tooltip(IComponent tooltipContent, …same options…)` — for component-based tooltips.
+- `.Tooltip(string tooltipHtml, TooltipAnimation animation = None, TooltipPlacement placement = Top, int delayShow = 250, int delayHide = 0, bool followCursor = false, int maxWidth = 350, bool arrow = false, string theme = null, IComponent parent = null)`
+- `.Tooltip(IComponent tooltip, bool interactive = false, …the same options…)` — for component-based tooltips.
 
-Set `interactive: true` to let users select/click inside the tooltip.
+Set `interactive: true` (component overload only) to let users select/click inside the tooltip.
+`.RemoveTooltip()` takes one away again.
 
 `Tippy.ShowFor(IComponent component, IComponent tooltipContent, out Action hide, …)` — show a tooltip programmatically; `hide` is an out-action to dismiss it.
 

--- a/Tesserae/skills/references/toggle-button.md
+++ b/Tesserae/skills/references/toggle-button.md
@@ -27,11 +27,11 @@ using static Tesserae.UI;
 var bold = Button("Bold").SetIcon(UIcons.Bold)
     .ToToggle()
     .Checked()
-    .OnChange((s, e) => Console.WriteLine($"Bold: {s.IsChecked}"));
+    .OnChange((s, e) => console.log($"Bold: {s.IsChecked}"));
 ```
 
 ## Related
 
-- Button — `.button.md`
-- Toggle — `.toggle.md`
+- Button — `button.md`
+- Toggle — `toggle.md`
 - Full docs & API: `/tesserae/components/toggle-button`

--- a/Tesserae/skills/references/toggle.md
+++ b/Tesserae/skills/references/toggle.md
@@ -31,7 +31,7 @@ Pair with `UI.Label(...).SetContent(toggle)` to give it a leading caption.
 using static Tesserae.UI;
 
 var notifications = Toggle("On", "Off").Checked();
-notifications.AsObservable().Observe(on => Console.WriteLine($"Notifications: {on}"));
+notifications.AsObservable().Observe(on => console.log($"Notifications: {on}"));
 
 var component = Stack().Children(
     Label("Notifications").Inline().SetContent(notifications),
@@ -41,7 +41,7 @@ var component = Stack().Children(
 
 ## Related
 
-- ToggleButton — `.toggle-button.md`
-- CheckBox — `.check-box.md`
+- ToggleButton — `toggle-button.md`
+- CheckBox — `check-box.md`
 - IconToggle (a segmented control of icons, one selected) — `icon-toggle.md`
 - Full docs & API: `/tesserae/components/toggle`

--- a/Tesserae/skills/references/tool-call.md
+++ b/Tesserae/skills/references/tool-call.md
@@ -26,7 +26,7 @@ Both carry an 8px bottom margin, so when you stack a pill above the answer text 
 - `.OnToggle(tc => ...)` — fires on expand/collapse.
 - `.SetContent(...)` / `.SetText(...)` / `.SetIcon(...)` — update fields.
 - `.SetProgress(string)` / `.SetProgress(IObservable<string>)` / `.ClearProgress()` — a live progress
-  line on the header row while the call runs (see `.live-progress.md`). Updates rewrite the text of
+  line on the header row while the call runs (see `live-progress.md`). Updates rewrite the text of
   the line already on screen, so a stream of updates never re-renders the call, and expanding it
   still opens the content full width underneath.
 - `Progress` — the `LiveProgress` itself, for finer control.
@@ -125,7 +125,7 @@ var failed = ToolCall(UIcons.Globe, "Fetch https://api.example.com/v1/status",
 
 ## Related
 
-- LiveProgress — `.live-progress.md`
-- Chat — `.chat.md`
-- Expander — `.expander.md`
+- LiveProgress — `live-progress.md`
+- Chat — `chat.md`
+- Expander — `expander.md`
 - Full docs & API: `/tesserae/components/tool-call`

--- a/Tesserae/skills/references/tree.md
+++ b/Tesserae/skills/references/tree.md
@@ -66,7 +66,7 @@ var tree = new Tree().Compact().SelectionEnabled().Items(
         await Task.Delay(500);
         return new[] { new Tree.Item("child.cs", UIcons.File) };
     })
-).OnSelected((s, item) => Console.WriteLine(item.Text));
+).OnSelected((s, item) => console.log(item.Text));
 ```
 
 Picking several files out of a folder tree, folders included:
@@ -81,7 +81,7 @@ var files = new Tree().Compact().Selectable(TreeSelectionMode.Multiple).CascadeS
 ).OnSelectionChanged((t, selected) =>
 {
     var picked = selected.Where(i => !i.HasChildren).ToArray();
-    Console.WriteLine(picked.Length + " files selected");
+    console.log(picked.Length + " files selected");
 });
 ```
 

--- a/Tesserae/skills/references/unsaved-changes-guard.md
+++ b/Tesserae/skills/references/unsaved-changes-guard.md
@@ -105,7 +105,7 @@ Two exits don't go through the router, and are handled differently:
   the `id` the indicator needs.
 - `MarkDirty(string tabIndicatorId)` / `MarkClean(string tabIndicatorId)` —
   toggle the tab's unsaved-changes dot. Call from the editor's own change-tracking
-  (a `TextArea.OnChanged`, a `Validator`, a `SettingsHolder.HasChanged`
+  (a `TextArea.OnChange`, a `Validator`, a `SettingsHolder.HasChanged`
   check, …). On a `closeable` tab the dot stands in for the close cross and gives
   way to it while the tab is pointed at, so the tab never changes width; on a tab
   without a close button it sits beside the label. See `pivot.md`.
@@ -162,10 +162,10 @@ hostView.WhenMounted(() => UnsavedChangesGuard.TrackOpenTabs());
 hostView.WhenRemoved(() => UnsavedChangesGuard.ForgetOpenTabs());
 
 pivot.Pivot("endpoint-abc123",
-    TabSaveIndicator.Title(tabIndicatorId, "Endpoint", UIcons.Code),
+    TabSaveIndicator.Title(tabIndicatorId, "Endpoint", UIcons.CodeSimple),
     () => EndpointEditor(), cached: true, closeable: true);
 
-codeEditor.OnChanged(() => TabSaveIndicator.MarkDirty(tabIndicatorId));
+codeEditor.OnChange((_, __) => TabSaveIndicator.MarkDirty(tabIndicatorId));
 TabSaveIndicator.OnSave(tabIndicatorId, SaveEndpointAsync);
 
 // when the tab closes:

--- a/Tesserae/skills/references/visibility-sensor.md
+++ b/Tesserae/skills/references/visibility-sensor.md
@@ -36,6 +36,6 @@ var stack = Stack().Children(
 
 ## Related
 
-- InfiniteScrollingList — `.infinite-scrolling-list.md`
-- VirtualizedList — `.virtualized-list.md`
+- InfiniteScrollingList — `infinite-scrolling-list.md`
+- VirtualizedList — `virtualized-list.md`
 - Full docs & API: `/tesserae/components/visibility-sensor`

--- a/Tesserae/skills/references/week-picker.md
+++ b/Tesserae/skills/references/week-picker.md
@@ -34,6 +34,6 @@ var component = Label("Pick a week:").SetContent(picker);
 
 ## Related
 
-- Date Picker — `.date-picker.md`
-- Time Picker — `.time-picker.md`
+- Date Picker — `date-picker.md`
+- Time Picker — `time-picker.md`
 - Full docs & API: `/tesserae/components/week-picker`

--- a/Tesserae/skills/references/wrap-a-javascript-library.md
+++ b/Tesserae/skills/references/wrap-a-javascript-library.md
@@ -13,10 +13,11 @@ global from C# through `Script.Write`.**
 
 ## 1. Bundle the library
 
-Put the minified library under `Tesserae/tps/assets/js/` and add it to the
-resource bundles in `Tesserae/tps.json`. It must appear in **both** the
-`tss-dep.js` and `tss-dep.min.js` bundles (keep the two file lists in sync —
-Transpose swaps between them for Debug vs Release builds):
+Put the minified library under your project's `tps/assets/js/` and add it to a resource
+bundle in its `tps.json`. Ship **both** spellings of the bundle — `…​.js` and `…​.min.js` —
+and keep the two file lists in sync, because Transpose swaps between them for Debug vs
+Release builds. This is exactly how the toolkit bundles its own dependencies in
+`Tesserae/tps.json`:
 
 ```jsonc
 {


### PR DESCRIPTION
Update skills documentation to clarify how components are wired into apps vs. the toolkit, improve explanations of sizing/layout mechanics, and fix reference link formatting throughout.

## Summary

This change refactors and clarifies several key sections of the Tesserae skills documentation:

1. **Component wiring guidance** — Restructure "Wiring it up" to distinguish between using a component in your own app (simple factory pattern) vs. contributing to the toolkit itself (repo conventions). Moves toolkit contribution details into a parenthetical note.

2. **Sizing and layout mechanics** — Expand explanations of how sizing helpers work on `IComponent`, clarify the wrap-and-transfer protocol, and document `ISpecialCaseStyling` behavior more clearly. Update `ObservableStack` docs to explain that configuration lives on the host `Stack`, not the observable wrapper.

3. **Reference link formatting** — Standardize all cross-reference links from `.slug.md` to `slug.md` format throughout the documentation tree (40+ files). This matches the actual file structure and improves consistency.

4. **Code examples and API updates** — Fix examples to use current APIs:
   - Replace `.Link()` with `.Class("tss-btn-link")` on buttons
   - Update `Grid.Rows()` to use `new[] { UnitSize.Auto(), ... }` syntax
   - Clarify `Tooltip()` parameter names and add `.RemoveTooltip()` documentation
   - Fix `Require` qualification to `Transpose.Require` to avoid ambiguity with `Tesserae.Require`
   - Update `ModalStack.Changed` example to use `Router.ReplaceQueryParameters()`
   - Replace `Console.WriteLine` with `console.log` in C# examples

5. **New guidance** — Add a callout in `SKILL.md` explaining how `using static Tesserae.UI;` hides nested types and requires qualification (e.g., `Tesserae.Float.Position.TopLeft`).

6. **Documentation improvements** — Expand `UnitSize` helpers documentation to include `100.vw()`, `100.vh()`, `UnitSize.Auto()`, `UnitSize.FitContent()`, and raw constructor usage. Update `icomponent.md` to reference `stack.md`, `grid.md`, and `layout-alignment.md` instead of the repo's internal `CLAUDE.md`.

All changes are documentation-only; no source code or component behavior is modified.

https://claude.ai/code/session_01JrNiar69ixxvwMDEivtfYn