### PR TITLE
Draw the SearchBox clear button ourselves instead of the browser's

### DIFF
--- a/Tesserae/skills/references/search-box.md
+++ b/Tesserae/skills/references/search-box.md
@@ -23,6 +23,8 @@ Bring factories into scope with `using static Tesserae.UI;`.
 - `.OnShortcut(Action)` — what that shortcut does *instead* of focusing the box, for a box that
   stands for a search happening somewhere else (a `CommandPalette`, a search page). Pressing the key
   works the same whether or not the box already holds the caret, which focusing does not.
+- `.Clear()` — empties the box, focuses it and fires `OnSearch` with an empty query. This is what the
+  trailing clear button does; the button itself appears whenever the box has text and needs no setup.
 - `.Focus()`, `.Disabled(bool = true)`, `.Height(UnitSize)` / `.H(int)`.
 
 ## Example

--- a/Tesserae/src/Components/SearchBox.cs
+++ b/Tesserae/src/Components/SearchBox.cs
@@ -17,6 +17,7 @@ namespace Tesserae
         private readonly HTMLElement     _iconContainer;
         private readonly HTMLElement     _shortcutContainer;
         private readonly HTMLElement     _paddingContainer;
+        private readonly HTMLElement     _clearButton;
 
         private string[]                       _shortcutKeys;
         private Action<Event>                  _globalShortcutHandler;
@@ -38,13 +39,33 @@ namespace Tesserae
             _iconContainer     = Div(Att("tss-searchbox-icon"), _icon);
             _shortcutContainer = Div(Att("tss-searchbox-shortcut"));
             _paddingContainer  = Div(Att("tss-searchbox-padding"));
-            _container         = Div(Att("tss-searchbox-container"), _iconContainer, InnerElement, _shortcutContainer, _paddingContainer);
+
+            //The browser's own cancel button on a type="search" input is hidden by the stylesheet: it is drawn in
+            //the browser's colours and weight rather than the toolkit's, Chromium alone shows it, and it comes and
+            //goes with focus. This one is drawn the same way CommandPalette draws its close button, and is
+            //shown whenever there is something to clear.
+            _clearButton = UI.Button(Att("tss-searchbox-clear", type: "button", title: "Clear", ariaLabel: "Clear"),
+                                     I(Att($"tss-searchbox-clear-icon {UIcons.CrossSmall.ToCssClass()}")));
+
+            _container = Div(Att("tss-searchbox-container"), _iconContainer, InnerElement, _clearButton, _shortcutContainer, _paddingContainer);
 
             AttachChange();
             AttachInput();
             AttachFocus();
             AttachBlur();
             AttachKeys();
+
+            SubscribeInputUpdated((_, __) => UpdateHasText());
+
+            //Pressing the button with the pointer must not take the caret out of the box - the user is about
+            //to type the next query.
+            _clearButton.addEventListener("mousedown", e => e.preventDefault());
+
+            _clearButton.addEventListener("click", e =>
+            {
+                StopEvent(e);
+                Clear();
+            });
 
             OnKeyPress((s, e) =>
             {
@@ -54,10 +75,34 @@ namespace Tesserae
                 }
             });
 
+            //Escape empties a search input in Chromium and raises this event rather than an input event, so the
+            //clear button has to be told here too.
             InnerElement.addEventListener("search", (_) =>
             {
+                UpdateHasText();
                 TriggerSearch();
             });
+        }
+
+        /// <summary>
+        /// Empties the box, puts the caret in it and raises <see cref="OnSearch"/> with the empty query - what
+        /// pressing the clear button does.
+        /// </summary>
+        public SearchBox Clear()
+        {
+            if (!IsEnabled) return this;
+
+            InnerElement.value = string.Empty;
+            RaiseOnInput(null);
+            InnerElement.focus();
+            TriggerSearch();
+
+            return this;
+        }
+
+        private void UpdateHasText()
+        {
+            _container.classList.toggle("tss-searchbox-has-text", !string.IsNullOrEmpty(InnerElement.value));
         }
 
         private void TriggerSearch()

--- a/Tesserae/tps/assets/css/tss.searchbox.css
+++ b/Tesserae/tps/assets/css/tss.searchbox.css
@@ -32,6 +32,17 @@
         opacity: 0.7;
     }
 
+    /* The browser's own cancel button: WebKit's glyph in WebKit's colours, and Chromium only. The
+       toolkit draws .tss-searchbox-clear in its place. */
+    .tss-searchbox::-webkit-search-cancel-button,
+    .tss-searchbox::-webkit-search-decoration,
+    .tss-searchbox::-webkit-search-results-button,
+    .tss-searchbox::-webkit-search-results-decoration {
+        -webkit-appearance: none;
+        appearance: none;
+        display: none;
+    }
+
 .tss-searchbox-container {
     display: inline-flex;
     position: relative;
@@ -114,6 +125,50 @@
     transition: width 0.167s ease 0s;
     width: 0px;
     height: 16px;
+}
+
+/* The clear button, drawn the way CommandPalette draws its close button: a flat square that only
+   colours in on hover, holding a cross-small glyph. It fills the row's height, capped at 28px so that
+   it sits inside the 36px box with its 1px border and 5px padding, and disappears while there is
+   nothing to clear so the input keeps the full width. */
+.tss-searchbox-clear {
+    display: none;
+    align-items: center;
+    justify-content: center;
+    align-self: center;
+    width: 28px;
+    height: 28px;
+    max-height: 100%;
+    flex-shrink: 0;
+    border: none;
+    border-radius: 6px;
+    background: transparent;
+    color: var(--tss-secondary-foreground-color);
+    cursor: pointer;
+    padding: 0;
+    margin: 0;
+    font: inherit;
+}
+
+    .tss-searchbox-clear:hover {
+        background: var(--tss-default-background-hover-color);
+        color: var(--tss-default-foreground-color);
+    }
+
+    .tss-searchbox-clear:focus-visible {
+        outline: 2px solid var(--tss-primary-border-color);
+        outline-offset: -2px;
+    }
+
+.tss-searchbox-container.tss-searchbox-has-text:not(.tss-disabled) > .tss-searchbox-clear {
+    display: inline-flex;
+}
+
+.tss-searchbox-clear-icon {
+    /* cross-small at 16px paints the same weight as the magnifier at 16px in .tss-searchbox-icon: the
+       plain cross glyph fills far more of its em box, so it is the small variant that matches. */
+    font-size: 16px;
+    line-height: 1;
 }
 
 .tss-searchbox-shortcut {


### PR DESCRIPTION
The X in a SearchBox was the native WebKit cancel button on the type="search" input: drawn in the browser's colour and weight rather than the toolkit's, shown only while the box had focus, and absent in Firefox altogether. In the gallery sidebar it came out as a heavy blue cross next to the light grey UIcons glyphs.

Hide the native control and add a button in the container, built the same way CommandPalette builds its close button: a flat 28px square with a cross-small glyph that colours in on hover. It appears whenever the box has text, whether or not it is focused, empties the box on click, keeps the caret in it and raises OnSearch with the empty query. A public Clear() does the same thing for callers.

The skill reference for the search box documents the new method.


Claude-Session: https://claude.ai/code/session_01EJ3EnomPCG5GRE2xM4k4SE