### PR TITLE
Update the Transpose packages to the latest release

### DIFF
--- a/Tesserae.Bench/Tesserae.Bench.csproj
+++ b/Tesserae.Bench/Tesserae.Bench.csproj
@@ -10,8 +10,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Transpose.BCL" Version="26.8.4275" />
-    <PackageReference Include="Transpose.Core" Version="26.7.3304" />
+    <PackageReference Include="Transpose.BCL" Version="26.8.4619" />
+    <PackageReference Include="Transpose.Core" Version="26.8.4597" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tesserae.Tests/Tesserae.Tests.csproj
+++ b/Tesserae.Tests/Tesserae.Tests.csproj
@@ -4,8 +4,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Transpose.BCL" Version="26.8.4500" />
-    <PackageReference Include="Transpose.Core" Version="26.8.4176" />
+    <PackageReference Include="Transpose.BCL" Version="26.8.4619" />
+    <PackageReference Include="Transpose.Core" Version="26.8.4597" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tesserae/Tesserae.csproj
+++ b/Tesserae/Tesserae.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Transpose.BCL" Version="26.8.4500" />
-    <PackageReference Include="Transpose.Core" Version="26.8.4176" />
-    <PackageReference Include="Transpose.Newtonsoft.Json" Version="26.8.4126" />
+    <PackageReference Include="Transpose.BCL" Version="26.8.4619" />
+    <PackageReference Include="Transpose.Core" Version="26.8.4597" />
+    <PackageReference Include="Transpose.Newtonsoft.Json" Version="26.8.4599" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Moves every `Transpose.*` reference in this repository to the current published release.

| Package | Tesserae | Tesserae.Tests | Tesserae.Bench | → |
| --- | --- | --- | --- | --- |
| `Transpose.BCL` | 26.8.4500 | 26.8.4500 | 26.8.4275 | **26.8.4619** |
| `Transpose.Core` | 26.8.4176 | 26.8.4176 | 26.7.3304 | **26.8.4597** |
| `Transpose.Newtonsoft.Json` | 26.8.4126 | — | — | **26.8.4599** |
| `Transpose.Build.Target` (SDK) | 26.8.4125 | 26.8.4125 | 26.8.4125 | unchanged, already current |

Tesserae.Bench was two releases further behind than the other two, so it now matches them.

## The compiler this needs

`Transpose.BCL` 26.8.4619 carries a build stamp of `26.8.4618`, so a consumer needs `Transpose.Compiler` >= 26.8.4618 or the build fails with `TPS0008`. That is the newest published compiler, and it is what `dotnet tool update --global Transpose.Compiler` in `.azure-devops/build-nuget-h5.yml` installs. `Transpose.Core` 26.8.4597 and `Transpose.Newtonsoft.Json` 26.8.4599 both stamp 26.8.4595, so they are covered by the same floor.

## Verification

All three projects built in **Release** against compiler 26.8.4618, no warnings and no errors:

- `Tesserae` — package built, still emitting all three variants (`tss.js`, `tss.min.js`, `tss.mjs` plus chunks), **32 chunks: 20 loaded up front, 12 on demand**, 213 types deferred, median 73.2 KB.
- `Tesserae.Tests` — site built, **20 chunks: 1 up front, 19 on demand**, 165 types deferred.
- `Tesserae.Bench` — site built.

Release specifically, because the module output and the `.min.js` resource selection only happen there.

---
_Generated by [Claude Code](https://claude.ai/code/session_011QmFZNQ8Tn48gznUET3t3U)_