### PR TITLE
Make Collapse() win against application display utilities

### DIFF
--- a/Tesserae/tps/assets/css/tss.animations.css
+++ b/Tesserae/tps/assets/css/tss.animations.css
@@ -35,7 +35,13 @@
     filter: saturate(0) !important;
 }
 
-.tss-collapse {
+/* The class is doubled on purpose: Collapse() must win against an application's display
+   utilities (e.g. a Bootstrap-style .app-d-flex { display: flex !important }), which are
+   single-class rules in stylesheets that load after this one - at equal (0,1,0) specificity
+   the later sheet wins and Collapse() silently stops hiding. (0,2,0) outranks any of them
+   regardless of load order, while staying below purposeful overrides like the mobile
+   navbar-drawer rule, which keeps a collapsed drawer display:flex to slide it off-screen. */
+.tss-collapse.tss-collapse {
     display:none !important;
 }
 


### PR DESCRIPTION
## What

`.tss-collapse` hid components with `display:none !important` at (0,1,0) specificity, so `Collapse()`'s effect depended on where `tss.css` sits in the page: any application utility that also sets `display` with `!important` at the same specificity in a later-loaded stylesheet (e.g. Curiosity's Bootstrap-derived `.msk-d-flex { display: flex !important }`) silently outranked it — `Collapse()` stopped hiding that element while `Show()` kept working. In Curiosity this surfaced as the folder navigator's folders pane, which could be shown but never hidden.

The selector now doubles the class — `.tss-collapse.tss-collapse` — which at (0,2,0) beats any single-class utility regardless of stylesheet load order, while still losing to the deliberate higher-specificity overrides. It stays a class-based mechanism, so every direct `classList.add/remove("tss-collapse")` call site (SidebarPivot, Stack's style propagation, consumer code) keeps working.

## Verification

Checked computed styles in Chromium against the built `tss.css` + Curiosity's `Curiosity.FrontEnd.ExternalBundle.css` (loaded after it, as in the real `index.html`):

| element | before | after |
|---|---|---|
| `msk-d-flex` + `tss-collapse` | `flex` (bug: visible) | `none`, hidden |
| `msk-d-flex`, not collapsed | `flex` | `flex` |
| `msk-d-inline-flex` + `tss-collapse` | `inline-flex` (visible) | `none`, hidden |
| mobile navbar drawer, collapsed (`body.tss-mobile … .tss-navbar-drawer.tss-collapse`, (0,4,1)) | `flex`, `translateX(-105%)` | unchanged — still slides off-screen |

`.tss-navbar-drawer.tss-collapse { display:none !important }` (tss.sidebar.css) ties at (0,2,0) but declares the same thing and loads later in the bundle, so it is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WALCAi7JEgrVpui8RF2HA9

---
_Generated by [Claude Code](https://claude.ai/code/session_01WALCAi7JEgrVpui8RF2HA9)_