### PR TITLE
Fix dropdown item rendering and layout for rich content

### DIFF
--- a/Tesserae.Tests/src/Samples/Inputs/DropdownSample.cs
+++ b/Tesserae.Tests/src/Samples/Inputs/DropdownSample.cs
@@ -95,10 +95,10 @@ namespace Tesserae.Tests.Samples
                             TwoLineItem("Singapore", "ap-southeast-1")
                         )),
                         Label("Emoji and interactive content (multi)").SetContent(Dropdown().Multi().Items(
-                            DropdownItem(() => HStack().AlignItemsCenter().Gap(8.px()).Children(Icon(Emoji.Pizza), TextBlock("Pizza")), () => HStack().AlignItemsCenter().Gap(4.px()).Children(Icon(Emoji.Pizza, TextSize.Small), TextBlock("Pizza").Small())).Selected(),
-                            DropdownItem(() => HStack().AlignItemsCenter().Gap(8.px()).Children(Icon(Emoji.Cheese), TextBlock("Cheese")), () => HStack().AlignItemsCenter().Gap(4.px()).Children(Icon(Emoji.Cheese, TextSize.Small), TextBlock("Cheese").Small())).Selected(),
-                            DropdownItem(() => HStack().AlignItemsCenter().Gap(8.px()).Children(TextBlock("Rated"), Rating(5).SetValue(4).ReadOnly()), () => TextBlock("Rated 4/5").Small()),
-                            DropdownItem(() => HStack().AlignItemsCenter().Gap(8.px()).Children(TextBlock("Shortcut"), KeyboardShortcut("Ctrl", "K")), () => TextBlock("Ctrl+K").Small())
+                            DropdownItem(HStack().AlignItemsCenter().Gap(8.px()).Children(Icon(Emoji.Pizza), TextBlock("Pizza")), HStack().AlignItemsCenter().Gap(4.px()).Children(Icon(Emoji.Pizza, TextSize.Small), TextBlock("Pizza").Small())).Selected(),
+                            DropdownItem(HStack().AlignItemsCenter().Gap(8.px()).Children(Icon(Emoji.Cheese), TextBlock("Cheese")), HStack().AlignItemsCenter().Gap(4.px()).Children(Icon(Emoji.Cheese, TextSize.Small), TextBlock("Cheese").Small())).Selected(),
+                            DropdownItem(HStack().AlignItemsCenter().Gap(8.px()).Children(TextBlock("Rated"), Rating(5).SetValue(4).ReadOnly()), TextBlock("Rated 4/5").Small()),
+                            DropdownItem(HStack().AlignItemsCenter().Gap(8.px()).Children(TextBlock("Shortcut"), KeyboardShortcut("Ctrl", "K")), TextBlock("Ctrl+K").Small())
                         )),
                         Label("Text that is far too long (multi)").SetContent(Dropdown().Multi().Items(
                             DropdownItem("A perfectly reasonable option").Selected(),
@@ -110,7 +110,7 @@ namespace Tesserae.Tests.Samples
                             SwatchItem("Seafoam", "#00b7c3").Selected(),
                             PersonRow("Ana Pereira", "ana@example.com").Selected(),
                             MetricItem("Revenue", new double[] { 3, 5, 4, 8, 6, 11, 9, 14 }, "#107c10").Selected(),
-                            DropdownItem(() => HStack().AlignItemsCenter().Gap(8.px()).Children(Icon(Emoji.Pizza), TextBlock("Pizza")), () => HStack().AlignItemsCenter().Gap(4.px()).Children(Icon(Emoji.Pizza, TextSize.Small), TextBlock("Pizza").Small())).Selected()
+                            DropdownItem(HStack().AlignItemsCenter().Gap(8.px()).Children(Icon(Emoji.Pizza), TextBlock("Pizza")), HStack().AlignItemsCenter().Gap(4.px()).Children(Icon(Emoji.Pizza, TextSize.Small), TextBlock("Pizza").Small())).Selected()
                         )),
                         TextBlock("WithCustomSelectionRender takes over the box completely: the selected items are handed to you and whatever you return is what the box shows - no clones, and no commas to get right."),
                         Label("Custom selection render (count)").SetContent(
@@ -255,18 +255,18 @@ namespace Tesserae.Tests.Samples
 
         // A two-line row with an avatar in the list, collapsing to avatar + first name in the box.
         private static Dropdown.Item PersonRow(string name, string email) =>
-            DropdownItem(() => PersonBlock(name, email), () => PersonChip(name)).SetKey(email).SetData(Initials(name));
+            DropdownItem(PersonBlock(name, email), PersonChip(name)).SetKey(email).SetData(Initials(name));
 
         // A badge is already a self-contained pill, so the box shows the same thing the list does.
         private static Dropdown.Item BadgeItem(string text, BadgeTone tone, UIcons icon) =>
-            DropdownItem(() => BadgeRow(text, tone, icon), () => Badge(text).Tone(tone).Pill()).SetKey(text);
+            DropdownItem(BadgeRow(text, tone, icon), Badge(text).Tone(tone).Pill()).SetKey(text);
 
         private static Dropdown.Item SwatchItem(string name, string color) =>
-            DropdownItem(() => SwatchRow(name, color, 16), () => SwatchRow(name, color, 10)).SetKey(name);
+            DropdownItem(SwatchRow(name, color, 16), SwatchRow(name, color, 10)).SetKey(name);
 
         // A chart inside an option - the tallest, widest thing here, and the box gets a smaller one.
         private static Dropdown.Item MetricItem(string name, double[] series, string color) =>
-            DropdownItem(() => MetricRow(name, series, color, 90, 24, labelWidth: 70), () => MetricRow(name, series, color, 36, 12)).SetKey(name);
+            DropdownItem(MetricRow(name, series, color, 90, 24, labelWidth: 70), MetricRow(name, series, color, 36, 12)).SetKey(name);
 
         // Deliberately gives no short form, so the box has to clip the two-line block itself.
         private static Dropdown.Item TwoLineItem(string title, string subtitle) =>

--- a/Tesserae.Tests/src/Samples/Inputs/DropdownSample.cs
+++ b/Tesserae.Tests/src/Samples/Inputs/DropdownSample.cs
@@ -69,7 +69,7 @@ namespace Tesserae.Tests.Samples
                     ),
                     SampleSubTitle("Mixed Renderings"),
                     VStack().Children(
-                        TextBlock("An item's content is any IComponent, and the box shows a clone of it - so whatever an option renders in the list, the box has to render inline, comma-separated, clipped to one 32px row. These are deliberately unreasonable options: they are here to keep the box honest about avatars, badges, charts, emoji, two-line blocks and text that is far too long."),
+                        TextBlock("An item's content is any IComponent, and the box draws its own second one - so whatever an option renders in the list, the box has to render inline, comma-separated, clipped to one 32px row. These are deliberately unreasonable options: they are here to keep the box honest about avatars, badges, charts, emoji, two-line blocks and text that is far too long."),
                         Label("People (avatar + two lines, multi)").SetContent(PeopleDropdown()),
                         Label("Status badges (multi)").SetContent(Dropdown().Multi().Items(
                             BadgeItem("Critical", BadgeTone.Danger,  UIcons.Exclamation).Selected(),

--- a/Tesserae.Tests/src/Samples/Inputs/DropdownSample.cs
+++ b/Tesserae.Tests/src/Samples/Inputs/DropdownSample.cs
@@ -157,8 +157,8 @@ namespace Tesserae.Tests.Samples
                             DeferredItem(900,  () => BadgeRow("Healthy", BadgeTone.Success, UIcons.CheckCircle)),
                             DeferredItem(1300, () => SwatchRow("Orchid", "#8764b8", 16))
                         )),
-                        TextBlock("One thing the box cannot do anything about: a Defer only loads its content once it is mounted, and a row is not in the document until the dropdown is first opened. So an option that is deferred, has no short form and is selected up front shows its placeholder in the box until you open the list once - there is nothing else to copy yet. It catches up as each Defer resolves."),
-                        TextBlock("An explicit short form is the way out, and is a live component rather than a copy, so a Defer inside one is mounted in the box and resolves there without the list ever being opened. Here both halves are deferred, on different delays."),
+                        TextBlock("A Defer normally waits to be mounted before it loads, and a row is not in the document until the dropdown is first opened - so a selected option would have sat in the box as a placeholder with nothing to make it resolve. Being selected is what settles it: the content is on show in the box, so the dropdown asks it to load whether or not the list has ever been opened. The two above are filled in without touching them. A Defer nested deeper inside the content, rather than being the content, still waits for the list to be opened."),
+                        TextBlock("An explicit short form is a live component rather than a copy, so a Defer inside one is mounted in the box and resolves there on its own. Here both halves are deferred, on different delays."),
                         Label("Deferred row and deferred short form (multi)").SetContent(Dropdown().Multi().Items(
                             DeferredPairItem(500,  1200, "Frankfurt",  "eu-central-1",   selected: true),
                             DeferredPairItem(800,  1600, "Oregon",     "us-west-2",      selected: true),

--- a/Tesserae.Tests/src/Samples/Inputs/DropdownSample.cs
+++ b/Tesserae.Tests/src/Samples/Inputs/DropdownSample.cs
@@ -67,7 +67,7 @@ namespace Tesserae.Tests.Samples
                             DropdownItem("High")
                         ))
                     ),
-                    SampleSubTitle("Wild Renderings"),
+                    SampleSubTitle("Mixed Renderings"),
                     VStack().Children(
                         TextBlock("An item's content is any IComponent, and the box shows a clone of it - so whatever an option renders in the list, the box has to render inline, comma-separated, clipped to one 32px row. These are deliberately unreasonable options: they are here to keep the box honest about avatars, badges, charts, emoji, two-line blocks and text that is far too long."),
                         Label("People (avatar + two lines, multi)").SetContent(PeopleDropdown()),
@@ -199,7 +199,7 @@ namespace Tesserae.Tests.Samples
                .SeeAlso(typeof(PickerSample), typeof(ChoiceGroupSample), typeof(TagsInputSample), typeof(SearchableListSample), typeof(MenuSample));
         }
 
-        // --- Wild renderings ------------------------------------------------------------------
+        // --- Mixed renderings ------------------------------------------------------------------
         // The content each option draws, defined once as an IComponent, so the plain options above and
         // the deferred ones below are demonstrably showing the same thing through different paths.
 

--- a/Tesserae.Tests/src/Samples/Inputs/DropdownSample.cs
+++ b/Tesserae.Tests/src/Samples/Inputs/DropdownSample.cs
@@ -166,7 +166,7 @@ namespace Tesserae.Tests.Samples
                         Label("Work shared between the two instances (multi, pre-selected)").SetContent(Dropdown().Multi().Items(
                             SharedWorkItem("Shared fetch", selected: true)
                         )),
-                        TextBlock("A short form is a separate factory, for when the box wants a shorter version of the option rather than the same one. Here both halves are deferred, on different delays."),
+                        TextBlock("Where the box wants a shorter version of the option rather than the same one, the short form is the factory - the row is needed now, the box's only if the option is ever selected. Here both halves are deferred, on different delays."),
                         Label("Deferred row and deferred short form (multi)").SetContent(Dropdown().Multi().Items(
                             DeferredPairItem(500,  1200, "Frankfurt",  "eu-central-1",   selected: true),
                             DeferredPairItem(800,  1600, "Oregon",     "us-west-2",      selected: true),
@@ -273,9 +273,8 @@ namespace Tesserae.Tests.Samples
             DropdownItem(() => TwoLineBlock(title, subtitle)).SetKey(subtitle);
 
         // --- The same content, arriving through a Defer ----------------------------------------
-        // No short form, so the box shows a copy of the row - which is exactly the case that has to
-        // catch up once the Defer resolves, and which is broken from the start when the option is
-        // selected before its content exists.
+        // One recipe, so the box builds its own second Defer from it and loads independently of the row -
+        // including when the option starts out selected and its content does not exist yet.
         private static int _deferredKey;
 
         private static Dropdown.Item DeferredItem(int delayMs, Func<IComponent> content, bool selected = false) =>
@@ -287,11 +286,11 @@ namespace Tesserae.Tests.Samples
                .SetKey($"deferred-{_deferredKey++}")
                .SelectedIf(selected);
 
-        // Both halves deferred, on different delays: the row is copied into the box, but the short form
-        // is a live component, so its own Defer resolves in the box itself.
+        // Both halves deferred, on different delays, and only the box's is a recipe: the row's Defer is
+        // needed now, the box's only if the option is ever selected - and each resolves where it lives.
         private static Dropdown.Item DeferredPairItem(int rowDelayMs, int chipDelayMs, string title, string subtitle, bool selected = false) =>
             DropdownItem(
-                    () => Defer(async () =>
+                    Defer(async () =>
                     {
                         await Task.Delay(rowDelayMs);
                         return TwoLineBlock(title, subtitle);

--- a/Tesserae.Tests/src/Samples/Inputs/DropdownSample.cs
+++ b/Tesserae.Tests/src/Samples/Inputs/DropdownSample.cs
@@ -67,7 +67,7 @@ namespace Tesserae.Tests.Samples
                             DropdownItem("High")
                         ))
                     ),
-                    SampleSubTitle("Mixed Renderings"),
+                    SampleSubTitle("Mixed"),
                     VStack().Children(
                         TextBlock("An item's content is any IComponent, and the box draws its own second one - so whatever an option renders in the list, the box has to render inline, comma-separated, clipped to one 32px row. These are deliberately unreasonable options: they are here to keep the box honest about avatars, badges, charts, emoji, two-line blocks and text that is far too long."),
                         Label("People (avatar + two lines, multi)").SetContent(PeopleDropdown()),

--- a/Tesserae.Tests/src/Samples/Inputs/DropdownSample.cs
+++ b/Tesserae.Tests/src/Samples/Inputs/DropdownSample.cs
@@ -67,6 +67,71 @@ namespace Tesserae.Tests.Samples
                             DropdownItem("High")
                         ))
                     ),
+                    SampleSubTitle("Wild Renderings"),
+                    VStack().Children(
+                        TextBlock("An item's content is any IComponent, and the box shows a clone of it - so whatever an option renders in the list, the box has to render inline, comma-separated, clipped to one 32px row. These are deliberately unreasonable options: they are here to keep the box honest about avatars, badges, charts, emoji, two-line blocks and text that is far too long."),
+                        Label("People (avatar + two lines, multi)").SetContent(PeopleDropdown()),
+                        Label("Status badges (multi)").SetContent(Dropdown().Multi().Items(
+                            BadgeItem("Critical", BadgeTone.Danger,  UIcons.Exclamation).Selected(),
+                            BadgeItem("Degraded", BadgeTone.Warning, UIcons.TriangleWarning).Selected(),
+                            BadgeItem("Healthy",  BadgeTone.Success, UIcons.CheckCircle),
+                            BadgeItem("Unknown",  BadgeTone.Neutral, UIcons.Interrogation)
+                        )),
+                        Label("Colour swatches (multi)").SetContent(Dropdown().Multi().Items(
+                            SwatchItem("Crimson", "#d13438").Selected(),
+                            SwatchItem("Marigold", "#eaa300").Selected(),
+                            SwatchItem("Seafoam", "#00b7c3").Selected(),
+                            SwatchItem("Orchid", "#8764b8")
+                        )),
+                        Label("Charts inside options (multi)").SetContent(Dropdown().Multi().Items(
+                            MetricItem("Revenue",  new double[] { 3, 5, 4, 8, 6, 11, 9, 14 }, "#107c10").Selected(),
+                            MetricItem("Sessions", new double[] { 14, 9, 11, 6, 8, 4, 5, 3 }, "#d13438").Selected(),
+                            MetricItem("Latency",  new double[] { 6, 6, 7, 6, 8, 7, 6, 7 }, "#8764b8")
+                        )),
+                        TextBlock("Content taller than the row is the one case the box cannot rescue: a comma next to a two-line block has nowhere good to sit. Give tall content a short form through the second DropdownItem argument, the way the People dropdown above does - this one deliberately does not, to show the difference."),
+                        Label("Two-line blocks, no short form (multi)").SetContent(Dropdown().Multi().Items(
+                            TwoLineItem("Frankfurt", "eu-central-1").Selected(),
+                            TwoLineItem("Oregon", "us-west-2").Selected(),
+                            TwoLineItem("Singapore", "ap-southeast-1")
+                        )),
+                        Label("Emoji and interactive content (multi)").SetContent(Dropdown().Multi().Items(
+                            DropdownItem(HStack().AlignItemsCenter().Gap(8.px()).Children(Icon(Emoji.Pizza), TextBlock("Pizza")), HStack().AlignItemsCenter().Gap(4.px()).Children(Icon(Emoji.Pizza, TextSize.Small), TextBlock("Pizza").Small())).Selected(),
+                            DropdownItem(HStack().AlignItemsCenter().Gap(8.px()).Children(Icon(Emoji.Cheese), TextBlock("Cheese")), HStack().AlignItemsCenter().Gap(4.px()).Children(Icon(Emoji.Cheese, TextSize.Small), TextBlock("Cheese").Small())).Selected(),
+                            DropdownItem(HStack().AlignItemsCenter().Gap(8.px()).Children(TextBlock("Rated"), Rating(5).SetValue(4).ReadOnly()), TextBlock("Rated 4/5").Small()),
+                            DropdownItem(HStack().AlignItemsCenter().Gap(8.px()).Children(TextBlock("Shortcut"), KeyboardShortcut("Ctrl", "K")), TextBlock("Ctrl+K").Small())
+                        )),
+                        Label("Text that is far too long (multi)").SetContent(Dropdown().Multi().Items(
+                            DropdownItem("A perfectly reasonable option").Selected(),
+                            DropdownItem("An option whose label someone pasted an entire sentence into, which the box has one clipped row to deal with").Selected(),
+                            DropdownItem("Another one, just as long, so that the clipping has to happen part way through a comma-separated list").Selected()
+                        )),
+                        Label("Everything at once (multi)").SetContent(Dropdown().Multi().Items(
+                            BadgeItem("Critical", BadgeTone.Danger, UIcons.Exclamation).Selected(),
+                            SwatchItem("Seafoam", "#00b7c3").Selected(),
+                            PersonRow("Ana Pereira", "ana@example.com").Selected(),
+                            MetricItem("Revenue", new double[] { 3, 5, 4, 8, 6, 11, 9, 14 }, "#107c10").Selected(),
+                            DropdownItem(HStack().AlignItemsCenter().Gap(8.px()).Children(Icon(Emoji.Pizza), TextBlock("Pizza")), HStack().AlignItemsCenter().Gap(4.px()).Children(Icon(Emoji.Pizza, TextSize.Small), TextBlock("Pizza").Small())).Selected()
+                        )),
+                        TextBlock("WithCustomSelectionRender takes over the box completely: the selected items are handed to you and whatever you return is what the box shows - no clones, and no commas to get right."),
+                        Label("Custom selection render (count)").SetContent(
+                            Dropdown().Multi()
+                               .WithCustomSelectionRender(items => Badge($"{items.Length} region{(items.Length == 1 ? "" : "s")} selected").Primary().Pill())
+                               .Items(
+                                    TwoLineItem("Frankfurt", "eu-central-1").Selected(),
+                                    TwoLineItem("Oregon", "us-west-2").Selected(),
+                                    TwoLineItem("Singapore", "ap-southeast-1")
+                                )),
+                        Label("Custom selection render (avatar pile)").SetContent(
+                            Dropdown().Multi()
+                               .WithCustomSelectionRender(items => HStack().AlignItemsCenter().Gap(4.px()).Children(
+                                    items.Take(4).Select(i => (IComponent)Avatar(initials: i.GetDataAs<string>()).Size(AvatarSize.XSmall)).ToArray()))
+                               .Items(
+                                    PersonRow("Ana Pereira", "ana@example.com").Selected(),
+                                    PersonRow("Bo Lindqvist", "bo@example.com").Selected(),
+                                    PersonRow("Chen Wei", "chen@example.com").Selected(),
+                                    PersonRow("Dara O'Neill", "dara@example.com")
+                                ))
+                    ),
                     SampleSubTitle("Async Loading"),
                     VStack().Children(
                         Label("Load on open (5s delay)").SetContent(Dropdown().Items(GetItemsAsync)),
@@ -103,6 +168,75 @@ namespace Tesserae.Tests.Samples
                 )).SetTitle("Usage")))
                .SeeAlso(typeof(PickerSample), typeof(ChoiceGroupSample), typeof(TagsInputSample), typeof(SearchableListSample), typeof(MenuSample));
         }
+
+        // --- Wild renderings ------------------------------------------------------------------
+        // Each of these builds an option whose content is a composed IComponent rather than a string.
+        // The second argument to DropdownItem is what the *box* shows once the option is selected,
+        // which is the escape hatch for content too tall or too wide to sit on one clipped row.
+
+        private static Dropdown PeopleDropdown() => Dropdown().Multi().Items(
+            PersonRow("Ana Pereira",  "ana@example.com").Selected(),
+            PersonRow("Bo Lindqvist", "bo@example.com").Selected(),
+            PersonRow("Chen Wei",     "chen@example.com"),
+            PersonRow("Dara O'Neill", "dara@example.com"));
+
+        // A two-line row with an avatar in the list, collapsing to avatar + first name in the box.
+        private static Dropdown.Item PersonRow(string name, string email)
+        {
+            var initials = string.Join("", name.Split(' ').Select(part => part.Substring(0, 1)));
+
+            return DropdownItem(
+                    HStack().AlignItemsCenter().Gap(8.px()).Children(
+                        Avatar(initials: initials).Size(AvatarSize.Small).Presence(AvatarPresence.Online),
+                        VStack().Children(
+                            TextBlock(name).Small(),
+                            TextBlock(email).Tiny().Secondary())),
+                    HStack().AlignItemsCenter().Gap(4.px()).Children(
+                        Avatar(initials: initials).Size(AvatarSize.XSmall),
+                        TextBlock(name.Split(' ')[0]).Small()))
+               .SetKey(email)
+               .SetData(initials);
+        }
+
+        // A badge is already a self-contained pill, so the box shows the same thing the list does.
+        private static Dropdown.Item BadgeItem(string text, BadgeTone tone, UIcons icon) =>
+            DropdownItem(Badge(text).Tone(tone).Pill().SetIcon(Tesserae.Icon.Transform(icon, UIconsWeight.Regular)),
+                         Badge(text).Tone(tone).Pill())
+               .SetKey(text);
+
+        // A colour chip drawn with a bare div, to prove the box does not care what the content is.
+        private static Dropdown.Item SwatchItem(string name, string color) =>
+            DropdownItem(SwatchRow(name, color, 16), SwatchRow(name, color, 10)).SetKey(name);
+
+        private static IComponent SwatchRow(string name, string color, int size) =>
+            HStack().AlignItemsCenter().Gap(8.px()).Children(
+                Raw(Div(Att(styles: s =>
+                {
+                    s.width        = $"{size}px";
+                    s.height       = $"{size}px";
+                    s.borderRadius = "4px";
+                    s.background   = color;
+                    s.flexShrink   = "0";
+                }))),
+                TextBlock(name).Small());
+
+        // A chart inside an option - the tallest, widest thing here, and the box gets a smaller one.
+        private static Dropdown.Item MetricItem(string name, double[] series, string color) =>
+            DropdownItem(
+                HStack().AlignItemsCenter().Gap(8.px()).Children(
+                    TextBlock(name).Small().W(70),
+                    Sparkline(series, width: 90, height: 24, color: color)),
+                HStack().AlignItemsCenter().Gap(4.px()).Children(
+                    TextBlock(name).Small(),
+                    Sparkline(series, width: 36, height: 12, color: color)))
+               .SetKey(name);
+
+        // Deliberately gives no short form, so the box has to clip the two-line block itself.
+        private static Dropdown.Item TwoLineItem(string title, string subtitle) =>
+            DropdownItem(VStack().Children(
+                    TextBlock(title).Small(),
+                    TextBlock(subtitle).Tiny().Secondary()))
+               .SetKey(subtitle);
 
         private static Dropdown StartLoadingAsyncDataImmediately(Dropdown dropdown)
         {

--- a/Tesserae.Tests/src/Samples/Inputs/DropdownSample.cs
+++ b/Tesserae.Tests/src/Samples/Inputs/DropdownSample.cs
@@ -95,10 +95,10 @@ namespace Tesserae.Tests.Samples
                             TwoLineItem("Singapore", "ap-southeast-1")
                         )),
                         Label("Emoji and interactive content (multi)").SetContent(Dropdown().Multi().Items(
-                            DropdownItem(HStack().AlignItemsCenter().Gap(8.px()).Children(Icon(Emoji.Pizza), TextBlock("Pizza")), HStack().AlignItemsCenter().Gap(4.px()).Children(Icon(Emoji.Pizza, TextSize.Small), TextBlock("Pizza").Small())).Selected(),
-                            DropdownItem(HStack().AlignItemsCenter().Gap(8.px()).Children(Icon(Emoji.Cheese), TextBlock("Cheese")), HStack().AlignItemsCenter().Gap(4.px()).Children(Icon(Emoji.Cheese, TextSize.Small), TextBlock("Cheese").Small())).Selected(),
-                            DropdownItem(HStack().AlignItemsCenter().Gap(8.px()).Children(TextBlock("Rated"), Rating(5).SetValue(4).ReadOnly()), TextBlock("Rated 4/5").Small()),
-                            DropdownItem(HStack().AlignItemsCenter().Gap(8.px()).Children(TextBlock("Shortcut"), KeyboardShortcut("Ctrl", "K")), TextBlock("Ctrl+K").Small())
+                            DropdownItem(() => HStack().AlignItemsCenter().Gap(8.px()).Children(Icon(Emoji.Pizza), TextBlock("Pizza")), () => HStack().AlignItemsCenter().Gap(4.px()).Children(Icon(Emoji.Pizza, TextSize.Small), TextBlock("Pizza").Small())).Selected(),
+                            DropdownItem(() => HStack().AlignItemsCenter().Gap(8.px()).Children(Icon(Emoji.Cheese), TextBlock("Cheese")), () => HStack().AlignItemsCenter().Gap(4.px()).Children(Icon(Emoji.Cheese, TextSize.Small), TextBlock("Cheese").Small())).Selected(),
+                            DropdownItem(() => HStack().AlignItemsCenter().Gap(8.px()).Children(TextBlock("Rated"), Rating(5).SetValue(4).ReadOnly()), () => TextBlock("Rated 4/5").Small()),
+                            DropdownItem(() => HStack().AlignItemsCenter().Gap(8.px()).Children(TextBlock("Shortcut"), KeyboardShortcut("Ctrl", "K")), () => TextBlock("Ctrl+K").Small())
                         )),
                         Label("Text that is far too long (multi)").SetContent(Dropdown().Multi().Items(
                             DropdownItem("A perfectly reasonable option").Selected(),
@@ -110,7 +110,7 @@ namespace Tesserae.Tests.Samples
                             SwatchItem("Seafoam", "#00b7c3").Selected(),
                             PersonRow("Ana Pereira", "ana@example.com").Selected(),
                             MetricItem("Revenue", new double[] { 3, 5, 4, 8, 6, 11, 9, 14 }, "#107c10").Selected(),
-                            DropdownItem(HStack().AlignItemsCenter().Gap(8.px()).Children(Icon(Emoji.Pizza), TextBlock("Pizza")), HStack().AlignItemsCenter().Gap(4.px()).Children(Icon(Emoji.Pizza, TextSize.Small), TextBlock("Pizza").Small())).Selected()
+                            DropdownItem(() => HStack().AlignItemsCenter().Gap(8.px()).Children(Icon(Emoji.Pizza), TextBlock("Pizza")), () => HStack().AlignItemsCenter().Gap(4.px()).Children(Icon(Emoji.Pizza, TextSize.Small), TextBlock("Pizza").Small())).Selected()
                         )),
                         TextBlock("WithCustomSelectionRender takes over the box completely: the selected items are handed to you and whatever you return is what the box shows - no clones, and no commas to get right."),
                         Label("Custom selection render (count)").SetContent(
@@ -145,7 +145,7 @@ namespace Tesserae.Tests.Samples
                     ),
                     SampleSubTitle("Deferred Mixed Content"),
                     VStack().Children(
-                        TextBlock("The same rich options as above, only now each one's content arrives through a Defer. This is the ordering that used to break the box: it shows a copy of the row, and a copy taken while the Defer was still on its loading placeholder stayed a placeholder for good - most visibly when an option is selected up front, before its content exists. Some of these are selected up front on purpose."),
+                        TextBlock("The same rich options as above, only now each one's content arrives through a Defer. An option is drawn twice - as a row in the list and, when selected, in the closed box - and because each is built from the factory the item was given, each is a live component: it mounts, so its Defer loads, wherever it is. Two of these are selected up front and fill themselves in without the list ever being opened."),
                         Label("Deferred rich options (multi, two pre-selected)").SetContent(Dropdown().Multi().Items(
                             DeferredItem(300,  () => BadgeRow("Critical", BadgeTone.Danger, UIcons.Exclamation),  selected: true),
                             DeferredItem(700,  () => SwatchRow("Seafoam", "#00b7c3", 16),                         selected: true),
@@ -157,8 +157,16 @@ namespace Tesserae.Tests.Samples
                             DeferredItem(900,  () => BadgeRow("Healthy", BadgeTone.Success, UIcons.CheckCircle)),
                             DeferredItem(1300, () => SwatchRow("Orchid", "#8764b8", 16))
                         )),
-                        TextBlock("A Defer normally waits to be mounted before it loads, and a row is not in the document until the dropdown is first opened - so a selected option would have sat in the box as a placeholder with nothing to make it resolve. Being selected is what settles it: the content is on show in the box, so the dropdown asks it to load whether or not the list has ever been opened. The two above are filled in without touching them. A Defer nested deeper inside the content, rather than being the content, still waits for the list to be opened."),
-                        TextBlock("An explicit short form is a live component rather than a copy, so a Defer inside one is mounted in the box and resolves there on its own. Here both halves are deferred, on different delays."),
+                        TextBlock("It does not matter how deep the Defer is either: the box builds the whole subtree, so a Defer buried inside the content mounts and loads there just as a top-level one does. The option below wraps a deferred fragment in a stack, and is selected up front."),
+                        Label("Deferred nested inside the content (multi, pre-selected)").SetContent(Dropdown().Multi().Items(
+                            NestedDeferredItem(600,  "Frankfurt",  "eu-central-1",  selected: true),
+                            NestedDeferredItem(1000, "Oregon",     "us-west-2")
+                        )),
+                        TextBlock("The price of two live components is that the factory runs twice, so whatever it does happens twice - two Defers, and two of whatever they call. Where that work is expensive, do it once outside the factory and let both instances await the same Task. The option below fetches once and is rendered twice from the result; the label shows how many times the 'fetch' actually ran."),
+                        Label("Work shared between the two instances (multi, pre-selected)").SetContent(Dropdown().Multi().Items(
+                            SharedWorkItem("Shared fetch", selected: true)
+                        )),
+                        TextBlock("A short form is a separate factory, for when the box wants a shorter version of the option rather than the same one. Here both halves are deferred, on different delays."),
                         Label("Deferred row and deferred short form (multi)").SetContent(Dropdown().Multi().Items(
                             DeferredPairItem(500,  1200, "Frankfurt",  "eu-central-1",   selected: true),
                             DeferredPairItem(800,  1600, "Oregon",     "us-west-2",      selected: true),
@@ -247,22 +255,22 @@ namespace Tesserae.Tests.Samples
 
         // A two-line row with an avatar in the list, collapsing to avatar + first name in the box.
         private static Dropdown.Item PersonRow(string name, string email) =>
-            DropdownItem(PersonBlock(name, email), PersonChip(name)).SetKey(email).SetData(Initials(name));
+            DropdownItem(() => PersonBlock(name, email), () => PersonChip(name)).SetKey(email).SetData(Initials(name));
 
         // A badge is already a self-contained pill, so the box shows the same thing the list does.
         private static Dropdown.Item BadgeItem(string text, BadgeTone tone, UIcons icon) =>
-            DropdownItem(BadgeRow(text, tone, icon), Badge(text).Tone(tone).Pill()).SetKey(text);
+            DropdownItem(() => BadgeRow(text, tone, icon), () => Badge(text).Tone(tone).Pill()).SetKey(text);
 
         private static Dropdown.Item SwatchItem(string name, string color) =>
-            DropdownItem(SwatchRow(name, color, 16), SwatchRow(name, color, 10)).SetKey(name);
+            DropdownItem(() => SwatchRow(name, color, 16), () => SwatchRow(name, color, 10)).SetKey(name);
 
         // A chart inside an option - the tallest, widest thing here, and the box gets a smaller one.
         private static Dropdown.Item MetricItem(string name, double[] series, string color) =>
-            DropdownItem(MetricRow(name, series, color, 90, 24, labelWidth: 70), MetricRow(name, series, color, 36, 12)).SetKey(name);
+            DropdownItem(() => MetricRow(name, series, color, 90, 24, labelWidth: 70), () => MetricRow(name, series, color, 36, 12)).SetKey(name);
 
         // Deliberately gives no short form, so the box has to clip the two-line block itself.
         private static Dropdown.Item TwoLineItem(string title, string subtitle) =>
-            DropdownItem(TwoLineBlock(title, subtitle)).SetKey(subtitle);
+            DropdownItem(() => TwoLineBlock(title, subtitle)).SetKey(subtitle);
 
         // --- The same content, arriving through a Defer ----------------------------------------
         // No short form, so the box shows a copy of the row - which is exactly the case that has to
@@ -271,7 +279,7 @@ namespace Tesserae.Tests.Samples
         private static int _deferredKey;
 
         private static Dropdown.Item DeferredItem(int delayMs, Func<IComponent> content, bool selected = false) =>
-            DropdownItem(Defer(async () =>
+            DropdownItem(() => Defer(async () =>
                 {
                     await Task.Delay(delayMs);
                     return content();
@@ -283,18 +291,55 @@ namespace Tesserae.Tests.Samples
         // is a live component, so its own Defer resolves in the box itself.
         private static Dropdown.Item DeferredPairItem(int rowDelayMs, int chipDelayMs, string title, string subtitle, bool selected = false) =>
             DropdownItem(
-                    Defer(async () =>
+                    () => Defer(async () =>
                     {
                         await Task.Delay(rowDelayMs);
                         return TwoLineBlock(title, subtitle);
                     }, loadMessage: Skeleton().Animated().W(120).H(16)),
-                    Defer(async () =>
+                    () => Defer(async () =>
                     {
                         await Task.Delay(chipDelayMs);
                         return TextBlock(title).Small();
                     }, loadMessage: Skeleton().Animated().W(60).H(12)))
                .SetKey(subtitle)
                .SelectedIf(selected);
+
+        // A Defer that is not the item's content but sits inside it, to show that the box mounts the whole
+        // subtree it builds rather than just its root.
+        private static Dropdown.Item NestedDeferredItem(int delayMs, string title, string subtitle, bool selected = false) =>
+            DropdownItem(() => HStack().AlignItemsCenter().Gap(8.px()).Children(
+                    Icon(UIcons.Globe),
+                    Defer(async () =>
+                    {
+                        await Task.Delay(delayMs);
+                        return TwoLineBlock(title, subtitle);
+                    }, loadMessage: Skeleton().Animated().W(100).H(16))))
+               .SetKey(subtitle)
+               .SelectedIf(selected);
+
+        // The factory runs once for the row and once for the box, so anything expensive in it runs twice
+        // unless the work itself is shared. One Task, awaited by both, is all that takes.
+        private static int _sharedFetchCount;
+
+        private static Dropdown.Item SharedWorkItem(string name, bool selected = false)
+        {
+            var fetchOnce = FetchOnceAsync(name);   // started once, here, not inside the factory
+
+            return DropdownItem(() => Defer(async () =>
+                {
+                    var value = await fetchOnce;
+                    return TextBlock(value).Small();
+                }, loadMessage: Skeleton().Animated().W(120).H(16)))
+               .SetKey(name)
+               .SelectedIf(selected);
+        }
+
+        private static async Task<string> FetchOnceAsync(string name)
+        {
+            await Task.Delay(600);
+            _sharedFetchCount++;
+            return $"{name} (fetched {_sharedFetchCount}x)";
+        }
 
         private static Dropdown StartLoadingAsyncDataImmediately(Dropdown dropdown)
         {
@@ -304,7 +349,7 @@ namespace Tesserae.Tests.Samples
 
         private Dropdown.Item DeferredDropdownItem(string text, int delayMs)
         {
-            return DropdownItem(Defer(async () =>
+            return DropdownItem(() => Defer(async () =>
             {
                 await Task.Delay(delayMs);
                 return Label($"Loaded {text}");

--- a/Tesserae.Tests/src/Samples/Inputs/DropdownSample.cs
+++ b/Tesserae.Tests/src/Samples/Inputs/DropdownSample.cs
@@ -143,6 +143,28 @@ namespace Tesserae.Tests.Samples
                         )),
                         Label("Empty State").SetContent(Dropdown("No items available").Items(new Dropdown.Item[0]))
                     ),
+                    SampleSubTitle("Deferred Mixed Content"),
+                    VStack().Children(
+                        TextBlock("The same rich options as above, only now each one's content arrives through a Defer. This is the ordering that used to break the box: it shows a copy of the row, and a copy taken while the Defer was still on its loading placeholder stayed a placeholder for good - most visibly when an option is selected up front, before its content exists. Some of these are selected up front on purpose."),
+                        Label("Deferred rich options (multi, two pre-selected)").SetContent(Dropdown().Multi().Items(
+                            DeferredItem(300,  () => BadgeRow("Critical", BadgeTone.Danger, UIcons.Exclamation),  selected: true),
+                            DeferredItem(700,  () => SwatchRow("Seafoam", "#00b7c3", 16),                         selected: true),
+                            DeferredItem(1100, () => PersonBlock("Ana Pereira", "ana@example.com")),
+                            DeferredItem(1500, () => MetricRow("Revenue", new double[] { 3, 5, 4, 8, 6, 11, 9, 14 }, "#107c10", 90, 24, labelWidth: 70))
+                        )),
+                        Label("Deferred rich options (single)").SetContent(Dropdown().Items(
+                            DeferredItem(400,  () => PersonBlock("Bo Lindqvist", "bo@example.com")),
+                            DeferredItem(900,  () => BadgeRow("Healthy", BadgeTone.Success, UIcons.CheckCircle)),
+                            DeferredItem(1300, () => SwatchRow("Orchid", "#8764b8", 16))
+                        )),
+                        TextBlock("One thing the box cannot do anything about: a Defer only loads its content once it is mounted, and a row is not in the document until the dropdown is first opened. So an option that is deferred, has no short form and is selected up front shows its placeholder in the box until you open the list once - there is nothing else to copy yet. It catches up as each Defer resolves."),
+                        TextBlock("An explicit short form is the way out, and is a live component rather than a copy, so a Defer inside one is mounted in the box and resolves there without the list ever being opened. Here both halves are deferred, on different delays."),
+                        Label("Deferred row and deferred short form (multi)").SetContent(Dropdown().Multi().Items(
+                            DeferredPairItem(500,  1200, "Frankfurt",  "eu-central-1",   selected: true),
+                            DeferredPairItem(800,  1600, "Oregon",     "us-west-2",      selected: true),
+                            DeferredPairItem(1100, 2000, "Singapore",  "ap-southeast-1")
+                        ))
+                    ),
                     SampleSubTitle("Lazy Search (SearchAsync)"),
                     VStack().Children(
                         TextBlock("With thousands of options there is no loading them all up front. Seed the dropdown with the first page, and let SearchAsync fetch the rest as the User types - the items it returns are added to the ones already there, so the seed and the current selection survive every lookup. This example holds 5,000 people and seeds only the first 20."),
@@ -170,44 +192,25 @@ namespace Tesserae.Tests.Samples
         }
 
         // --- Wild renderings ------------------------------------------------------------------
-        // Each of these builds an option whose content is a composed IComponent rather than a string.
-        // The second argument to DropdownItem is what the *box* shows once the option is selected,
-        // which is the escape hatch for content too tall or too wide to sit on one clipped row.
+        // The content each option draws, defined once as an IComponent, so the plain options above and
+        // the deferred ones below are demonstrably showing the same thing through different paths.
 
-        private static Dropdown PeopleDropdown() => Dropdown().Multi().Items(
-            PersonRow("Ana Pereira",  "ana@example.com").Selected(),
-            PersonRow("Bo Lindqvist", "bo@example.com").Selected(),
-            PersonRow("Chen Wei",     "chen@example.com"),
-            PersonRow("Dara O'Neill", "dara@example.com"));
+        private static IComponent PersonBlock(string name, string email) =>
+            HStack().AlignItemsCenter().Gap(8.px()).Children(
+                Avatar(initials: Initials(name)).Size(AvatarSize.Small).Presence(AvatarPresence.Online),
+                VStack().Children(
+                    TextBlock(name).Small(),
+                    TextBlock(email).Tiny().Secondary()));
 
-        // A two-line row with an avatar in the list, collapsing to avatar + first name in the box.
-        private static Dropdown.Item PersonRow(string name, string email)
-        {
-            var initials = string.Join("", name.Split(' ').Select(part => part.Substring(0, 1)));
+        private static IComponent PersonChip(string name) =>
+            HStack().AlignItemsCenter().Gap(4.px()).Children(
+                Avatar(initials: Initials(name)).Size(AvatarSize.XSmall),
+                TextBlock(name.Split(' ')[0]).Small());
 
-            return DropdownItem(
-                    HStack().AlignItemsCenter().Gap(8.px()).Children(
-                        Avatar(initials: initials).Size(AvatarSize.Small).Presence(AvatarPresence.Online),
-                        VStack().Children(
-                            TextBlock(name).Small(),
-                            TextBlock(email).Tiny().Secondary())),
-                    HStack().AlignItemsCenter().Gap(4.px()).Children(
-                        Avatar(initials: initials).Size(AvatarSize.XSmall),
-                        TextBlock(name.Split(' ')[0]).Small()))
-               .SetKey(email)
-               .SetData(initials);
-        }
-
-        // A badge is already a self-contained pill, so the box shows the same thing the list does.
-        private static Dropdown.Item BadgeItem(string text, BadgeTone tone, UIcons icon) =>
-            DropdownItem(Badge(text).Tone(tone).Pill().SetIcon(Tesserae.Icon.Transform(icon, UIconsWeight.Regular)),
-                         Badge(text).Tone(tone).Pill())
-               .SetKey(text);
+        private static IComponent BadgeRow(string text, BadgeTone tone, UIcons icon) =>
+            Badge(text).Tone(tone).Pill().SetIcon(Tesserae.Icon.Transform(icon, UIconsWeight.Regular));
 
         // A colour chip drawn with a bare div, to prove the box does not care what the content is.
-        private static Dropdown.Item SwatchItem(string name, string color) =>
-            DropdownItem(SwatchRow(name, color, 16), SwatchRow(name, color, 10)).SetKey(name);
-
         private static IComponent SwatchRow(string name, string color, int size) =>
             HStack().AlignItemsCenter().Gap(8.px()).Children(
                 Raw(Div(Att(styles: s =>
@@ -220,23 +223,78 @@ namespace Tesserae.Tests.Samples
                 }))),
                 TextBlock(name).Small());
 
+        private static IComponent MetricRow(string name, double[] series, string color, double width, double height, int labelWidth = 0) =>
+            HStack().AlignItemsCenter().Gap(8.px()).Children(
+                labelWidth > 0 ? TextBlock(name).Small().W(labelWidth) : TextBlock(name).Small(),
+                Sparkline(series, width: width, height: height, color: color));
+
+        private static IComponent TwoLineBlock(string title, string subtitle) =>
+            VStack().Children(
+                TextBlock(title).Small(),
+                TextBlock(subtitle).Tiny().Secondary());
+
+        private static string Initials(string name) => string.Join("", name.Split(' ').Select(part => part.Substring(0, 1)));
+
+        // --- Options built from that content --------------------------------------------------
+        // The second argument to DropdownItem is what the *box* shows once the option is selected,
+        // which is the escape hatch for content too tall or too wide to sit on one clipped row.
+
+        private static Dropdown PeopleDropdown() => Dropdown().Multi().Items(
+            PersonRow("Ana Pereira",  "ana@example.com").Selected(),
+            PersonRow("Bo Lindqvist", "bo@example.com").Selected(),
+            PersonRow("Chen Wei",     "chen@example.com"),
+            PersonRow("Dara O'Neill", "dara@example.com"));
+
+        // A two-line row with an avatar in the list, collapsing to avatar + first name in the box.
+        private static Dropdown.Item PersonRow(string name, string email) =>
+            DropdownItem(PersonBlock(name, email), PersonChip(name)).SetKey(email).SetData(Initials(name));
+
+        // A badge is already a self-contained pill, so the box shows the same thing the list does.
+        private static Dropdown.Item BadgeItem(string text, BadgeTone tone, UIcons icon) =>
+            DropdownItem(BadgeRow(text, tone, icon), Badge(text).Tone(tone).Pill()).SetKey(text);
+
+        private static Dropdown.Item SwatchItem(string name, string color) =>
+            DropdownItem(SwatchRow(name, color, 16), SwatchRow(name, color, 10)).SetKey(name);
+
         // A chart inside an option - the tallest, widest thing here, and the box gets a smaller one.
         private static Dropdown.Item MetricItem(string name, double[] series, string color) =>
-            DropdownItem(
-                HStack().AlignItemsCenter().Gap(8.px()).Children(
-                    TextBlock(name).Small().W(70),
-                    Sparkline(series, width: 90, height: 24, color: color)),
-                HStack().AlignItemsCenter().Gap(4.px()).Children(
-                    TextBlock(name).Small(),
-                    Sparkline(series, width: 36, height: 12, color: color)))
-               .SetKey(name);
+            DropdownItem(MetricRow(name, series, color, 90, 24, labelWidth: 70), MetricRow(name, series, color, 36, 12)).SetKey(name);
 
         // Deliberately gives no short form, so the box has to clip the two-line block itself.
         private static Dropdown.Item TwoLineItem(string title, string subtitle) =>
-            DropdownItem(VStack().Children(
-                    TextBlock(title).Small(),
-                    TextBlock(subtitle).Tiny().Secondary()))
-               .SetKey(subtitle);
+            DropdownItem(TwoLineBlock(title, subtitle)).SetKey(subtitle);
+
+        // --- The same content, arriving through a Defer ----------------------------------------
+        // No short form, so the box shows a copy of the row - which is exactly the case that has to
+        // catch up once the Defer resolves, and which is broken from the start when the option is
+        // selected before its content exists.
+        private static int _deferredKey;
+
+        private static Dropdown.Item DeferredItem(int delayMs, Func<IComponent> content, bool selected = false) =>
+            DropdownItem(Defer(async () =>
+                {
+                    await Task.Delay(delayMs);
+                    return content();
+                }, loadMessage: Skeleton().Animated().W(120).H(16)))
+               .SetKey($"deferred-{_deferredKey++}")
+               .SelectedIf(selected);
+
+        // Both halves deferred, on different delays: the row is copied into the box, but the short form
+        // is a live component, so its own Defer resolves in the box itself.
+        private static Dropdown.Item DeferredPairItem(int rowDelayMs, int chipDelayMs, string title, string subtitle, bool selected = false) =>
+            DropdownItem(
+                    Defer(async () =>
+                    {
+                        await Task.Delay(rowDelayMs);
+                        return TwoLineBlock(title, subtitle);
+                    }, loadMessage: Skeleton().Animated().W(120).H(16)),
+                    Defer(async () =>
+                    {
+                        await Task.Delay(chipDelayMs);
+                        return TextBlock(title).Small();
+                    }, loadMessage: Skeleton().Animated().W(60).H(12)))
+               .SetKey(subtitle)
+               .SelectedIf(selected);
 
         private static Dropdown StartLoadingAsyncDataImmediately(Dropdown dropdown)
         {
@@ -250,7 +308,7 @@ namespace Tesserae.Tests.Samples
             {
                 await Task.Delay(delayMs);
                 return Label($"Loaded {text}");
-            }, loadMessage: Skeleton().Animated().W(500).H(32)));
+            }, loadMessage: Skeleton().Animated().W(120).H(16)));
         }
 
         // Stands in for the server: 5,000 options that would be senseless to render up front.

--- a/Tesserae/skills/references/dropdown.md
+++ b/Tesserae/skills/references/dropdown.md
@@ -12,7 +12,9 @@ item loading, custom selection rendering, and validation. Items are
 ## Create
 
 `UI.Dropdown()` (or `UI.Dropdown(string noItemsText)`) — the dropdown.
-`UI.DropdownItem(string text, string selectedText = "", UIcons? icon = null)` — an option;
+`UI.DropdownItem(string text, string selectedText = "", UIcons? icon = null)` — a plain option.
+`UI.DropdownItem(Func<IComponent> content, Func<IComponent> selectedContent = null)` — an option that
+draws components; see **Rich item content** for why these are factories and not components.
 `UI.DropdownItem()` for a divider/header placeholder.
 Bring factories into scope with `using static Tesserae.UI;`.
 
@@ -88,55 +90,49 @@ returning the first page for an empty term restores the seed list.
 
 ## Rich item content
 
-An item's content is any `IComponent` — an avatar and two lines of text, a badge, a colour swatch, a
-sparkline — and the box shows a **clone** of it, laid out inline and comma-separated on a single
-~32px row. So whatever an option renders in the list, the box has to render on one clipped line.
-
-The second argument to `UI.DropdownItem` is the escape hatch: it is what the box shows once the
-option is selected, and it is worth giving whenever the list content is taller or wider than one
-row. Content taller than the row is the one case the box cannot rescue — a separator next to a
-two-line block has nowhere good to sit.
+An option is drawn **twice**: as a row in the open list, and — when it is selected — in the closed
+box, laid out inline and comma-separated on a single ~32px row. A component can only be in one of
+those places at a time, so `DropdownItem` takes **factories** rather than components and calls one
+for each:
 
 ```csharp
 DropdownItem(
-    // In the list: avatar, name, email.
-    HStack().AlignItemsCenter().Gap(8.px()).Children(
+    // The row: called immediately.
+    () => HStack().AlignItemsCenter().Gap(8.px()).Children(
         Avatar(initials: "AP").Size(AvatarSize.Small),
         VStack().Children(TextBlock("Ana Pereira").Small(), TextBlock("ana@example.com").Tiny().Secondary())),
-    // In the box: avatar and first name, one line.
-    HStack().AlignItemsCenter().Gap(4.px()).Children(
+    // The box: called the first time the option is selected. Optional - without it the box builds a
+    // second one from the first factory, which is right whenever the content fits on one clipped row.
+    () => HStack().AlignItemsCenter().Gap(4.px()).Children(
         Avatar(initials: "AP").Size(AvatarSize.XSmall),
         TextBlock("Ana").Small()))
    .SetKey("ana@example.com");
 ```
 
-### Content that loads asynchronously
+Give the second factory whenever the row is taller or wider than one line — a two-line block, a
+chart. Content taller than the row is the one thing the box cannot lay out well.
 
-The copy the box shows is taken when the item becomes selected and is kept in step with the row
-afterwards, so a `Defer` (or an image, or anything bound to an observable) that resolves later shows
-up in the box too.
+Two consequences of the box having its own instance, both worth knowing:
 
-A `Defer` normally waits to be **mounted** before it loads, and an option's row is not in the
-document until the dropdown is first opened — so a selected option would otherwise sit in the box as
-a loading placeholder with nothing to make it resolve. Being selected is what settles it: its content
-is on show in the box, so the dropdown asks it to load whether or not the list has ever been opened.
-
-That covers a `Defer` that *is* the item's content. One nested deeper — a `Defer` inside a `Stack`
-inside the item — is not reachable this way and still waits for the list to be opened. Giving the
-item an explicit short form sidesteps the whole question, since a short form is a live component
-mounted in the box and resolves there on its own:
+- **It is live.** It mounts, so a `Defer` in it loads — at any depth, not just at the top — it
+  animates, and it reacts. (This is why it is a factory: a *copy* of the row would be inert.)
+- **Its state is its own**, and the factory runs twice. Put something interactive in an option and the
+  list's copy and the box's copy will not share state — give the box a read-only short form if that
+  matters. More importantly, whatever the factory *does* it does twice, so share expensive work
+  rather than repeating it:
 
 ```csharp
-DropdownItem(
-    Defer(async () => await LoadTheWholeRow(id),  loadMessage: Skeleton().Animated().W(120).H(16)),
-    Defer(async () => await LoadJustTheLabel(id), loadMessage: Skeleton().Animated().W(60).H(12)))
+var load = LoadOnceAsync(id);   // started once, outside the factory
+
+DropdownItem(() => Defer(async () => Render(await load),
+                         loadMessage: Skeleton().Animated().W(120).H(16)))
    .SetKey(id)
-   .Selected();
+   .Selected();                 // fills itself in without the list ever being opened
 ```
 
 To take over the box entirely instead — a count, a pile of avatars — use
-`.WithCustomSelectionRender(items => ...)`. That replaces the clones altogether, separators
-included, so you own the whole presentation.
+`.WithCustomSelectionRender(items => ...)`. That replaces the per-item elements altogether,
+separators included, so you own the whole presentation.
 
 ## Related
 

--- a/Tesserae/skills/references/dropdown.md
+++ b/Tesserae/skills/references/dropdown.md
@@ -13,8 +13,12 @@ item loading, custom selection rendering, and validation. Items are
 
 `UI.Dropdown()` (or `UI.Dropdown(string noItemsText)`) — the dropdown.
 `UI.DropdownItem(string text, string selectedText = "", UIcons? icon = null)` — a plain option.
-`UI.DropdownItem(Func<IComponent> content, Func<IComponent> selectedContent = null)` — an option that
-draws components; see **Rich item content** for why these are factories and not components.
+`UI.DropdownItem(IComponent content, IComponent selectedContent)` — an option drawing components you
+have already built: one for the row, one for the box. Both are required and must be different
+instances.
+`UI.DropdownItem(Func<IComponent> content, Func<IComponent> selectedContent = null)` — the same from
+recipes, so one recipe can serve both, and the box's is built only if the option is selected.
+See **Rich item content**.
 `UI.DropdownItem()` for a divider/header placeholder.
 Bring factories into scope with `using static Tesserae.UI;`.
 
@@ -91,35 +95,44 @@ returning the first page for an empty term restores the seed list.
 ## Rich item content
 
 An option is drawn **twice**: as a row in the open list, and — when it is selected — in the closed
-box, laid out inline and comma-separated on a single ~32px row. A component can only be in one of
-those places at a time, so `DropdownItem` takes **factories** rather than components and calls one
-for each:
+box, laid out inline and comma-separated on a single ~32px row. A component exists at exactly one
+place in the DOM, so each place needs its own. There are two ways to say that.
+
+**Pass both components** when you have them and they are cheap. Both are required, and they must be
+different instances — the same one in both places does not draw twice, it moves out of the row:
 
 ```csharp
 DropdownItem(
-    // The row: called immediately.
-    () => HStack().AlignItemsCenter().Gap(8.px()).Children(
+    HStack().AlignItemsCenter().Gap(8.px()).Children(          // the row
         Avatar(initials: "AP").Size(AvatarSize.Small),
         VStack().Children(TextBlock("Ana Pereira").Small(), TextBlock("ana@example.com").Tiny().Secondary())),
-    // The box: called the first time the option is selected. Optional - without it the box builds a
-    // second one from the first factory, which is right whenever the content fits on one clipped row.
-    () => HStack().AlignItemsCenter().Gap(4.px()).Children(
+    HStack().AlignItemsCenter().Gap(4.px()).Children(          // the box
         Avatar(initials: "AP").Size(AvatarSize.XSmall),
         TextBlock("Ana").Small()))
    .SetKey("ana@example.com");
 ```
 
-Give the second factory whenever the row is taller or wider than one line — a two-line block, a
-chart. Content taller than the row is the one thing the box cannot lay out well.
+**Pass a recipe** to have one description serve both, and to build the box's only if the option is
+ever selected — the better choice for expensive content, for long lists, and whenever the row and
+the box should look the same:
+
+```csharp
+DropdownItem(() => BadgeRow(status));                             // one recipe, used for both
+DropdownItem(() => FullRow(id), () => ShortChip(id));             // a recipe for each
+```
+
+Give the box its own, shorter form whenever the row is taller or wider than one line — a two-line
+block, a chart. Content taller than the row is the one thing the box cannot lay out well.
 
 Two consequences of the box having its own instance, both worth knowing:
 
+
 - **It is live.** It mounts, so a `Defer` in it loads — at any depth, not just at the top — it
   animates, and it reacts. (This is why it is a factory: a *copy* of the row would be inert.)
-- **Its state is its own**, and the factory runs twice. Put something interactive in an option and the
-  list's copy and the box's copy will not share state — give the box a read-only short form if that
-  matters. More importantly, whatever the factory *does* it does twice, so share expensive work
-  rather than repeating it:
+- **Its state is its own.** Put something interactive in an option and the list's and the box's will
+  not share state — give the box a read-only short form if that matters.
+- **A single recipe runs twice**, so whatever it does happens twice. Share expensive work rather than
+  repeating it:
 
 ```csharp
 var load = LoadOnceAsync(id);   // started once, outside the factory

--- a/Tesserae/skills/references/dropdown.md
+++ b/Tesserae/skills/references/dropdown.md
@@ -86,6 +86,34 @@ var dd = Dropdown()
 The callback is also called with an empty string when the User clears the box, so
 returning the first page for an empty term restores the seed list.
 
+## Rich item content
+
+An item's content is any `IComponent` — an avatar and two lines of text, a badge, a colour swatch, a
+sparkline — and the box shows a **clone** of it, laid out inline and comma-separated on a single
+~32px row. So whatever an option renders in the list, the box has to render on one clipped line.
+
+The second argument to `UI.DropdownItem` is the escape hatch: it is what the box shows once the
+option is selected, and it is worth giving whenever the list content is taller or wider than one
+row. Content taller than the row is the one case the box cannot rescue — a separator next to a
+two-line block has nowhere good to sit.
+
+```csharp
+DropdownItem(
+    // In the list: avatar, name, email.
+    HStack().AlignItemsCenter().Gap(8.px()).Children(
+        Avatar(initials: "AP").Size(AvatarSize.Small),
+        VStack().Children(TextBlock("Ana Pereira").Small(), TextBlock("ana@example.com").Tiny().Secondary())),
+    // In the box: avatar and first name, one line.
+    HStack().AlignItemsCenter().Gap(4.px()).Children(
+        Avatar(initials: "AP").Size(AvatarSize.XSmall),
+        TextBlock("Ana").Small()))
+   .SetKey("ana@example.com");
+```
+
+To take over the box entirely instead — a count, a pile of avatars — use
+`.WithCustomSelectionRender(items => ...)`. That replaces the clones altogether, separators
+included, so you own the whole presentation.
+
 ## Related
 
 - ChoiceGroup, Toggle — alternative single-choice inputs

--- a/Tesserae/skills/references/dropdown.md
+++ b/Tesserae/skills/references/dropdown.md
@@ -110,6 +110,26 @@ DropdownItem(
    .SetKey("ana@example.com");
 ```
 
+### Content that loads asynchronously
+
+The copy the box shows is taken when the item becomes selected and is kept in step with the row
+afterwards, so a `Defer` (or an image, or anything bound to an observable) that resolves later shows
+up in the box too.
+
+One case is worth knowing about: a `Defer` only loads its content once it is **mounted**, and an
+option's row is not in the document until the dropdown is first opened. An option that is deferred,
+has no short form, and is selected up front therefore shows its loading placeholder in the box until
+the list is opened once. Giving it an explicit short form avoids that entirely — a short form is a
+live component mounted in the box, so its own `Defer` resolves there straight away:
+
+```csharp
+DropdownItem(
+    Defer(async () => await LoadTheWholeRow(id),  loadMessage: Skeleton().Animated().W(120).H(16)),
+    Defer(async () => await LoadJustTheLabel(id), loadMessage: Skeleton().Animated().W(60).H(12)))
+   .SetKey(id)
+   .Selected();
+```
+
 To take over the box entirely instead — a count, a pile of avatars — use
 `.WithCustomSelectionRender(items => ...)`. That replaces the clones altogether, separators
 included, so you own the whole presentation.

--- a/Tesserae/skills/references/dropdown.md
+++ b/Tesserae/skills/references/dropdown.md
@@ -14,11 +14,15 @@ item loading, custom selection rendering, and validation. Items are
 `UI.Dropdown()` (or `UI.Dropdown(string noItemsText)`) — the dropdown.
 `UI.DropdownItem(string text, string selectedText = "", UIcons? icon = null)` — a plain option.
 `UI.DropdownItem(IComponent content, IComponent selectedContent)` — an option drawing components you
-have already built: one for the row, one for the box. Both are required and must be different
-instances.
+have already built: one for the row, one for the box. They must be different instances; pass the same
+one twice, or `null` for the box, and it falls back to copying the row and says so on the console.
 `UI.DropdownItem(Func<IComponent> content, Func<IComponent> selectedContent = null)` — the same from
 recipes, so one recipe can serve both, and the box's is built only if the option is selected.
 See **Rich item content**.
+`UI.DropdownItem(IComponent content)` — **obsolete**. Draws that one component in the row and a
+`cloneNode` copy of it in the box. The copy has no event listeners, no mount registration and no
+component identity, so a `Defer` inside it never loads and nothing in it ever reacts. It still works,
+so existing code keeps running; the compiler warns, and the fix is the `Func<IComponent>` overload.
 `UI.DropdownItem()` for a divider/header placeholder.
 Bring factories into scope with `using static Tesserae.UI;`.
 
@@ -98,8 +102,8 @@ An option is drawn **twice**: as a row in the open list, and — when it is sele
 box, laid out inline and comma-separated on a single ~32px row. A component exists at exactly one
 place in the DOM, so each place needs its own. There are two ways to say that.
 
-**Pass both components** when you have them and they are cheap. Both are required, and they must be
-different instances — the same one in both places does not draw twice, it moves out of the row:
+**Pass both components** when you have them and they are cheap. They must be different instances —
+the same one in both places does not draw twice, it moves out of the row:
 
 ```csharp
 DropdownItem(

--- a/Tesserae/skills/references/dropdown.md
+++ b/Tesserae/skills/references/dropdown.md
@@ -16,8 +16,10 @@ item loading, custom selection rendering, and validation. Items are
 `UI.DropdownItem(IComponent content, IComponent selectedContent)` — an option drawing components you
 have already built: one for the row, one for the box. They must be different instances; pass the same
 one twice, or `null` for the box, and it falls back to copying the row and says so on the console.
-`UI.DropdownItem(Func<IComponent> content, Func<IComponent> selectedContent = null)` — the same from
-recipes, so one recipe can serve both, and the box's is built only if the option is selected.
+`UI.DropdownItem(Func<IComponent> content)` — one recipe, used for the row and again for the box, so
+the two are separate live components and the box's is built only if the option is selected.
+`UI.DropdownItem(IComponent content, Func<IComponent> selectedContent)` — a component for the row and
+a recipe for the box, for a long list whose options each want a shorter form in the box.
 See **Rich item content**.
 `UI.DropdownItem(IComponent content)` — **obsolete**. Draws that one component in the row and a
 `cloneNode` copy of it in the box. The copy has no event listeners, no mount registration and no
@@ -116,13 +118,13 @@ DropdownItem(
    .SetKey("ana@example.com");
 ```
 
-**Pass a recipe** to have one description serve both, and to build the box's only if the option is
-ever selected — the better choice for expensive content, for long lists, and whenever the row and
-the box should look the same:
+**Pass a recipe** to have one description serve both — the better choice for expensive content, for
+long lists, and whenever the row and the box should look the same. Only the box's component can be
+deferred: the row's is what the item renders, so it is always built now.
 
 ```csharp
-DropdownItem(() => BadgeRow(status));                             // one recipe, used for both
-DropdownItem(() => FullRow(id), () => ShortChip(id));             // a recipe for each
+DropdownItem(() => BadgeRow(status));               // one recipe, used for both
+DropdownItem(FullRow(id), () => ShortChip(id));     // row now, box's short form only if selected
 ```
 
 Give the box its own, shorter form whenever the row is taller or wider than one line — a two-line
@@ -136,7 +138,7 @@ Two consequences of the box having its own instance, both worth knowing:
 - **Its state is its own.** Put something interactive in an option and the list's and the box's will
   not share state — give the box a read-only short form if that matters.
 - **A single recipe runs twice**, so whatever it does happens twice. Share expensive work rather than
-  repeating it:
+  repeating it (the second run only happens if the option is selected):
 
 ```csharp
 var load = LoadOnceAsync(id);   // started once, outside the factory

--- a/Tesserae/skills/references/dropdown.md
+++ b/Tesserae/skills/references/dropdown.md
@@ -116,11 +116,15 @@ The copy the box shows is taken when the item becomes selected and is kept in st
 afterwards, so a `Defer` (or an image, or anything bound to an observable) that resolves later shows
 up in the box too.
 
-One case is worth knowing about: a `Defer` only loads its content once it is **mounted**, and an
-option's row is not in the document until the dropdown is first opened. An option that is deferred,
-has no short form, and is selected up front therefore shows its loading placeholder in the box until
-the list is opened once. Giving it an explicit short form avoids that entirely — a short form is a
-live component mounted in the box, so its own `Defer` resolves there straight away:
+A `Defer` normally waits to be **mounted** before it loads, and an option's row is not in the
+document until the dropdown is first opened — so a selected option would otherwise sit in the box as
+a loading placeholder with nothing to make it resolve. Being selected is what settles it: its content
+is on show in the box, so the dropdown asks it to load whether or not the list has ever been opened.
+
+That covers a `Defer` that *is* the item's content. One nested deeper — a `Defer` inside a `Stack`
+inside the item — is not reachable this way and still waits for the list to be opened. Giving the
+item an explicit short form sidesteps the whole question, since a short form is a live component
+mounted in the box and resolves there on its own:
 
 ```csharp
 DropdownItem(

--- a/Tesserae/src/Base/UI.Components.cs
+++ b/Tesserae/src/Base/UI.Components.cs
@@ -1291,6 +1291,11 @@ namespace Tesserae
         /// <summary>
         /// Creates a <see cref="Tesserae.Dropdown.Item"/> component.
         /// </summary>
+        public static Dropdown.Item DropdownItem(IComponent content, IComponent selectedContent) => new Dropdown.Item(content, selectedContent);
+
+        /// <summary>
+        /// Creates a <see cref="Tesserae.Dropdown.Item"/> component.
+        /// </summary>
         public static Dropdown.Item DropdownItem(Func<IComponent> content, Func<IComponent> selectedContent = null) => new Dropdown.Item(content, selectedContent);
 
         /// <summary>

--- a/Tesserae/src/Base/UI.Components.cs
+++ b/Tesserae/src/Base/UI.Components.cs
@@ -1291,7 +1291,7 @@ namespace Tesserae
         /// <summary>
         /// Creates a <see cref="Tesserae.Dropdown.Item"/> component.
         /// </summary>
-        public static Dropdown.Item DropdownItem(IComponent content, IComponent selectedContent = null) => new Dropdown.Item(content, selectedContent);
+        public static Dropdown.Item DropdownItem(Func<IComponent> content, Func<IComponent> selectedContent = null) => new Dropdown.Item(content, selectedContent);
 
         /// <summary>
         /// Creates a <see cref="Tesserae.ContextMenu"/> component.

--- a/Tesserae/src/Base/UI.Components.cs
+++ b/Tesserae/src/Base/UI.Components.cs
@@ -1289,6 +1289,15 @@ namespace Tesserae
         public static Dropdown.Item DropdownItem(string text, string selectedText = string.Empty, UIcons? icon = null) => new Dropdown.Item(text, selectedText, icon);
 
         /// <summary>
+        /// Creates a <see cref="Tesserae.Dropdown.Item"/> component from a single component, which is drawn in
+        /// the list and copied into the closed box. Obsolete - the copy has no event listeners and never loads
+        /// a <see cref="Defer(Func{Task{IComponent}})"/>; pass a <see cref="Func{IComponent}"/> instead and the
+        /// list and the box each get their own live component from the same recipe.
+        /// </summary>
+        [Obsolete("The box gets a copy of the row, which has no listeners and never loads a Defer. Pass a Func<IComponent> instead, so the box builds its own live component from the same recipe.")]
+        public static Dropdown.Item DropdownItem(IComponent content) => new Dropdown.Item(content);
+
+        /// <summary>
         /// Creates a <see cref="Tesserae.Dropdown.Item"/> component.
         /// </summary>
         public static Dropdown.Item DropdownItem(IComponent content, IComponent selectedContent) => new Dropdown.Item(content, selectedContent);

--- a/Tesserae/src/Base/UI.Components.cs
+++ b/Tesserae/src/Base/UI.Components.cs
@@ -1303,9 +1303,17 @@ namespace Tesserae
         public static Dropdown.Item DropdownItem(IComponent content, IComponent selectedContent) => new Dropdown.Item(content, selectedContent);
 
         /// <summary>
-        /// Creates a <see cref="Tesserae.Dropdown.Item"/> component.
+        /// Creates a <see cref="Tesserae.Dropdown.Item"/> component from a component for the row and a recipe
+        /// for the box, so the box's is built only if the option is selected.
         /// </summary>
-        public static Dropdown.Item DropdownItem(Func<IComponent> content, Func<IComponent> selectedContent = null) => new Dropdown.Item(content, selectedContent);
+        public static Dropdown.Item DropdownItem(IComponent content, Func<IComponent> selectedContent) => new Dropdown.Item(content, selectedContent);
+
+        /// <summary>
+        /// Creates a <see cref="Tesserae.Dropdown.Item"/> component from one recipe, used for the row in the
+        /// list and again for the closed box - so the two are separate, live components, and the box's is built
+        /// only if the option is selected.
+        /// </summary>
+        public static Dropdown.Item DropdownItem(Func<IComponent> content) => new Dropdown.Item(content);
 
         /// <summary>
         /// Creates a <see cref="Tesserae.ContextMenu"/> component.

--- a/Tesserae/src/Components/Dropdown.cs
+++ b/Tesserae/src/Components/Dropdown.cs
@@ -29,7 +29,6 @@ namespace Tesserae
 
         private HTMLDivElement           _spinner;
         private bool                     _isChanged;
-        private bool                     _boxRefreshQueued;
         private bool                     _isClearingOtherSelections;
         private bool                     _callSelectOnChangingItemSelections;
         private bool                     _fitContent = false;
@@ -478,9 +477,6 @@ namespace Tesserae
         {
             ClearSearch();
             ResetSearchItems();
-            // The search is off and the highlights are gone, so the box can safely copy the rows again -
-            // this is what picks up content that arrived while the list was being filtered.
-            RenderSelected();
             InnerElement.setAttribute("aria-expanded", "false");
             // The click/dblclick/contextmenu/wheel listeners are attached once to
             // _contentHtml when it's first created (see Show) and intentionally live
@@ -669,8 +665,6 @@ namespace Tesserae
                 _childContainer.appendChild(component.Render());
                 component.SelectedItem -= OnItemSelected; //Ensure OnItemSelected is only hooked once
                 component.SelectedItem += OnItemSelected;
-                component.SelectedRenderInvalidated -= OnSelectedRenderInvalidated;
-                component.SelectedRenderInvalidated += OnSelectedRenderInvalidated;
             });
 
             EnsureAsyncLoadingStateDisabled(); // If we got here because an async request completed OR while one was in flight but a synchronous call to this method came in after it started but before finishing then ensure to remove its loading state
@@ -724,8 +718,6 @@ namespace Tesserae
                 _childContainer.appendChild(child.Render());
                 child.SelectedItem -= OnItemSelected; //Ensure OnItemSelected is only hooked once
                 child.SelectedItem += OnItemSelected;
-                child.SelectedRenderInvalidated -= OnSelectedRenderInvalidated;
-                child.SelectedRenderInvalidated += OnSelectedRenderInvalidated;
 
                 existing.Add(child);
                 added++;
@@ -907,41 +899,9 @@ namespace Tesserae
             return this;
         }
 
-        // A row whose content arrived after the box copied it. Redraw the box so the copy catches up. Not
-        // while a search is running: the filter highlights matches by wrapping them in <mark>, and copying
-        // that into the box would put the highlight there too - Hide redraws once the highlight is undone.
-        private void OnSelectedRenderInvalidated(Item sender)
-        {
-            if (!string.IsNullOrEmpty(_search)) return;
-            if (_boxRefreshQueued) return;
-
-            // Content can land in bursts, and an option is free to hold something that redraws itself
-            // continuously - one copy per frame is enough either way.
-            _boxRefreshQueued = true;
-
-            window.requestAnimationFrame(_ =>
-            {
-                _boxRefreshQueued = false;
-                RenderSelected();
-            });
-        }
-
         private void RenderSelected()
         {
             ClearChildren(InnerElement);
-
-            // Only the items on show in the box need watching, and only until they are replaced by the next
-            // render. Everything else stops, so the observers never outnumber the current selection.
-            if (_lastRenderedItems is object)
-            {
-                foreach (var item in _lastRenderedItems)
-                {
-                    item.WatchForBox(item.IsSelected);
-
-                    // Its content is visible in the box, so it has to load whether or not the list was opened.
-                    if (item.IsSelected) item.EnsureContentLoadedForBox();
-                }
-            }
 
             if (SelectedItems.Any())
             {
@@ -953,17 +913,13 @@ namespace Tesserae
                 {
                     for (var i = 0; i < SelectedItems.Length; i++)
                     {
-                        var sel   = SelectedItems[i];
-                        var clone = sel.RenderSelected();
-                        clone.classList.remove("tss-dropdown-item");
-                        clone.classList.remove("tss-selected");
-                        clone.classList.add("tss-dropdown-item-on-box");
+                        var onBox = SelectedItems[i].RenderSelected();
 
                         if (_fitContent)
                         {
-                            clone.classList.add("tss-dropdown-fit-content");
+                            onBox.classList.add("tss-dropdown-fit-content");
                         }
-                        InnerElement.appendChild(clone);
+                        InnerElement.appendChild(onBox);
                     }
                 }
             }
@@ -1285,20 +1241,22 @@ namespace Tesserae
         {
             private readonly HTMLElement InnerElement;
 
-            // Only set when the caller gave an explicit short form for the box. Without one the box
-            // shows a copy of the row, made when it is asked for rather than held here - see RenderSelected.
-            private readonly HTMLElement SelectedElement;
+            // The recipe for what the box draws, not an instance of it. An element exists at exactly one
+            // place in the DOM, so the list and the box each need their own live component, and only the
+            // caller can produce a second one - which is why this is a factory. Copying the row instead,
+            // which is what this used to do, hands the box a dead picture: cloneNode carries attributes
+            // but not event listeners, not DomObserver's mount registration and not component identity,
+            // so a Defer in the copy never loaded and nothing in it ever reacted to anything.
+            private readonly Func<IComponent> _selectedContentFactory;
 
-            private MutationObserver _boxContentObserver;
-
-            // The component the row draws. Held so that a Defer in it can be asked to load when this item
-            // is the one on show in the box - see EnsureContentLoadedForBox.
-            private readonly IComponent _content;
-            private          bool       _boxLoadRequested;
+            // Built the first time the box asks for it, so an option nobody selected costs nothing - which
+            // is what keeps a deferred option lazy until it is either listed or selected.
+            private HTMLElement _selectedElement;
             /// <summary>
             /// Initializes a new instance of this class.
             /// </summary>
-            public Item(string text, string selectedText = null, UIcons? icon = null) : this(GetContent(text, icon), GetContent(string.IsNullOrEmpty(selectedText) ? text : selectedText, icon))
+            public Item(string text, string selectedText = null, UIcons? icon = null)
+                : this(() => GetContent(text, icon), () => GetContent(string.IsNullOrEmpty(selectedText) ? text : selectedText, icon))
             {
             }
 
@@ -1321,19 +1279,28 @@ namespace Tesserae
             private dynamic _data;
 
             /// <summary>
-            /// Initializes a new instance of this class.
+            /// Initializes a new instance of this class. Both arguments are factories rather than components
+            /// because the option is drawn twice - once as a row in the list, once in the closed box - and a
+            /// component can only be in one of those places at a time. <paramref name="content"/> is called
+            /// now, to build the row; <paramref name="selectedContent"/> is called the first time the box
+            /// needs it. Pass only <paramref name="content"/> and the box builds a second one from the same
+            /// recipe, which is right for anything that fits on the box's single clipped row; pass a
+            /// <paramref name="selectedContent"/> to give the box a shorter form of the same option.
+            /// <para>
+            /// The two are independent instances, which is what makes the one in the box live: it mounts, so
+            /// a <see cref="UI.Defer(Func{Task{IComponent}})"/> in it loads, and it keeps its own state. An
+            /// option holding something interactive will therefore not share that state between the list and
+            /// the box - if that matters, give the box its own read-only short form.
+            /// </para>
             /// </summary>
-            public Item(IComponent content, IComponent selectedContent)
+            public Item(Func<IComponent> content, Func<IComponent> selectedContent = null)
             {
-                InnerElement = Button(Att("tss-dropdown-item", role: "option"));
-                InnerElement.appendChild(content.Render());
-                _content = content;
+                if (content is null) throw new ArgumentNullException(nameof(content));
 
-                if (selectedContent is object && selectedContent != content)
-                {
-                    SelectedElement = Button(Att("tss-dropdown-item"));
-                    SelectedElement.appendChild(selectedContent.Render());
-                }
+                _selectedContentFactory = selectedContent ?? content;
+
+                InnerElement = Button(Att("tss-dropdown-item", role: "option"));
+                InnerElement.appendChild(content().Render());
 
                 InnerElement.addEventListener("click",     OnItemClick);
                 InnerElement.addEventListener("mouseover", OnItemMouseOver);
@@ -1456,72 +1423,22 @@ namespace Tesserae
             }
 
             /// <summary>
-            /// The element the dropdown's box shows for this item while it is selected. With an explicit
-            /// short form that is the component the caller gave, which is live and needs no copying. Without
-            /// one it is a copy of the row, taken now rather than when the item was constructed: content that
-            /// arrives asynchronously - a <see cref="UI.Defer(Func{Task{IComponent}})"/>, an image, anything
-            /// bound to an observable - would otherwise be frozen in the box at whatever the row looked like
-            /// before it loaded, which for a Defer means its loading placeholder, forever.
+            /// The element the dropdown's box shows for this item while it is selected: its own component,
+            /// built from the factory the item was given, so it is mounted and live in the box rather than a
+            /// copy of the row. Built once and reused.
             /// </summary>
             public HTMLElement RenderSelected()
             {
-                if (SelectedElement is object) return SelectedElement;
-
-                var copy = (HTMLElement)InnerElement.cloneNode(true);
-
-                // The row carries state that belongs to the list and must not come along. The filter shows
-                // and hides rows by writing an inline display, and an inline display beats the box's own
-                // rule - a copy taken after any filtering arrived in the box as a block, which is what
-                // stacked the chips and pushed their content out of the row. role and aria-selected
-                // describe an option inside a listbox, and the box is not one; the copy is a picture of the
-                // selection, so it is not focusable either.
-                copy.style.display = "";
-                copy.removeAttribute("role");
-                copy.removeAttribute("aria-selected");
-                copy.tabIndex = -1;
-
-                return copy;
-            }
-
-            /// <summary>
-            /// Asks the row's content to load because it is on show in the box. A <see cref="IDefer"/> waits to
-            /// be mounted before loading, and a row is not in the document until the dropdown is first opened -
-            /// so an option selected before that would sit in the box as a loading placeholder with nothing to
-            /// make it resolve. Called once per item: Refresh re-runs the generator.
-            /// </summary>
-            internal void EnsureContentLoadedForBox()
-            {
-                // An explicit short form is mounted in the box itself, so it loads without any help.
-                if (_boxLoadRequested || SelectedElement is object) return;
-
-                _boxLoadRequested = true;
-
-                (_content as IDefer)?.Refresh();
-            }
-
-            /// <summary>
-            /// Raised when the row's own content changed, so a copy of it taken earlier is now out of date.
-            /// </summary>
-            internal event ComponentEventHandler<Item> SelectedRenderInvalidated;
-
-            /// <summary>
-            /// Starts or stops watching the row for content that arrives after the box already copied it. Only
-            /// the items currently in the box are watched, and only those without an explicit short form -
-            /// an explicit one is a live component and is never a copy.
-            /// </summary>
-            internal void WatchForBox(bool watch)
-            {
-                if (!watch || SelectedElement is object)
+                if (_selectedElement is null)
                 {
-                    _boxContentObserver?.disconnect();
-                    _boxContentObserver = null;
-                    return;
+                    // Not a row: it carries no role or aria-selected, and nothing in the box is in the tab
+                    // order - the box is a picture of the selection, and the list is what you interact with.
+                    _selectedElement          = Button(Att("tss-dropdown-item-on-box"));
+                    _selectedElement.tabIndex = -1;
+                    _selectedElement.appendChild(_selectedContentFactory().Render());
                 }
 
-                if (_boxContentObserver is object) return;
-
-                _boxContentObserver = new MutationObserver((_, __) => SelectedRenderInvalidated?.Invoke(this));
-                _boxContentObserver.observe(InnerElement, new MutationObserverInit { childList = true, characterData = true, subtree = true });
+                return _selectedElement;
             }
 
             /// <summary>

--- a/Tesserae/src/Components/Dropdown.cs
+++ b/Tesserae/src/Components/Dropdown.cs
@@ -1247,10 +1247,16 @@ namespace Tesserae
             // which is what this used to do, hands the box a dead picture: cloneNode carries attributes
             // but not event listeners, not DomObserver's mount registration and not component identity,
             // so a Defer in the copy never loaded and nothing in it ever reacted to anything.
+            //
+            // Null on the paths that still take that copy, kept working for code written before this was a
+            // factory: the obsolete single-component constructor, and a box component given as null or as
+            // the row's own instance - see CopyRowForBox.
             private readonly Func<IComponent> _selectedContentFactory;
 
             // Built the first time the box asks for it, so an option nobody selected costs nothing - which
-            // is what keeps a deferred option lazy until it is either listed or selected.
+            // is what keeps a deferred option lazy until it is either listed or selected. The copy-the-row
+            // paths fill it in the constructor instead, since the copy has to be taken before anything else
+            // touches the row.
             private HTMLElement _selectedElement;
             /// <summary>
             /// Initializes a new instance of this class.
@@ -1279,44 +1285,93 @@ namespace Tesserae
             private dynamic _data;
 
             /// <summary>
+            /// Initializes a new instance of this class from a single component, which is drawn in the list
+            /// and <em>copied</em> into the closed box.
+            /// <para>
+            /// Obsolete because that copy is a dead picture: <c>cloneNode</c> carries attributes but not event
+            /// listeners, not DomObserver's mount registration and not component identity, so a
+            /// <see cref="UI.Defer(Func{Task{IComponent}})"/> inside it never loads and nothing in it ever
+            /// reacts. Use <see cref="Item(Func{IComponent}, Func{IComponent})"/> instead: one recipe, from
+            /// which the list and the box each get their own live component.
+            /// </para>
+            /// </summary>
+            [Obsolete("The box gets a copy of the row, which has no listeners and never loads a Defer. Pass a Func<IComponent> instead, so the box builds its own live component from the same recipe.")]
+            public Item(IComponent content) : this(content, null)
+            {
+            }
+
+            /// <summary>
             /// Initializes a new instance of this class from two components the caller has already built: one
-            /// for the row in the list, one for the closed box. Both are needed, and they must be different
-            /// instances, because an element exists at exactly one place in the DOM - there is no way to draw
-            /// one component in both places. To supply a single recipe and let the box build its own second
-            /// instance from it, use the <see cref="Item(Func{IComponent}, Func{IComponent})"/> overload,
-            /// which also defers building the box's one until the option is actually selected.
+            /// for the row in the list, one for the closed box. They must be different instances, because an
+            /// element exists at exactly one place in the DOM - there is no way to draw one component in both
+            /// places. To supply a single recipe and let the box build its own second instance from it, use
+            /// the <see cref="Item(Func{IComponent}, Func{IComponent})"/> overload, which also defers building
+            /// the box's one until the option is actually selected.
+            /// <para>
+            /// Passing <c>null</c> for <paramref name="selectedContent"/>, or the same instance twice, falls
+            /// back to the obsolete behaviour of copying the row into the box and says so on the console.
+            /// </para>
             /// </summary>
             public Item(IComponent content, IComponent selectedContent)
             {
-                if (content is null) throw new ArgumentNullException(nameof(content));
-
-                // A null short form used to mean "copy the row into the box", and a copy is a picture: no
-                // listeners, no mount registration, no identity, so a Defer in it never loaded and nothing in
-                // it ever reacted. Pass a factory instead and the box gets a real second component.
-                if (selectedContent is null)
+                // Nothing to draw and nothing to fall back to. Reporting it beats throwing: a throw out of a
+                // component's constructor takes down the whole page it was being built into, so the option
+                // renders empty and the console says which call did it.
+                if (content is null)
                 {
-                    throw new ArgumentNullException(nameof(selectedContent),
-                        "A Dropdown.Item needs its own component for the box. Pass one, or use the Func<IComponent> overload to have it built from the same recipe as the row.");
+                    console.error("Dropdown.Item: content is null, the option will render empty.");
+                    content = TextBlock("");
                 }
-
-                // The same instance in both places does not draw twice - appending it to the box moves it out
-                // of the row, leaving the row empty.
-                if (selectedContent == content)
-                {
-                    throw new ArgumentException(
-                        "The row and the box need separate components; the same instance cannot be in both. Use the Func<IComponent> overload to build one for each from the same recipe.",
-                        nameof(selectedContent));
-                }
-
-                // Safe to hand these straight back as factories: each is invoked exactly once - the row's in
-                // this constructor, the box's on the first RenderSelected, which caches what it builds.
-                _selectedContentFactory = () => selectedContent;
 
                 InnerElement = Button(Att("tss-dropdown-item", role: "option"));
                 InnerElement.appendChild(content.Render());
 
+                // A null short form has always meant "copy the row into the box", and the same instance twice
+                // cannot draw twice - appending it to the box moves it out of the row, leaving the row empty -
+                // so that means the copy too. Both keep working, both are the obsolete behaviour: a copy is a
+                // picture, with no listeners, no mount registration and no identity.
+                if (selectedContent is null || selectedContent == content)
+                {
+                    CopyRowForBox();
+                }
+                else
+                {
+                    // Safe to hand this straight back as a factory: it is invoked exactly once, on the first
+                    // RenderSelected, which caches what it builds.
+                    _selectedContentFactory = () => selectedContent;
+                }
+
                 InnerElement.addEventListener("click",     OnItemClick);
                 InnerElement.addEventListener("mouseover", OnItemMouseOver);
+            }
+
+            // Said once per session, not once per option: a list built the old way would otherwise print a
+            // line per item. [Obsolete] is where this is meant to be caught, at build time; this is for the
+            // build that does not surface the warning.
+            private static bool _reportedRowCopy;
+
+            // The pre-factory behaviour, kept so code written against it keeps working: the box shows a copy
+            // of the row. Taken here rather than on the first RenderSelected so it is a copy of the option as
+            // it was built, before selection state or a filter's <mark> highlighting reached the row - which
+            // is what the old constructor, cloning before anything was selected, copied.
+            private void CopyRowForBox()
+            {
+                if (!_reportedRowCopy)
+                {
+                    _reportedRowCopy = true;
+                    console.error("Dropdown.Item: the box has no component of its own, so it gets a copy of the row - which has no event listeners and never loads a Defer. Pass a separate component for the box, or a Func<IComponent> to have one built from the same recipe as the row.");
+                }
+
+                _selectedElement = (HTMLElement)InnerElement.cloneNode(true);
+
+                // Not a row: the box carries no role or aria-selected, is out of the tab order, and is styled
+                // as the box's own single clipped line.
+                _selectedElement.classList.remove("tss-dropdown-item");
+                _selectedElement.classList.remove("tss-selected");
+                _selectedElement.classList.add("tss-dropdown-item-on-box");
+                _selectedElement.removeAttribute("role");
+                _selectedElement.removeAttribute("aria-selected");
+                _selectedElement.tabIndex = -1;
             }
 
             /// <summary>
@@ -1338,7 +1393,13 @@ namespace Tesserae
             /// </summary>
             public Item(Func<IComponent> content, Func<IComponent> selectedContent = null)
             {
-                if (content is null) throw new ArgumentNullException(nameof(content));
+                // Same reasoning as the component overload: an empty option and a console message, rather
+                // than a throw that takes the page down with it.
+                if (content is null)
+                {
+                    console.error("Dropdown.Item: content is null, the option will render empty.");
+                    content = () => TextBlock("");
+                }
 
                 _selectedContentFactory = selectedContent ?? content;
 
@@ -1468,7 +1529,8 @@ namespace Tesserae
             /// <summary>
             /// The element the dropdown's box shows for this item while it is selected: its own component,
             /// built from the factory the item was given, so it is mounted and live in the box rather than a
-            /// copy of the row. Built once and reused.
+            /// copy of the row. Built once and reused. Where there was no second recipe to build from - the
+            /// obsolete single-component path - this is instead the copy of the row taken in the constructor.
             /// </summary>
             public HTMLElement RenderSelected()
             {

--- a/Tesserae/src/Components/Dropdown.cs
+++ b/Tesserae/src/Components/Dropdown.cs
@@ -1262,7 +1262,7 @@ namespace Tesserae
             /// Initializes a new instance of this class.
             /// </summary>
             public Item(string text, string selectedText = null, UIcons? icon = null)
-                : this(() => GetContent(text, icon), () => GetContent(string.IsNullOrEmpty(selectedText) ? text : selectedText, icon))
+                : this(GetContent(text, icon), () => GetContent(string.IsNullOrEmpty(selectedText) ? text : selectedText, icon))
             {
             }
 
@@ -1296,7 +1296,7 @@ namespace Tesserae
             /// </para>
             /// </summary>
             [Obsolete("The box gets a copy of the row, which has no listeners and never loads a Defer. Pass a Func<IComponent> instead, so the box builds its own live component from the same recipe.")]
-            public Item(IComponent content) : this(content, null)
+            public Item(IComponent content) : this(content, (IComponent)null)
             {
             }
 
@@ -1314,17 +1314,7 @@ namespace Tesserae
             /// </summary>
             public Item(IComponent content, IComponent selectedContent)
             {
-                // Nothing to draw and nothing to fall back to. Reporting it beats throwing: a throw out of a
-                // component's constructor takes down the whole page it was being built into, so the option
-                // renders empty and the console says which call did it.
-                if (content is null)
-                {
-                    console.error("Dropdown.Item: content is null, the option will render empty.");
-                    content = TextBlock("");
-                }
-
-                InnerElement = Button(Att("tss-dropdown-item", role: "option"));
-                InnerElement.appendChild(content.Render());
+                InnerElement = BuildRow(content);
 
                 // A null short form has always meant "copy the row into the box", and the same instance twice
                 // cannot draw twice - appending it to the box moves it out of the row, leaving the row empty -
@@ -1375,39 +1365,76 @@ namespace Tesserae
             }
 
             /// <summary>
-            /// Initializes a new instance of this class from factories rather than components, which is what
-            /// lets a single recipe serve both places the option is drawn - the row in the list and the closed
-            /// box - since a component can only be in one of them at a time. <paramref name="content"/> is
-            /// called now, to build the row; <paramref name="selectedContent"/> is called the first time the
-            /// box needs it, so an option nobody selects never builds one. Pass only
-            /// <paramref name="content"/> and the box builds its own from that same recipe, which is right for
-            /// anything that fits on the box's single clipped row; pass a <paramref name="selectedContent"/>
-            /// to give the box a shorter form of the same option. Where both components are cheap and already
-            /// at hand, <see cref="Item(IComponent, IComponent)"/> takes them directly.
+            /// Initializes a new instance of this class from one recipe, which serves both places the option
+            /// is drawn - the row in the list and the closed box - since a component can only be in one of
+            /// them at a time. It is called now to build the row, and again the first time the box needs one,
+            /// so an option nobody selects only ever builds the row. This is the overload to reach for
+            /// whenever the row and the box should look the same; where the box wants a shorter form, give it
+            /// its own through <see cref="Item(IComponent, Func{IComponent})"/> or
+            /// <see cref="Item(IComponent, IComponent)"/>.
             /// <para>
             /// The two are independent instances, which is what makes the one in the box live: it mounts, so
             /// a <see cref="UI.Defer(Func{Task{IComponent}})"/> in it loads, and it keeps its own state. An
             /// option holding something interactive will therefore not share that state between the list and
             /// the box - if that matters, give the box its own read-only short form.
             /// </para>
+            /// <para>
+            /// The recipe running twice means whatever it does happens twice. Share expensive work by starting
+            /// it outside the recipe - one Task, awaited by both - rather than repeating it inside.
+            /// </para>
             /// </summary>
-            public Item(Func<IComponent> content, Func<IComponent> selectedContent = null)
+            public Item(Func<IComponent> content) : this(content is null ? null : content(), content ?? _emptyContent)
             {
-                // Same reasoning as the component overload: an empty option and a console message, rather
-                // than a throw that takes the page down with it.
-                if (content is null)
+            }
+
+            /// <summary>
+            /// Initializes a new instance of this class from a component for the row and a recipe for the box,
+            /// which is what defers the box's until the option is actually selected - so an option nobody
+            /// selects never builds one. The row cannot be deferred the same way: it is built here, because
+            /// this is where the item's element comes from.
+            /// <para>
+            /// Use this over <see cref="Item(IComponent, IComponent)"/> for a long list of options that each
+            /// want a shorter form in the box: the list pays for its rows either way, and this way it does not
+            /// also pay for a box component per option that only one of them will ever use.
+            /// </para>
+            /// </summary>
+            public Item(IComponent content, Func<IComponent> selectedContent)
+            {
+                InnerElement = BuildRow(content);
+
+                if (selectedContent is null)
                 {
-                    console.error("Dropdown.Item: content is null, the option will render empty.");
-                    content = () => TextBlock("");
+                    CopyRowForBox();
                 }
-
-                _selectedContentFactory = selectedContent ?? content;
-
-                InnerElement = Button(Att("tss-dropdown-item", role: "option"));
-                InnerElement.appendChild(content().Render());
+                else
+                {
+                    _selectedContentFactory = selectedContent;
+                }
 
                 InnerElement.addEventListener("click",     OnItemClick);
                 InnerElement.addEventListener("mouseover", OnItemMouseOver);
+            }
+
+            // What a null content falls back to, so a broken option renders empty instead of taking the page
+            // down with it - and so the single-recipe overload still has a recipe to hand the box.
+            private static readonly Func<IComponent> _emptyContent = () => TextBlock("");
+
+            // The row's element, which is what Render returns - so it is built in the constructor whichever
+            // overload is used, and only the box's component can be deferred.
+            private static HTMLElement BuildRow(IComponent content)
+            {
+                // Nothing to draw and nothing to fall back to. Reporting it beats throwing: a throw out of a
+                // component's constructor takes down the whole page it was being built into, so the option
+                // renders empty and the console says which call did it.
+                if (content is null)
+                {
+                    console.error("Dropdown.Item: content is null, the option will render empty.");
+                    content = TextBlock("");
+                }
+
+                var row = Button(Att("tss-dropdown-item", role: "option"));
+                row.appendChild(content.Render());
+                return row;
             }
 
             private event  BeforeSelectEventHandler<Item> BeforeSelectedItem;

--- a/Tesserae/src/Components/Dropdown.cs
+++ b/Tesserae/src/Components/Dropdown.cs
@@ -29,6 +29,7 @@ namespace Tesserae
 
         private HTMLDivElement           _spinner;
         private bool                     _isChanged;
+        private bool                     _boxRefreshQueued;
         private bool                     _isClearingOtherSelections;
         private bool                     _callSelectOnChangingItemSelections;
         private bool                     _fitContent = false;
@@ -477,6 +478,9 @@ namespace Tesserae
         {
             ClearSearch();
             ResetSearchItems();
+            // The search is off and the highlights are gone, so the box can safely copy the rows again -
+            // this is what picks up content that arrived while the list was being filtered.
+            RenderSelected();
             InnerElement.setAttribute("aria-expanded", "false");
             // The click/dblclick/contextmenu/wheel listeners are attached once to
             // _contentHtml when it's first created (see Show) and intentionally live
@@ -665,6 +669,8 @@ namespace Tesserae
                 _childContainer.appendChild(component.Render());
                 component.SelectedItem -= OnItemSelected; //Ensure OnItemSelected is only hooked once
                 component.SelectedItem += OnItemSelected;
+                component.SelectedRenderInvalidated -= OnSelectedRenderInvalidated;
+                component.SelectedRenderInvalidated += OnSelectedRenderInvalidated;
             });
 
             EnsureAsyncLoadingStateDisabled(); // If we got here because an async request completed OR while one was in flight but a synchronous call to this method came in after it started but before finishing then ensure to remove its loading state
@@ -718,6 +724,8 @@ namespace Tesserae
                 _childContainer.appendChild(child.Render());
                 child.SelectedItem -= OnItemSelected; //Ensure OnItemSelected is only hooked once
                 child.SelectedItem += OnItemSelected;
+                child.SelectedRenderInvalidated -= OnSelectedRenderInvalidated;
+                child.SelectedRenderInvalidated += OnSelectedRenderInvalidated;
 
                 existing.Add(child);
                 added++;
@@ -899,9 +907,38 @@ namespace Tesserae
             return this;
         }
 
+        // A row whose content arrived after the box copied it. Redraw the box so the copy catches up. Not
+        // while a search is running: the filter highlights matches by wrapping them in <mark>, and copying
+        // that into the box would put the highlight there too - Hide redraws once the highlight is undone.
+        private void OnSelectedRenderInvalidated(Item sender)
+        {
+            if (!string.IsNullOrEmpty(_search)) return;
+            if (_boxRefreshQueued) return;
+
+            // Content can land in bursts, and an option is free to hold something that redraws itself
+            // continuously - one copy per frame is enough either way.
+            _boxRefreshQueued = true;
+
+            window.requestAnimationFrame(_ =>
+            {
+                _boxRefreshQueued = false;
+                RenderSelected();
+            });
+        }
+
         private void RenderSelected()
         {
             ClearChildren(InnerElement);
+
+            // Only the items on show in the box need watching, and only until they are replaced by the next
+            // render. Everything else stops, so the observers never outnumber the current selection.
+            if (_lastRenderedItems is object)
+            {
+                foreach (var item in _lastRenderedItems)
+                {
+                    item.WatchForBox(item.IsSelected);
+                }
+            }
 
             if (SelectedItems.Any())
             {
@@ -1244,7 +1281,12 @@ namespace Tesserae
         public sealed class Item : IComponent
         {
             private readonly HTMLElement InnerElement;
+
+            // Only set when the caller gave an explicit short form for the box. Without one the box
+            // shows a copy of the row, made when it is asked for rather than held here - see RenderSelected.
             private readonly HTMLElement SelectedElement;
+
+            private MutationObserver _boxContentObserver;
             /// <summary>
             /// Initializes a new instance of this class.
             /// </summary>
@@ -1278,11 +1320,7 @@ namespace Tesserae
                 InnerElement = Button(Att("tss-dropdown-item", role: "option"));
                 InnerElement.appendChild(content.Render());
 
-                if (selectedContent is null || selectedContent == content)
-                {
-                    SelectedElement = (HTMLElement)InnerElement.cloneNode(true);
-                }
-                else
+                if (selectedContent is object && selectedContent != content)
                 {
                     SelectedElement = Button(Att("tss-dropdown-item"));
                     SelectedElement.appendChild(selectedContent.Render());
@@ -1409,9 +1447,39 @@ namespace Tesserae
             }
 
             /// <summary>
-            /// Renders the selected.
+            /// The element the dropdown's box shows for this item while it is selected. With an explicit
+            /// short form that is the component the caller gave, which is live and needs no copying. Without
+            /// one it is a copy of the row, taken now rather than when the item was constructed: content that
+            /// arrives asynchronously - a <see cref="UI.Defer(Func{Task{IComponent}})"/>, an image, anything
+            /// bound to an observable - would otherwise be frozen in the box at whatever the row looked like
+            /// before it loaded, which for a Defer means its loading placeholder, forever.
             /// </summary>
-            public HTMLElement RenderSelected() => SelectedElement;
+            public HTMLElement RenderSelected() => SelectedElement ?? (HTMLElement)InnerElement.cloneNode(true);
+
+            /// <summary>
+            /// Raised when the row's own content changed, so a copy of it taken earlier is now out of date.
+            /// </summary>
+            internal event ComponentEventHandler<Item> SelectedRenderInvalidated;
+
+            /// <summary>
+            /// Starts or stops watching the row for content that arrives after the box already copied it. Only
+            /// the items currently in the box are watched, and only those without an explicit short form -
+            /// an explicit one is a live component and is never a copy.
+            /// </summary>
+            internal void WatchForBox(bool watch)
+            {
+                if (!watch || SelectedElement is object)
+                {
+                    _boxContentObserver?.disconnect();
+                    _boxContentObserver = null;
+                    return;
+                }
+
+                if (_boxContentObserver is object) return;
+
+                _boxContentObserver = new MutationObserver((_, __) => SelectedRenderInvalidated?.Invoke(this));
+                _boxContentObserver.observe(InnerElement, new MutationObserverInit { childList = true, characterData = true, subtree = true });
+            }
 
             /// <summary>
             /// Configures the component to header.

--- a/Tesserae/src/Components/Dropdown.cs
+++ b/Tesserae/src/Components/Dropdown.cs
@@ -405,17 +405,26 @@ namespace Tesserae
             var items        = GetItems();
             var visibleItems = items.Where(i => i.item.style.display != "none").Select(i => (item: i.item, height: i.item.getBoundingClientRect().As<DOMRect>().height)).ToArray();
 
-            double searchBoxHeight = 0;
+            // Everything in the popup that is not a row: its own border and padding, and - when there
+            // is one - the search box plus the gap under it. Measured rather than assumed, and
+            // measured with the constraints lifted, because a min/max height left over from the last
+            // call would otherwise be counted as part of the chrome.
+            _popupDiv.style.minHeight = "0px";
+            _popupDiv.style.maxHeight = "none";
 
-            if (_searchBox is object)
-            {
-                var sbr = _searchBox.Render().getBoundingClientRect().As<DOMRect>();
-                var pdr = _popupDiv.getBoundingClientRect().As<DOMRect>();
-                searchBoxHeight = sbr.height + (sbr.top - pdr.top) + 8;
-            }
+            var chrome = _popupDiv.getBoundingClientRect().As<DOMRect>().height
+                       - _childContainer.getBoundingClientRect().As<DOMRect>().height;
 
-            var maxHeight = visibleItems.Length > 0 ? visibleItems.Sum(h => h.height) + "px" : "80vh";
-            var minHeight = ((visibleItems.Length > 0 ? visibleItems.Take(5).Select((h,i) => h.height + (i == 0 ? 0 : 16)).Sum() + 9: 0 ) + searchBoxHeight) + "px" ;
+            // The popup is exactly as tall as the rows it shows, and never shorter than the first five
+            // of them, so that filtering down to one row does not collapse it to a sliver. Both bounds
+            // have to carry the chrome: leaving it out of the maximum is what used to put a scrollbar
+            // on a list that fits, and the minimum used to add 16px per row for a gap between rows
+            // that does not exist, which is where the empty space below the last row came from.
+            var rows        = visibleItems.Sum(h => h.height);
+            var atLeastRows = visibleItems.Take(5).Sum(h => h.height);
+
+            var maxHeight = visibleItems.Length > 0 ? rows + chrome + "px" : "80vh";
+            var minHeight = (visibleItems.Length > 0 ? atLeastRows + chrome : 0) + "px";
 
             _popupDiv.style.minHeight = minHeight;
             _popupDiv.style.maxHeight = maxHeight;
@@ -448,6 +457,11 @@ namespace Tesserae
                     {
                         _popupDiv.style.height = window.innerHeight - rect.bottom - 1 + "px";
                     }
+
+                    // There is not enough room on either side for the whole list, so the height set
+                    // just above is the real constraint - the five-row floor has to yield to it or the
+                    // popup runs off the screen instead of scrolling.
+                    _popupDiv.style.minHeight = "0px";
                 }
                 else
                 {

--- a/Tesserae/src/Components/Dropdown.cs
+++ b/Tesserae/src/Components/Dropdown.cs
@@ -1279,13 +1279,56 @@ namespace Tesserae
             private dynamic _data;
 
             /// <summary>
-            /// Initializes a new instance of this class. Both arguments are factories rather than components
-            /// because the option is drawn twice - once as a row in the list, once in the closed box - and a
-            /// component can only be in one of those places at a time. <paramref name="content"/> is called
-            /// now, to build the row; <paramref name="selectedContent"/> is called the first time the box
-            /// needs it. Pass only <paramref name="content"/> and the box builds a second one from the same
-            /// recipe, which is right for anything that fits on the box's single clipped row; pass a
-            /// <paramref name="selectedContent"/> to give the box a shorter form of the same option.
+            /// Initializes a new instance of this class from two components the caller has already built: one
+            /// for the row in the list, one for the closed box. Both are needed, and they must be different
+            /// instances, because an element exists at exactly one place in the DOM - there is no way to draw
+            /// one component in both places. To supply a single recipe and let the box build its own second
+            /// instance from it, use the <see cref="Item(Func{IComponent}, Func{IComponent})"/> overload,
+            /// which also defers building the box's one until the option is actually selected.
+            /// </summary>
+            public Item(IComponent content, IComponent selectedContent)
+            {
+                if (content is null) throw new ArgumentNullException(nameof(content));
+
+                // A null short form used to mean "copy the row into the box", and a copy is a picture: no
+                // listeners, no mount registration, no identity, so a Defer in it never loaded and nothing in
+                // it ever reacted. Pass a factory instead and the box gets a real second component.
+                if (selectedContent is null)
+                {
+                    throw new ArgumentNullException(nameof(selectedContent),
+                        "A Dropdown.Item needs its own component for the box. Pass one, or use the Func<IComponent> overload to have it built from the same recipe as the row.");
+                }
+
+                // The same instance in both places does not draw twice - appending it to the box moves it out
+                // of the row, leaving the row empty.
+                if (selectedContent == content)
+                {
+                    throw new ArgumentException(
+                        "The row and the box need separate components; the same instance cannot be in both. Use the Func<IComponent> overload to build one for each from the same recipe.",
+                        nameof(selectedContent));
+                }
+
+                // Safe to hand these straight back as factories: each is invoked exactly once - the row's in
+                // this constructor, the box's on the first RenderSelected, which caches what it builds.
+                _selectedContentFactory = () => selectedContent;
+
+                InnerElement = Button(Att("tss-dropdown-item", role: "option"));
+                InnerElement.appendChild(content.Render());
+
+                InnerElement.addEventListener("click",     OnItemClick);
+                InnerElement.addEventListener("mouseover", OnItemMouseOver);
+            }
+
+            /// <summary>
+            /// Initializes a new instance of this class from factories rather than components, which is what
+            /// lets a single recipe serve both places the option is drawn - the row in the list and the closed
+            /// box - since a component can only be in one of them at a time. <paramref name="content"/> is
+            /// called now, to build the row; <paramref name="selectedContent"/> is called the first time the
+            /// box needs it, so an option nobody selects never builds one. Pass only
+            /// <paramref name="content"/> and the box builds its own from that same recipe, which is right for
+            /// anything that fits on the box's single clipped row; pass a <paramref name="selectedContent"/>
+            /// to give the box a shorter form of the same option. Where both components are cheap and already
+            /// at hand, <see cref="Item(IComponent, IComponent)"/> takes them directly.
             /// <para>
             /// The two are independent instances, which is what makes the one in the box live: it mounts, so
             /// a <see cref="UI.Defer(Func{Task{IComponent}})"/> in it loads, and it keeps its own state. An

--- a/Tesserae/src/Components/Dropdown.cs
+++ b/Tesserae/src/Components/Dropdown.cs
@@ -937,6 +937,9 @@ namespace Tesserae
                 foreach (var item in _lastRenderedItems)
                 {
                     item.WatchForBox(item.IsSelected);
+
+                    // Its content is visible in the box, so it has to load whether or not the list was opened.
+                    if (item.IsSelected) item.EnsureContentLoadedForBox();
                 }
             }
 
@@ -1287,6 +1290,11 @@ namespace Tesserae
             private readonly HTMLElement SelectedElement;
 
             private MutationObserver _boxContentObserver;
+
+            // The component the row draws. Held so that a Defer in it can be asked to load when this item
+            // is the one on show in the box - see EnsureContentLoadedForBox.
+            private readonly IComponent _content;
+            private          bool       _boxLoadRequested;
             /// <summary>
             /// Initializes a new instance of this class.
             /// </summary>
@@ -1319,6 +1327,7 @@ namespace Tesserae
             {
                 InnerElement = Button(Att("tss-dropdown-item", role: "option"));
                 InnerElement.appendChild(content.Render());
+                _content = content;
 
                 if (selectedContent is object && selectedContent != content)
                 {
@@ -1454,7 +1463,41 @@ namespace Tesserae
             /// bound to an observable - would otherwise be frozen in the box at whatever the row looked like
             /// before it loaded, which for a Defer means its loading placeholder, forever.
             /// </summary>
-            public HTMLElement RenderSelected() => SelectedElement ?? (HTMLElement)InnerElement.cloneNode(true);
+            public HTMLElement RenderSelected()
+            {
+                if (SelectedElement is object) return SelectedElement;
+
+                var copy = (HTMLElement)InnerElement.cloneNode(true);
+
+                // The row carries state that belongs to the list and must not come along. The filter shows
+                // and hides rows by writing an inline display, and an inline display beats the box's own
+                // rule - a copy taken after any filtering arrived in the box as a block, which is what
+                // stacked the chips and pushed their content out of the row. role and aria-selected
+                // describe an option inside a listbox, and the box is not one; the copy is a picture of the
+                // selection, so it is not focusable either.
+                copy.style.display = "";
+                copy.removeAttribute("role");
+                copy.removeAttribute("aria-selected");
+                copy.tabIndex = -1;
+
+                return copy;
+            }
+
+            /// <summary>
+            /// Asks the row's content to load because it is on show in the box. A <see cref="IDefer"/> waits to
+            /// be mounted before loading, and a row is not in the document until the dropdown is first opened -
+            /// so an option selected before that would sit in the box as a loading placeholder with nothing to
+            /// make it resolve. Called once per item: Refresh re-runs the generator.
+            /// </summary>
+            internal void EnsureContentLoadedForBox()
+            {
+                // An explicit short form is mounted in the box itself, so it loads without any help.
+                if (_boxLoadRequested || SelectedElement is object) return;
+
+                _boxLoadRequested = true;
+
+                (_content as IDefer)?.Refresh();
+            }
 
             /// <summary>
             /// Raised when the row's own content changed, so a copy of it taken earlier is now out of date.

--- a/Tesserae/src/Components/PivotSelector.cs
+++ b/Tesserae/src/Components/PivotSelector.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using static Transpose.Core.dom;
@@ -116,7 +116,7 @@ namespace Tesserae
 
         private void UpdateDropdownItems()
         {
-            _dropdown.Items(_orderedTabs.Select(t => DropdownItem(t.CreateTitle(), t.CreateTitle()).SetData(t.Id).SelectedIf(t.Id == _currentSelectedID)).ToArray());
+            _dropdown.Items(_orderedTabs.Select(t => DropdownItem(t.CreateTitle).SetData(t.Id).SelectedIf(t.Id == _currentSelectedID)).ToArray());
         }
 
         /// <summary>

--- a/Tesserae/tps/assets/css/tss.dropdown.css
+++ b/Tesserae/tps/assets/css/tss.dropdown.css
@@ -210,12 +210,19 @@
     padding-left: 32px !important;
 }
 
+    /* The checkbox and its tick are absolutely positioned, so they need centring against the row
+       rather than a fixed offset from its top: an option whose content is two lines tall (or a badge,
+       or an avatar) is taller than the 32px a fixed 8px offset was measured against, and the checkbox
+       stayed up by the first line instead of sitting beside the content. The tick keeps the 2.5px
+       optical rise above the box's centre that its old top: 10px against top: 8px gave it - the ink
+       of a rotated checkmark sits low in its own box. */
     .tss-dropdown-multi > .tss-dropdown-item:before {
         content: " ";
         display: block;
         position: absolute;
         left: 8px;
-        top: 8px;
+        top: 50%;
+        transform: translateY(-50%);
         width: 20px;
         height: 20px;
         border-radius: 2px;
@@ -237,12 +244,12 @@
         position: absolute;
         display: none;
         left: 15px;
-        top: 10px;
+        top: 50%;
         width: 6px;
         height: 11px;
         border: solid var(--tss-default-border-color);
         border-width: 0 1px 1px 0;
-        transform: rotate(45deg);
+        transform: translateY(calc(-50% - 2.5px)) rotate(45deg);
     }
 
     .tss-dropdown-multi > .tss-dropdown-item:hover:after {
@@ -347,6 +354,14 @@
     min-height: 32px;
     line-height: 32px;
 }
+
+    /* The 32px line-height above is what centres a single line of text in the row, but line-height is
+       inherited: an option whose content is a stack of two text blocks got 32px per line and the row
+       came out twice as tall as its content, with the two lines pushed apart and the centred checkbox
+       stranded in the gap between them. The content keeps its own line-height; the row keeps its. */
+    .tss-dropdown-popup .tss-dropdown-item > * {
+        line-height: normal;
+    }
 
     .tss-dropdown-popup .tss-dropdown-item .tss-btn {
         min-height: 24px !important;

--- a/Tesserae/tps/assets/css/tss.dropdown.css
+++ b/Tesserae/tps/assets/css/tss.dropdown.css
@@ -290,14 +290,33 @@
     width: auto;
 }
 
-.tss-dropdown > .tss-dropdown-item-on-box:not(:first-child) {
-    margin-left: 2px;
+/* An option's content is usually a Button, and the box shows a clone of it. .tss-btn brings a
+   min-width of 80px and a min-height of 36px, neither of which makes sense for a chip in a
+   comma-separated list inside a 32px row: the width reserves 80px per chip, so the comma after one
+   ends up stranded half a word away from it, and the height overflows the row and gets clipped.
+   .tss-dropdown-item-on-box resets both on the clone's root, but the Button is one level further
+   in - so reset it there too, and let the content size itself. */
+.tss-dropdown-item-on-box .tss-btn {
+    min-width: unset;
+    min-height: unset;
+    padding: 0;
+    margin: 0;
 }
 
+/* The ", " between the selected items shown in the box. The separator is generated on the item that
+   *follows* it, so it has to hug the item before it - any margin on this side of the item lands
+   between the previous word and its comma - and put its breathing room after itself instead.
+   .tss-dropdown-item-on-box is an inline-flex container, so this pseudo-element is a flex item and
+   not inline text: left alone it stretches and draws the comma at the top of that stretched box,
+   which is what "height: 0" used to paper over and why the comma floated above the text. Everything
+   in the box is centred on the row (.tss-dropdown is a centred inline-flex), so centring the
+   separator too is what lines it up - with text, with an avatar, with a chart, with anything. */
 .tss-dropdown > .tss-dropdown-item-on-box:not(:first-child)::before {
-    content:',';
-    padding-right:6px;
-    height:0px;
+    content: ',';
+    align-self: center;
+    padding-right: 4px;
+    /* Never let the separator be what makes the row taller. */
+    line-height: 1;
 }
 
 .tss-dropdown-fit-content {

--- a/Tesserae/tps/assets/css/tss.dropdown.css
+++ b/Tesserae/tps/assets/css/tss.dropdown.css
@@ -346,13 +346,22 @@
     padding-top: 8px;
 }
 
+/* A row pays for its breathing room in padding, not in line-height. Using a 32px line-height for it
+   only ever worked for text: line-height sets the strut of a *text* line, so anything else an option
+   renders eats into that space instead of being given its own - a 28px avatar in a 32px line box came
+   out with 1px above and below it, while a plain label got 5 and a badge got 6. The air was whatever
+   the line box happened to have left over, so it changed with the content. Padding gives every row
+   the same margin around whatever it draws, and min-height stays as the floor that keeps a short row
+   from looking cropped. 4px is what leaves the ordinary single-line row at the 34px it has always
+   been, so this costs nothing anywhere it was already right. */
 .tss-dropdown-popup .tss-dropdown-item {
     margin: 0 8px;
     width: calc(100% - 16px);
     box-sizing: border-box;
     border-radius: 6px;
     min-height: 32px;
-    line-height: 32px;
+    line-height: 20px;
+    padding: 4px 8px;
 }
 
     /* The 32px line-height above is what centres a single line of text in the row, but line-height is


### PR DESCRIPTION
## Summary

This change fixes critical issues with how dropdown items render their content in both the list and the closed box, particularly for rich content like avatars, badges, charts, and deferred components. The box now builds its own live component from a factory instead of cloning the row, which enables event listeners, Defer loading, and proper state management.

## Key Changes

**Dropdown.Item architecture overhaul:**
- Replaced single-component model with factory-based approach: items now accept `Func<IComponent>` to build independent instances for the list row and the closed box
- Added four constructor overloads to support different use cases:
  - `Item(Func<IComponent> content)` — one recipe for both places
  - `Item(IComponent content, Func<IComponent> selectedContent)` — row now, box's short form deferred
  - `Item(IComponent content, IComponent selectedContent)` — both pre-built (must be different instances)
  - `Item(IComponent content)` — **obsolete**, falls back to cloning with console warning
- The box's component is now built lazily on first `RenderSelected()` call, so unselected options pay no cost
- Marked obsolete path with `[Obsolete]` attribute and runtime console error to guide migration

**Dropdown popup layout fixes:**
- Rewrote height calculation to measure actual chrome (borders, padding, search box) instead of assuming it
- Fixed min/max height to account for chrome properly — previously omitting chrome from max height caused spurious scrollbars, and including gaps in min height created empty space below the last row
- When viewport space is constrained, min-height yields to the real constraint so the popup scrolls instead of running off-screen
- Checkbox centering: changed from fixed `top: 8px` to `top: 50%; transform: translateY(-50%)` so it stays centered against rows of any height (two-line blocks, badges, avatars)
- Checkbox tick optical adjustment: adjusted transform to `translateY(calc(-50% - 2.5px))` to maintain ink positioning

**Box item styling:**
- Reset `.tss-btn` min-width, min-height, padding, and margin on items in the box so they size to content instead of reserving 80×36px per chip
- Fixed separator (comma) styling: changed from `height: 0px` (which floated it above text) to `align-self: center` so it aligns with any content type
- Adjusted separator padding from `6px` to `4px` for tighter spacing

**Row item styling:**
- Changed from `line-height: 32px` to `line-height: 20px` with `padding: 4px 8px` so rows with multi-line content (stacks, two-line blocks) don't stretch to double height
- Inherited line-height no longer forces two-line content apart

**Sample additions:**
- Added "Mixed Renderings" section demonstrating rich content: people (avatar + two lines), badges, color swatches, charts, emoji, interactive content, and long text
- Added "Deferred Mixed Content" section showing the same content arriving through `Defer`, including nested defers, shared work patterns, and deferred short forms
- Added helper methods for building reusable content components (`PersonBlock`, `BadgeRow`, `SwatchRow`, `MetricRow`, etc.) and their corresponding dropdown items

**Documentation updates:**
- Updated `dropdown.md` reference with new factory overloads and detailed "Rich item content" section
- Explained the two-instance requirement, deferred box building, live component behavior, and state isolation
- Added guidance on sharing expensive work and using `WithCustomSelectionRender` for full control

## Notable Implementation Details

- The box's component is a factory, not a pre-built instance, because an element can only exist in one DOM location at a time — the list and box each need their own live instance
- Deferred components now work correctly in both places: the row's Defer loads when the list opens, the box's loads when the option is selected (or immediately if pre-selected)
- The obsolete single-component path is preserved for backward compatibility but logs a console error and warns at compile time via `[Obsolete]`
- Checkbox and separator alignment now works correctly with any content

https://claude.ai/code/session_018fdMP8K56syBNwakZ5Juh7